### PR TITLE
fix(host): quiet the remaining stateless-cloud Sentry classes (PRODUCT-1504)

### DIFF
--- a/packages/domain/src/json-salvage.test.ts
+++ b/packages/domain/src/json-salvage.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { firstJsonValueEnd, salvageLeadingJson } from "./json-salvage";
 import { loadRoutineRuns, loadRoutines } from "./routines";
-import { loadJson, type TextStore } from "./store";
+import { loadJson, parseJsonDoc, type TextStore } from "./store";
 
 const ROOT = "Personal/Slack Test";
 
@@ -67,4 +67,14 @@ test("loadJson still throws on a mangled file, naming the key", async () => {
   );
   await store.writeText("k.json", "﻿[]\n");
   expect(await loadJson(store, "k.json", null)).toEqual([]);
+});
+
+test("parseJsonDoc strips a BOM, salvages trailing junk, and names the key", () => {
+  expect(parseJsonDoc(`\uFEFF{"a":1}`, "config.json")).toEqual({ a: 1 });
+  expect(parseJsonDoc('[{"id":"r1"}]junk after', "routines.json")).toEqual([
+    { id: "r1" },
+  ]);
+  expect(() => parseJsonDoc("{oops", "learnings.json")).toThrow(
+    /learnings\.json is not valid JSON/,
+  );
 });

--- a/packages/domain/src/store.ts
+++ b/packages/domain/src/store.ts
@@ -37,20 +37,27 @@ export async function loadJson<T>(
 ): Promise<T> {
   const raw = await store.readText(key);
   if (raw === null) return fallback;
-  // A leading byte-order mark is an encoding artifact, not content: files-first
-  // docs get hand-written by agents, users and editors, and `JSON.parse` rejects
-  // a BOM outright (HOU-953). The host's Vfs already drops it on decode; strip
-  // here too so EVERY TextStore impl reads a BOM'd doc rather than declaring the
-  // user's data corrupt over one invisible byte.
+  return parseJsonDoc(raw, key) as T;
+}
+
+/**
+ * The ONE way any Houston code turns a `.houston` doc's text into a value:
+ * every reader (pod read paths, doc-shadow projection, pooled-turn doc
+ * publish) must parse identically or the doc-served and pod-served answers
+ * drift. A leading byte-order mark is an encoding artifact, not content:
+ * files-first docs get hand-written by agents, users and editors, and
+ * `JSON.parse` rejects a BOM outright (HOU-953). A complete value followed by
+ * trailing bytes (an outside writer appended or overlapped the doc) keeps the
+ * value: nothing the user wrote is lost, and the next save rewrites the file
+ * clean. Anything else throws with the key named.
+ */
+export function parseJsonDoc(raw: string, key: string): unknown {
   const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
   try {
-    return JSON.parse(text) as T;
+    return JSON.parse(text) as unknown;
   } catch (err) {
-    // A complete value followed by trailing bytes (an outside writer appended
-    // or overlapped the doc) keeps the value: nothing the user wrote is lost,
-    // and the next save rewrites the file clean. Anything else still throws.
     const salvaged = salvageLeadingJson(text);
-    if (salvaged !== undefined) return salvaged as T;
+    if (salvaged !== undefined) return salvaged;
     throw new Error(
       `${key} is not valid JSON (${err instanceof Error ? err.message : String(err)})`,
     );

--- a/packages/host/src/docs/project-family.ts
+++ b/packages/host/src/docs/project-family.ts
@@ -1,0 +1,103 @@
+import {
+  docKey,
+  type HoustonFamily,
+  normalizeActivities,
+  normalizeLearnings,
+  normalizeRoutineRuns,
+  normalizeRoutines,
+  parseJsonDoc,
+} from "@houston/domain";
+import type { HoustonEvent } from "@houston/protocol";
+import type { WorkspacePaths } from "../paths";
+import type { WorkspaceStore } from "../ports";
+import type { Vfs } from "../vfs";
+import type { DocShadow } from "./http-shadow";
+
+export const EVENT_FAMILY: Partial<
+  Record<HoustonEvent["type"], HoustonFamily>
+> = {
+  ActivityChanged: "activity",
+  RoutinesChanged: "routines",
+  RoutineRunsChanged: "routine_runs",
+  ConfigChanged: "config",
+  LearningsChanged: "learnings",
+};
+
+export interface ProjectorDeps {
+  store: WorkspaceStore;
+  vfs: Vfs;
+  paths: WorkspacePaths;
+  shadow: DocShadow;
+}
+
+/** Every agent id the host serves, across all workspaces. */
+export async function listAgentIds(store: WorkspaceStore): Promise<string[]> {
+  const agents: string[] = [];
+  for (const workspace of await store.listWorkspaces()) {
+    for (const agent of await store.listAgents(workspace.id)) {
+      agents.push(agent.id);
+    }
+  }
+  return agents;
+}
+
+/** Read one agent's family file and PUT it into the doc shadow. */
+export async function putFamilyDoc(
+  deps: ProjectorDeps,
+  agentId: string,
+  family: HoustonFamily,
+): Promise<void> {
+  const agent = await deps.store.getAgent(agentId);
+  if (!agent) return;
+  const workspace = await deps.store.getWorkspace(agent.workspaceId);
+  if (!workspace) return;
+  const root = deps.paths.agentRoot(workspace, agent);
+  const key = docKey(root, family);
+  const raw = await deps.vfs.readText(key);
+  if (raw === null) {
+    // A vanished/never-written family file must still converge the doc:
+    // the pod's own read of an absent file answers empty, so the doc does
+    // too (else a deleted routines.json would keep firing removed routines
+    // through the external scheduler forever).
+    await deps.shadow.put(family, family === "config" ? {} : []);
+    return;
+  }
+  // Same tolerant parse as the pod's own read (loadJson): BOM strip +
+  // trailing-junk salvage, and an unparseable file names its key. A file
+  // the pod can read must never crash-loop the projection (HOUSTON-APP-5A9).
+  const parsed = parseJsonDoc(raw, key);
+  // Every family the gateway can serve pod-less is projected NORMALIZED —
+  // the exact shape the pod's own read would return (malformed entries
+  // dropped, defaults applied), so the doc-served answer and the pod-served
+  // answer stay byte-equivalent. Behavior lives once, in the domain
+  // normalizers; they are idempotent, so each doc also remains a valid
+  // family file for any future reconstruction. For host-written files this
+  // is a byte-level no-op.
+  await deps.shadow.put(family, normalizeFamilyDoc(family, parsed, key));
+}
+
+function normalizeFamilyDoc(
+  family: HoustonFamily,
+  parsed: unknown,
+  key: string,
+): unknown {
+  switch (family) {
+    case "activity":
+      return normalizeActivities(parsed, key).items;
+    case "routines":
+      return normalizeRoutines(parsed, key).items;
+    case "routine_runs":
+      return normalizeRoutineRuns(parsed, key).items;
+    case "learnings":
+      return normalizeLearnings(parsed, key).items;
+    case "config":
+      // config.json is one object; a non-object file reads as empty.
+      return parsed !== null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+        ? parsed
+        : {};
+    default:
+      return parsed;
+  }
+}

--- a/packages/host/src/docs/projector.test.ts
+++ b/packages/host/src/docs/projector.test.ts
@@ -1,5 +1,5 @@
 import { docKey } from "@houston/domain";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { LocalPaths } from "../paths";
 import { MemoryWorkspaceStore } from "../store/memory";
 import { MemoryVfs } from "../vfs";
@@ -395,4 +395,123 @@ test("boundAgent resolves after the seed to the bound id, or undefined", async (
   const ambiguous = new DocShadowProjector({ store, vfs, paths, shadow });
   ambiguous.seed();
   expect(await ambiguous.boundAgent()).toBeUndefined();
+});
+
+test("a family file with trailing junk projects its salvaged leading value", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "A",
+  });
+  const root = paths.agentRoot(workspace, agent);
+  const puts: { family: string; doc: unknown }[] = [];
+  const shadow: DocShadow = {
+    async seed() {},
+    async put(family, doc) {
+      puts.push({ family, doc });
+    },
+  };
+  const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+  // An outside writer appended a partial second copy after the value — the
+  // exact file the pod's own read (loadJson) salvages. The projection must
+  // serve the same salvaged answer, not crash (HOUSTON-APP-5A9).
+  const value = [{ id: "l1", text: "kept", created_at: "now" }];
+  await vfs.writeText(
+    docKey(root, "learnings"),
+    `${JSON.stringify(value)}[{ "id": "l1",`,
+  );
+
+  projector.onEvent({ type: "LearningsChanged", agentPath: agent.id });
+  await projector.flush();
+
+  expect(puts.find((p) => p.family === "learnings")).toEqual({
+    family: "learnings",
+    doc: value,
+  });
+});
+
+test("an unparseable family file fails only its family and names the doc key", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "A",
+  });
+  const root = paths.agentRoot(workspace, agent);
+  const puts: { family: string; doc: unknown }[] = [];
+  const shadow: DocShadow = {
+    async seed() {},
+    async put(family, doc) {
+      puts.push({ family, doc });
+    },
+  };
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await vfs.writeText(docKey(root, "learnings"), "{oops");
+    await vfs.writeText(
+      docKey(root, "activity"),
+      JSON.stringify([{ id: "m1", title: "T", status: "needs_you" }]),
+    );
+    const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+    projector.seed();
+    await projector.flush();
+
+    // Every OTHER family still seeded; the mangled one reported its key.
+    expect(puts.map((p) => p.family)).not.toContain("learnings");
+    expect(puts.find((p) => p.family === "activity")).toBeTruthy();
+    const reported = errors.mock.calls.some((call) =>
+      call.some(
+        (arg) =>
+          arg instanceof Error &&
+          arg.message.includes(docKey(root, "learnings")),
+      ),
+    );
+    expect(reported).toBe(true);
+  } finally {
+    errors.mockRestore();
+  }
+});
+
+test("cross-agent refusals are a latched warn, never repeated per family", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  await store.createAgent({ workspaceId: workspace.id, name: "A" });
+  const shadow: DocShadow = { async seed() {}, async put() {} };
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+    projector.seed();
+    await projector.flush();
+
+    const stray = await store.createAgent({
+      workspaceId: workspace.id,
+      name: "B",
+    });
+    for (let i = 0; i < 3; i++) {
+      projector.onEvent({ type: "LearningsChanged", agentPath: stray.id });
+      await projector.flush();
+    }
+
+    const refusals = warns.mock.calls.filter((call) =>
+      String(call[0]).includes("refusing cross-agent projection"),
+    );
+    expect(refusals).toHaveLength(1);
+    // The designed outcome never reaches the error (Sentry) channel.
+    expect(
+      errors.mock.calls.some((call) =>
+        String(call[0]).includes("refusing cross-agent projection"),
+      ),
+    ).toBe(false);
+  } finally {
+    warns.mockRestore();
+    errors.mockRestore();
+  }
 });

--- a/packages/host/src/docs/projector.ts
+++ b/packages/host/src/docs/projector.ts
@@ -1,24 +1,11 @@
-import {
-  docKey,
-  type HoustonFamily,
-  normalizeActivities,
-  normalizeLearnings,
-  normalizeRoutineRuns,
-  normalizeRoutines,
-} from "@houston/domain";
+import type { HoustonFamily } from "@houston/domain";
 import type { HoustonEvent } from "@houston/protocol";
-import type { WorkspacePaths } from "../paths";
-import type { WorkspaceStore } from "../ports";
-import type { Vfs } from "../vfs";
-import type { DocShadow } from "./http-shadow";
-
-const EVENT_FAMILY: Partial<Record<HoustonEvent["type"], HoustonFamily>> = {
-  ActivityChanged: "activity",
-  RoutinesChanged: "routines",
-  RoutineRunsChanged: "routine_runs",
-  ConfigChanged: "config",
-  LearningsChanged: "learnings",
-};
+import {
+  EVENT_FAMILY,
+  listAgentIds,
+  type ProjectorDeps,
+  putFamilyDoc,
+} from "./project-family";
 
 /**
  * Projects watcher-observed family files into the managed DB shadow. The same
@@ -37,15 +24,9 @@ export class DocShadowProjector {
   // refused — nothing may cross-post into the bound agent's doc.
   private bound: string | undefined;
   private addressing = false;
+  private readonly refused = new Set<string>();
 
-  constructor(
-    private readonly deps: {
-      store: WorkspaceStore;
-      vfs: Vfs;
-      paths: WorkspacePaths;
-      shadow: DocShadow;
-    },
-  ) {}
+  constructor(private readonly deps: ProjectorDeps) {}
 
   seed(): void {
     // Revision seed first, then ONE content projection of every family for
@@ -65,7 +46,7 @@ export class DocShadowProjector {
   }
 
   private async seedContent(): Promise<void> {
-    const agents = await this.listAgentIds();
+    const agents = await listAgentIds(this.deps.store);
     if (agents.length === 0) {
       // Cloud pods can reach boot before the workspace tree hydrates (seen
       // live: real agent pods with zero agents at seed time). Not an error
@@ -171,36 +152,21 @@ export class DocShadowProjector {
       return;
     }
     if (agentId !== this.bound) {
-      console.error(
-        `[doc-shadow] refusing cross-agent projection ${agentId}#${family} (route bound to ${this.bound})`,
-      );
+      // The refusal is the DESIGNED outcome (rename leftovers beside the live
+      // agent fire watcher events too), so it is a warn, and latched: one
+      // leftover directory otherwise repeats this on every file change.
+      const refusedKey = `${agentId}#${family}`;
+      if (!this.refused.has(refusedKey)) {
+        this.refused.add(refusedKey);
+        console.warn(
+          `[doc-shadow] refusing cross-agent projection ${refusedKey} (route bound to ${this.bound})`,
+        );
+      }
       return;
     }
-    const agent = await this.deps.store.getAgent(agentId);
-    if (!agent) return;
-    const workspace = await this.deps.store.getWorkspace(agent.workspaceId);
-    if (!workspace) return;
-    const root = this.deps.paths.agentRoot(workspace, agent);
-    const key = docKey(root, family);
-    const raw = await this.deps.vfs.readText(key);
-    if (raw === null) {
-      // A vanished/never-written family file must still converge the doc:
-      // the pod's own read of an absent file answers empty, so the doc does
-      // too (else a deleted routines.json would keep firing removed routines
-      // through the external scheduler forever).
-      await this.deps.shadow.put(family, family === "config" ? {} : []);
-      return;
-    }
-    const parsed = JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown;
-    // Every family the gateway can serve pod-less is projected NORMALIZED —
-    // the exact shape the pod's own read would return (malformed entries
-    // dropped, defaults applied), so the doc-served answer and the pod-served
-    // answer stay byte-equivalent. Behavior lives once, in the domain
-    // normalizers; they are idempotent, so each doc also remains a valid
-    // family file for any future reconstruction. For host-written files this
-    // is a byte-level no-op.
-    await this.deps.shadow.put(family, normalizeFamilyDoc(family, parsed, key));
+    await putFamilyDoc(this.deps, agentId, family);
   }
+
   /**
    * Bind on first projection when boot found no agents. True = agentId is
    * the host's single agent; the remaining families are enqueued so the
@@ -211,7 +177,7 @@ export class DocShadowProjector {
     agentId: string,
     family: HoustonFamily,
   ): Promise<boolean> {
-    const agents = await this.listAgentIds();
+    const agents = await listAgentIds(this.deps.store);
     if (agents.length !== 1 || agents[0] !== agentId) return false;
     this.bound = agentId;
     console.warn(
@@ -221,41 +187,5 @@ export class DocShadowProjector {
       if (other && other !== family) this.enqueue(agentId, other);
     }
     return true;
-  }
-
-  private async listAgentIds(): Promise<string[]> {
-    const agents: string[] = [];
-    for (const workspace of await this.deps.store.listWorkspaces()) {
-      for (const agent of await this.deps.store.listAgents(workspace.id)) {
-        agents.push(agent.id);
-      }
-    }
-    return agents;
-  }
-}
-
-function normalizeFamilyDoc(
-  family: HoustonFamily,
-  parsed: unknown,
-  key: string,
-): unknown {
-  switch (family) {
-    case "activity":
-      return normalizeActivities(parsed, key).items;
-    case "routines":
-      return normalizeRoutines(parsed, key).items;
-    case "routine_runs":
-      return normalizeRoutineRuns(parsed, key).items;
-    case "learnings":
-      return normalizeLearnings(parsed, key).items;
-    case "config":
-      // config.json is one object; a non-object file reads as empty.
-      return parsed !== null &&
-        typeof parsed === "object" &&
-        !Array.isArray(parsed)
-        ? parsed
-        : {};
-    default:
-      return parsed;
   }
 }

--- a/packages/host/src/docs/view-warm.ts
+++ b/packages/host/src/docs/view-warm.ts
@@ -1,6 +1,7 @@
 import type { HoustonEvent } from "@houston/protocol";
 import type { EventHub } from "../events/hub";
 import type { WorkspaceStore } from "../ports";
+import { listAgentIds } from "./project-family";
 import { VIEW_RESTS } from "./view-capture";
 
 // The ladder must OUTLAST the launcher's 60s boot-health budget
@@ -49,12 +50,7 @@ async function fetchView(
 }
 
 async function singleAgentId(store: WorkspaceStore): Promise<string | null> {
-  const agents: string[] = [];
-  for (const workspace of await store.listWorkspaces()) {
-    for (const agent of await store.listAgents(workspace.id)) {
-      agents.push(agent.id);
-    }
-  }
+  const agents = await listAgentIds(store);
   // Same single-agent rule as the doc projector: the doc route names ONE
   // agent; on any other host shape the warm quietly stands down.
   return agents.length === 1 ? (agents[0] ?? null) : null;

--- a/packages/host/src/store-sync/daemon-policy.ts
+++ b/packages/host/src/store-sync/daemon-policy.ts
@@ -4,6 +4,7 @@ import {
   type SyncResult,
   syncBack,
 } from "@houston/runtime-client/object-sync";
+import { type TreeWatch, watchTree } from "../watch/watch-tree";
 
 export const DEFAULT_QUIET_MS = 3_000;
 export const DEFAULT_INTERVAL_MS = 300_000;
@@ -49,6 +50,62 @@ export function logHydrated(
 ): void {
   opts.log(
     `[store-sync] hydrated ${objectCount} objects in ${Date.now() - startedAt}ms`,
+  );
+}
+
+/**
+ * Watch the tree, degrading to the periodic pass alone when the watcher
+ * cannot start or later fails. onError fires at most once (ENOSPC on the
+ * pod's inotify budget — HOU-841); the tree watch keeps whatever coverage it
+ * already has, and the periodic pass guarantees eventual sync regardless.
+ */
+export function startTreeWatch(
+  opts: StoreSyncOptions,
+  onDirty: () => void,
+): TreeWatch | undefined {
+  try {
+    return watchTree(opts.rootDir, onDirty, {
+      excludeDirs: opts.watchExcludeDirs,
+      onError: (err) =>
+        opts.log(
+          "[store-sync] filesystem watcher degraded; periodic sync covers changes",
+          err,
+        ),
+    });
+  } catch (err) {
+    opts.log(
+      "[store-sync] filesystem watcher failed; using periodic sync",
+      err,
+    );
+    return undefined;
+  }
+}
+
+/** Consecutive failed passes before a sync failure reports with its error.
+ *  At the 5-min periodic interval this is ~15 min of sustained failure. */
+const REPORT_AFTER_FAILURES = 3;
+
+/**
+ * One failed pass is a deploy-window blip the next pass absorbs (the gateway
+ * restarts, the pod's network tears down): a breadcrumb, not a report
+ * (HOUSTON-APP-58V). A streak means the store is actually unreachable — that
+ * reports with the error attached.
+ */
+export function logSyncFailed(
+  opts: StoreSyncOptions,
+  trigger: string,
+  consecutiveFailures: number,
+  err: unknown,
+): void {
+  if (consecutiveFailures >= REPORT_AFTER_FAILURES) {
+    opts.log(
+      `[store-sync] ${trigger} sync failed ${consecutiveFailures} times in a row; will retry`,
+      err,
+    );
+    return;
+  }
+  opts.log(
+    `[store-sync] ${trigger} sync failed; will retry (${err instanceof Error ? err.message : String(err)})`,
   );
 }
 

--- a/packages/host/src/store-sync/daemon.test.ts
+++ b/packages/host/src/store-sync/daemon.test.ts
@@ -387,3 +387,54 @@ test("a fencing loss latches once, halts scheduling, and skips the final drain",
   expect(fencingLogs[0]?.err).toBeUndefined();
   expect(fencingLogs[0]?.message).toContain("lease lost");
 });
+
+test("a transient sync failure is a breadcrumb; only a streak reports the error", async () => {
+  const remoteRoot = mkdtempSync(join(tmpdir(), "store-sync-flaky-remote-"));
+  const localRoot = mkdtempSync(join(tmpdir(), "store-sync-flaky-local-"));
+  const inner = new LocalDirStore(remoteRoot);
+  let failing = true;
+  const flaky: ObjectStore = {
+    list: (prefix) => inner.list(prefix),
+    download: (key, dest) => inner.download(key, dest),
+    upload: (src, key) => {
+      if (failing) return Promise.reject(new TypeError("fetch failed"));
+      return inner.upload(src, key);
+    },
+    delete: (key) => inner.delete(key),
+  };
+  const logs: Array<{ message: string; err?: unknown }> = [];
+  const daemon = new StoreSyncDaemon({
+    store: flaky,
+    rootDir: localRoot,
+    quietMs: 20,
+    intervalMs: 40,
+    log: (message, err) => logs.push({ message, err }),
+  });
+  await daemon.hydrate();
+  daemon.start();
+  writeFileSync(join(localRoot, "notes.txt"), "notes");
+
+  const failures = () => logs.filter((l) => l.message.includes("sync failed"));
+  await eventually(() => expect(failures().length).toBeGreaterThanOrEqual(4));
+
+  // Deploy-window blips (the first two passes) stay err-less breadcrumbs with
+  // the cause inlined; the sustained streak reports with the error attached.
+  expect(failures()[0]?.err).toBeUndefined();
+  expect(failures()[0]?.message).toContain("fetch failed");
+  expect(failures()[1]?.err).toBeUndefined();
+  expect(failures().some((l) => l.err !== undefined)).toBe(true);
+
+  // Recovery resets the streak: the next lone failure is a breadcrumb again.
+  failing = false;
+  await eventually(() =>
+    expect(readFileSync(join(remoteRoot, "notes.txt"), "utf8")).toBe("notes"),
+  );
+  failing = true;
+  writeFileSync(join(localRoot, "notes.txt"), "notes v2");
+  const seen = failures().length;
+  await eventually(() => expect(failures().length).toBeGreaterThan(seen));
+  expect(failures()[seen]?.err).toBeUndefined();
+
+  failing = false;
+  await daemon.stop();
+});

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -4,16 +4,18 @@ import {
   hydrate,
   StoreFencedError,
 } from "@houston/runtime-client/object-sync";
-import { type TreeWatch, watchTree } from "../watch/watch-tree";
+import type { TreeWatch } from "../watch/watch-tree";
 import {
   DEFAULT_INTERVAL_MS,
   DEFAULT_MAX_HYDRATE_BYTES,
   DEFAULT_QUIET_MS,
   logHydrated,
+  logSyncFailed,
   logSyncResult,
   runSyncBack,
   STORE_SYNC_EXCLUDES,
   type StoreSyncOptions,
+  startTreeWatch,
 } from "./daemon-policy";
 
 export { STORE_SYNC_EXCLUDES, type StoreSyncOptions } from "./daemon-policy";
@@ -31,6 +33,7 @@ export class StoreSyncDaemon {
   private syncPromise: Promise<void> | undefined;
   private rerunRequested = false;
   private fencedLatch = false;
+  private consecutiveFailures = 0;
 
   constructor(private readonly opts: StoreSyncOptions) {}
 
@@ -59,25 +62,7 @@ export class StoreSyncDaemon {
     }
     if (this.started || this.fencedLatch) return;
     this.started = true;
-    try {
-      this.watcher = watchTree(this.opts.rootDir, () => this.markDirty(), {
-        excludeDirs: this.opts.watchExcludeDirs,
-        // Fires at most once (ENOSPC on the pod's inotify budget — HOU-841);
-        // the tree watch keeps whatever coverage it already has, and the
-        // periodic pass guarantees eventual sync regardless.
-        onError: (err) =>
-          this.opts.log(
-            "[store-sync] filesystem watcher degraded; periodic sync covers changes",
-            err,
-          ),
-      });
-    } catch (err) {
-      this.opts.log(
-        "[store-sync] filesystem watcher failed; using periodic sync",
-        err,
-      );
-      this.watcher = undefined;
-    }
+    this.watcher = startTreeWatch(this.opts, () => this.markDirty());
     this.intervalTimer = setInterval(
       () => this.runInBackground("periodic"),
       this.opts.intervalMs ?? DEFAULT_INTERVAL_MS,
@@ -139,7 +124,7 @@ export class StoreSyncDaemon {
     )
       return;
     void this.requestSync().catch((err) => {
-      this.opts.log(`[store-sync] ${trigger} sync failed; will retry`, err);
+      logSyncFailed(this.opts, trigger, this.consecutiveFailures, err);
     });
   }
 
@@ -165,10 +150,14 @@ export class StoreSyncDaemon {
     try {
       result = await runSyncBack(this.opts, this.manifest, this.excludes);
     } catch (err) {
-      if (!(err instanceof StoreFencedError)) throw err;
+      if (!(err instanceof StoreFencedError)) {
+        this.consecutiveFailures += 1;
+        throw err;
+      }
       this.loseFence(err);
       return;
     }
+    this.consecutiveFailures = 0;
     this.manifest = result.manifest;
     if (version === this.dirtyVersion) this.dirty = false;
     logSyncResult(result, this.opts);

--- a/packages/host/src/vfs/lazy-store.test.ts
+++ b/packages/host/src/vfs/lazy-store.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -211,4 +217,24 @@ test("moving a missing or deleted source throws like the real filesystem", async
   await expect(
     vfs.move("workspaces/P/Bob/report.csv", "workspaces/P/Bob/x.txt"),
   ).rejects.toThrow(/source not found/);
+});
+
+test("an object deleted remotely after the listing reads as absent, not a failure", async () => {
+  const { vfs, storeRoot } = await seeded();
+  // Another writer deleted it between the turn's listing and this first
+  // read: a vanished object is a delete, never a failed turn
+  // (HOUSTON-APP-5AS).
+  rmSync(join(storeRoot, PREFIX, "workspaces/P/Bob/report.csv"));
+  expect(await vfs.readText("workspaces/P/Bob/report.csv")).toBeNull();
+  // Listings agree with the read, and the vanished key never enters the
+  // sync-back manifest as something to re-create or delete.
+  expect(await vfs.list("workspaces/P/Bob")).not.toContain(
+    "workspaces/P/Bob/report.csv",
+  );
+
+  // Moving a vanished source fails like a missing file, not like a store error.
+  rmSync(join(storeRoot, PREFIX, "workspaces/P/Bob/docs/notes.md"));
+  await expect(
+    vfs.move("workspaces/P/Bob/docs/notes.md", "workspaces/P/Bob/n.md"),
+  ).rejects.toThrow("move: source not found");
 });

--- a/packages/host/src/vfs/lazy-store.ts
+++ b/packages/host/src/vfs/lazy-store.ts
@@ -1,6 +1,7 @@
 import {
   excluded,
   type ObjectMetadata,
+  ObjectNotFoundError,
 } from "@houston/runtime-client/object-sync";
 import { FsVfs } from "./fs";
 import { fetchObject, type LazyBudget } from "./lazy-store-fetch";
@@ -82,7 +83,16 @@ export class LazyStoreVfs implements Vfs {
     if (local !== null) return local;
     const meta = this.state.visible(key);
     if (!meta) return null;
-    await this.materialize(key, meta);
+    try {
+      await this.materialize(key, meta);
+    } catch (error) {
+      if (!(error instanceof ObjectNotFoundError)) throw error;
+      // Vanished between the listing and this first read: another writer
+      // deleted it, so the key is absent — never a failed read
+      // (HOUSTON-APP-5AS). Dropped from the remote view so listings agree.
+      this.state.remote.delete(key);
+      return null;
+    }
     return this.local.readBytes(key);
   }
 
@@ -151,7 +161,13 @@ export class LazyStoreVfs implements Vfs {
     this.state.assertWritable(toKey);
     const meta = this.state.visible(fromKey);
     if ((await this.local.readBytes(fromKey)) === null && meta) {
-      await this.materialize(fromKey, meta);
+      try {
+        await this.materialize(fromKey, meta);
+      } catch (error) {
+        if (!(error instanceof ObjectNotFoundError)) throw error;
+        this.state.remote.delete(fromKey);
+        throw new Error(`move: source not found: ${fromKey}`);
+      }
     }
     await this.local.move(fromKey, toKey);
     this.state.written(toKey);

--- a/packages/runtime-client/src/object-sync/http-store-errors.ts
+++ b/packages/runtime-client/src/object-sync/http-store-errors.ts
@@ -1,4 +1,5 @@
 import {
+  ObjectNotFoundError,
   ObjectTooLargeError,
   StoreConflictError,
   StoreFencedError,
@@ -13,6 +14,7 @@ export async function objectStoreResponseError(
   const message = `object store ${method} ${key} failed (${res.status})${
     body ? `: ${body.slice(0, 200)}` : ""
   }`;
+  if (res.status === 404) return new ObjectNotFoundError(key, message);
   if (res.status === 413) return new ObjectTooLargeError(key, message);
   if (res.status === 409) return new StoreFencedError(key, message);
   if (res.status === 412) return new StoreConflictError(key, message);

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -835,3 +835,30 @@ test("segment-glob excludes match exactly one segment per `*` and only the named
   ).toBe(false);
   expect(excluded("workspace/.houston/runtime/x", ex)).toBe(false);
 });
+
+test("an object deleted between the listing and its download is skipped, not fatal", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, "agent-1", {
+    "workspace/keep.txt": "keep",
+    "workspace/vanishes.txt": "gone",
+  });
+  const listing = await store.list("agent-1");
+  rmSync(join(storeRoot, "agent-1", "workspace", "vanishes.txt"));
+  // The stale listing still names the deleted object — the boot-gating pass
+  // must treat the vanish as a delete, not fail the whole hydration.
+  const stale: ObjectStore = {
+    list: async () => listing,
+    download: (key, dest) => store.download(key, dest),
+    upload: (src, key) => store.upload(src, key),
+    delete: (key) => store.delete(key),
+  };
+
+  const manifest = await hydrate(stale, "agent-1", work);
+
+  expect([...manifest.keys()]).toEqual(["workspace/keep.txt"]);
+  expect(readFileSync(join(work, "workspace", "keep.txt"), "utf8")).toBe(
+    "keep",
+  );
+  // Nothing half-fetched survives to be mistaken for a fresh local write.
+  expect(existsSync(join(work, "workspace", "vanishes.txt"))).toBe(false);
+});

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -1,7 +1,7 @@
-import { stat } from "node:fs/promises";
+import { rm, stat } from "node:fs/promises";
 import { basename, join, sep } from "node:path";
 import { fileSha256 } from "./file-hash";
-import type { ObjectStore } from "./object-store";
+import { ObjectNotFoundError, type ObjectStore } from "./object-store";
 
 /**
  * Durable engine state is materialized into a local cache, then synchronized
@@ -161,6 +161,15 @@ export async function hydrate(
         }
         manifest.set(rel, { hash: await fileSha256(dest, size), generation });
       } catch (err) {
+        // Vanished between the listing and its download: another writer
+        // deleted it. The object is simply not part of this hydration —
+        // failing the whole (boot-gating) pass over it would wedge the pod.
+        // A half-opened destination must not survive outside the manifest:
+        // sync-back would read it as a fresh local write of an empty file.
+        if (err instanceof ObjectNotFoundError) {
+          await rm(join(destDir, ...rel.split("/")), { force: true });
+          continue;
+        }
         if (!failed) {
           failed = true;
           firstError = err;

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -21,6 +21,7 @@ export type {
 export type { ObjectStore, WriteOptions, WriteResult } from "./object-store";
 export {
   LocalDirStore,
+  ObjectNotFoundError,
   ObjectTooLargeError,
   StoreConflictError,
   StoreFencedError,

--- a/packages/runtime-client/src/object-sync/object-store.ts
+++ b/packages/runtime-client/src/object-sync/object-store.ts
@@ -52,6 +52,21 @@ export class ObjectTooLargeError extends Error {
   }
 }
 
+/**
+ * The object vanished between a listing and this request: another writer
+ * deleted it. Readers treat it as an absent key, never a failure — a stale
+ * manifest entry must not fail a whole turn (HOUSTON-APP-5AS).
+ */
+export class ObjectNotFoundError extends Error {
+  constructor(
+    readonly key: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ObjectNotFoundError";
+  }
+}
+
 /** The gateway rejected a stale pod after another boot acquired the lease. */
 export class StoreFencedError extends Error {
   constructor(
@@ -128,10 +143,20 @@ export class LocalDirStore implements ObjectStore {
 
   async download(key: string, destFile: string): Promise<void> {
     await mkdir(dirname(destFile), { recursive: true });
-    await pipeline(
-      createReadStream(this.fileFor(key)),
-      createWriteStream(destFile),
-    );
+    try {
+      await pipeline(
+        createReadStream(this.fileFor(key)),
+        createWriteStream(destFile),
+      );
+    } catch (error) {
+      // Same taxonomy as the HTTP store's 404: a listed file deleted before
+      // the read is a vanished object, not an adapter failure.
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      throw new ObjectNotFoundError(
+        key,
+        `object store GET ${key} failed (404): object not found`,
+      );
+    }
   }
 
   async upload(

--- a/packages/runtime/src/turn/gcs-store.ts
+++ b/packages/runtime/src/turn/gcs-store.ts
@@ -1,5 +1,8 @@
 import { Storage } from "@google-cloud/storage";
-import type { ObjectStore } from "@houston/runtime-client/object-sync";
+import {
+  ObjectNotFoundError,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
 
 /**
  * GCS-backed ObjectStore. Auth is Application Default Credentials (the Cloud
@@ -21,7 +24,17 @@ export class GcsStore implements ObjectStore {
   }
 
   async download(key: string, destFile: string): Promise<void> {
-    await this.bucket.file(key).download({ destination: destFile });
+    try {
+      await this.bucket.file(key).download({ destination: destFile });
+    } catch (error) {
+      // Same taxonomy as the HTTP store: a listed object deleted before the
+      // read is a vanished object, and readers treat it as an absent key.
+      if ((error as { code?: unknown }).code !== 404) throw error;
+      throw new ObjectNotFoundError(
+        key,
+        `object store GET ${key} failed (404): object not found`,
+      );
+    }
   }
 
   async upload(srcFile: string, key: string): Promise<void> {

--- a/packages/runtime/src/turn/turn-activity-doc.ts
+++ b/packages/runtime/src/turn/turn-activity-doc.ts
@@ -1,6 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { normalizeActivities, normalizeRoutineRuns } from "@houston/domain";
+import {
+  normalizeActivities,
+  normalizeRoutineRuns,
+  parseJsonDoc,
+} from "@houston/domain";
 import { fetchWithRetry } from "@houston/runtime-client/object-sync";
 import type { TurnServerDeps } from "./server-types";
 import {
@@ -160,8 +164,9 @@ export async function publishTurnActivityDoc(
       join(filesystem.workspaceDir, ".houston", "activity", "activity.json"),
       "utf8",
     );
-    const parsed = JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown;
-    const doc = normalizeActivities(parsed, key).items;
+    // Same tolerant parse as every other doc reader (BOM strip + salvage), so
+    // the pooled path publishes exactly what the standing projector would.
+    const doc = normalizeActivities(parseJsonDoc(raw, key), key).items;
     const { org, agent } = poolIdentity(turn.gcsPrefix);
     return await publish(
       {
@@ -197,6 +202,7 @@ export async function publishTurnRunsDoc(
   const baseUrl = deps.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
   if (turn.shadow || !baseUrl || !turn.claim || !turn.hostToken) return null;
   try {
+    const runsKey = turnRoutineRunsKey(filesystem.workspaceRel);
     const raw = await readFile(
       join(
         filesystem.workspaceDir,
@@ -206,11 +212,7 @@ export async function publishTurnRunsDoc(
       ),
       "utf8",
     );
-    const parsed = JSON.parse(raw.replace(/^\uFEFF/, "")) as unknown;
-    const doc = normalizeRoutineRuns(
-      parsed,
-      turnRoutineRunsKey(filesystem.workspaceRel),
-    ).items;
+    const doc = normalizeRoutineRuns(parseJsonDoc(raw, runsKey), runsKey).items;
     const { org, agent } = poolIdentity(turn.gcsPrefix);
     return await publish(
       {


### PR DESCRIPTION
Round 2 of the stateless-architecture Sentry triage (follow-up to #1386/#1387). Four unresolved classes remained; each fix keeps the doc-served and pod-served answers identical.

## HOUSTON-APP-5A9 — projector crashes on a family file the pod can read
`DocShadowProjector` parsed family files with a bare `JSON.parse`, while the pod's own read path (`loadJson`) BOM-strips and salvages trailing junk. One mangled file crash-looped the boot seed on every pod wake, with no doc key in the error. The tolerant parse is now shared (`parseJsonDoc` in `@houston/domain`) and used by `loadJson`, the projector, and the pooled-turn doc publish; a genuinely unparseable file fails only its family and names its key.

## HOUSTON-APP-5A8 — cross-agent refusal spam
Refusing a projection from a non-bound agent directory is the DESIGNED outcome (rename leftovers beside the live agent fire watcher events too), but it logged at error level on every file change. Now a latched warn per agent#family.

## HOUSTON-APP-5AS — pooled turn 500s when a listed object vanishes
An object deleted between the store listing and its first read failed the whole turn (`[turn] unhandled`, object store GET 404). A vanished object is a delete: new typed `ObjectNotFoundError` raised uniformly by the HTTP, GCS, and local-dir store adapters; the lazy vfs reads the key as absent (and drops it from listings), eager hydrate skips it instead of failing the boot-gating pass, and a move of a vanished source fails like a missing file.

## HOUSTON-APP-58V — store-sync reports the first transient blip
`StoreSyncDaemon` attached the error (= Sentry report) to the very first failed pass even though the periodic pass retries forever and deploy-window blips self-heal. Failures now stay err-less breadcrumbs (cause inlined) until 3 consecutive passes fail (~15 min at the 5-min interval); recovery resets the streak. Shutdown-path failures still always report.

Also: `projector.ts` and `daemon.ts` were over the 200-line cap — extracted `docs/project-family.ts` (family map + normalize/put + agent listing, now shared with `view-warm.ts`) and moved watcher/failure logging policy into `daemon-policy.ts`.

## Tests
- projector: salvaged trailing-junk file projects; unparseable file fails only its family and names the key; refusals are one latched warn, never on the error channel
- lazy vfs: vanished object reads as absent and drops from listings; vanished move source fails like a missing file
- hydrate: vanished object is skipped, nothing half-fetched survives
- daemon: first failures are breadcrumbs with the cause inlined, the streak reports with the error, recovery resets

All of: `pnpm check`, `check:boundaries`, host/runtime/domain/runtime-client vitest suites, and workspace typecheck pass.

Linear: PRODUCT-1504