### PR TITLE
fix(runtime): break the op-apply/op-route import cycle that deadlocked pool-worker boot

### DIFF
--- a/packages/runtime/src/turn/import-cycles.test.ts
+++ b/packages/runtime/src/turn/import-cycles.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The turn worker ships as an esbuild bundle (selfhost/bundle.mjs). esbuild's
+ * __esm module emulation awaits each imported module's evaluation, so an
+ * import CYCLE anywhere in a graph that also contains top-level await becomes
+ * a boot DEADLOCK: both sides await each other forever, the event loop
+ * empties, and node exits with no output at all (observed as the staging
+ * engine-pool CrashLoopBackOff of 2026-08-24, op-apply ↔ op-route). Plain ESM
+ * (tsx, node on sources) tolerates the same cycle, so nothing else catches it.
+ * This test statically forbids relative-import cycles inside src/turn.
+ */
+
+const turnDir = dirname(fileURLToPath(import.meta.url));
+
+function relativeImports(file: string): string[] {
+  const source = readFileSync(join(turnDir, file), "utf8");
+  const specs: string[] = [];
+  const re = /(?:from|import)\s*\(?\s*["'](\.\/[^"']+)["']\s*\)?/g;
+  for (let m = re.exec(source); m; m = re.exec(source)) {
+    // `import type { ... }` is erased by esbuild and creates no runtime edge.
+    const statementStart = source.lastIndexOf("import", m.index);
+    const statement = source.slice(statementStart, m.index + m[0].length);
+    if (/^import\s+type\b/.test(statement)) continue;
+    specs.push(`${m[1].replace(/^\.\//, "").replace(/\.(js|ts)$/, "")}.ts`);
+  }
+  return specs;
+}
+
+describe("turn module graph", () => {
+  it("has no runtime import cycles (esbuild + top-level await deadlocks on them)", () => {
+    const files = readdirSync(turnDir).filter(
+      (f) => f.endsWith(".ts") && !f.endsWith(".test.ts"),
+    );
+    const graph = new Map(files.map((f) => [f, relativeImports(f)]));
+
+    const OK = 2;
+    const VISITING = 1;
+    const state = new Map<string, number>();
+    const cycles: string[] = [];
+    const visit = (file: string, path: string[]) => {
+      if (state.get(file) === OK) return;
+      if (state.get(file) === VISITING) {
+        cycles.push([...path.slice(path.indexOf(file)), file].join(" -> "));
+        return;
+      }
+      state.set(file, VISITING);
+      for (const dep of graph.get(file) ?? []) {
+        if (graph.has(dep)) visit(dep, [...path, file]);
+      }
+      state.set(file, OK);
+    };
+    for (const file of files) visit(file, []);
+
+    expect(cycles).toEqual([]);
+  });
+});

--- a/packages/runtime/src/turn/import-cycles.test.ts
+++ b/packages/runtime/src/turn/import-cycles.test.ts
@@ -1,5 +1,5 @@
-import { readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, posix, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
@@ -10,32 +10,83 @@ import { describe, expect, it } from "vitest";
  * a boot DEADLOCK: both sides await each other forever, the event loop
  * empties, and node exits with no output at all (observed as the staging
  * engine-pool CrashLoopBackOff of 2026-08-24, op-apply ↔ op-route). Plain ESM
- * (tsx, node on sources) tolerates the same cycle, so nothing else catches it.
- * This test statically forbids relative-import cycles inside src/turn.
+ * (tsx, node on sources) tolerates the same cycle, so nothing else catches
+ * it. This test statically forbids relative-import cycles that pass through
+ * src/turn, following `./` and `../` edges across the whole runtime source.
+ *
+ * Coverage is static-literal only: dynamic import() with a non-literal
+ * specifier would be invisible here (none exist in this package today).
  */
 
 const turnDir = dirname(fileURLToPath(import.meta.url));
+const srcDir = resolve(turnDir, "..");
 
-function relativeImports(file: string): string[] {
-  const source = readFileSync(join(turnDir, file), "utf8");
-  const specs: string[] = [];
-  const re = /(?:from|import)\s*\(?\s*["'](\.\/[^"']+)["']\s*\)?/g;
-  for (let m = re.exec(source); m; m = re.exec(source)) {
-    // `import type { ... }` is erased by esbuild and creates no runtime edge.
-    const statementStart = source.lastIndexOf("import", m.index);
-    const statement = source.slice(statementStart, m.index + m[0].length);
-    if (/^import\s+type\b/.test(statement)) continue;
-    specs.push(`${m[1].replace(/^\.\//, "").replace(/\.(js|ts)$/, "")}.ts`);
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry))
+      out.push(full);
   }
-  return specs;
+  return out;
+}
+
+/** Resolve a `./x` / `../x` specifier the way the bundler does. */
+function resolveSpec(fromFile: string, spec: string): string | null {
+  const base = resolve(dirname(fromFile), spec.replace(/\.js$/, ""));
+  for (const candidate of [
+    base.endsWith(".ts") || base.endsWith(".tsx") ? base : null,
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+  ]) {
+    if (!candidate) continue;
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // not this candidate
+    }
+  }
+  return null;
+}
+
+/** Runtime (non-type-erased) relative import edges of one file. */
+function runtimeEdges(file: string): string[] {
+  const source = readFileSync(file, "utf8");
+  const edges: string[] = [];
+  // Whole statements: static import/export-from (multiline) and literal
+  // dynamic import(). Matching the full statement (not just the specifier)
+  // lets the type-only checks below see their own statement — never a
+  // neighboring one.
+  const re =
+    /(?:\b(?:import|export)\s+(?:type\s+)?[^;'"]*?from\s*["'](\.\.?\/[^"']+)["'])|(?:\bimport\s*\(\s*["'](\.\.?\/[^"']+)["']\s*\))/g;
+  for (let m = re.exec(source); m; m = re.exec(source)) {
+    const statement = m[0];
+    const spec = m[1] ?? m[2];
+    // `import type ... from` / `export type ... from` are erased.
+    if (/^(?:import|export)\s+type\b/.test(statement)) continue;
+    // `import { type A, type B } from` with ONLY type specifiers is erased
+    // too; a mixed list keeps the runtime edge.
+    const braces = statement.match(/\{([^}]*)\}/);
+    if (braces) {
+      const names = braces[1]
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (names.length > 0 && names.every((n) => /^type\s/.test(n))) continue;
+    }
+    const target = resolveSpec(file, spec);
+    if (target) edges.push(target);
+  }
+  return edges;
 }
 
 describe("turn module graph", () => {
-  it("has no runtime import cycles (esbuild + top-level await deadlocks on them)", () => {
-    const files = readdirSync(turnDir).filter(
-      (f) => f.endsWith(".ts") && !f.endsWith(".test.ts"),
-    );
-    const graph = new Map(files.map((f) => [f, relativeImports(f)]));
+  it("has no runtime import cycles through src/turn (esbuild + top-level await deadlocks on them)", () => {
+    const files = sourceFiles(srcDir);
+    const graph = new Map(files.map((f) => [f, runtimeEdges(f)]));
+    const inTurn = (f: string) => dirname(f) === turnDir;
 
     const OK = 2;
     const VISITING = 1;
@@ -44,13 +95,15 @@ describe("turn module graph", () => {
     const visit = (file: string, path: string[]) => {
       if (state.get(file) === OK) return;
       if (state.get(file) === VISITING) {
-        cycles.push([...path.slice(path.indexOf(file)), file].join(" -> "));
+        const loop = [...path.slice(path.indexOf(file)), file];
+        if (loop.some(inTurn))
+          cycles.push(
+            loop.map((f) => posix.normalize(relative(srcDir, f))).join(" -> "),
+          );
         return;
       }
       state.set(file, VISITING);
-      for (const dep of graph.get(file) ?? []) {
-        if (graph.has(dep)) visit(dep, [...path, file]);
-      }
+      for (const dep of graph.get(file) ?? []) visit(dep, [...path, file]);
       state.set(file, OK);
     };
     for (const file of files) visit(file, []);

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -11,6 +11,7 @@ import { applyAnonymizeOp } from "./op-anonymize";
 import { applyApiKeyConnect, credentialOpFiles } from "./op-credential";
 import { applyEndpointConnect } from "./op-endpoint";
 import { applyRouteOp } from "./op-route";
+import { conversationScope, engineAgentId } from "./op-scope";
 import {
   claimActiveProviderIn,
   putSettingsIn,
@@ -65,40 +66,6 @@ const answered = (
     include: (rel) => set.has(rel),
   };
 };
-
-/** Everything an agent-level route may touch: the agent's whole directory
- *  (family files, skills, markdown, any agentfile path the pod would
- *  accept) — never the runtime tree (conversations, sessions, auth), which
- *  stays conversation-scoped. Mirrors the pod-store's ops-claim scope. */
-export function agentRouteScope(workspaceRel: string): OpResult["include"] {
-  const root = `${workspaceRel}/`;
-  const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
-  return (rel) => rel.startsWith(root) && !rel.startsWith(runtime);
-}
-
-/** One conversation's file + sessions. */
-export function conversationScope(
-  dataRel: string,
-  cid: string,
-): OpResult["include"] {
-  const file = posix.join(
-    dataRel,
-    "conversations",
-    `${encodeURIComponent(cid)}.json`,
-  );
-  const sessions = `${posix.join(dataRel, "sessions", cid)}/`;
-  return (rel) => rel === file || rel.startsWith(sessions);
-}
-
-/**
- * The engine's agent id ("Workspace/Agent") from the hydrated layout. The
- * gateway's envelope names the agent by SLUG; turns never need the engine
- * id (the layout resolver finds the single agent), but the host handlers
- * address the agent by its id — so it is derived here, never trusted.
- */
-export function engineAgentId(filesystem: TurnFilesystem): string {
-  return filesystem.workspaceRel.replace(/^workspaces\//, "");
-}
 
 export async function applyOp(
   op: OpRequest,

--- a/packages/runtime/src/turn/op-route.ts
+++ b/packages/runtime/src/turn/op-route.ts
@@ -5,8 +5,8 @@ import { archiveTouchesRuntime } from "@houston/host/src/routes/migration-import
 import { PrefixedVfs } from "@houston/host/src/vfs";
 import type { HoustonEvent } from "@houston/protocol";
 import type { OpResult } from "./op-apply";
-import { agentRouteScope, engineAgentId } from "./op-apply";
 import { isCustomIntegrationOpRoute } from "./op-route-allowlist";
+import { agentRouteScope, engineAgentId } from "./op-scope";
 import type { OpRequest } from "./parse-op-request";
 import type { TurnFilesystem } from "./turn-filesystem";
 import { poolIdentity } from "./turn-store";

--- a/packages/runtime/src/turn/op-scope.ts
+++ b/packages/runtime/src/turn/op-scope.ts
@@ -1,0 +1,47 @@
+import { posix } from "node:path";
+import type { TurnFilesystem } from "./turn-filesystem";
+
+/**
+ * Leaf module — op-apply and op-route both need these, and op-apply already
+ * imports op-route for dispatch. Keeping the shared scope helpers in either
+ * of them closes an import cycle, which the esbuild bundle (selfhost
+ * bundle.mjs) turns into a boot deadlock once any module in the graph uses
+ * top-level await: each side's evaluation awaits the other's forever, the
+ * event loop empties, and the worker exits without a line of output. Plain
+ * ESM (tsx/node on sources) tolerates the cycle, so only bundled pool
+ * workers died. Nothing here may import another ./op-* module.
+ */
+
+/** The shape of `OpResult["include"]` without importing op-apply. */
+export type OpInclude = (relativePath: string) => boolean;
+
+/** Everything an agent-level route may touch: the agent's whole directory
+ *  (family files, skills, markdown, any agentfile path the pod would
+ *  accept) — never the runtime tree (conversations, sessions, auth), which
+ *  stays conversation-scoped. Mirrors the pod-store's ops-claim scope. */
+export function agentRouteScope(workspaceRel: string): OpInclude {
+  const root = `${workspaceRel}/`;
+  const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
+  return (rel) => rel.startsWith(root) && !rel.startsWith(runtime);
+}
+
+/** One conversation's file + sessions. */
+export function conversationScope(dataRel: string, cid: string): OpInclude {
+  const file = posix.join(
+    dataRel,
+    "conversations",
+    `${encodeURIComponent(cid)}.json`,
+  );
+  const sessions = `${posix.join(dataRel, "sessions", cid)}/`;
+  return (rel) => rel === file || rel.startsWith(sessions);
+}
+
+/**
+ * The engine's agent id ("Workspace/Agent") from the hydrated layout. The
+ * gateway's envelope names the agent by SLUG; turns never need the engine
+ * id (the layout resolver finds the single agent), but the host handlers
+ * address the agent by its id — so it is derived here, never trusted.
+ */
+export function engineAgentId(filesystem: TurnFilesystem): string {
+  return filesystem.workspaceRel.replace(/^workspaces\//, "");
+}


### PR DESCRIPTION
## What broke

Since the tranche-2 op work merged (#1391), every staging `engine-pool` worker crash-looped at boot with **zero output** — the only line was Node's `Warning: Detected unsettled top-level await at main.ts:103`, then a silent exit (code 13).

## Root cause

The production worker runs the esbuild bundle (`selfhost/bundle.mjs`), and esbuild's `__esm` initializers **await** each imported module's evaluation. Tranche 2 left an import cycle: `op-apply` imports `applyRouteOp` from `op-route`, and `op-route` imported `agentRouteScope`/`engineAgentId` back from `op-apply`. Because the turn graph also contains top-level await (`auth/storage.ts`), the two initializers deadlock awaiting each other, the event loop empties, and node exits without printing anything.

Plain ESM tolerates the cycle — tsx, vitest, and `pnpm dev` all boot fine — which is why nothing caught it before the bundle hit staging.

Verified by bisection on the published engine images (`1d8eddd` boots and registers, `a86ee9f` dies pre-heartbeat) and by step-tracing the bundle: evaluation stops inside `init_op_route` → `await init_op_apply()` while `init_op_apply` is awaiting `init_op_route`.

## Fix

- The shared scope helpers move to a leaf module `turn/op-scope.ts` (`agentRouteScope`, `conversationScope`, `engineAgentId`); `op-route` no longer imports `op-apply` at runtime (its `OpResult` import is type-only, erased).
- New test `turn/import-cycles.test.ts` statically forbids runtime import cycles inside `src/turn` — red on the old code (reports `op-apply.ts -> op-route.ts -> op-apply.ts`), green after the move — so the next cycle fails in CI instead of as a silent worker crash-loop.

## Verification

- Rebuilt the bundle and ran it inside the exact staging engine image with the pod's turn-mode env: worker boots, stays healthy, and registers with the gateway (heartbeat observed).
- `@houston/runtime` suite: 156 files / 1366 tests green; `pnpm typecheck` and `pnpm check` clean.
- Staging mitigation until this deploys: the pool StatefulSet is pinned to the last good engine image (`1d8eddd`); the next engine roll from main picks this fix up and unpins it.