### PR TITLE
fix(skills): keep the agent Skills search across a store install (PRODUCT-1512)

### DIFF
--- a/app/src/components/agent/skills-content.tsx
+++ b/app/src/components/agent/skills-content.tsx
@@ -89,13 +89,11 @@ export function SkillsContent({
     query,
     onQueryChange: setQuery,
     onSearch,
-    onInstallCommunity: onInstallCommunity
-      ? async (skill, signal) => {
-          const result = await onInstallCommunity(skill, signal);
-          if (!signal?.aborted) setQuery("");
-          return result;
-        }
-      : undefined,
+    // The query survives an install (PRODUCT-1512): clearing it would snap the
+    // Store back to the browse shelves mid-flow, so the user can keep
+    // installing more results from the same search — matching the global
+    // skills page.
+    onInstallCommunity,
     onPreviewCommunity,
     installedSkillNames,
   });

--- a/app/tests/skill-chat-setup.test.ts
+++ b/app/tests/skill-chat-setup.test.ts
@@ -557,4 +557,14 @@ describe("the agent Skills section's one writable door", () => {
     ok(!surface.includes("useDeleteSkill"));
     ok(surface.includes("useSkills("));
   });
+
+  it("keeps the search query across a store install", () => {
+    // PRODUCT-1512: the section once wrapped `onInstallCommunity` in a
+    // `setQuery("")` reset, which snapped the Store from the search results
+    // back to the browse shelves after every install. The handler must pass
+    // through untouched (as the global skills page does) so the user can keep
+    // installing from the same search.
+    ok(content.includes("onInstallCommunity,"));
+    ok(!content.includes('setQuery("")'));
+  });
 });


### PR DESCRIPTION
## Summary

In an agent's Skills section, installing a skill from Store search results snapped the view back to the browse shelves and cleared the search box, so installing several skills from one search meant retyping the query every time.

**Root cause:** `SkillsContent` (the agent-scoped surface) wrapped `onInstallCommunity` in a handler that called `setQuery("")` after a successful install. The marketplace's shelves-vs-results view is derived purely from the query (`showsShelves` in `ui/skills`), so clearing it discards the results grid. The global skills page (`skills-view`) passes the handler through untouched, which is why it never had the bug.

**Fix:** drop the wrapper and pass `onInstallCommunity` straight through, matching the global page. Added a source-guard test beside the existing ones for this file asserting the query survives an install.

PRODUCT-1512

## Repro (before)

1. Open an agent → Skills section.
2. Type a query in the search field that returns store results (e.g. "meeting").
3. Install one of the results.
4. Bug: the view jumps back to the browse shelves and the search field is empty.

## Verify (after)

1. Same steps 1–3.
2. The search field keeps the query and the results grid stays, with the installed skill marked installed; further results can be installed without retyping.
3. Sidebar Skills page behaves as before (unchanged code path).

## Tests

- `cd app && pnpm test` — 3761 pass, includes the new guard in `app/tests/skill-chat-setup.test.ts`.
- `pnpm check`, `app pnpm tsgo --noEmit` clean.