### PR TITLE
fix(runtime): pool turns honor their pinned provider; post-failure serves bypass the negative cache (PRODUCT-1515)

### DIFF
--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -107,6 +107,40 @@ test("404 means not connected and is cached as a negative result", async () => {
   expect(calls).toHaveLength(1);
 });
 
+test("invalidate sheds a cached negative so the next get sees a reconnect (PRODUCT-1515)", async () => {
+  // A reconnect capture lands centrally without passing through this process,
+  // so only an explicit invalidate can make the post-reconnect retry see it
+  // inside the 15s cache window.
+  const { calls, fetchImpl } = fakeFetch((_call, index) =>
+    index === 0
+      ? json({ error: "org not connected" }, 404)
+      : json(gatewayCredential()),
+  );
+  const s = store(fetchImpl);
+
+  expect(await s.get("ws_1", "openai-codex")).toBeNull();
+  s.invalidate("openai-codex");
+  const got = await s.get("ws_1", "openai-codex");
+  expect(got?.accessToken).toBe("AT-central");
+  expect(calls).toHaveLength(2);
+});
+
+test("invalidate is scoped to the acting identity", async () => {
+  const { calls, fetchImpl } = fakeFetch(() =>
+    json({ error: "org not connected" }, 404),
+  );
+  const s = store(fetchImpl);
+  const acting = { actingAs: actingAs() };
+
+  expect(await s.get("ws_1", "openai-codex")).toBeNull();
+  expect(await s.get("ws_1", "openai-codex", acting)).toBeNull();
+  // Invalidating the member's row leaves the team's cached answer in place.
+  s.invalidate("openai-codex", acting);
+  expect(await s.get("ws_1", "openai-codex")).toBeNull();
+  expect(await s.get("ws_1", "openai-codex", acting)).toBeNull();
+  expect(calls).toHaveLength(3);
+});
+
 test("404 adopts a legacy fallback credential with insert-only PUT, then re-gets the winner", async () => {
   const legacy: WorkspaceCredential = {
     workspaceId: "ws_1",

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -89,6 +89,10 @@ export class RemoteCredentialStore implements CredentialStore {
     return this.withWorkspace(workspaceId, adopted);
   }
 
+  invalidate(provider: string, acting?: CredentialActing): void {
+    this.cache.delete(scopeKeyOf(acting, provider));
+  }
+
   async put(
     cred: WorkspaceCredential,
     opts?: { ifAbsent?: boolean } & CredentialActing,

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -416,6 +416,15 @@ export interface CredentialStore {
     acting?: CredentialActing,
   ): Promise<WorkspaceCredential | null>;
   /**
+   * Drop any locally cached answer for this (identity, provider) row so the
+   * next `get` reads the backing store. Implemented only by stores that cache
+   * (the remote store's 15s window): a reconnect capture can land centrally
+   * WITHOUT passing through this process, so a serve that must see it — the
+   * retry right after a reconnect — has to shed the cached "not connected"
+   * first (PRODUCT-1515).
+   */
+  invalidate?(provider: string, acting?: CredentialActing): void;
+  /**
    * Upsert (overwrite in place on refresh). `ifAbsent` makes it a FILL, not a
    * clobber: an existing entry is left untouched. Required for any push of a
    * CACHED credential snapshot (the desktop reconcile) — the central copy may

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -832,3 +832,58 @@ test("an anthropic token below pi's floor is still served while live (guard owns
   expect(r.out.status).toBe(200);
   expect(r.out.body.access).toBe("sk-ant-oat01-four-minutes");
 });
+
+test("fresh=1 sheds the store's cached answer before the read (PRODUCT-1515)", async () => {
+  // The post-reconnect retry: the failing turn populated the remote store's
+  // 15s negative cache moments before the reconnect landed centrally, so the
+  // runtime's fresh serve must invalidate that row first — scoped to the
+  // acting identity whose credential failed.
+  const memory = new MemoryCredentialStore();
+  await memory.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "AT-fresh",
+    refreshToken: "",
+    expiresAt: FRESH_EXPIRES,
+  });
+  const invalidated: { provider: string; actingAs?: string }[] = [];
+  const credentials: CredentialStore = {
+    get: (workspaceId, provider, acting) =>
+      memory.get(workspaceId, provider, acting),
+    put: (cred, opts) => memory.put(cred, opts),
+    remove: (workspaceId, provider, acting) =>
+      memory.remove(workspaceId, provider, acting),
+    removeIfAccess: (workspaceId, provider, sha, opts) =>
+      memory.removeIfAccess(workspaceId, provider, sha, opts),
+    invalidate: (provider, acting) =>
+      invalidated.push({ provider, actingAs: acting?.actingAs }),
+  };
+  const serve = (query: string, actingAs?: string) => {
+    const out = mockRes();
+    return handleSandboxCredential(
+      { vault, credentials },
+      "GET",
+      "/sandbox/credential",
+      new URL(`http://x/sandbox/credential?${query}`),
+      mockReq("sbx", actingAs),
+      out.res,
+    ).then(() => out);
+  };
+
+  const plain = await serve("provider=openai-codex");
+  expect(plain.out.status).toBe(200);
+  expect(invalidated).toEqual([]);
+
+  const fresh = await serve("provider=openai-codex&fresh=1");
+  expect(fresh.out.status).toBe(200);
+  expect(invalidated).toEqual([
+    { provider: "openai-codex", actingAs: undefined },
+  ]);
+
+  // A member's fresh serve invalidates THAT member's row, not the team's.
+  await serve("provider=openai-codex&fresh=1", ACTING);
+  expect(invalidated[1]).toEqual({
+    provider: "openai-codex",
+    actingAs: ACTING,
+  });
+});

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -99,6 +99,15 @@ export async function handleSandboxCredential(
   const actingHeader = req.headers["x-houston-acting-as"];
   const actingAs = Array.isArray(actingHeader) ? actingHeader[0] : actingHeader;
   const acting = actingAs ? { actingAs } : undefined;
+  // `fresh=1` = the runtime is retrying after this provider FAILED a turn's
+  // auth (its auth-failure mark is active). A reconnect capture lands in the
+  // central store without passing through this process, so the remote store's
+  // 15s cached "not connected" — populated by the failing turn moments earlier
+  // — would fail the very retry the reconnect just unblocked, re-rendering the
+  // reconnect card in a loop (PRODUCT-1515). Bounded: the runtime sends it
+  // only while a failure mark is active, at most once per serve sync.
+  if (url.searchParams.get("fresh") === "1")
+    deps.credentials.invalidate?.(provider, acting);
   let deadError: RemoteCredentialDeadError | undefined;
   let cred = null;
   try {

--- a/packages/runtime/src/auth/serve-probe.test.ts
+++ b/packages/runtime/src/auth/serve-probe.test.ts
@@ -3,6 +3,7 @@ import {
   describeProbeError,
   normalizeProbeDetail,
   PROBE_CONCURRENCY,
+  probePath,
   probeProvider,
   probeProviders,
   type ServeProbe,
@@ -123,6 +124,17 @@ test("normalizeProbeDetail replaces every echo of the probe's own provider id", 
   // A body that never mentions the id passes through untouched.
   expect(normalizeProbeDetail("qwen", '{"error":"gateway error"}')).toBe(
     '{"error":"gateway error"}',
+  );
+});
+
+test("probePath asks for a fresh serve only while an auth failure is active", () => {
+  // PRODUCT-1515: the post-reconnect retry must not re-read the host's 15s
+  // cached "not connected" that the failing turn itself populated.
+  expect(probePath("anthropic", true)).toBe(
+    "/sandbox/credential?provider=anthropic&fresh=1",
+  );
+  expect(probePath("anthropic", false)).toBe(
+    "/sandbox/credential?provider=anthropic",
   );
 });
 

--- a/packages/runtime/src/auth/serve-probe.ts
+++ b/packages/runtime/src/auth/serve-probe.ts
@@ -1,6 +1,7 @@
 import { config } from "../config";
 import { currentCredentialScope } from "../session/acting-context";
 import type { ServedCredential } from "./auth-file";
+import { authFailureActive } from "./credential-health";
 
 /**
  * Central credential probes for serve mode (PRODUCT-1324 / HOUSTON-APP-4YV).
@@ -106,6 +107,20 @@ function isTimeout(err: unknown): boolean {
   );
 }
 
+/**
+ * The serve route for one provider's probe (exported for its test). `fresh`
+ * rides when the provider's CURRENT credential failed a turn's auth
+ * (`authFailureActive`): it asks the host to shed its short serve cache before
+ * answering, because a reconnect lands centrally WITHOUT passing through the
+ * host process — the cached "not connected" the failing turn populated moments
+ * earlier is exactly the state the post-reconnect retry must not re-read
+ * (PRODUCT-1515). The mark auto-heals on the credential change the fresh serve
+ * delivers, so the bypass lasts only while the failure does.
+ */
+export function probePath(id: string, fresh: boolean): string {
+  return `/sandbox/credential?provider=${id}${fresh ? "&fresh=1" : ""}`;
+}
+
 /** One provider's central lookup — a single attempt. Never throws — an
  *  internal serve hiccup for ONE provider must not strand the others. */
 async function probeOnce(id: string): Promise<ServeProbe> {
@@ -115,7 +130,7 @@ async function probeOnce(id: string): Promise<ServeProbe> {
   const { actingAs } = currentCredentialScope();
   try {
     const res = await fetch(
-      `${config.controlPlaneUrl}/sandbox/credential?provider=${id}`,
+      `${config.controlPlaneUrl}${probePath(id, authFailureActive(id))}`,
       {
         headers: {
           Authorization: `Bearer ${config.sandboxToken}`,

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -109,7 +109,7 @@ export async function executeTurn(
         if (!turn.credential) throw new Error("shadow turn needs a credential");
         await createTurnModelRuntime(
           dataDir,
-          turn.credential.provider,
+          turn.provider || turn.credential.provider,
           turn.model,
           timings,
         );
@@ -150,6 +150,13 @@ export async function executeTurn(
           effectiveTurn = {
             ...turn,
             text: routinePhase.text,
+            // The routine's pinned provider is the routine's own statement of
+            // what it runs on — it must outrank the dispatcher-attached
+            // credential's provider, or a mismatched serve silently moves the
+            // fire onto a provider the routine never picked (PRODUCT-1515).
+            ...(routinePhase.provider
+              ? { provider: routinePhase.provider }
+              : {}),
             ...(routinePhase.model ? { model: routinePhase.model } : {}),
             ...(routinePhase.effort ? { effort: routinePhase.effort } : {}),
             mode: "auto",

--- a/packages/runtime/src/turn/parse-turn-request.ts
+++ b/packages/runtime/src/turn/parse-turn-request.ts
@@ -181,6 +181,7 @@ export function parseTurnRequest(body: unknown): TurnRequest {
     nonce: typeof b.nonce === "string" ? b.nonce : undefined,
     gcsPrefix: prefix,
     credential,
+    provider: nonEmpty(b.provider) ? b.provider : undefined,
     model: typeof b.model === "string" ? b.model : undefined,
     effort: typeof b.effort === "string" ? b.effort : undefined,
     // Never trust the wire: only the known mode literals ("plan", "auto") pass;

--- a/packages/runtime/src/turn/pi-turn-request.test.ts
+++ b/packages/runtime/src/turn/pi-turn-request.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import { piTurnRequest } from "./pi-turn-request";
+import type { TurnRequest } from "./types";
+
+/**
+ * PRODUCT-1515: the provider a pool turn runs on. The turn's PIN (the
+ * conversation's picked provider, forwarded by the dispatcher — or a routine's
+ * own pinned provider overlaid by executeTurn) must outrank the attached
+ * credential's provider: a dispatcher that serves the wrong credential fails
+ * as the PINNED provider's auth error instead of silently running the turn on
+ * a provider the user never picked.
+ */
+
+const emit = () => {};
+const signal = new AbortController().signal;
+
+const base: TurnRequest = {
+  workspaceId: "w1",
+  agentId: "a1",
+  conversationId: "c1",
+  text: "hi",
+  gcsPrefix: "ws/w1/a1",
+  credential: {
+    provider: "anthropic",
+    access: "AT",
+    expires: 1,
+    accountId: null,
+    kind: "oauth",
+  },
+};
+
+test("the pinned provider outranks the attached credential's", () => {
+  const turn = piTurnRequest(
+    { ...base, provider: "openrouter" },
+    "t1",
+    emit,
+    signal,
+  );
+  expect(turn.provider).toBe("openrouter");
+});
+
+test("an unpinned legacy dispatch runs on the credential's provider", () => {
+  expect(piTurnRequest(base, "t1", emit, signal).provider).toBe("anthropic");
+});
+
+test("no pin and no credential leaves the provider unattributed", () => {
+  expect(
+    piTurnRequest({ ...base, credential: null }, "t1", emit, signal).provider,
+  ).toBe("");
+});

--- a/packages/runtime/src/turn/pi-turn-request.ts
+++ b/packages/runtime/src/turn/pi-turn-request.ts
@@ -12,7 +12,12 @@ export function piTurnRequest(
   return {
     conversationId: turn.conversationId,
     text: turn.text,
-    provider: turn.credential?.provider ?? "",
+    // The turn's PIN outranks the attached credential: a dispatcher that
+    // serves a different provider's credential must fail as the PINNED
+    // provider's auth error, never silently run (and bill) the turn on a
+    // provider the user did not pick (PRODUCT-1515). Legacy dispatches carry
+    // no pin, so the credential's provider stays the selection there.
+    provider: turn.provider || turn.credential?.provider || "",
     emit,
     signal,
     nonce: turn.nonce,

--- a/packages/runtime/src/turn/server.test.ts
+++ b/packages/runtime/src/turn/server.test.ts
@@ -245,6 +245,46 @@ test("a routine's model/effort pin reaches the pi turn", async () => {
   }
 });
 
+test("a turn's pinned provider outranks the attached credential's (PRODUCT-1515)", async () => {
+  // A dispatcher that serves a different provider's credential must fail as
+  // the PINNED provider's auth error, never silently run the turn on the
+  // credential's provider.
+  let seen: string | undefined;
+  const capture: typeof runPiTurn = async (_root, turn) => {
+    seen = turn.provider;
+    turn.emit({
+      type: "user",
+      data: { content: turn.text, ts: 1 },
+      turnId: turn.turnId,
+    });
+    return {};
+  };
+  const s = createTurnServer({ store, token: "", runTurn: capture });
+  await new Promise<void>((r) => s.listen(0, "127.0.0.1", () => r()));
+  const addr = s.address();
+  const b = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+  try {
+    await (
+      await fetch(`${b}/turn`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(turnBody({ provider: "openrouter" })),
+      })
+    ).text();
+    expect(seen).toBe("openrouter");
+    await (
+      await fetch(`${b}/turn`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(turnBody()),
+      })
+    ).text();
+    expect(seen).toBe(CRED.provider);
+  } finally {
+    s.close();
+  }
+});
+
 test("every frame of a turn — including the server's terminal — carries ONE turnId", async () => {
   seed("workspace/notes.txt", "hello-from-gcs");
   const res = await post(turnBody());

--- a/packages/runtime/src/turn/types.test.ts
+++ b/packages/runtime/src/turn/types.test.ts
@@ -155,3 +155,12 @@ test("a non-routine turn still requires text", () => {
     /missing 'text'/,
   );
 });
+
+test("parseTurnRequest carries the turn's pinned provider; junk reads as absent", () => {
+  expect(parseTurnRequest({ ...BASE, provider: "openrouter" }).provider).toBe(
+    "openrouter",
+  );
+  expect(parseTurnRequest(BASE).provider).toBeUndefined();
+  expect(parseTurnRequest({ ...BASE, provider: "" }).provider).toBeUndefined();
+  expect(parseTurnRequest({ ...BASE, provider: 5 }).provider).toBeUndefined();
+});

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -18,6 +18,16 @@ export interface TurnRequest {
   gcsPrefix: string;
   /** null = workspace not connected yet (the turn fails with a clear error). */
   credential: ServedCredential | null;
+  /**
+   * The provider this turn is PINNED to — the conversation's picked provider,
+   * forwarded by the dispatcher. When present it is the provider the turn runs
+   * on (and the provider a failure names), even if the attached credential
+   * belongs to a different provider: a dispatcher that serves the wrong
+   * credential must surface as THIS provider's auth error, never silently move
+   * the turn onto a provider the user did not pick (PRODUCT-1515). Absent =
+   * legacy dispatch: the credential's provider is the pin.
+   */
+  provider?: string;
   /** Per-turn model override (a routine's pinned model). Absent = inherit. */
   model?: string;
   /** Per-turn reasoning-effort override (a routine's pinned effort). Absent = inherit. */


### PR DESCRIPTION
Fixes PRODUCT-1515 — a chat asked to reconnect Anthropic while the conversation's selected provider was OpenRouter, and reconnecting "succeeded" only for the next turn to ask again.

## Root causes

**1. Wrong-provider resolution on the stateless (pool) turn path.** A pool turn ran on whatever credential the dispatcher attached: `TurnRequest` had no `provider` field, and `executeTurn` dropped the routine's own pinned provider (`RoutinePhase.provider` was computed by `prepareRoutineTurn` and never consumed). A dispatch that attaches a different provider's credential silently moved the turn — and its auth-error card — onto a provider the conversation never picked. The card then truthfully named that wrong provider ("Sign in to Anthropic again") while the picker showed OpenRouter.

**2. The reconnect loop.** The pod host's `RemoteCredentialStore` caches a "not connected" answer for 15s, and only its own `put()` invalidates it. A reconnect capture lands in the central store without passing through the pod's host process, so the auto-resume fired right after "Reconnected" re-read the cached null, got the marked 404 (which also drops the runtime's served entry), and re-rendered the reconnect card.

## Fix

- `TurnRequest.provider` (new, optional): the conversation's pinned provider, forwarded by the dispatcher. `piTurnRequest` runs the turn on the pin, falling back to the attached credential's provider only for legacy dispatches; `executeTurn` overlays a routine's pinned provider onto the turn. A mismatched credential now fails as the **pinned** provider's auth error instead of silently running (and billing) on the wrong one.
- The runtime's serve probe appends `fresh=1` while the provider's auth-failure mark is active; `handleSandboxCredential` then sheds the store's cached row (new optional `CredentialStore.invalidate`) before the read. The mark auto-heals on the credential change the fresh serve delivers, so the bypass lasts only while the failure does.

Dispatchers that today choose the served credential can start forwarding the conversation's pinned provider via the new field; absent it, behavior is unchanged.

## Repro (before)

1. Agent with a routine or task conversation pinned to OpenRouter (picker shows e.g. "OpenRouter: Fusion"); dispatcher attaches an Anthropic credential to the machine turn.
2. The turn runs on Anthropic; if that credential is dead, the chat shows "Sign in to Anthropic again" even though the conversation's provider is OpenRouter.
3. Reconnect Anthropic → "Reconnected" → auto-resume within 15s of the failing turn hits the host's cached "not connected" → the card returns.

## Verify (after)

- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` — green (new coverage: `pi-turn-request.test.ts`, pinned-provider e2e in `server.test.ts`, `types.test.ts` parse cases, `probePath` in `serve-probe.test.ts`, `invalidate` in `remote-store.test.ts`, `fresh=1` in `credential.test.ts`).
- A pool turn with `provider: "openrouter"` and an `anthropic` credential runs (and attributes any failure to) OpenRouter — see the `server.test.ts` case.
- A serve with `fresh=1` re-reads the central store inside the 15s cache window — see the `remote-store.test.ts` / `credential.test.ts` cases.