### PR TITLE
fix(runtime): classify Xiaomi 'Not supported model' as model_unavailable (PRODUCT-1517)

### DIFF
--- a/app/src/components/ai-hub/provider-modal.tsx
+++ b/app/src/components/ai-hub/provider-modal.tsx
@@ -14,6 +14,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { ProviderConnections } from "../../hooks/use-provider-connections.ts";
 import type { HubCatalog } from "../../lib/ai-hub/catalog-types.ts";
+import { providerDescription } from "../../lib/provider-overrides.ts";
 import type { ProviderInfo } from "../../lib/providers.ts";
 import { BrandMark } from "../provider-browser/brand-mark.tsx";
 import {
@@ -60,6 +61,14 @@ export function ProviderModal({
     [catalog, provider],
   );
   const isLocal = provider.auth === "openaiCompatible";
+  // Most hub providers have no aiHub:providers.* marketing copy — without a
+  // default the modal renders the raw lookup key ("providers.xiaomi.description",
+  // PRODUCT-1517). Fall back to the provider-list row's one-liner, which every
+  // id resolves to.
+  const description = t(
+    `providers.${providerDescriptionKey(provider.id)}.description`,
+    { defaultValue: providerDescription(provider.id) },
+  );
 
   // Local model: the bridge state + a disconnect that tears the tunnel down.
   const {
@@ -85,7 +94,7 @@ export function ProviderModal({
           {provider.name}
         </span>
         <p className="text-[13px] leading-relaxed text-ink-muted">
-          {t(`providers.${providerDescriptionKey(provider.id)}.description`)}
+          {description}
         </p>
         <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
           {models.length > 0 && (
@@ -135,9 +144,7 @@ export function ProviderModal({
       open={open}
       onClose={onClose}
       title={provider.name}
-      description={t(
-        `providers.${providerDescriptionKey(provider.id)}.description`,
-      )}
+      description={description}
       header={header}
       footer={footer}
     >

--- a/app/src/components/provider-browser/provider-grouping.ts
+++ b/app/src/components/provider-browser/provider-grouping.ts
@@ -202,7 +202,8 @@ export type ProviderDescriptionKey =
   | "amazon-bedrock"
   | "minimax"
   | "nvidia"
-  | "openai-compatible";
+  | "openai-compatible"
+  | "xiaomi";
 
 /**
  * Every connect-card id and the `aiHub:providers.*` key its copy lives under.
@@ -225,12 +226,16 @@ const DESCRIPTION_KEY_BY_ID = {
   minimax: "minimax",
   nvidia: "nvidia",
   "openai-compatible": "openai-compatible",
+  // Not a connect card, but its hub modal rendered the raw fallback key
+  // ("providers.xiaomi.description") once the provider shipped (PRODUCT-1517).
+  xiaomi: "xiaomi",
 } satisfies Record<string, ProviderDescriptionKey>;
 
 /**
- * Map a card id to its description key. Unknown ids fall back to the id itself,
- * so an unwired provider surfaces a missing-key string in the UI (a visible bug)
- * instead of a silent, wrong description.
+ * Map a card id to its description key. Unknown ids fall back to the id itself
+ * so a lookup never borrows another provider's copy; the modal catches the
+ * resulting missing key with the provider-list one-liner (`providerDescription`)
+ * rather than rendering it raw (PRODUCT-1517).
  */
 export function providerDescriptionKey(
   providerId: string,

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -132,6 +132,9 @@
     },
     "openai-compatible": {
       "description": "Run models on your own computer with Ollama, LM Studio, and friends."
+    },
+    "xiaomi": {
+      "description": "MiMo models from Xiaomi: fast, low-cost, built for agent work."
     }
   },
   "toast": {},

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -132,6 +132,9 @@
     },
     "openai-compatible": {
       "description": "Ejecuta modelos en tu propio computador con Ollama, LM Studio y similares."
+    },
+    "xiaomi": {
+      "description": "Modelos MiMo de Xiaomi: rápidos, económicos y hechos para el trabajo con agentes."
     }
   },
   "toast": {},

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -132,6 +132,9 @@
     },
     "openai-compatible": {
       "description": "Rode modelos no seu próprio computador com Ollama, LM Studio e afins."
+    },
+    "xiaomi": {
+      "description": "Modelos MiMo da Xiaomi: rápidos, acessíveis e feitos para o trabalho com agentes."
     }
   },
   "toast": {},

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -335,6 +335,42 @@ test("GitHub Copilot model_not_supported → model_unavailable + gpt-4.1 fallbac
   });
 });
 
+test("Xiaomi 'Not supported model' 400 → model_unavailable + mimo-v2.5-pro fallback (PRODUCT-1517)", () => {
+  // Verbatim from a Token Plan gateway answering mimo-v2.5-pro-ultraspeed — a
+  // model only the general endpoint serves. Xiaomi checks the key before the
+  // model (a bad key answers 401 for any model id), so the credential is fine
+  // and only the pick is out of reach. The reversed word order ("Not supported
+  // model", not "model not supported") matched no pattern and degraded to
+  // `unknown` — the report-bug card instead of switch-model.
+  const message =
+    '400: {"code":"400","message":"Not supported model mimo-v2.5-pro-ultraspeed"}';
+  const err = classifyProviderError({
+    provider: "xiaomi",
+    model: "mimo-v2.5-pro-ultraspeed",
+    message,
+  });
+  expect(err).toEqual({
+    kind: "model_unavailable",
+    provider: "xiaomi",
+    model: "mimo-v2.5-pro-ultraspeed",
+    reason: "unknown",
+    suggested_fallback: "mimo-v2.5-pro",
+    message,
+  });
+});
+
+test("Xiaomi fallback model itself unsupported → no self-referential fallback", () => {
+  const err = classifyProviderError({
+    provider: "xiaomi",
+    model: "mimo-v2.5-pro",
+    message:
+      '400: {"code":"400","message":"Not supported model mimo-v2.5-pro"}',
+  });
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable")
+    expect(err.suggested_fallback).toBeNull();
+});
+
 test("Copilot 'not available for integrator' 400 → model_unavailable + gpt-4.1 fallback (HOU-977)", () => {
   // Copilot's NEWER wording for the same plan-doesn't-serve-this-model failure:
   // no `model_not_supported` code, just prose naming the integrator and the

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -168,6 +168,15 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // key rather than "could not verify" (PRODUCT-1411: the whole kimi-k2
   // preview series was retired 2026-05-25 while pi's catalog still lists it).
   "not found the model",
+  // Xiaomi MiMo's reversed word order — 400 `{"code":"400","message":"Not
+  // supported model mimo-v2.5-pro-ultraspeed"}` — from a Token Plan gateway
+  // for a model only the general endpoint serves (the plan catalogs are a
+  // subset; see runtime `ai/xiaomi-endpoint.ts`). Xiaomi checks the key
+  // before the model (a bad key answers 401 for any model id), so the body
+  // proves the credential and only the MODEL is out of reach. None of the
+  // phrasings above match this order, so it degraded to `unknown` — the
+  // report-bug card instead of switch-model (PRODUCT-1517).
+  "not supported model",
 ];
 
 /**
@@ -298,6 +307,16 @@ const NVIDIA_BROAD_FALLBACK = "meta/llama-3.3-70b-instruct";
  * the broadest-served Kimi model we have evidence for (PRODUCT-1411).
  */
 const MOONSHOT_BROAD_FALLBACK = "kimi-k2.6";
+
+/**
+ * The Xiaomi MiMo model offered as the one-click switch target when a pick
+ * answers `Not supported model`: mimo-v2.5-pro is in EVERY Xiaomi catalog —
+ * the general endpoint and all three Token Plan gateways (pi's xiaomi /
+ * xiaomi-token-plan-* tables) — while mimo-v2.5-pro-ultraspeed is
+ * general-only, which is exactly the pick that strands a Token Plan key
+ * (PRODUCT-1517).
+ */
+const XIAOMI_BROAD_FALLBACK = "mimo-v2.5-pro";
 
 /**
  * Map a failed model request to a typed `ProviderError`, then stamp WHOSE
@@ -458,7 +477,9 @@ function broadFallback(provider: string, model: string): string | null {
       ? COPILOT_BASE_FALLBACK
       : provider === "moonshotai"
         ? MOONSHOT_BROAD_FALLBACK
-        : null;
+        : provider === "xiaomi"
+          ? XIAOMI_BROAD_FALLBACK
+          : null;
   return fallback && fallback !== model ? fallback : null;
 }
 


### PR DESCRIPTION
## Root cause

A Xiaomi MiMo Token Plan key chats against its plan gateway (`token-plan-*.xiaomimimo.com`), whose model catalog is a **subset** of the general endpoint's — it does not serve `mimo-v2.5-pro-ultraspeed`. The chat picker deliberately offers the full catalog and lets an unservable pick fail the turn honestly as `ModelUnavailable` (HOU-976 §6), but Xiaomi's rejection body uses a reversed word order —

```
400: {"code":"400","message":"Not supported model mimo-v2.5-pro-ultraspeed"}
```

— which matched none of the `MODEL_UNAVAILABLE_PATTERNS` phrasings ("model not supported", "is not supported", …). The turn therefore degraded to `kind=unknown`: the "Something unexpected happened / Report bug" card instead of the switch-model card, and a Sentry error per attempt (HOUSTON-APP-5BC).

The other two MiMo models in the report fail with `402 Insufficient account balance` — already correctly classified as `quota_exhausted` ("Out of capacity" card); that is the provider's real answer, not a Houston bug.

Secondary bug visible in the same screenshots: the AI-hub provider modal rendered its raw i18n lookup key (`providers.xiaomi.description`) because Xiaomi (like every non-connect-card provider) has no authored `aiHub:providers.*` copy and the modal had no fallback.

## Fix

- `packages/runtime/src/ai/provider-error.ts`: add the `"not supported model"` pattern (Xiaomi checks the key before the model, so the body proves the credential — only the MODEL is out of reach) and a `mimo-v2.5-pro` one-click fallback, the one model every Xiaomi endpoint (general + all three Token Plan gateways) serves. Via `PROVES_AUTH`, connect-time verification now also treats this body as key-accepted.
- `app/src/components/ai-hub/provider-modal.tsx`: fall back to the provider-list one-liner (`providerDescription`) when a provider has no authored modal copy — fixes the raw-key leak for every such provider.
- Authored Xiaomi modal copy in `en`/`es`/`pt` (`ai-hub.json`) + wired `xiaomi` into `DESCRIPTION_KEY_BY_ID`.

## Before (reproduction)

1. Connect Xiaomi MiMo with a Token Plan (`tp-…`) key (endpoint prober persists the plan gateway, #1393).
2. In chat, pick **MiMo-V2.5-Pro-UltraSpeed** and send any message.
3. Turn fails with "Something unexpected happened … Raw output: 400: {"code":"400","message":"Not supported model mimo-v2.5-pro-ultraspeed"}" and a Report bug button; Sentry logs `[provider_error] … kind=unknown`.
4. Open the AI Models hub → Xiaomi MiMo: the modal shows the literal text `providers.xiaomi.description`.

## After (verification)

1. Same setup, same UltraSpeed send → the **model-unavailable card** ("switch model") naming `mimo-v2.5-pro-ultraspeed` with a one-click switch to `mimo-v2.5-pro`; no Report bug card, no Sentry error event (`model_unavailable` is an expected-kind breadcrumb).
2. Hub → Xiaomi MiMo modal shows "MiMo models from Xiaomi: fast, low-cost, built for agent work." (localized in es/pt); any other non-curated provider (e.g. Groq) shows its list one-liner instead of a raw key.
3. `pnpm --filter @houston/runtime test` — 1368 pass, incl. new verbatim-body tests; `cd app && pnpm tsgo --noEmit && pnpm test && pnpm check-locales`; `pnpm check` — all green.

PRODUCT-1517
