### PR TITLE
fix(dashboard): still-waking pods at sweep escalation stay quiet, re-sweeps outlive a pod wake (PRODUCT-1528)

### DIFF
--- a/app/src/hooks/queries/all-conversations-sweep.ts
+++ b/app/src/hooks/queries/all-conversations-sweep.ts
@@ -95,12 +95,12 @@ export function recoverFromSweep(
 
 /**
  * Tell someone the sweep was incomplete, in the register the failures earn
- * (HOUSTON-APP-538): an asleep pod still waking / a device that dropped
- * offline get their quiet informational toasts (no Sentry — the re-sweep
- * already scheduled above heals the hole once the pod is up), everything else
- * — and ANY failure still standing at escalation — the real error report. The
- * per-agent reasons ride the diagnostic line so the log and the report say
- * WHY, not just who.
+ * (HOUSTON-APP-538, HOUSTON-APP-58Q): an asleep pod still waking / a device
+ * that dropped offline get their quiet informational toasts at notice AND at
+ * escalation (no Sentry — a pod can legitimately take longer to wake than the
+ * whole re-sweep run, so "still waking at the end" is not a bug), everything
+ * else the real error report. The per-agent reasons ride the diagnostic line
+ * so the log and the report say WHY, not just who.
  */
 function surfacePartialSweep(
   surface: PartialSweepSurface,
@@ -110,17 +110,19 @@ function surfacePartialSweep(
   const named = failedAgents
     .map((f) => `${f.agentPath} (${describeReason(f.reason)})`)
     .join(", ");
-  switch (partialSweepToastKind(surface, reason)) {
+  const still =
+    surface === "escalate" ? "still unread after re-sweeps" : "unread";
+  switch (partialSweepToastKind(reason)) {
     case "waking":
       showEngineWakingToast(
         "list_all_conversations_partial",
-        `missions unread for ${failedAgents.length} waking agent(s): ${named}`,
+        `missions ${still} for ${failedAgents.length} waking agent(s): ${named}`,
       );
       return;
     case "connectivity":
       showConnectivityErrorToast(
         "list_all_conversations_partial",
-        `missions unread for ${failedAgents.length} agent(s) while offline: ${named}`,
+        `missions ${still} for ${failedAgents.length} agent(s) while offline: ${named}`,
       );
       return;
     case "error":

--- a/app/src/lib/all-conversations-recovery.ts
+++ b/app/src/lib/all-conversations-recovery.ts
@@ -63,17 +63,26 @@ export function mergePartialSweep<T extends AgentScopedRow>(
  * an agent that stays broken must not keep the fleet awake all session. After
  * the last delay the aggregate waits for a real signal instead — a remount, an
  * event-stream reconnect, or an event naming that agent.
+ *
+ * The run must outlive a LEGITIMATE pod wake (HOUSTON-APP-58Q): the gateway
+ * holds a cold start for up to five minutes before giving up, so a ladder
+ * that ended at 85s abandoned the board — hole frozen, run escalated — while
+ * the pod was still coming up as designed.
  */
-export const PARTIAL_SWEEP_RETRY_DELAYS_MS = [5_000, 20_000, 60_000];
+export const PARTIAL_SWEEP_RETRY_DELAYS_MS = [
+  5_000, 20_000, 60_000, 120_000, 180_000,
+];
 
 export type PartialSweepSurface =
   /** First partial sweep of a run: tell the user once, CLASSIFIED — a waking
    *  pod or an offline drop gets its quiet informational surface, anything
    *  else the real error report. */
   | "notice"
-  /** The bounded re-sweeps are exhausted and the hole is still open. Whatever
-   *  the reason looked like, a pod that never came up through the whole run is
-   *  the bug report we want — always the error surface. */
+  /** The bounded re-sweeps are exhausted and the hole is still open. Still
+   *  CLASSIFIED by reason (HOUSTON-APP-58Q): an engine roll can restart a busy
+   *  pod hours into a deploy, so "still waking when the run ran out" is the
+   *  platform working as designed, not the crashloop report — only a real
+   *  failure earns the error surface here. */
   | "escalate";
 
 export interface PartialSweepDecision {

--- a/app/src/lib/partial-sweep-surface.ts
+++ b/app/src/lib/partial-sweep-surface.ts
@@ -17,7 +17,6 @@
  * hooks/queries/all-conversations-sweep.ts.
  */
 
-import type { PartialSweepSurface } from "./all-conversations-recovery.ts";
 import { isEngineWakingError } from "./engine-waking-error.ts";
 import { isNetworkTransportError } from "./network-transport-error.ts";
 
@@ -43,24 +42,24 @@ export function representativeSweepFailure(
 export type PartialSweepToast = "waking" | "connectivity" | "error";
 
 /**
- * Which surface an incomplete sweep earns.
+ * Which surface an incomplete sweep earns, at notice AND at escalation.
  *
- * A first-notice sweep whose failures are all expected environment states gets
- * the matching quiet informational surface, exactly like every other per-agent
- * call (lib/tauri.ts `surfaceError`): an asleep engine pod still waking is the
+ * A sweep whose failures are all expected environment states gets the matching
+ * quiet informational surface, exactly like every other per-agent call
+ * (lib/tauri.ts `surfaceError`): an asleep engine pod still waking is the
  * gateway working as designed (HOU-1114), and the device dropping offline
- * mid-sweep is HOU-1085 — in both cases the board keeps painting the
- * carried-forward rows and the scheduled re-sweep heals the hole, so nothing
- * in Houston broke and there is nothing to report. A real failure, or ANY
- * failure still standing when the recovery run escalates (a pod that never
- * woke through the whole run is a crashloop or a capacity problem — the bug
- * report we want), takes the error surface (toast path + Sentry) as before.
+ * mid-sweep is HOU-1085 — the board keeps painting the carried-forward rows,
+ * so nothing in Houston broke and there is nothing to report. Escalation used
+ * to override this to the error surface ("a pod that never woke through the
+ * whole run is a crashloop"), but the client cannot conclude that
+ * (HOUSTON-APP-58Q): the gateway holds a legitimate cold start for minutes and
+ * an engine roll restarts busy pods hours into a deploy, so every escalated
+ * report was a still-waking pod filed as a bug. Only a real failure — at any
+ * point of the run — takes the error surface (toast path + Sentry).
  */
 export function partialSweepToastKind(
-  surface: PartialSweepSurface,
   representativeReason: unknown,
 ): PartialSweepToast {
-  if (surface === "escalate") return "error";
   if (isEngineWakingError(representativeReason)) return "waking";
   if (isNetworkTransportError(representativeReason)) return "connectivity";
   return "error";

--- a/app/tests/all-conversations-recovery.test.ts
+++ b/app/tests/all-conversations-recovery.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   mergePartialSweep,
@@ -98,6 +98,14 @@ describe("planPartialSweep", () => {
     deepStrictEqual(
       planPartialSweep(1, PARTIAL_SWEEP_RETRY_DELAYS_MS.length + 1),
       {},
+    );
+  });
+
+  it("the run outlives a legitimate pod wake — the gateway holds a cold start up to five minutes (HOUSTON-APP-58Q)", () => {
+    const total = PARTIAL_SWEEP_RETRY_DELAYS_MS.reduce((a, b) => a + b, 0);
+    ok(
+      total >= 300_000,
+      `re-sweep run is ${total}ms, shorter than the wake hold`,
     );
   });
 

--- a/app/tests/partial-sweep-surface.test.ts
+++ b/app/tests/partial-sweep-surface.test.ts
@@ -50,34 +50,30 @@ describe("representativeSweepFailure", () => {
   });
 });
 
+// The kind is reason-only (HOUSTON-APP-58Q). Escalation used to force the
+// error surface on the theory that a pod "never actually woke" — but the
+// client cannot conclude that: the gateway holds a legitimate cold start for
+// minutes and an engine roll restarts busy pods hours into a deploy, so every
+// escalated report was a still-waking pod filed as a bug (26 users in one
+// release). Expected states now stay quiet however long they last; a real
+// failure reports at any point of the run.
 describe("partialSweepToastKind", () => {
-  it("gives a waking pod the quiet HOU-1114 surface, not a bug report", () => {
-    strictEqual(partialSweepToastKind("notice", wakingError()), "waking");
+  it("gives a waking pod the quiet HOU-1114 surface, not a bug report — at notice and at escalation alike", () => {
+    strictEqual(partialSweepToastKind(wakingError()), "waking");
   });
 
   it("gives an offline drop the connectivity surface (HOU-1085)", () => {
-    strictEqual(
-      partialSweepToastKind("notice", offlineError()),
-      "connectivity",
-    );
+    strictEqual(partialSweepToastKind(offlineError()), "connectivity");
   });
 
   it("keeps the error surface for a real per-agent failure", () => {
-    strictEqual(partialSweepToastKind("notice", realError()), "error");
+    strictEqual(partialSweepToastKind(realError()), "error");
   });
 
   it("a coding-bug TypeError is never mistaken for connectivity", () => {
     strictEqual(
-      partialSweepToastKind(
-        "notice",
-        new TypeError("undefined is not a function"),
-      ),
+      partialSweepToastKind(new TypeError("undefined is not a function")),
       "error",
     );
-  });
-
-  it("escalation always reports — even a 'waking' pod, because it never actually woke", () => {
-    strictEqual(partialSweepToastKind("escalate", wakingError()), "error");
-    strictEqual(partialSweepToastKind("escalate", offlineError()), "error");
   });
 });


### PR DESCRIPTION
Fixes PRODUCT-1528 (Sentry HOUSTON-APP-58Q: `list_all_conversations_stuck`).

## Root cause

Every current event on the Sentry issue carries only expected pod-not-up reasons (`engine proxy failed` 502 / `engine unavailable` 503). The first-notice path already classifies those as quiet "waking" states (the HOUSTON-APP-538 fix, extended to the 502 in the PRODUCT-1403 fix), but the escalation path forced the error surface unconditionally: `partialSweepToastKind` returned `"error"` for any `"escalate"`, on the theory that a pod still down after the whole re-sweep run "never actually woke" and must be crashlooping.

The client cannot conclude that. The re-sweep run lasted only 85s (5s + 20s + 60s), while the gateway legitimately holds a cold start for up to five minutes, and an engine roll restarts busy pods hours into a deploy. So every escalated report was a still-waking pod filed as a bug — 26 users, 50 events, all of them the platform working as designed. And because the run gave up at 85s, the board's hole stayed frozen until an unrelated signal (remount, event-stream reconnect) happened to refetch: the user-visible "missions remain unread".

## Fix

- `app/src/lib/partial-sweep-surface.ts`: the toast kind is now reason-only. Expected environment states (pod waking, device offline) keep their quiet informational surfaces at notice AND at escalation; a real failure takes the error surface (toast + Sentry) at any point of the run, including escalation — so the `list_all_conversations_stuck` report still exists for genuine failures.
- `app/src/lib/all-conversations-recovery.ts`: the re-sweep ladder is extended from `[5s, 20s, 60s]` to `[5s, 20s, 60s, 120s, 180s]` (385s total) so the run outlives a legitimate pod wake and actually heals the board in the common case, instead of abandoning it at 85s. Still bounded: five re-sweeps, then the aggregate waits for a real signal as before.
- `app/src/hooks/queries/all-conversations-sweep.ts`: escalated quiet toasts say "still unread after re-sweeps" in their diagnostic line so logs stay distinguishable from the first notice.

## Before

1. On the hosted profile, open the board while an agent's engine pod is restarting under an engine roll (or cold-starting for longer than ~85s).
2. The sweep comes back partial with `engine proxy failed (engine error 502)` for that agent; re-sweeps run at 5s/20s/60s and give up.
3. At 85s the run escalates: a `list_all_conversations_stuck` error event reaches Sentry (and the error-toast bookkeeping) even though the pod is coming up as designed, and the board's carried-forward hole stays until some unrelated refetch.

## After

1. Same setup. Re-sweeps now continue at 120s and 180s, so a pod that wakes inside the gateway's five-minute hold fills the hole without any user action.
2. If the pod is still unreachable when the run ends, the surface is the quiet engine-waking toast ("missions still unread after re-sweeps ... waking agent(s)") — logged, no Sentry event, matching how every other per-agent read treats a waking pod.
3. A real failure (e.g. a 500) anywhere in the run, including at escalation, still produces the `list_all_conversations_stuck` / `list_all_conversations_partial` error report.

## Verification

- `app/tests/partial-sweep-surface.test.ts`: escalation-forces-error test replaced with the reason-only contract; real failures still map to `error`.
- `app/tests/all-conversations-recovery.test.ts`: new guard asserting the ladder total covers the five-minute wake hold (`>= 300s`).
- `pnpm check` (Biome), `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (3761 pass, 0 fail).