### PR TITLE
fix(host): view refresh after a delete's SkillsChanged stays silent (PRODUCT-1526)

### DIFF
--- a/packages/host/src/docs/view-warm.test.ts
+++ b/packages/host/src/docs/view-warm.test.ts
@@ -66,6 +66,62 @@ test("a SkillsChanged event re-fetches /skills for that agent (debounced)", asyn
   vi.useRealTimers();
 });
 
+// An agent delete/rename unlinks its skills tree; the watcher classifies each
+// unlink as SkillsChanged for the now-gone path, and the debounced refresh
+// then 404s. A gone agent is the delete's designed outcome, never an error
+// (HOUSTON-APP-5AP).
+test("a refresh 404 for an agent no longer in the store stays silent", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const fetchImpl = vi.fn(
+    async () => new Response('{"error":"agent not found"}', { status: 404 }),
+  ) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const events = hub();
+  refreshViewsOnEvents({
+    port: 4318,
+    token: "t",
+    store,
+    events,
+    userId: "local-owner",
+    fetchImpl,
+  });
+  events.fire({ type: "SkillsChanged", agentPath: "Personal/Deleted" });
+  await vi.advanceTimersByTimeAsync(600);
+  expect(fetchImpl).toHaveBeenCalledTimes(1);
+  expect(errorSpy).not.toHaveBeenCalled();
+  errorSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+test("a refresh failure for an agent still in the store reports", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Only",
+  });
+  const fetchImpl = vi.fn(
+    async () => new Response("{}", { status: 500 }),
+  ) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const events = hub();
+  refreshViewsOnEvents({
+    port: 4318,
+    token: "t",
+    store,
+    events,
+    userId: "local-owner",
+    fetchImpl,
+  });
+  events.fire({ type: "SkillsChanged", agentPath: agent.id });
+  await vi.advanceTimersByTimeAsync(600);
+  expect(errorSpy).toHaveBeenCalledOnce();
+  errorSpy.mockRestore();
+  vi.useRealTimers();
+});
+
 test("a global CustomIntegrationsChanged resolves the single agent", async () => {
   vi.useFakeTimers();
   const store = new MemoryWorkspaceStore();

--- a/packages/host/src/docs/view-warm.ts
+++ b/packages/host/src/docs/view-warm.ts
@@ -112,6 +112,12 @@ export function refreshViewsOnEvents(
         if (agentId === null) return;
         const status = await fetchView(opts, agentId, rest, 1);
         if (status !== 200) {
+          // An agent delete/rename unlinks `.agents/skills/**`, and the FS
+          // watcher classifies each unlink as SkillsChanged for the now-gone
+          // path — by refresh time the route answers 404 "agent not found".
+          // That is the designed outcome of the delete, not a refresh failure;
+          // there is no view left to keep fresh (HOUSTON-APP-5AP).
+          if ((await opts.store.getAgent(agentId)) === null) return;
           console.error(
             `[view-docs] refresh of ${rest} after ${event.type} answered ${status}`,
           );


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-5AP (`[view-docs] refresh of skills after SkillsChanged answered 404`) has two flavors:

- **Boot-warm 503 give-ups** — the overwhelming bulk of the events (198 of 200 sampled, all 2026-08-24). Already fixed by #1386 (boot warm outlasts the runtime's 60s boot budget); the deployed engine builds predate that merge, so the tail drains with the next engine roll. No code change here for that flavor.
- **Refresh 404 after `SkillsChanged`** — the residual this PR fixes. An agent delete (or rename) unlinks `.agents/skills/**`; the FS watcher classifies each unlink as `SkillsChanged` for the now-gone agent path, and 500 ms later the debounced view refresh GETs `/agents/<gone>/skills`, receives 404 "agent not found", and reports it as an error. The gone agent is the delete's designed outcome — there is no view left to keep fresh.

## Fix

`refreshViewsOnEvents` (`packages/host/src/docs/view-warm.ts`): on a non-200 refresh, first check whether the event's agent still exists in the store; if it is gone, skip the report silently. A non-200 for an agent that still exists stays loud.

## Before

1. On a host with view-doc publishing active, install a skill on an agent, then delete (or rename) the agent.
2. The watcher's `SkillsChanged` for the removed skills files fires the debounced refresh against the deleted agent's route.
3. `[view-docs] refresh of skills after SkillsChanged answered 404` lands in the log / Sentry.

## After

1. Same steps: the refresh still runs, gets the 404, sees the agent is no longer in the store, and stays silent.
2. A refresh failure for a live agent (e.g. a 500) still reports — covered by the new tests.

## Tests

- `view-warm.test.ts`: refresh 404 for an agent no longer in the store stays silent; refresh failure for a live agent still reports.
- `pnpm --filter @houston/host test`: 175 files, 1597 tests passed. `pnpm check` clean.

PRODUCT-1526