### PR TITLE
fix(runtime-client): retry object-store 500s that wrap an upstream transient status (PRODUCT-1529)

### DIFF
--- a/packages/runtime-client/src/object-sync/retry.test.ts
+++ b/packages/runtime-client/src/object-sync/retry.test.ts
@@ -34,6 +34,57 @@ test("returns a transient status untouched on the final attempt", async () => {
   expect(waits).toEqual([1, 2]);
 });
 
+test("retries a gateway 500 that wraps an upstream transient status", async () => {
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    return calls < 3
+      ? new Response(
+          JSON.stringify({
+            error:
+              "googleapi: got HTTP response code 503 with body: Service Unavailable",
+          }),
+          { status: 500 },
+        )
+      : new Response(null, { status: 200 });
+  };
+  const res = await fetchWithRetry(fetchImpl, "https://store.test", undefined, {
+    delaysMs: [0, 0],
+    sleep: async () => {},
+  });
+  expect(res.status).toBe(200);
+  expect(calls).toBe(3);
+});
+
+test("a plain 500 is the server's answer and is never retried", async () => {
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+  };
+  const res = await fetchWithRetry(fetchImpl, "https://store.test", undefined, {
+    delaysMs: [0, 0],
+    sleep: async () => {},
+  });
+  expect(res.status).toBe(500);
+  expect(calls).toBe(1);
+});
+
+test("a wrapped-transient 500 returned on the final attempt keeps a readable body", async () => {
+  const body = JSON.stringify({
+    error:
+      "googleapi: got HTTP response code 503 with body: Service Unavailable",
+  });
+  const fetchImpl: typeof fetch = async () =>
+    new Response(body, { status: 500 });
+  const res = await fetchWithRetry(fetchImpl, "https://store.test", undefined, {
+    delaysMs: [0],
+    sleep: async () => {},
+  });
+  expect(res.status).toBe(500);
+  expect(await res.text()).toBe(body);
+});
+
 test("an empty delay list disables retries entirely", async () => {
   let calls = 0;
   const fetchImpl: typeof fetch = async () => {

--- a/packages/runtime-client/src/object-sync/retry.ts
+++ b/packages/runtime-client/src/object-sync/retry.ts
@@ -2,12 +2,30 @@
  * Managed pods reach the object store through the gateway, so a single
  * transient blip (gateway restart, DNS hiccup) must not fail a whole boot
  * hydrate or sync-back. Retries are bounded and limited to failures that carry
- * no deterministic answer: network-level rejections thrown by fetch itself and
- * 502/503/504 responses. Every other status is the server's real answer and is
- * returned to the caller unretried.
+ * no deterministic answer: network-level rejections thrown by fetch itself,
+ * 502/503/504 responses, and gateway 500s that wrap an upstream transient
+ * status in the body (the gateway reports GCS failures as
+ * `500 {"error":"googleapi: got HTTP response code 503 ..."}`). Every other
+ * status is the server's real answer and is returned to the caller unretried.
  */
 
 const TRANSIENT_STATUSES = new Set([502, 503, 504]);
+
+const WRAPPED_TRANSIENT_BODY = /\bgot HTTP response code (?:502|503|504)\b/;
+
+async function isTransientResponse(res: Response): Promise<boolean> {
+  if (TRANSIENT_STATUSES.has(res.status)) return true;
+  if (res.status !== 500) return false;
+  try {
+    // Sniff a clone so the caller's body stays readable if this attempt is
+    // the one returned.
+    return WRAPPED_TRANSIENT_BODY.test(await res.clone().text());
+  } catch {
+    // An unreadable body cannot prove the 500 wraps a transient upstream
+    // failure; the response goes back to the caller as the server's answer.
+    return false;
+  }
+}
 
 /** One delay per retry, so attempts = delays + 1. */
 export const DEFAULT_RETRY_DELAYS_MS = [500, 2000];
@@ -45,7 +63,7 @@ export async function fetchWithRetry(
     try {
       const attemptInit = opts.body ? { ...init, body: opts.body() } : init;
       const res = await fetchImpl(url, attemptInit);
-      if (lastAttempt || !TRANSIENT_STATUSES.has(res.status)) return res;
+      if (lastAttempt || !(await isTransientResponse(res))) return res;
     } catch (err) {
       if (lastAttempt) throw err;
     }


### PR DESCRIPTION
Fixes PRODUCT-1529.

## Root cause

The object-store retry ladder (`packages/runtime-client/src/object-sync/retry.ts`) only treats literal 502/503/504 responses as transient. When the storage backend returns a transient 503, the gateway reports it as a **500** whose body carries the upstream status:

```
object store PUT claude-login/projects/.../<id>.jsonl failed (500): {"error":"googleapi: got HTTP response code 503 with body: Service Unavailable"}
```

Because the outer status is 500, the ladder never retried, and a single upstream blip failed the whole sync-back PUT (693 events, 10 users).

## Fix

`fetchWithRetry` now sniffs 500 responses for a wrapped upstream transient status (`got HTTP response code 502|503|504`) and retries those on the existing bounded ladder (500ms/2000ms). Sniffing reads a `clone()` so a returned response keeps a readable body. Everything else is unchanged:

- plain 500s (and all other statuses) remain the server's real answer, returned unretried
- generation-guarded writes still disable retries entirely (`retryable: false`), so no replay-safety change

All object-store traffic (hydrate, sync-back, turn transcripts) goes through this one choke point, so the fix covers every PUT/GET/DELETE path.

## Before (reproduces the bug)

Point an `HttpObjectStore` at a stub that answers `500 {"error":"googleapi: got HTTP response code 503 with body: Service Unavailable"}` once and then 200: `upload()` throws on the first answer without any retry.

## After (verification)

- `pnpm --filter @houston/runtime-client test` — new tests in `retry.test.ts`:
  - a wrapped-transient 500 is retried and succeeds on a later attempt
  - a plain 500 is never retried
  - a wrapped-transient 500 returned on the final attempt keeps a readable body
- Full suites green: runtime-client 186, host 1597, runtime 1374, domain 200; `pnpm check` exits 0.