### PR TITLE
fix(app): desktop session refresher must rethrow transient failures, not flatten to null (PRODUCT-1531)

### DIFF
--- a/app/src/components/shell/engine-gate.tsx
+++ b/app/src/components/shell/engine-gate.tsx
@@ -10,7 +10,6 @@ import {
 import { hostedGateState } from "../../lib/engine-mode";
 import i18n from "../../lib/i18n";
 import { isIdentityConfigured, refreshNow } from "../../lib/identity";
-import { logger } from "../../lib/logger";
 import { SignInScreen } from "../auth/sign-in-screen";
 import { StorageUnavailableScreen } from "../auth/storage-unavailable-screen";
 import { WorkspaceLoading } from "./workspace-loading";
@@ -42,18 +41,18 @@ function HostedEngineGate({ children }: { children: ReactNode }) {
     // The 401 → refresh → replay seam (HOU-687): when the gateway rejects a
     // bearer (token expired while the app idled, connections severed by a
     // gateway roll), the adapter force-mints a fresh ID token and retries
-    // instead of toasting. `refreshNow` returns null on a terminal refresh
-    // failure (revoked/expired refresh token) — a real sign-out surfaced by the
-    // auth gate; a transient throw is logged and treated as null so the 401
-    // surfaces rather than crashing the refresher (parity with the old path).
-    return installHostedSessionRefresh(async () => {
-      try {
-        return await refreshNow();
-      } catch (e) {
-        logger.warn(`[auth] hosted session refresh failed: ${e}`);
-        return null;
-      }
-    });
+    // instead of toasting. `refreshNow`'s answer is three-valued and must pass
+    // through INTACT (HOU-1106): a token means refreshed; null means the
+    // session is terminally gone (a real sign-out — this gate surfaces the
+    // sign-in screen); and a transient `IdentityError("network")` (the
+    // identity service unreachable while a sleep-wake reconnect settles)
+    // THROWS, so the adapter's classifier reads it as connectivity and the
+    // read retries as the reconnect settles. Catching that throw and
+    // answering null — as this seam once did — is indistinguishable from the
+    // terminal sign-out: the stale-token 401 stood and every live query
+    // reported a bogus "invalid or expired token" storm to Sentry
+    // (PRODUCT-1531).
+    return installHostedSessionRefresh(refreshNow);
   }, []);
 
   useEffect(() => {

--- a/app/tests/identity-refresh.test.ts
+++ b/app/tests/identity-refresh.test.ts
@@ -155,6 +155,32 @@ test("refreshNow returns null when there is no stored session", async () => {
   assert.equal(calls, 0);
 });
 
+test("refreshNow RETHROWS a transient network failure and keeps the session", async () => {
+  // The three-valued contract (HOU-1106) the hosted-session seam depends on:
+  // null is reserved for a TERMINAL sign-out, so a transient failure (identity
+  // service unreachable while a sleep-wake reconnect settles) must throw
+  // IdentityError("network") — and the installer (engine-gate) must pass that
+  // throw through to the adapter's connectivity classifier. Flattening it to
+  // null made the stale-token 401 stand and every live query reported a bogus
+  // "invalid or expired token" storm (PRODUCT-1531).
+  await seedSession();
+  const { refreshNow } = await import("../src/lib/identity/refresh.ts");
+  const { loadSession } = await import("../src/lib/identity/session-store.ts");
+  const { isIdentityError } = await import("../src/lib/identity/errors.ts");
+
+  globalThis.fetch = (async () => {
+    throw new TypeError("Load failed"); // transport rejection, no HTTP response
+  }) as typeof fetch;
+
+  await assert.rejects(refreshNow(), (e: unknown) => {
+    assert.ok(isIdentityError(e), "expected a typed IdentityError");
+    assert.equal(e.code, "network");
+    return true;
+  });
+  // Transient ≠ sign-out: the stored session must survive for the retry.
+  assert.deepEqual(await loadSession(), SESSION);
+});
+
 test("proactive refresh backs off on a transient failure near expiry (no hot loop)", async () => {
   // A session already inside the skew window: the expiry-based delay is 0, so
   // without backoff a failing refresh would reschedule at 0 and hammer the


### PR DESCRIPTION
## Summary

**Sentry HOUSTON-APP-4W4** (488 events / 84 users, still occurring on 0.6.9): bursts of `invalid or expired token (engine error 401)` across every live query at once (`list_conversations`, `list_skills`, `get_org`, `get_preference`, ...) on the desktop cloud profile.

**Root cause:** a sleep-wake reconnect fires every live query with the ID token that expired during sleep; the gateway 401s and `gatewayAuthFetch` asks the session-refresh seam for a fresh bearer. The seam's contract is three-valued (HOU-1106, #1196): token = refreshed, **null = terminal sign-out**, **transient throw = connectivity** (blind-retried by `transientRetryFetch`, never reported). #1196 fixed the adapter side, but the **desktop installer** in `EngineGate` still wrapped `refreshNow()` in a catch-to-null — so a transient `IdentityError("network")` (identity service unreachable while the reconnect settles) read as a terminal sign-out: the stale-token 401 stood, and every live query reported the bogus auth error to Sentry. The web installer (`webRefreshIdToken`) already lets the throw propagate; desktop was the only surface flattening it.

**Fix:** pass `refreshNow` through intact. The adapter already classifies the throw as connectivity (`Load failed (session refresh)`) and re-runs the refresh on each read retry, so the burst self-heals as the reconnect settles — one deduped connectivity notice at worst, no Sentry storm. Terminal refresh failures are unchanged: `refreshNow` clears the session and resolves null, and the auth gate surfaces the sign-in screen.

**Test:** new direct test pinning `refreshNow`'s transient contract — a transport-level fetch rejection rethrows `IdentityError("network")` and the stored session survives for the retry (flattening regression guard).

## Before (bug reproduction)
1. On a desktop build with the hosted cloud profile, sign in and let the app idle past ID-token expiry (>1h, e.g. laptop asleep).
2. Wake the machine; while the network reconnect is still settling (identity endpoint briefly unreachable), the app refetches every live query.
3. Every query surfaces `invalid or expired token (engine error 401)` — one Sentry event per query (the HOUSTON-APP-4W4 storm) — even though the user's session is perfectly valid moments later.

## After (verification)
1. Same wake-from-sleep sequence: the transient refresh failure now rides the connectivity path — reads blind-retry, the refresh re-runs as the network settles, and the queries recover with a fresh token. No auth errors, no Sentry events (`error_kind: auth` for this signature should flatline after rollout).
2. Real sign-out still works: revoke the refresh token (or delete the test account) → next refresh clears the session and the sign-in screen appears.
3. `cd app && pnpm test` — includes the new `refreshNow RETHROWS a transient network failure and keeps the session` test, which fails against the old flattening behavior.

## Checks
- `pnpm check` ✅  `cd app && pnpm test` (3762 pass) ✅  `cd app && pnpm tsgo --noEmit` ✅  `pnpm --filter houston-web typecheck` ✅