### PR TITLE
fix(runtime): classify the three openai-compatible failures Sentry read as unknown (PRODUCT-1530)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -1256,3 +1256,79 @@ test("Anthropic consumer-terms 400 stays unknown with the actionable excerpt (HO
   expect(err.kind).toBe("unknown");
   if (err.kind === "unknown") expect(err.raw_excerpt).toBe(message);
 });
+
+test("pi 0.84 setModel 'No API key for <provider>/<model>' → unauthenticated / no_credentials (PRODUCT-1530)", () => {
+  // AgentSession.setModel's checkAuth throw dropped the "found": on a cloud
+  // pod whose credential store served no key for a configured custom endpoint
+  // this fired as `unknown` — a Sentry error per turn — instead of reconnect.
+  const err = classifyProviderError({
+    provider: "openai-compatible",
+    model: "gemma4:latest",
+    message: "No API key for openai-compatible/gemma4:latest",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
+});
+
+test("pi 0.84 api-layer 'No API key for provider: <id>' → unauthenticated / no_credentials", () => {
+  const err = classifyProviderError({
+    provider: "openai-compatible",
+    model: null,
+    message: "No API key for provider: openai-compatible",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
+});
+
+test("local-override mismatch → model_unavailable with the served model as the fallback (PRODUCT-1530)", () => {
+  // The runtime's own guard (`localOverrideError`): a conversation pinned to a
+  // model the reconfigured endpoint no longer serves fails EVERY turn with
+  // this message. The endpoint names its one served model — the definitive
+  // one-click switch target.
+  const message =
+    'The local endpoint serves "qwen2.5-coder:14b", not "gemma4:latest". Pick the local model (or switch the active provider) before this turn.';
+  const err = classifyProviderError({
+    provider: "openai-compatible",
+    model: "gemma4:latest",
+    message,
+  });
+  expect(err).toEqual({
+    kind: "model_unavailable",
+    provider: "openai-compatible",
+    model: "gemma4:latest",
+    reason: "unknown",
+    suggested_fallback: "qwen2.5-coder:14b",
+    message,
+  });
+});
+
+test("custom endpoint 404 (HTML body) → model_unavailable, never unknown (PRODUCT-1530)", () => {
+  // A base URL that doesn't host the OpenAI API answers the completions POST
+  // with its web server's 404 page — raw HTML that read as `unknown` and
+  // fired a Sentry error per turn. The credential is fine; the endpoint
+  // config / model pick is the fix, so switch-model is the honest card.
+  const err = classifyProviderError({
+    provider: "openai-compatible",
+    model: "gemma4:e4b-it-qat",
+    message:
+      "404 <!DOCTYPE html>\n<html>\n<head>\n<title>Not Found</title>\n</head>\n<body>404 Not Found</body>\n</html>",
+  });
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable") {
+    expect(err.reason).toBe("unknown");
+    expect(err.suggested_fallback).toBeNull();
+  }
+});
+
+test("a 404 on any OTHER provider still falls through to unknown", () => {
+  // The custom-endpoint 404 verdict is provider-scoped: other providers' 404s
+  // keep their own explicit patterns (NVIDIA's account gate, Azure's
+  // DeploymentNotFound, Moonshot's retired models).
+  const err = classifyProviderError({
+    provider: "openai",
+    model: "gpt-5.5",
+    message:
+      "404 <!DOCTYPE html><html><head><title>Not Found</title></head></html>",
+  });
+  expect(err.kind).toBe("unknown");
+});

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -107,9 +107,19 @@ const INVALID_KEY_PATTERNS = [
  * this; without the pattern it degraded to `unknown` — the generic error card
  * instead of the reconnect card (HOU-956: "Provider is not configured:
  * google" after a Gemini model was picked with no google key stored).
+ *
+ * pi 0.84 added two more missing-credential shapes with the "found" dropped:
+ * AgentSession.setModel throws `No API key for <provider>/<model>` and the
+ * api layers throw `No API key for provider: <provider>`. On a cloud pod the
+ * openai-compatible provider hits the first whenever the gateway credential
+ * store served no key (not even the keyless placeholder) for a configured
+ * endpoint; "no api key found" never matches either, so both degraded to
+ * `unknown` — a Sentry error per turn instead of the reconnect card
+ * (PRODUCT-1530).
  */
 const NO_CREDENTIALS_PATTERNS = [
   "no api key found",
+  "no api key for",
   "no provider connected",
   "no local model configured",
   "provider is not configured",
@@ -177,6 +187,15 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // phrasings above match this order, so it degraded to `unknown` — the
   // report-bug card instead of switch-model (PRODUCT-1517).
   "not supported model",
+  // The runtime's OWN local-override guard (`localOverrideError`,
+  // ai/openai-compatible.ts): a turn pinned to a model the configured custom
+  // endpoint doesn't serve — a conversation pinned before the endpoint was
+  // reconfigured keeps failing every turn. The endpoint is fine; only the
+  // pinned MODEL is out of reach, and the message names the served model, so
+  // the switch-model card can offer it one-click (`localServedFallback`)
+  // instead of the report-bug card firing a Sentry error per turn
+  // (PRODUCT-1530: 550 events from 4 users).
+  "local endpoint serves",
 ];
 
 /**
@@ -319,6 +338,41 @@ const MOONSHOT_BROAD_FALLBACK = "kimi-k2.6";
 const XIAOMI_BROAD_FALLBACK = "mimo-v2.5-pro";
 
 /**
+ * The OpenAI-compatible (custom endpoint) provider id — duplicated from
+ * `ai/openai-compatible.ts` on purpose, like COPILOT_BASE_FALLBACK, so this
+ * classifier stays pure (that module drags in fs + config).
+ */
+const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
+
+/**
+ * The custom (OpenAI-compatible) endpoint answered the completions request
+ * with a 404: the base URL doesn't host the OpenAI API at that path (a
+ * reverse proxy's HTML "Not Found" page, an Ollama base URL missing `/v1`)
+ * or the server doesn't know the configured model (Ollama's "model '<id>'
+ * not found, try pulling it first"). Either way the credential is not the
+ * problem and no retry helps — the fix is the endpoint config / model pick,
+ * so the switch-model card is the honest one. Without this the raw body
+ * (often a full HTML document) read as `unknown` — the report-bug card plus
+ * a Sentry error per turn (PRODUCT-1530). Scoped to this provider: other
+ * providers' 404s keep their own explicit patterns (NVIDIA's account gate,
+ * Azure's DeploymentNotFound, Moonshot's retired models).
+ */
+function isCustomEndpoint404(provider: string, status: number | null): boolean {
+  return provider === OPENAI_COMPATIBLE_PROVIDER && status === 404;
+}
+
+/**
+ * The served model a local-override mismatch names (`The local endpoint
+ * serves "<model>", not "<override>". …`) — offered as the one-click switch
+ * target, since it is by definition the ONLY model the endpoint serves.
+ */
+const LOCAL_ENDPOINT_SERVES = /local endpoint serves "([^"]+)"/i;
+
+function localServedFallback(message: string): string | null {
+  return message.match(LOCAL_ENDPOINT_SERVES)?.[1] ?? null;
+}
+
+/**
  * Map a failed model request to a typed `ProviderError`, then stamp WHOSE
  * credential ran the turn (`stampCredentialScope`).
  *
@@ -452,7 +506,10 @@ function classify(input: ProviderErrorInput): ProviderError {
   // (Copilot premium model on Copilot Free, etc.). Needs a known model id to
   // render the "switch model" card — without one it can't name what to switch
   // away from, so it falls through to `unknown`.
-  if (model && isModelUnavailable(lower)) {
+  if (
+    model &&
+    (isModelUnavailable(lower) || isCustomEndpoint404(provider, status))
+  ) {
     return {
       kind: "model_unavailable",
       provider,
@@ -460,7 +517,10 @@ function classify(input: ProviderErrorInput): ProviderError {
       reason: modelUnavailableReason(lower),
       // Offer a concrete switch target only when we know one AND it isn't the
       // failing model itself (a base Copilot model never reports unavailable).
-      suggested_fallback: broadFallback(provider, model),
+      // A local-override mismatch names the endpoint's one served model —
+      // the definitive target, ahead of any per-provider default.
+      suggested_fallback:
+        localServedFallback(message) ?? broadFallback(provider, model),
       message,
     };
   }


### PR DESCRIPTION
## Root cause

PRODUCT-1530. The Sentry group behind this issue (550 events / 4 users) is fingerprinted per `provider=openai-compatible kind=unknown`, and sampling the events shows THREE distinct failure texts the classifier (`packages/runtime/src/ai/provider-error.ts`) failed to type — each an expected user-configuration state that then logged at error severity (`provider-error-log.ts` treats `unknown` as unseen-and-untriaged) and rendered the report-bug card instead of an actionable one:

1. **`The local endpoint serves "qwen2.5-coder:14b", not "gemma4:latest". …`** (dominant, 7/10 sampled) — the runtime's own `localOverrideError` guard: a conversation pinned to a model the reconfigured custom endpoint no longer serves fails every turn. No pattern matched it.
2. **`No API key for openai-compatible/gemma4:latest`** — pi 0.84's `AgentSession.setModel` throw dropped the word "found", so the existing `no api key found` pattern missed it (same for the api layers' `No API key for provider: <id>`).
3. **`404 <!DOCTYPE html>…`** (the issue title's snapshot) — a custom endpoint base URL that doesn't host the OpenAI API answers the completions POST with its web server's raw HTML 404 page.

## Fix

All in the pure classifier + its tests:

- `no api key for` added to `NO_CREDENTIALS_PATTERNS` → `unauthenticated / no_credentials` (reconnect card, undelivered-prompt auto-resume, warning-level log).
- `local endpoint serves` added to `MODEL_UNAVAILABLE_PATTERNS`, and the served model named in the message is offered as `suggested_fallback` → the switch-model card gains a one-click "Switch to <served model>" action.
- A provider-scoped branch: `openai-compatible` + HTTP 404 → `model_unavailable` (the endpoint config / model pick is the fix; no retry or reconnect helps). Other providers' 404s keep their existing explicit patterns and still fall through to `unknown`.

`model_unavailable` and `unauthenticated/no_credentials` are already expected kinds in `provider-error-log.ts`, so these now log as warnings (Sentry breadcrumbs), not errors.

## Before (reproduce)

1. Connect the OpenAI-compatible provider to a local server serving model A; start a conversation so it pins model A; reconfigure the endpoint to model B; send another message → chat shows the generic "Something unexpected happened" card and the engine logs `[provider_error] … kind=unknown :: The local endpoint serves …` at **error** severity (a Sentry error per turn).
2. Point the endpoint's base URL at any web server that isn't an OpenAI API (e.g. an Ollama host without `/v1`) → same unknown card with raw HTML in the excerpt.

## After (verify)

- `cd packages/runtime && npx vitest run src/ai/provider-error.test.ts` — 95 tests pass, including the five new PRODUCT-1530 cases.
- Repro step 1 now renders the model-unavailable card with a one-click "Switch to <served model>" button, and the log line reads `kind=model_unavailable` at warning severity.
- Repro step 2 renders the model-unavailable card instead of the raw-HTML unknown card.
- `pnpm check`, `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test`, and the repo typecheck all pass.