### PR TITLE
fix(providers): azure endpoint rides the central credential so every runtime can aim the served key (PRODUCT-1532)

### DIFF
--- a/packages/host/src/channel/capture-credential.test.ts
+++ b/packages/host/src/channel/capture-credential.test.ts
@@ -393,3 +393,38 @@ test("a new-format AQ. google auth key captures too (PRODUCT-1368)", async () =>
   expect(result).toEqual({ ok: true, provider: "google" });
   expect(stored[0]?.accessToken).toBe("AQ.Ab8RN6JkyDLMExampleAuthKey");
 });
+
+test("an azure api_key capture stores the exported endpoint as enterpriseUrl (PRODUCT-1532)", async () => {
+  // The runtime exports azure's per-resource endpoint beside the key; the
+  // central row must keep them together or every OTHER runtime is served a
+  // key aimed at nothing ("base URL is required" on each turn).
+  const { credentials, puts } = recordingStore();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request) => {
+      if (String(input).includes("/auth/export"))
+        return Response.json({
+          provider: "azure-openai-responses",
+          kind: "api_key",
+          key: "azure-key",
+          enterpriseUrl: "https://acme.openai.azure.com",
+        });
+      return new Response("not found", { status: 404 });
+    }),
+  );
+  expect(
+    await captureRuntimeCredential({
+      endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+      credentials,
+      workspaceId: "workspace",
+      provider: "azure-openai-responses",
+    }),
+  ).toEqual({ ok: true, provider: "azure-openai-responses" });
+  expect(puts).toHaveLength(1);
+  expect(puts[0]?.credential).toMatchObject({
+    provider: "azure-openai-responses",
+    kind: "api_key",
+    accessToken: "azure-key",
+    enterpriseUrl: "https://acme.openai.azure.com",
+  });
+});

--- a/packages/host/src/channel/capture-credential.ts
+++ b/packages/host/src/channel/capture-credential.ts
@@ -124,6 +124,11 @@ export async function captureRuntimeCredential(args: {
         accessToken: credential.key,
         refreshToken: "",
         expiresAt: Number.MAX_SAFE_INTEGER,
+        // Azure exports its per-resource endpoint beside the key — a central
+        // row without it serves a key aimed at nothing (PRODUCT-1532).
+        ...(credential.enterpriseUrl
+          ? { enterpriseUrl: credential.enterpriseUrl }
+          : {}),
       },
       { actingAs, ifAbsent },
     );

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -522,6 +522,12 @@ export class ProxyChannel implements RuntimeChannel {
           refreshToken: "",
           expiresAt: 0,
           kind: "api_key",
+          // The provider endpoint (Azure's per-resource URL) rides the row's
+          // non-secret enterpriseUrl slot: the key is served workspace-wide,
+          // and a runtime that never ran this connect needs the endpoint with
+          // it or every turn dies before HTTP (PRODUCT-1532). The runtime
+          // just verified the key AGAINST this endpoint, so it is proven.
+          ...(providerEndpoint ? { enterpriseUrl: providerEndpoint } : {}),
         },
         { actingAs: ctx.actingAs },
       );

--- a/packages/host/src/channel/turn.ts
+++ b/packages/host/src/channel/turn.ts
@@ -137,15 +137,10 @@ export class TurnChannel implements RuntimeChannel {
     apiKey: string,
     endpoint?: string,
   ): Promise<void> {
-    // Azure OpenAI needs its per-resource endpoint hydrated into every
-    // per-turn data dir, and this channel has no write for it yet — refuse
-    // loudly rather than store a key that can never make a request
-    // (PRODUCT-1477; mirrors the Claude refusal below).
-    if (endpoint !== undefined) {
-      throw new Error(
-        `${provider} isn't available in the cloud per-turn runtime yet.`,
-      );
-    }
+    // Azure OpenAI's per-resource endpoint rides the credential row's
+    // non-secret enterpriseUrl slot (PRODUCT-1532): the per-turn runtime
+    // receives it baked into each POST /turn and lands it in the turn's data
+    // dir (execute-turn), so the key is never stored aimed at nothing.
     await this.deps.credentials.put({
       workspaceId: ctx.workspace.id,
       provider,
@@ -153,6 +148,7 @@ export class TurnChannel implements RuntimeChannel {
       refreshToken: "",
       expiresAt: 0,
       kind: "api_key",
+      ...(endpoint ? { enterpriseUrl: endpoint } : {}),
     });
   }
 

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -388,10 +388,12 @@ export interface WorkspaceCredential {
   /** Credential kind. Absent is read as "oauth" (every legacy credential). */
   kind?: "oauth" | "api_key";
   /**
-   * GitHub Copilot Enterprise (GHE): the company GitHub domain (e.g.
-   * `acme.ghe.com`) this credential was issued for. Absent = individual Copilot
-   * (github.com). The central refresh hits `api.<domain>/copilot_internal/v2/token`,
-   * and it's served back so the runtime points the model at the enterprise API.
+   * Non-secret provider base URL the credential was issued against, served
+   * back so every runtime can aim the token. Two providers use it: GitHub
+   * Copilot Enterprise stores the company GitHub domain (e.g. `acme.ghe.com`;
+   * the central refresh hits `api.<domain>/copilot_internal/v2/token`), and
+   * Azure OpenAI stores its per-resource endpoint (PRODUCT-1532 — the key is
+   * unusable without it). Absent = the provider's default base URL.
    */
   enterpriseUrl?: string;
   /** Scope selected by the gateway when this credential was served. */

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -103,6 +103,12 @@ export async function dispatchTurn(
                     expires: cred.expiresAt,
                     accountId: cred.accountId ?? null,
                     kind: isApiKeyCredential(cred) ? "api_key" : "oauth",
+                    // Non-secret provider base URL riding the row (Copilot
+                    // Enterprise domain, Azure's resource endpoint) — dropping
+                    // it here silently unaims the served key (PRODUCT-1532).
+                    ...(cred.enterpriseUrl
+                      ? { enterpriseUrl: cred.enterpriseUrl }
+                      : {}),
                   }
                 : null,
             }),

--- a/packages/runtime/src/ai/azure-openai.test.ts
+++ b/packages/runtime/src/ai/azure-openai.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test, vi } from "vitest";
@@ -38,6 +38,50 @@ test("normalizeAzureEndpoint accepts https, trims a trailing slash, rejects the 
   expect(() => normalizeAzureEndpoint("http://acme.openai.azure.com")).toThrow(
     /https/,
   );
+});
+
+test("applyServedAzureEndpoint lands a served endpoint, idempotently, azure-only, never throwing", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-azure-served-"));
+  const {
+    AZURE_OPENAI,
+    applyServedAzureEndpoint,
+    azureBaseUrl,
+    azureEndpointFileIn,
+  } = await import("./azure-openai");
+
+  // The served row's endpoint lands where model resolution reads it —
+  // normalized exactly like a connect-time paste.
+  applyServedAzureEndpoint(
+    AZURE_OPENAI,
+    "https://acme.openai.azure.com/",
+    dataDir,
+  );
+  expect(azureBaseUrl(dataDir)).toBe("https://acme.openai.azure.com");
+
+  // Same value again: no rewrite (the file's mtime is what store-sync watches).
+  const file = azureEndpointFileIn(dataDir);
+  const before = statSync(file).mtimeMs;
+  applyServedAzureEndpoint(
+    AZURE_OPENAI,
+    "https://acme.openai.azure.com",
+    dataDir,
+  );
+  expect(statSync(file).mtimeMs).toBe(before);
+
+  // A different served value replaces the stored one (a reconnect elsewhere).
+  applyServedAzureEndpoint(
+    AZURE_OPENAI,
+    "https://other.openai.azure.com",
+    dataDir,
+  );
+  expect(azureBaseUrl(dataDir)).toBe("https://other.openai.azure.com");
+
+  // Non-azure providers (copilot's enterprise domain) and absent values are
+  // ignored; a malformed central value reports but never throws or clobbers.
+  applyServedAzureEndpoint("github-copilot", "acme.ghe.com", dataDir);
+  applyServedAzureEndpoint(AZURE_OPENAI, null, dataDir);
+  applyServedAzureEndpoint(AZURE_OPENAI, "not-a-url", dataDir);
+  expect(azureBaseUrl(dataDir)).toBe("https://other.openai.azure.com");
 });
 
 test("setAzureEndpoint persists and azure models resolve with the stored base URL", async () => {

--- a/packages/runtime/src/ai/azure-openai.ts
+++ b/packages/runtime/src/ai/azure-openai.ts
@@ -99,6 +99,36 @@ export function setAzureEndpoint(raw: string): void {
 }
 
 /**
+ * Persist an endpoint that arrived RIDING a served credential — the
+ * `enterpriseUrl` slot of the central azure row (the Copilot Enterprise
+ * precedent: a non-secret provider base URL the key needs to be usable). The
+ * KEY is workspace-central and served to every runtime, but this file is
+ * per-runtime — so any runtime that didn't run the connect (another agent's
+ * pod, a recycled pod, a second desktop agent) held the key aimed at nothing
+ * and every azure turn died with "base URL is required" (PRODUCT-1532).
+ * Idempotent: writes only when the stored value differs. Never throws — a
+ * malformed central value must not take down the serve sweep or the turn; it
+ * reports and leaves whatever is stored in place.
+ */
+export function applyServedAzureEndpoint(
+  provider: string,
+  endpoint: string | null | undefined,
+  dataDir: string = config.dataDir,
+): void {
+  if (provider !== AZURE_OPENAI || !endpoint) return;
+  try {
+    if (azureBaseUrl(dataDir) === normalizeAzureEndpoint(endpoint)) return;
+    setAzureEndpointIn(dataDir, endpoint);
+  } catch (e) {
+    console.error(
+      `[serve] served azure endpoint is invalid; keeping the stored one: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  }
+}
+
+/**
  * Overlay the stored endpoint onto a resolved azure catalog model. pi's azure
  * client resolves the base URL as option → env → `model.baseUrl`, and the
  * catalog ships `""` — so without this overlay every request throws "base URL

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -1332,3 +1332,23 @@ test("a 404 on any OTHER provider still falls through to unknown", () => {
   });
   expect(err.kind).toBe("unknown");
 });
+
+test("Azure missing base URL → unauthenticated / no_credentials (PRODUCT-1532)", () => {
+  // pi's azure client throws this before any HTTP when the per-resource
+  // endpoint never landed on THIS runtime — the key alone can't be aimed.
+  const err = classifyProviderError({
+    provider: "azure-openai-responses",
+    model: "gpt-5.4-mini",
+    message:
+      "Azure OpenAI base URL is required. Set AZURE_OPENAI_BASE_URL or AZURE_OPENAI_RESOURCE_NAME, or pass azureBaseUrl, azureResourceName, or model.baseUrl.",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
+  // Any other provider mentioning a base URL keeps its own classification.
+  const other = classifyProviderError({
+    provider: "openrouter",
+    model: "some-model",
+    message: "base URL is required",
+  });
+  expect(other.kind).toBe("unknown");
+});

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -1,6 +1,7 @@
 import { getOverflowPatterns } from "@earendil-works/pi-ai";
 import type { AuthFailureCause, ProviderError } from "@houston/runtime-client";
 import { servedScopeFor } from "../auth/served-scope";
+import { AZURE_OPENAI } from "./azure-openai";
 
 /**
  * Classify a failed model request into a typed `ProviderError` so the chat can
@@ -430,6 +431,18 @@ function classify(input: ProviderErrorInput): ProviderError {
       reason: "unknown",
       suggested_fallback:
         model === NVIDIA_BROAD_FALLBACK ? null : NVIDIA_BROAD_FALLBACK,
+      message,
+    };
+  }
+  // Azure OpenAI with no per-resource endpoint on THIS runtime — pi throws
+  // "base URL is required" before any HTTP. The key may be fine; the half of
+  // the credential that aims it (the endpoint) never landed here. The honest
+  // card is reconnect, which re-collects the endpoint (PRODUCT-1532).
+  if (provider === AZURE_OPENAI && lower.includes("base url is required")) {
+    return {
+      kind: "unauthenticated",
+      provider,
+      cause: "no_credentials",
       message,
     };
   }

--- a/packages/runtime/src/auth/export.test.ts
+++ b/packages/runtime/src/auth/export.test.ts
@@ -155,3 +155,40 @@ test("exportCredential reads the setup token from auth.json; excludeServed consu
     },
   );
 });
+
+test("an azure api_key export carries the stored endpoint as enterpriseUrl (PRODUCT-1532)", () => {
+  withDataDir(
+    {
+      "auth.json": {
+        "azure-openai-responses": { type: "api_key", key: "azure-key" },
+      },
+      "azure-endpoint.json": { baseUrl: "https://acme.openai.azure.com" },
+    },
+    () => {
+      // The endpoint lives in its own file, not auth.json — the export joins
+      // them so the captured central row serves a usable credential.
+      expect(exportCredential("azure-openai-responses")).toEqual({
+        provider: "azure-openai-responses",
+        kind: "api_key",
+        key: "azure-key",
+        enterpriseUrl: "https://acme.openai.azure.com",
+      });
+    },
+  );
+  withDataDir(
+    {
+      "auth.json": {
+        "azure-openai-responses": { type: "api_key", key: "azure-key" },
+      },
+    },
+    () => {
+      // No stored endpoint (a legacy connect): the export stays key-only
+      // rather than inventing an empty enterpriseUrl.
+      expect(exportCredential("azure-openai-responses")).toEqual({
+        provider: "azure-openai-responses",
+        kind: "api_key",
+        key: "azure-key",
+      });
+    },
+  );
+});

--- a/packages/runtime/src/auth/export.ts
+++ b/packages/runtime/src/auth/export.ts
@@ -1,3 +1,4 @@
+import { AZURE_OPENAI, azureBaseUrl } from "../ai/azure-openai";
 import { config } from "../config";
 import { currentCredentialScope } from "../session/acting-context";
 import {
@@ -28,6 +29,10 @@ export type ExportedApiKeyCredential = {
   provider: string;
   kind: "api_key";
   key: string;
+  /** Azure OpenAI's per-resource endpoint, exported beside the key so the
+   *  central row can serve it back to runtimes that never ran the connect
+   *  (PRODUCT-1532). Rides the same non-secret slot Copilot Enterprise uses. */
+  enterpriseUrl?: string;
 };
 
 export type ExportedCredential =
@@ -130,7 +135,7 @@ export function exportCredential(
   opts?: { excludeServed?: boolean },
 ): ExportedCredential | null {
   const scopeKey = currentCredentialScope().key;
-  return selectExportCredential(
+  const selected = selectExportCredential(
     readAuthFile(authPathIn(config.dataDir, scopeKey)),
     provider,
     opts?.excludeServed
@@ -143,4 +148,18 @@ export function exportCredential(
         }
       : undefined,
   );
+  // Azure's key is unusable without its per-resource endpoint, which lives in
+  // its own file (ai/azure-openai.ts), not auth.json — export it alongside so
+  // the capture stores a row every other runtime can actually use
+  // (PRODUCT-1532).
+  if (
+    selected &&
+    "kind" in selected &&
+    selected.kind === "api_key" &&
+    selected.provider === AZURE_OPENAI
+  ) {
+    const endpoint = azureBaseUrl();
+    return endpoint ? { ...selected, enterpriseUrl: endpoint } : selected;
+  }
+  return selected;
 }

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -1516,3 +1516,42 @@ test("a served google key with the real AIza shape is applied normally", async (
     expect(reports).toEqual([]);
   });
 });
+
+test("a served azure credential lands its endpoint file beside auth.json (PRODUCT-1532)", async () => {
+  // The azure KEY is workspace-central, but the per-resource endpoint used to
+  // live only where the connect ran — every other runtime was served a key
+  // aimed at nothing and each turn died with "base URL is required". The
+  // endpoint now rides the row's enterpriseUrl slot; the sweep must land it.
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const provider = new URL(String(input)).searchParams.get("provider");
+    if (provider === "azure-openai-responses") {
+      return new Response(
+        JSON.stringify({
+          provider: "azure-openai-responses",
+          kind: "api_key",
+          access: "azure-key",
+          expires: Number.MAX_SAFE_INTEGER,
+          accountId: null,
+          enterpriseUrl: "https://acme.openai.azure.com",
+        }),
+        { status: 200 },
+      );
+    }
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  await withServeMode(fetchImpl, async () => {
+    expect(await syncServedCredential()).toEqual(["azure-openai-responses"]);
+    const auth = JSON.parse(
+      readFileSync(join(config.dataDir, "auth.json"), "utf8"),
+    ) as Record<string, { type: string; key?: string }>;
+    expect(auth["azure-openai-responses"]).toEqual({
+      type: "api_key",
+      key: "azure-key",
+    });
+    expect(
+      JSON.parse(
+        readFileSync(join(config.dataDir, "azure-endpoint.json"), "utf8"),
+      ),
+    ).toEqual({ baseUrl: "https://acme.openai.azure.com" });
+  });
+});

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -1,3 +1,4 @@
+import { applyServedAzureEndpoint } from "../ai/azure-openai";
 import { piApiKeyProviderIds } from "../ai/pi-catalog";
 import { PROVIDERS } from "../ai/providers";
 import { clearGhostClaudeCredential } from "../backends/claude/credential-status";
@@ -236,6 +237,11 @@ async function runServedSync(): Promise<string[]> {
         );
       }
       const didApply = applyServedCredential(authPathFor(), probe.cred);
+      // Azure's per-resource endpoint rides the served row (its
+      // `enterpriseUrl` slot). Landed OUTSIDE the didApply gate: the apply
+      // guard protects a mid-capture refresh token, which an api_key row
+      // never carries, and the endpoint write is idempotent (PRODUCT-1532).
+      applyServedAzureEndpoint(probe.id, probe.cred.enterpriseUrl);
       // WHOSE credential this was, remembered for the provider-error stamp and
       // the /providers row. Recorded on the gateway's ANSWER, not on the write:
       // a skipped apply is the mid-capture guard over this same scope's own

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WireFrame } from "@houston/runtime-client";
+import { applyServedAzureEndpoint } from "../ai/azure-openai";
 import { applyServedCredential } from "../auth/auth-file";
 import { runWithActingContext } from "../session/acting-context";
 import { releaseConversation, runWithConversationScope } from "../session/bus";
@@ -84,7 +85,17 @@ export async function executeTurn(
     timings.t_hydrated = performance.now();
     const { dataDir } = filesystem;
     const authPath = join(dataDir, "auth.json");
-    if (turn.credential) applyServedCredential(authPath, turn.credential);
+    if (turn.credential) {
+      applyServedCredential(authPath, turn.credential);
+      // Azure's per-resource endpoint rides the served credential; land it in
+      // THIS turn's hydrated root so model resolution finds a base URL even
+      // when this agent never ran the connect itself (PRODUCT-1532).
+      applyServedAzureEndpoint(
+        turn.credential.provider,
+        turn.credential.enterpriseUrl,
+        dataDir,
+      );
+    }
     timings.t_cred_written = performance.now();
 
     const sse = openSSE(res);

--- a/packages/runtime/src/turn/op-credential.test.ts
+++ b/packages/runtime/src/turn/op-credential.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+import { pushApiKeyCredential } from "./op-credential";
+
+test("the pool-op push carries azure's endpoint on the central row (PRODUCT-1532)", async () => {
+  // The gateway's credential store round-trips enterpriseUrl opaquely; a push
+  // without it stored a key every OTHER runtime is served aimed at nothing.
+  const bodies: Array<Record<string, unknown>> = [];
+  const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  expect(
+    await pushApiKeyCredential({
+      credentialsBaseUrl: "http://gateway.test",
+      orgSlug: "org",
+      agentSlug: "agent",
+      hostToken: "host-token",
+      provider: "azure-openai-responses",
+      apiKey: "azure-key",
+      enterpriseUrl: "https://acme.openai.azure.com",
+      fetchImpl,
+    }),
+  ).toBeNull();
+  expect(bodies).toHaveLength(1);
+  expect(bodies[0]).toMatchObject({
+    kind: "api_key",
+    access: "azure-key",
+    enterpriseUrl: "https://acme.openai.azure.com",
+  });
+
+  // A provider with no endpoint keeps its exact historical body — no
+  // enterpriseUrl key at all.
+  await pushApiKeyCredential({
+    credentialsBaseUrl: "http://gateway.test",
+    orgSlug: "org",
+    agentSlug: "agent",
+    hostToken: "host-token",
+    provider: "openrouter",
+    apiKey: "or-key",
+    fetchImpl,
+  });
+  expect(bodies[1]).not.toHaveProperty("enterpriseUrl");
+});

--- a/packages/runtime/src/turn/op-credential.ts
+++ b/packages/runtime/src/turn/op-credential.ts
@@ -110,6 +110,11 @@ export async function applyApiKeyConnect(
     hostToken: opts.hostToken,
     provider: opts.provider,
     apiKey: key,
+    // Azure's endpoint rides the central row (its enterpriseUrl slot) so
+    // every runtime this key is later served to can aim it (PRODUCT-1532).
+    ...(opts.provider === AZURE_OPENAI && opts.endpoint
+      ? { enterpriseUrl: normalizeAzureEndpoint(opts.endpoint) }
+      : {}),
     ...(opts.actingAs ? { actingAs: opts.actingAs } : {}),
     ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
   });
@@ -131,6 +136,8 @@ export async function pushApiKeyCredential(opts: {
   hostToken: string;
   provider: string;
   apiKey: string;
+  /** Non-secret provider base URL stored beside the key (azure's endpoint). */
+  enterpriseUrl?: string;
   actingAs?: string;
   fetchImpl?: typeof fetch;
 }): Promise<OpAnswer | null> {
@@ -152,6 +159,7 @@ export async function pushApiKeyCredential(opts: {
         refreshToken: "",
         expiresAt: 0,
         kind: "api_key",
+        ...(opts.enterpriseUrl ? { enterpriseUrl: opts.enterpriseUrl } : {}),
       },
       opts.actingAs ? { actingAs: opts.actingAs } : {},
     );

--- a/packages/runtime/src/turn/turn-model.test.ts
+++ b/packages/runtime/src/turn/turn-model.test.ts
@@ -65,3 +65,17 @@ test("a non-custom provider still resolves through the pi catalog", () => {
   const model = resolveTurnModel(dataDir, "anthropic") as ResolvedModel;
   expect(model.provider).toBe("anthropic");
 });
+
+test("azure resolves with the endpoint hydrated into THIS turn's data dir", async () => {
+  const { AZURE_OPENAI, setAzureEndpointIn } = await import(
+    "../ai/azure-openai"
+  );
+  const dataDir = tmpDataDir();
+  // The endpoint file arrives via hydration (a pool-op connect's sync-back or
+  // the served credential's landing) — never via config.dataDir, which is the
+  // WORKER's own root and empty for this agent (PRODUCT-1532).
+  setAzureEndpointIn(dataDir, "https://acme.openai.azure.com");
+  const model = resolveTurnModel(dataDir, AZURE_OPENAI) as ResolvedModel;
+  expect(model.provider).toBe(AZURE_OPENAI);
+  expect(model.baseUrl).toBe("https://acme.openai.azure.com");
+});

--- a/packages/runtime/src/turn/turn-model.ts
+++ b/packages/runtime/src/turn/turn-model.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { AZURE_OPENAI, withAzureBaseUrl } from "../ai/azure-openai";
 import {
   buildActiveCustomModel,
   OPENAI_COMPATIBLE,
@@ -53,6 +54,15 @@ export function resolveTurnModel(
   // same per-dataDir rule as qwen above (ai/xiaomi-endpoint.ts).
   if (provider === XIAOMI_PROVIDER_ID)
     return withXiaomiBaseUrl(
+      safeGetModel(provider, modelId, !!override),
+      dataDir,
+    );
+  // Azure's per-resource endpoint is likewise a per-dataDir file: safeGetModel's
+  // built-in overlay reads config.dataDir — the WORKER's own root, never a
+  // hydrated turn root — so without this the turn throws "base URL is
+  // required" before any HTTP (PRODUCT-1532).
+  if (provider === AZURE_OPENAI)
+    return withAzureBaseUrl(
       safeGetModel(provider, modelId, !!override),
       dataDir,
     );


### PR DESCRIPTION
Fixes PRODUCT-1532 (Azure models not working).

## Root cause

The Azure OpenAI **key** is workspace-central: it is stored once and served to every runtime (other agents' pods, recycled pods, per-turn/pool roots). The **per-resource endpoint** however lived only in the connect-time runtime's local `azure-endpoint.json`. Any runtime that didn't run the connect was served a key aimed at nothing: the provider read as connected, the model picker offered every Azure model, and each turn died before any HTTP with

> Azure OpenAI base URL is required. Set AZURE_OPENAI_BASE_URL or AZURE_OPENAI_RESOURCE_NAME, …

surfaced as an unclassified "Something unexpected happened" card (Sentry `HOUSTON-APP-5BG`; the failing pod had started 3 minutes earlier — key served, endpoint absent).

## Fix

The endpoint now rides the credential row's non-secret `enterpriseUrl` slot — the exact mechanism Copilot Enterprise already uses, and the gateway already stores/serves the field opaquely, so no gateway change is needed.

- **Store it on every central write:** standing-runtime connect (`ProxyChannel`), pool-op connect push (`op-credential`), per-turn channel (which can now accept Azure instead of refusing), and capture (`/auth/export` now joins the endpoint file to an Azure `api_key` export).
- **Land it wherever a served credential is applied:** the serve sweep (`auth/serve.ts`) and the per-turn baked credential (`execute-turn.ts`) write `azure-endpoint.json` beside the key, idempotently, never throwing on a malformed central value.
- **Per-turn model resolution:** `resolveTurnModel` overlays Azure's endpoint from THIS turn's hydrated `dataDir` (like qwen/xiaomi) — `safeGetModel`'s built-in overlay reads the worker's own `config.dataDir`, which is empty for the agent.
- **Latent drop fixed:** the TS per-turn dispatch body (`start-turn.ts`) now forwards `enterpriseUrl` — it was silently dropping the Copilot Enterprise domain too.
- **Residual classification:** `base URL is required` on Azure now classifies as `unauthenticated / no_credentials`, so a legacy central row (stored before this fix, endpoint-less) shows the actionable reconnect card instead of "could not classify".

## Before the fix (repro)

1. Connect Azure OpenAI (key + endpoint) on one agent — the connect verifies live and works there.
2. Open a **different** agent in the same workspace (or wait for the connected agent's pod to be recycled/served fresh): Azure shows connected and its models are pickable.
3. Send any message on an Azure model → error card "Something unexpected happened … Azure OpenAI base URL is required".

## After the fix (verify)

1. Reconnect Azure OpenAI once anywhere (this stores the endpoint on the central row).
2. On a different agent / after a pod restart, pick any Azure model and send a message → the turn runs; the runtime log line `[turn] provider=azure-openai-responses … baseUrl=` shows the resource endpoint instead of empty.
3. `azure-endpoint.json` appears beside `auth.json` in a runtime that never ran the connect.
4. Suites: `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test`, `pnpm check`, `pnpm check:boundaries` all green (new tests: served-endpoint landing, per-dataDir turn resolution, export/capture/push carrying the endpoint, error classification).

Note: central Azure rows stored **before** this fix have no endpoint; those users reconnect Azure once and are healed for every agent from then on.