### PR TITLE
fix(runtime): a spent single-use pod logs at info, not error (PRODUCT-1534)

### DIFF
--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -102,7 +102,12 @@ async function start(): Promise<Server> {
     // quietly for recycle — masking the clean-exit signal the recycler reads.
     let spent = config.poolSingleUse && workerSpent();
     if (spent) {
-      console.error(
+      // A single-use worker that served its one turn, latched spent, exited,
+      // and got its container restarted in place is a NORMAL lifecycle state,
+      // not a failure — it idles here until the recycler deletes the pod.
+      // Log at info: console.error is captured into Sentry (see the capture
+      // feed above), so an error level would page on every healthy recycle.
+      console.info(
         "[turn] pod is spent (single-use marker present); refusing to register until the pod is recycled",
       );
     }


### PR DESCRIPTION
## What

A single-use Kata pool worker that served its one turn, latched itself spent, exited, and got its container restarted in place idles until the recycler deletes the pod. That NORMAL lifecycle state was logged via `console.error` (`packages/runtime/src/main.ts`), and `installRuntimeLogging` captures console.error into Sentry — so **every healthy recycle raised a Sentry error alert** (issue 7694264980, surfaced by the first live Kata pool test; server_name=engine-pool-1).

## Fix

Downgrade the one line to `console.info`: a spent-and-idling pod is a lifecycle breadcrumb, not a failure. No behavior change — the pod still refuses to register and waits for recycle.

## Not in this PR (follow-up, cloud repo)

Staging pool workers are also mislabeled `environment=production` in Sentry because `k8s/gke/pool.yaml` doesn't inject `SENTRY_ENVIRONMENT`. Tracked in PRODUCT-1534 part 2 — a separate small cloud PR.

## Context

PRODUCT-1534. The recycle frequency (and thus this log's volume) drops further once PRODUCT-1533 stops metadata ops from spending workers.