### PR TITLE
fix(shell): an abandoned Claude login times out at info, not error (PRODUCT-1545)

### DIFF
--- a/app/src-tauri/src/claude_login/runner.rs
+++ b/app/src-tauri/src/claude_login/runner.rs
@@ -142,7 +142,13 @@ where
             if let Err(e) = child.kill().await {
                 tracing::error!("[claude-login] failed to kill helper after timeout: {e}");
             }
-            tracing::error!(
+            // INFO, not error: an abandoned login (user closed the consent
+            // tab or walked away) is expected behavior and this expiry IS the
+            // designed teardown — same reasoning as the oauth-loopback
+            // listener timeout and the runtime's abandoned-login expiry.
+            // Nothing in Houston broke, so don't mint a Sentry event per
+            // abandonment; the frontend toasts its own retryable copy.
+            tracing::info!(
                 "[claude-login] timed out after {}s with no result",
                 LOGIN_TIMEOUT.as_secs()
             );


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-4XT (321 events, 0 users affected): every native Claude sign-in that a user starts but never finishes — closed the consent tab, walked away mid browser-approve — hits the 900s login timeout in `claude_login/runner.rs`, which logged the expiry with `tracing::error!`. The Tauri Sentry plugin ships error-level tracing as Sentry events, so each abandonment minted a Sentry error even though nothing in Houston broke: the timeout IS the designed teardown, and the frontend already toasts authored, retryable copy (`providers:claudeLogin.timeout`).

This downgrades the abandoned-login timeout log to `tracing::info!`, matching the two sibling flows that already classify the same situation as expected behavior: the oauth-loopback listener timeout (`oauth_loopback/listener.rs`, info) and the runtime's abandoned-login expiry (`packages/runtime/src/auth/login.ts`, warn). No behavior change — the kill, the `claude-login://done` payload, and the frontend toast are untouched.

Fixes PRODUCT-1545.

## Before

1. Open provider settings and start a native Claude sign-in (the `claude auth login` helper spawns and the browser opens).
2. Close the browser tab without approving and leave the app open for 15 minutes.
3. The helper is killed, the app toasts "Claude sign-in timed out. Please try connecting again." — and Sentry receives a new `[claude-login] timed out after 900s with no result` error event.

## After

Same steps: identical user-facing behavior (helper killed, same toast, retry works), but the expiry lands in the log at info level, so no Sentry error event is created. Verify via `~/.houston/logs/backend.log.<date>`: the line appears as INFO, and HOUSTON-APP-4XT stops accruing events on builds carrying this change.

## Testing

- `cargo check` clean
- `cargo test claude_login` — 36 passed