### PR TITLE
fix(shell): an abandoned Codex sign-in times out at info, not error (PRODUCT-1548)

### DIFF
--- a/app/src-tauri/src/codex_oauth_loopback.rs
+++ b/app/src-tauri/src/codex_oauth_loopback.rs
@@ -74,7 +74,11 @@ pub async fn start_codex_oauth_loopback(app: AppHandle) -> Result<(), String> {
             // documented event-callback exception to the no-silent-failure
             // rule (no UI thread here). The frontend's retry is the safety net.
             Ok(Err(e)) => tracing::error!("[codex-oauth-loopback] listener error: {e}"),
-            Err(_) => tracing::error!(
+            // Expected: the user closed the consent tab or bailed on the
+            // login, so no callback ever arrives. Nothing in Houston broke —
+            // info keeps it out of Sentry (issue 7615221773), matching the
+            // GCIP loopback's timeout arm.
+            Err(_) => tracing::info!(
                 "[codex-oauth-loopback] timed out after {}s with no callback; freeing port",
                 LISTEN_TIMEOUT.as_secs()
             ),


### PR DESCRIPTION
Fixes PRODUCT-1548 (Sentry HOUSTON-APP-4WV).

## Root cause

When a user starts the Codex (ChatGPT) sign-in and never completes it — closes the consent tab, bails on the login — the one-shot loopback listener gives up after 300s and frees port 1455. That timeout arm logged at `tracing::error!`, and the `sentry_tracing` layer promotes every ERROR from our targets into a standalone Sentry event. Result: 253 Sentry events for expected user behavior, 0 users actually affected — nothing in Houston broke.

The generic GCIP sign-in loopback already logs its identical timeout at `info` (`oauth_loopback/listener.rs`); the Codex listener was never aligned.

## Fix

The timeout arm logs at `info`, keeping it visible in the backend log (and as a Sentry breadcrumb) without minting a Sentry event. Genuine listener errors (`accept` failures etc.) stay at `error`.

## Before

1. Desktop app → connect ChatGPT/Codex → the consent tab opens.
2. Close the tab without signing in; wait 300s.
3. `backend.log` shows `[codex-oauth-loopback] timed out after 300s ...` at ERROR and a Sentry event lands in HOUSTON-APP-4WV.

## After

1. Same steps: the line logs at INFO, the port is freed, retry still works.
2. No new Sentry event; the line still appears as a breadcrumb on real errors.

## Verification

- `cargo check` clean, `cargo test codex_oauth_loopback` 7/7 pass.
- Ongoing: HOUSTON-APP-4WV event count stays flat after this ships.