### PR TITLE
fix(runtime): classify Codex deactivated_workspace as a terminal auth failure (PRODUCT-1547)

### DIFF
--- a/packages/runtime/src/ai/provider-error-log.test.ts
+++ b/packages/runtime/src/ai/provider-error-log.test.ts
@@ -83,6 +83,27 @@ describe("logProviderError", () => {
     );
   });
 
+  it("keeps a deactivated ChatGPT workspace a warning — user account state, not custody", () => {
+    // OpenAI authenticated the served token and rejected the WORKSPACE behind
+    // it (PRODUCT-1547): only the user can fix that, the reconnect card says
+    // so, and a Sentry error per retried turn adds no signal.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    logProviderError(
+      {
+        kind: "unauthenticated",
+        provider: "openai-codex",
+        cause: "token_revoked",
+        message: '{"detail":{"code":"deactivated_workspace"}}',
+      },
+      { model: "gpt-5.5" },
+    );
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("kind=unauthenticated cause=token_revoked ::"),
+    );
+  });
+
   it("keeps a caller-cancelled abort a warning even as kind=unknown", () => {
     // The AbortError a mid-request cancel raises ("This operation was
     // aborted") classifies as unknown, but it is the user's Stop or a dropped

--- a/packages/runtime/src/ai/provider-error-log.ts
+++ b/packages/runtime/src/ai/provider-error-log.ts
@@ -29,6 +29,17 @@ const EXPECTED_KINDS: ReadonlySet<ProviderError["kind"]> = new Set([
  */
 const EXPECTED_UNKNOWN_DETAIL = /operation was aborted/i;
 
+/**
+ * Auth bodies that are the USER's account standing, not broken credential
+ * custody: ChatGPT's `deactivated_workspace` means OpenAI authenticated the
+ * served token and then rejected the WORKSPACE behind it (subscription ended,
+ * account deactivated). The reconnect card already tells the user, and only
+ * they can fix it — a Sentry error per retried turn adds no signal
+ * (PRODUCT-1547). Custody-break auth failures (4XG-style storms) carry none
+ * of these bodies and stay errors.
+ */
+const EXPECTED_AUTH_DETAIL = /deactivated_workspace/i;
+
 export interface ProviderErrorLogContext {
   model?: string | null;
   status?: number | null;
@@ -69,6 +80,8 @@ export function logProviderError(
   const expected =
     EXPECTED_KINDS.has(error.kind) ||
     (error.kind === "unauthenticated" && error.cause === "no_credentials") ||
+    (error.kind === "unauthenticated" &&
+      EXPECTED_AUTH_DETAIL.test(verbatim ?? "")) ||
     (error.kind === "unknown" && EXPECTED_UNKNOWN_DETAIL.test(verbatim ?? ""));
   if (expected) console.warn(line);
   else console.error(line);

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -68,6 +68,23 @@ test.each([
   if (err.kind === "unauthenticated") expect(err.cause).toBe("token_revoked");
 });
 
+test("Codex deactivated workspace → unauthenticated / token_revoked (PRODUCT-1547)", () => {
+  // ChatGPT rejects the WORKSPACE behind an otherwise-valid OAuth token with
+  // this bare structured body — no status, no prose — so nothing else in the
+  // classifier can match it and it degraded to `unknown` (report-bug card +
+  // a Sentry error per turn). Terminal for this account: the reconnect card's
+  // "access revoked, sign in again" is the honest copy, and the strict
+  // revocation-report gate (auth/revocation-markers.ts) deliberately does NOT
+  // list it — the token still works, so nothing may delete it.
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    message: '{"detail":{"code":"deactivated_workspace"}}',
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("token_revoked");
+});
+
 test("pi prompt-time 'No API key found' → unauthenticated / no_credentials (HOU-718)", () => {
   // pi RAISES this (formatNoApiKeyFoundMessage) when the user logged out of a
   // provider that stayed selected — it never arrives as an errored

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -51,6 +51,15 @@ const TERMINAL_SESSION_PATTERNS = [
   "session was terminated",
   "log in again",
   "login again",
+  // ChatGPT's structured code when the OAuth account's workspace itself was
+  // deactivated (subscription ended, admin/OpenAI deactivation). The body is
+  // the bare `{"detail":{"code":"deactivated_workspace"}}` — no status, no
+  // prose — so nothing else here matches it and it degraded to `unknown`: the
+  // report-bug card plus a Sentry error per turn instead of the reconnect card
+  // (PRODUCT-1547: 331 events from 11 users). Terminal for THIS account —
+  // signing in again only helps with a different/reactivated one — which is
+  // exactly what the token_revoked copy says.
+  "deactivated_workspace",
 ];
 
 const INVALID_KEY_PATTERNS = [


### PR DESCRIPTION
## Summary

PRODUCT-1547 / Sentry HOUSTON-APP-56R: `openai-codex` turns failing with the bare body `{"detail":{"code":"deactivated_workspace"}}` classified as `kind=unknown` — the report-bug card for the user plus a Sentry **error** per retried turn (331 events / 11 users since Aug 5).

**Root cause:** ChatGPT rejects the workspace behind an otherwise-valid OAuth token with a structured code only — no HTTP status, no prose — so nothing in the classifier's pattern lists matched it and it fell through to `unknown`.

**Fix (two parts):**
- `ai/provider-error.ts`: add `deactivated_workspace` to `TERMINAL_SESSION_PATTERNS` → classifies as `unauthenticated` / `token_revoked`, rendering the reconnect card ("access revoked, sign in again" — the honest copy: only a different/reactivated account helps). The strict revocation-report gate (`auth/revocation-markers.ts`) deliberately does NOT get this marker — the token itself still works, so nothing may delete the credential.
- `ai/provider-error-log.ts`: log this body at **warning**, not error. OpenAI authenticated the served token and rejected the user's workspace (subscription/account standing) — an expected user state like `no_credentials`, not broken credential custody. Custody-break auth failures carry none of this body and stay errors.

## Before (reproduction)

1. Connect ChatGPT (Codex) with an account whose workspace has been deactivated, and send a message on a `gpt-5.5` conversation.
2. The turn fails with the generic "something went wrong" report-bug card, and the engine logs `[provider_error] … kind=unknown :: {"detail":{"code":"deactivated_workspace"}}` at error level (a Sentry error event per turn).

Without such an account: `pnpm --filter @houston/runtime test` on `main` fails the two new tests (classifier returns `kind: "unknown"` for this body).

## After (verification)

1. Same turn now renders the reconnect card ("Your access was revoked — sign in again") with a working Reconnect action; signing into a valid account auto-resumes the turn.
2. Engine log line becomes `kind=unauthenticated cause=token_revoked` at warning level — no Sentry error event.
3. `pnpm --filter @houston/runtime test` — 1398 tests pass, including:
   - `Codex deactivated workspace → unauthenticated / token_revoked (PRODUCT-1547)`
   - `keeps a deactivated ChatGPT workspace a warning — user account state, not custody`
4. `pnpm check` exits 0.