### PR TITLE
fix(host): local cron fires defer to the control-plane routine delivery (PRODUCT-1549)

### DIFF
--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -43,7 +43,11 @@ import { forward } from "../proxy/route";
 import { CredentialServeHealer } from "../routes/credential-healer";
 import { CUSTOM_OAUTH_CALLBACK_PATH } from "../routes/custom-integrations-oauth";
 import { ChannelRoutineFirer } from "../schedule/firer";
-import { type RoutineSchedulerMode, Scheduler } from "../schedule/scheduler";
+import {
+  EXTERNAL_FIRE_GRACE_MS,
+  type RoutineSchedulerMode,
+  Scheduler,
+} from "../schedule/scheduler";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
 import { syncSharedEndpoint } from "../shared-endpoint/sync";
 import { LocalWorkspaceStore } from "../store/local";
@@ -186,6 +190,17 @@ export interface LocalHostOptions {
   passive?: boolean;
   /** Cron ownership. `external` keeps reconcile alive but skips local fires. */
   routineSchedulerMode?: RoutineSchedulerMode;
+  /**
+   * True when a control-plane fire scheduler also delivers scheduled routine
+   * instants to this host (`/agents/:id/routine-fires`) — the managed-cloud
+   * topology, NOT self-host (which sets HOUSTON_MANAGED_CLOUD without any
+   * control plane). That delivery carries the creator's minted acting
+   * identity, so its turn runs on the creator's own credentials; the local
+   * cron path can only run on the shared team scope. When true, local cron
+   * fires wait out EXTERNAL_FIRE_GRACE_MS so the delivery wins every live
+   * race and the local scan stays a backstop for delivery outages.
+   */
+  externalRoutineFires?: boolean;
   /**
    * True only when a trusted gateway fronts EVERY request to this host (the
    * managed cloud pod: the gateway enforces the pod token and mints/strips
@@ -738,6 +753,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     replyReader: transcriptShadow,
     mode: opts.routineSchedulerMode ?? "local",
     dedupTtlSec: opts.gatewayFronted ? 86_400 : 3600,
+    cronFireGraceMs: opts.externalRoutineFires ? EXTERNAL_FIRE_GRACE_MS : 0,
   });
   // Managed pods sample their own busy state (the gateway can only see AWAKE
   // from outside) and report per-day active totals to the compute-usage ingest.

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -205,6 +205,12 @@ const host = buildLocalHost({
   // A trigger backend exists only on managed cloud (see `triggersEnabled`).
   triggersEnabled,
   routineSchedulerMode,
+  // The control plane's fire scheduler delivers scheduled instants (with the
+  // creator's minted acting identity) only in the managed-cloud topology; the
+  // pod-store env is its marker. Self-host sets HOUSTON_MANAGED_CLOUD with no
+  // control plane, so it must NOT get the backstop grace this enables — its
+  // local cron is the only scheduler.
+  externalRoutineFires: !!managedStore?.podGateway,
   // Managed pods sit behind the gateway (it enforces the pod token and mints
   // x-houston-acting-as); relay that header to the runtime so integration
   // calls act as the driving user. Desktop/self-host stay direct → false.

--- a/packages/host/src/schedule/agent-scan.ts
+++ b/packages/host/src/schedule/agent-scan.ts
@@ -41,6 +41,14 @@ export interface AgentScanDeps {
   dedupTtlSec: number;
   /** External mode skips only cron evaluation/firing; reconcile still runs. */
   cronFiresEnabled: boolean;
+  /**
+   * Backstop delay for cron fires (scheduler.ts EXTERNAL_FIRE_GRACE_MS): an
+   * instant is only eligible once it is this old, so the control plane's
+   * identity-carrying delivery wins every live race and the local cron picks
+   * up only instants that delivery left unclaimed. 0 = fire on due (desktop /
+   * self-host, where no external delivery exists).
+   */
+  cronFireGraceMs: number;
   replyReader?: ReconcileDeps["replyReader"];
 }
 
@@ -75,8 +83,15 @@ export async function scanAgent(
     if (deps.cronFiresEnabled) {
       const root = deps.paths.agentRoot(ws, agent);
       const { items: routines } = await loadRoutines(deps.vfs, root);
+      // The grace shifts the WHOLE evaluation window, not just a threshold on
+      // `at`: consecutive ticks' shifted windows still tile exactly, so every
+      // instant is evaluated once — `at` stays the true cron instant, and the
+      // dedup key below matches the one the external delivery burns.
+      const grace = deps.cronFireGraceMs;
+      const evalSince = grace ? new Date(since.getTime() - grace) : since;
+      const evalNow = grace ? new Date(now.getTime() - grace) : now;
       for (const routine of routines) {
-        const at = dueAt(routine, since, now, timezone);
+        const at = dueAt(routine, evalSince, evalNow, timezone);
         if (!at) continue;
         const won = await burnRoutineFireInstant(
           deps.lock,

--- a/packages/host/src/schedule/agent-scan.ts
+++ b/packages/host/src/schedule/agent-scan.ts
@@ -41,14 +41,6 @@ export interface AgentScanDeps {
   dedupTtlSec: number;
   /** External mode skips only cron evaluation/firing; reconcile still runs. */
   cronFiresEnabled: boolean;
-  /**
-   * Backstop delay for cron fires (scheduler.ts EXTERNAL_FIRE_GRACE_MS): an
-   * instant is only eligible once it is this old, so the control plane's
-   * identity-carrying delivery wins every live race and the local cron picks
-   * up only instants that delivery left unclaimed. 0 = fire on due (desktop /
-   * self-host, where no external delivery exists).
-   */
-  cronFireGraceMs: number;
   replyReader?: ReconcileDeps["replyReader"];
 }
 
@@ -83,15 +75,8 @@ export async function scanAgent(
     if (deps.cronFiresEnabled) {
       const root = deps.paths.agentRoot(ws, agent);
       const { items: routines } = await loadRoutines(deps.vfs, root);
-      // The grace shifts the WHOLE evaluation window, not just a threshold on
-      // `at`: consecutive ticks' shifted windows still tile exactly, so every
-      // instant is evaluated once — `at` stays the true cron instant, and the
-      // dedup key below matches the one the external delivery burns.
-      const grace = deps.cronFireGraceMs;
-      const evalSince = grace ? new Date(since.getTime() - grace) : since;
-      const evalNow = grace ? new Date(now.getTime() - grace) : now;
       for (const routine of routines) {
-        const at = dueAt(routine, evalSince, evalNow, timezone);
+        const at = dueAt(routine, since, now, timezone);
         if (!at) continue;
         const won = await burnRoutineFireInstant(
           deps.lock,

--- a/packages/host/src/schedule/scheduler-mode.test.ts
+++ b/packages/host/src/schedule/scheduler-mode.test.ts
@@ -13,6 +13,7 @@ import { workspaceRoot } from "../routes/agent-data";
 import { MemoryWorkspaceStore } from "../store/memory";
 import { MemoryTurnBus } from "../turn/bus";
 import { MemoryVfs } from "../vfs";
+import { burnRoutineFireInstant } from "./fire-lock";
 import { type FiringJob, type RoutineFirer, Scheduler } from "./scheduler";
 
 const SINCE = new Date("2026-06-12T13:59:00.000Z");
@@ -65,4 +66,59 @@ test("external mode disables only cron firing and still reconciles running runs"
   const { items } = await loadRoutineRuns(vfs, root);
   expect(items).toHaveLength(1);
   expect(items[0]).toMatchObject({ id: "existing-run", status: "error" });
+});
+
+async function graceSetup() {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const ws = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({ workspaceId: ws.id, name: "A" });
+  const scheduled = routine("scheduled");
+  await setPreference(vfs, ws.id, "timezone", "UTC");
+  await saveRoutines(vfs, workspaceRoot(ws, agent), [scheduled]);
+  const firer = new CaptureFirer();
+  const lock = new MemoryTurnBus();
+  const scheduler = new Scheduler({
+    store,
+    vfs,
+    paths: new CloudPaths(),
+    lock,
+    firer,
+    cronFireGraceMs: 120_000,
+    now: () => SINCE,
+    newId: () => "run-1",
+  });
+  return { scheduler, firer, lock };
+}
+
+test("cron fire grace defers a due instant, then fires it once aged past the grace", async () => {
+  const { scheduler, firer } = await graceSetup();
+
+  // Due at 14:00:00; at 14:00:30 the instant is younger than the grace, so the
+  // external delivery still owns it.
+  await scheduler.tick(DUE);
+  expect(firer.jobs).toHaveLength(0);
+
+  // 14:02:30: the shifted windows tile — this tick's window now covers the
+  // instant, and it fires exactly once with the TRUE cron time.
+  await scheduler.tick(new Date("2026-06-12T14:02:30.000Z"));
+  expect(firer.jobs).toHaveLength(1);
+
+  await scheduler.tick(new Date("2026-06-12T14:04:30.000Z"));
+  expect(firer.jobs).toHaveLength(1);
+});
+
+test("a graced fire dedupes against an instant the external delivery already burned", async () => {
+  const { scheduler, firer, lock } = await graceSetup();
+
+  // The control-plane delivery fired the 14:00:00 instant on time; its burn
+  // uses the same key the graced local scan will contest.
+  const instant = new Date("2026-06-12T14:00:00.000Z");
+  expect(await burnRoutineFireInstant(lock, "scheduled", instant, 3600)).toBe(
+    true,
+  );
+
+  await scheduler.tick(DUE);
+  await scheduler.tick(new Date("2026-06-12T14:02:30.000Z"));
+  expect(firer.jobs).toHaveLength(0);
 });

--- a/packages/host/src/schedule/scheduler-mode.test.ts
+++ b/packages/host/src/schedule/scheduler-mode.test.ts
@@ -68,7 +68,7 @@ test("external mode disables only cron firing and still reconciles running runs"
   expect(items[0]).toMatchObject({ id: "existing-run", status: "error" });
 });
 
-async function graceSetup() {
+async function graceSetup(startAt: Date = SINCE) {
   const store = new MemoryWorkspaceStore();
   const vfs = new MemoryVfs();
   const ws = await store.getOrCreatePersonalWorkspace("alice");
@@ -85,7 +85,7 @@ async function graceSetup() {
     lock,
     firer,
     cronFireGraceMs: 120_000,
-    now: () => SINCE,
+    now: () => startAt,
     newId: () => "run-1",
   });
   return { scheduler, firer, lock };
@@ -120,5 +120,18 @@ test("a graced fire dedupes against an instant the external delivery already bur
 
   await scheduler.tick(DUE);
   await scheduler.tick(new Date("2026-06-12T14:02:30.000Z"));
+  expect(firer.jobs).toHaveLength(0);
+});
+
+test("the grace look-back never replays instants due before scheduler start", async () => {
+  // A pod restarted 30s AFTER the 14:00:00 instant fired (and its
+  // process-local burn was lost): the shifted window would reach back to it,
+  // but the start clamp keeps a fresh replica from replaying history.
+  const { scheduler, firer } = await graceSetup(
+    new Date("2026-06-12T14:00:30.000Z"),
+  );
+
+  await scheduler.tick(new Date("2026-06-12T14:02:30.000Z"));
+  await scheduler.tick(new Date("2026-06-12T14:04:30.000Z"));
   expect(firer.jobs).toHaveLength(0);
 });

--- a/packages/host/src/schedule/scheduler.ts
+++ b/packages/host/src/schedule/scheduler.ts
@@ -70,6 +70,7 @@ export interface SchedulerDeps {
 export class Scheduler {
   private timer: ReturnType<typeof setInterval> | undefined;
   private lastTick: Date;
+  private startedAt: Date;
   private readonly intervalMs: number;
   private readonly dedupTtlSec: number;
   private readonly now: () => Date;
@@ -81,11 +82,13 @@ export class Scheduler {
     this.intervalMs = deps.intervalMs ?? 30_000;
     this.dedupTtlSec = deps.dedupTtlSec ?? 3600;
     this.lastTick = this.now();
+    this.startedAt = this.lastTick;
   }
 
   start(): void {
     if (this.timer) return;
     this.lastTick = this.now();
+    this.startedAt = this.lastTick;
     this.timer = setInterval(() => {
       void this.tick(this.now()).catch((err) =>
         console.error(
@@ -117,8 +120,22 @@ export class Scheduler {
       console.error("[scheduler] workspace listing failed:", reason(err));
       return;
     }
+    // The backstop grace shifts the WHOLE cron-eval window, not a threshold on
+    // each instant: consecutive ticks' shifted windows still tile exactly, so
+    // every instant is evaluated once, at the true cron time — the dedup key
+    // the fire burns matches the one the external delivery burned. The left
+    // edge clamps to scheduler start: without it the shift would reach up to
+    // one grace BEFORE this process existed, and a pod restarting right after
+    // a delivered fire would re-fire that instant (the fire lock is
+    // process-local) — "a freshly started replica never replays history"
+    // must survive the grace.
+    const grace = this.deps.cronFireGraceMs ?? 0;
+    const evalSince = grace
+      ? new Date(Math.max(since.getTime() - grace, this.startedAt.getTime()))
+      : since;
+    const evalNow = grace ? new Date(now.getTime() - grace) : now;
     for (const ws of workspaces) {
-      await this.scanWorkspace(ws, since, now);
+      await this.scanWorkspace(ws, evalSince, evalNow);
     }
   }
 
@@ -146,7 +163,6 @@ export class Scheduler {
             newId: this.newId,
             dedupTtlSec: this.dedupTtlSec,
             cronFiresEnabled: this.deps.mode !== "external",
-            cronFireGraceMs: this.deps.cronFireGraceMs ?? 0,
           },
           ws,
           agent,

--- a/packages/host/src/schedule/scheduler.ts
+++ b/packages/host/src/schedule/scheduler.ts
@@ -13,6 +13,23 @@ export type { FireLock } from "./fire-lock";
 
 export type RoutineSchedulerMode = "local" | "external";
 
+/**
+ * How long a local cron scan waits past a due instant before firing it, where
+ * an external fire delivery also runs (managed cloud). The control plane's
+ * delivery carries the routine creator's minted acting identity, so its turn
+ * resolves the creator's own credentials; the pod-local path can only run on
+ * the shared team scope (pods cannot mint identity — HOU-976 D10), where a
+ * member's personally-connected provider reads as "not connected". Racing the
+ * delivery at second granularity made WHICH credentials a run used depend on
+ * scheduler load: at the top of the hour the delivery lags behind the herd of
+ * due routines, the local scan won the per-instant dedup burn, and the run
+ * failed no_provider (PRODUCT-1549). The grace keeps the local cron as a
+ * genuine backstop: it fires only instants the external delivery has left
+ * unclaimed for this long. Must stay well under the dedup TTL and above the
+ * delivery's worst observed top-of-hour lag (~15s).
+ */
+export const EXTERNAL_FIRE_GRACE_MS = 120_000;
+
 export interface SchedulerDeps {
   store: WorkspaceStore;
   vfs: Vfs;
@@ -27,6 +44,8 @@ export interface SchedulerDeps {
   dedupTtlSec?: number;
   /** `external` disables cron fires only. Default `local`. */
   mode?: RoutineSchedulerMode;
+  /** Backstop delay for cron fires (see EXTERNAL_FIRE_GRACE_MS). Default 0. */
+  cronFireGraceMs?: number;
   now?: () => Date;
   newId?: () => string;
   replyReader?: ReconcileDeps["replyReader"];
@@ -127,6 +146,7 @@ export class Scheduler {
             newId: this.newId,
             dedupTtlSec: this.dedupTtlSec,
             cronFiresEnabled: this.deps.mode !== "external",
+            cronFireGraceMs: this.deps.cronFireGraceMs ?? 0,
           },
           ws,
           agent,


### PR DESCRIPTION
Fixes PRODUCT-1549 (routine works at :20/:40, fails every :00 with `no_provider`).

## Root cause

On managed-cloud pods **two schedulers race every scheduled routine instant**, and which one wins decides which credentials the run gets:

- The **control plane's fire delivery** (`/agents/:id/routine-fires`) carries the routine creator's minted acting identity, so the turn resolves the **creator's own** credentials.
- The **pod-local cron scan** cannot mint identity (by design, HOU-976 D10), so its fire runs on the **shared team** credential scope.

The per-instant dedup burn arbitrates the race. At the top of the hour the control plane's delivery lags a few seconds behind the herd of due hourly routines, the pod-local scan wins the burn, and — when the agent's saved provider is connected on the creator's personal scope but not the team scope — the runtime correctly refuses to run (sticky saved pick, never silently switch) and the run is recorded `runtime 409 no_provider` in 0s. Verified in production logs for the reported routine: the failing :00 instants were pod-fired on the team scope (credential serve answered the team row, "org not connected"), while the succeeding :20/:40 instants were control-plane-delivered with the acting identity (personal rows served, turn ran). This also explains matching :00 failure bursts across many other workspaces.

## Fix

Local cron fires now wait out a 120s grace (`EXTERNAL_FIRE_GRACE_MS`) on deployments where the external fire delivery exists (managed-cloud pod-store marker; desktop and self-host are unchanged — their local cron is the only scheduler and still fires on due). The identity-carrying delivery therefore wins every live race, and the pod-local cron remains a genuine backstop that picks up any instant the delivery leaves unclaimed for 2 minutes. The scan's evaluation window is shifted whole, so consecutive ticks still tile exactly and the dedup key remains the true cron instant — an instant the delivery already burned is still deduped, never double-fired.

## Verification

Before (reproduces on a managed pod): a routine on a 20-minute schedule whose creator's provider is connected personally (not on the team scope) fails exactly the top-of-hour instants with `runtime 409 … no_provider` in 0s, while :20/:40 succeed.

After: the pod-local scan never fires an instant younger than 120s, so every live instant is fired by the control-plane delivery under the creator's identity; the :00 runs succeed. If the delivery is down, the pod fires the instant ~2 minutes late (backstop behavior, previously the racy path).

Tests: `scheduler-mode.test.ts` covers the grace deferral, the exactly-once fire after the grace, and dedup against an externally burned instant. Full `@houston/host` (1600), `@houston/runtime` (1398), `@houston/domain` (200) suites pass; Biome + typecheck clean.