### PR TITLE
fix(runtime): log Anthropic org-policy block as warning, not Sentry error

### DIFF
--- a/packages/runtime/src/ai/provider-error-log.test.ts
+++ b/packages/runtime/src/ai/provider-error-log.test.ts
@@ -45,7 +45,7 @@ describe("logProviderError", () => {
     // `[provider_error] provider=X model=Y status=Z error=SLUG kind=K cause=C :: text`
     // — the exact shape runtime-client sentry/client.ts PROVIDER_ERROR_LINE
     // captures into the (provider, kind, cause, sdk-slug) fingerprint.
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     logProviderError(
       {
         kind: "unauthenticated",
@@ -59,14 +59,19 @@ describe("logProviderError", () => {
         sdkError: "oauth_org_not_allowed",
       },
     );
-    expect(error).toHaveBeenCalledWith(
+    expect(warn).toHaveBeenCalledWith(
       "[provider_error] provider=anthropic model=claude-fable-5 status=403 " +
         "error=oauth_org_not_allowed kind=unauthenticated cause=org_policy_blocked " +
         ":: Your organization has disabled Claude subscription access",
     );
   });
 
-  it("keeps org_policy_blocked at error level — broken access, not an expected user state", () => {
+  it("keeps org_policy_blocked a warning — the user's org policy, not broken custody", () => {
+    // Anthropic authenticated the token and its org policy rejected the
+    // surface (PRODUCT-1553): the card already offers the API-key remedy,
+    // only the org admin can lift the block, and every retried turn
+    // re-fires. HOUSTON-APP-4XG-style custody breaks carry other causes and
+    // stay errors.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     logProviderError({
@@ -75,8 +80,8 @@ describe("logProviderError", () => {
       cause: "org_policy_blocked",
       message: "Your organization has disabled Claude subscription access",
     });
-    expect(warn).not.toHaveBeenCalled();
-    expect(error).toHaveBeenCalledWith(
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
       expect.stringContaining(
         "kind=unauthenticated cause=org_policy_blocked ::",
       ),

--- a/packages/runtime/src/ai/provider-error-log.ts
+++ b/packages/runtime/src/ai/provider-error-log.ts
@@ -72,14 +72,20 @@ export function logProviderError(
     `[provider_error] provider=${error.provider} model=${ctx.model ?? "?"} ` +
     `status=${ctx.status ?? "?"}${ctx.sdkError ? ` error=${ctx.sdkError}` : ""} ` +
     `kind=${error.kind}${cause} :: ${verbatim}`;
-  // `no_credentials` is the one auth cause that is an expected USER state, not
-  // broken custody: the provider was simply never connected (or the user
-  // logged out with it still selected). It became loggable when the
-  // pre-session guards started reporting (HOU-1156) — keep it a warning or
-  // every fresh install fires Sentry errors.
+  // Two auth causes are expected USER states, not broken custody.
+  // `no_credentials`: the provider was simply never connected (or the user
+  // logged out with it still selected) — loggable since the pre-session
+  // guards started reporting (HOU-1156); keep it a warning or every fresh
+  // install fires Sentry errors. `org_policy_blocked`: the provider
+  // authenticated the token and then its org policy rejected subscription
+  // access for this environment (Anthropic's `oauth_org_not_allowed`) — the
+  // card already tells the user to switch to an API key, only their org admin
+  // can lift the block, and every retried turn re-fires it.
   const expected =
     EXPECTED_KINDS.has(error.kind) ||
-    (error.kind === "unauthenticated" && error.cause === "no_credentials") ||
+    (error.kind === "unauthenticated" &&
+      (error.cause === "no_credentials" ||
+        error.cause === "org_policy_blocked")) ||
     (error.kind === "unauthenticated" &&
       EXPECTED_AUTH_DETAIL.test(verbatim ?? "")) ||
     (error.kind === "unknown" && EXPECTED_UNKNOWN_DETAIL.test(verbatim ?? ""));

--- a/packages/runtime/src/backends/claude/errors.test.ts
+++ b/packages/runtime/src/backends/claude/errors.test.ts
@@ -84,17 +84,19 @@ test("oauth_org_not_allowed → unauthenticated with the org_policy_blocked caus
   });
 });
 
-test("org_policy_blocked stays an ERROR-level log — broken access, not an expected user state", () => {
-  // Unlike no_credentials (a fresh install is not a bug), an org-policy block
-  // means turns are failing on access the user believes they have; it must
-  // keep firing Sentry events so the family stays countable.
+test("org_policy_blocked logs a WARNING — the user's org policy, not broken custody", () => {
+  // The family was kept error-level to count it (PRODUCT-1393); counted, it
+  // proved to be pure user-org state — Anthropic authenticated the token and
+  // rejected the surface, the card already says "use an API key", and only
+  // the org admin can lift the block. Every retried turn re-fires, so an
+  // error-level event per turn is noise (PRODUCT-1553).
   mapSdkError("oauth_org_not_allowed", {
     message: "Your organization has disabled Claude subscription access",
     model: null,
   });
-  expect(consoleError).toHaveBeenCalledOnce();
-  expect(consoleWarn).not.toHaveBeenCalled();
-  expect(consoleError).toHaveBeenCalledWith(
+  expect(consoleWarn).toHaveBeenCalledOnce();
+  expect(consoleError).not.toHaveBeenCalled();
+  expect(consoleWarn).toHaveBeenCalledWith(
     expect.stringContaining(
       "error=oauth_org_not_allowed kind=unauthenticated cause=org_policy_blocked",
     ),


### PR DESCRIPTION
Fixes PRODUCT-1553.

## Root cause

Anthropic's `oauth_org_not_allowed` (mapped to `unauthenticated` / `cause=org_policy_blocked`) means the provider authenticated the served token and then its **org policy** rejected Claude subscription access for this environment. The chat already renders the honest org-policy card with the API-key remedy, and only the user's org admin can lift the block — yet `logProviderError` still logged it at error level, so every retried turn fired a Sentry error event (26 users / 224 events since 08-18).

The family was deliberately kept error-level to make it countable when it got its own fingerprint. Counted, it proved to be pure user-org state, matching the existing carve-outs for `no_credentials` and ChatGPT's `deactivated_workspace`.

## Change

- `packages/runtime/src/ai/provider-error-log.ts`: `org_policy_blocked` joins `no_credentials` as an expected auth cause → `console.warn` (Sentry breadcrumb) instead of `console.error` (Sentry event). Custody-break auth failures carry other causes and stay errors.
- Updated the two tests that pinned the old error-level behavior; the line-format regex contract test is unchanged in shape.

## Verify

Before: `pnpm --filter @houston/runtime test -- provider-error-log` on `main` — the org_policy_blocked case asserts `console.error`; on a pod, an org-blocked account fires an error-level `[provider_error] … cause=org_policy_blocked` Sentry event per retried turn.

After: same suite passes with the case asserting `console.warn`; the line still emits verbatim (breadcrumb), classification, card, and fingerprint tags unchanged. Full runtime suite: 159 files / 1398 tests green; Biome + typecheck clean.