### PR TITLE
fix(host): retry the shutdown store-sync flush before reporting data loss (PRODUCT-1552)

### DIFF
--- a/packages/host/src/store-sync/daemon-policy.ts
+++ b/packages/host/src/store-sync/daemon-policy.ts
@@ -29,6 +29,8 @@ export interface StoreSyncOptions {
   maxHydrateBytes?: number;
   /** Gateway's explicit generation-precondition capability (boot lease). */
   generations?: boolean;
+  /** One delay per retry of the shutdown flush; override to speed up tests. */
+  finalSyncRetryDelaysMs?: number[];
   log: (msg: string, err?: unknown) => void;
 }
 
@@ -107,6 +109,42 @@ export function logSyncFailed(
   opts.log(
     `[store-sync] ${trigger} sync failed; will retry (${err instanceof Error ? err.message : String(err)})`,
   );
+}
+
+/** One delay per retry of the shutdown flush, so attempts = delays + 1. */
+export const FINAL_SYNC_RETRY_DELAYS_MS = [1_000, 4_000];
+
+/**
+ * The shutdown flush races the same deploy window that drains the pod (an
+ * engine roll restarts the gateway too), and unlike the periodic pass it has
+ * no next tick to absorb a blip — sync-back's generation-guarded uploads get
+ * exactly one fetch attempt, so a lone `fetch failed` used to abort the whole
+ * final sync (HOUSTON-APP-58V). Bounded retries absorb the blip; only
+ * exhausting them reports with the error, because at that point recent local
+ * changes really may be lost.
+ */
+export async function runFinalSync(
+  opts: StoreSyncOptions,
+  syncOnce: () => Promise<void>,
+): Promise<void> {
+  const delays = opts.finalSyncRetryDelaysMs ?? FINAL_SYNC_RETRY_DELAYS_MS;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await syncOnce();
+    } catch (err) {
+      if (attempt >= delays.length) {
+        opts.log(
+          "[store-sync] FINAL sync failed; local changes may be lost",
+          err,
+        );
+        return;
+      }
+      opts.log(
+        `[store-sync] FINAL sync failed; retrying (${err instanceof Error ? err.message : String(err)})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delays[attempt]));
+    }
+  }
 }
 
 export function logSyncResult(

--- a/packages/host/src/store-sync/daemon.test.ts
+++ b/packages/host/src/store-sync/daemon.test.ts
@@ -388,6 +388,87 @@ test("a fencing loss latches once, halts scheduling, and skips the final drain",
   expect(fencingLogs[0]?.message).toContain("lease lost");
 });
 
+test("the final sync retries a shutdown blip and flushes on a later attempt (HOUSTON-APP-58V)", async () => {
+  const remoteRoot = mkdtempSync(join(tmpdir(), "store-sync-final-remote-"));
+  const localRoot = mkdtempSync(join(tmpdir(), "store-sync-final-local-"));
+  const inner = new LocalDirStore(remoteRoot);
+  let failures = 0;
+  const flaky: ObjectStore = {
+    list: (prefix) => inner.list(prefix),
+    download: (key, dest) => inner.download(key, dest),
+    upload: (src, key) => {
+      if (failures < 1) {
+        failures += 1;
+        return Promise.reject(new TypeError("fetch failed"));
+      }
+      return inner.upload(src, key);
+    },
+    delete: (key) => inner.delete(key),
+  };
+  const logs: Array<{ message: string; err?: unknown }> = [];
+  const daemon = new StoreSyncDaemon({
+    store: flaky,
+    rootDir: localRoot,
+    quietMs: 60_000,
+    intervalMs: 60_000,
+    finalSyncRetryDelaysMs: [5],
+    log: (message, err) => logs.push({ message, err }),
+  });
+  await daemon.hydrate();
+  daemon.start();
+  writeFileSync(join(localRoot, "final.txt"), "final");
+  await daemon.stop();
+
+  // The blip was absorbed: the file flushed, the retry logged as an err-less
+  // breadcrumb with the cause inlined, and nothing reported as an error.
+  expect(readFileSync(join(remoteRoot, "final.txt"), "utf8")).toBe("final");
+  const finalFailures = logs.filter((l) =>
+    l.message.includes("FINAL sync failed"),
+  );
+  expect(finalFailures).toHaveLength(1);
+  expect(finalFailures[0]?.err).toBeUndefined();
+  expect(finalFailures[0]?.message).toContain("fetch failed");
+});
+
+test("the final sync reports with the error only after exhausting its retries", async () => {
+  const remoteRoot = mkdtempSync(join(tmpdir(), "store-sync-final-remote-"));
+  const localRoot = mkdtempSync(join(tmpdir(), "store-sync-final-local-"));
+  const inner = new LocalDirStore(remoteRoot);
+  let attempts = 0;
+  const dead: ObjectStore = {
+    list: (prefix) => inner.list(prefix),
+    download: (key, dest) => inner.download(key, dest),
+    upload: () => {
+      attempts += 1;
+      return Promise.reject(new TypeError("fetch failed"));
+    },
+    delete: (key) => inner.delete(key),
+  };
+  const logs: Array<{ message: string; err?: unknown }> = [];
+  const daemon = new StoreSyncDaemon({
+    store: dead,
+    rootDir: localRoot,
+    quietMs: 60_000,
+    intervalMs: 60_000,
+    finalSyncRetryDelaysMs: [5, 5],
+    log: (message, err) => logs.push({ message, err }),
+  });
+  await daemon.hydrate();
+  daemon.start();
+  writeFileSync(join(localRoot, "final.txt"), "final");
+  await daemon.stop();
+
+  expect(attempts).toBe(3);
+  const finalFailures = logs.filter((l) =>
+    l.message.includes("FINAL sync failed"),
+  );
+  expect(finalFailures).toHaveLength(3);
+  expect(finalFailures[0]?.err).toBeUndefined();
+  expect(finalFailures[1]?.err).toBeUndefined();
+  expect(finalFailures[2]?.err).toBeDefined();
+  expect(finalFailures[2]?.message).toContain("local changes may be lost");
+});
+
 test("a transient sync failure is a breadcrumb; only a streak reports the error", async () => {
   const remoteRoot = mkdtempSync(join(tmpdir(), "store-sync-flaky-remote-"));
   const localRoot = mkdtempSync(join(tmpdir(), "store-sync-flaky-local-"));

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -12,6 +12,7 @@ import {
   logHydrated,
   logSyncFailed,
   logSyncResult,
+  runFinalSync,
   runSyncBack,
   STORE_SYNC_EXCLUDES,
   type StoreSyncOptions,
@@ -89,14 +90,7 @@ export class StoreSyncDaemon {
       this.started = false;
       return;
     }
-    try {
-      await this.syncOnce();
-    } catch (err) {
-      this.opts.log(
-        "[store-sync] FINAL sync failed; local changes may be lost",
-        err,
-      );
-    }
+    await runFinalSync(this.opts, () => this.syncOnce());
     this.started = false;
   }
 


### PR DESCRIPTION
Fixes PRODUCT-1552 (Sentry HOUSTON-APP-58V: `TypeError: fetch failed` in `fetchWithRetry`, 37 users / 42 events).

## Root cause

`StoreSyncDaemon.stop()`'s final sync got exactly one shot. Sync-back uploads are generation-guarded, so `fetchWithRetry` runs them with `retryable: false` — a single network-level `fetch failed` (the gateway restarting in the same deploy window that drains the pod) aborted the entire final flush, and `stop()` logged "FINAL sync failed; local changes may be lost" with the error attached, which the severity log reports as a Sentry error.

The periodic flavor of this issue was already quieted by the PRODUCT-1504 three-strike rule; sampled events on the newest deployed build are exclusively the shutdown flavor (two pods failing in the same second — a gateway restart window), which had no "next pass" to absorb the blip.

## Fix

`stop()` now runs the final flush through `runFinalSync` (new, in `daemon-policy.ts`): bounded retries (1s, 4s → 3 attempts). A blip logs an err-less breadcrumb with the cause inlined; only exhausting the retries reports with the error attached — at that point recent local changes really may be lost, so it stays a Sentry error. This also directly reduces the data-loss risk the message warns about: a rerun of `syncOnce` re-walks and uploads only the still-unsynced changes, and a lost-success replay resolves through the existing generation-conflict refresh path.

## Before the fix

1. Managed-cloud pod with unsynced local changes receives its drain.
2. The gateway restarts (deploy window) while `stop()` runs the final sync-back; one `TypeError: fetch failed` from the guarded upload aborts the whole pass.
3. `[store-sync] FINAL sync failed; local changes may be lost` reports to Sentry with the error, and changes since the last periodic pass are lost.

Reproduced in `daemon.test.ts` by a store whose first upload rejects with `TypeError("fetch failed")` — on the old code `stop()` reported the error immediately and the file never flushed.

## Verify after the fix

- `pnpm --filter @houston/host test -- store-sync/daemon` — new tests: "the final sync retries a shutdown blip and flushes on a later attempt (HOUSTON-APP-58V)" (blip absorbed, file flushed, err-less breadcrumb) and "the final sync reports with the error only after exhausting its retries" (3 attempts, error attached only on the last log).
- In production: HOUSTON-APP-58V event volume on releases containing this commit should drop to near zero; remaining events indicate the store was genuinely unreachable for ≥5s during shutdown.

Full gates: `pnpm check` exits 0; host suite 1603 passed / 175 files.