### PR TITLE
perf(engine): self-contained engine bundle — kills 7-10s of module-resolution I/O per pool worker boot (PRODUCT-1550)

### DIFF
--- a/selfhost/bundle.mjs
+++ b/selfhost/bundle.mjs
@@ -1,22 +1,28 @@
 import { build } from "esbuild";
 
-const workspaceImport = /^(?:@houston\/|@houston-ai\/agent-schemas(?:\/|$))/;
-
-function shouldExternalize(path) {
-  if (
-    path.startsWith(".") ||
-    path.startsWith("/") ||
-    workspaceImport.test(path)
-  )
-    return false;
-  return true;
-}
+// Externalize ONLY what genuinely cannot live inside the bundle. Everything
+// else is inlined: a worker VM boot used to spend 7-10s of its ~15s start in
+// Node module RESOLUTION (getPackageScopeConfig/internalModuleStat walks over
+// the Kata guest filesystem, profiled 2026-08-27) because every npm import
+// stayed external. The same code as one self-contained file evaluates in
+// ~0.3s.
+//  - @anthropic-ai/claude-agent-sdk: lazily imported, and it spawns the
+//    `claude` subprocess from its own package directory — bundling would
+//    break that file layout. Cloud never reaches it (Anthropic is OFF there);
+//    selfhost resolves it from node_modules as before.
+//  - @silvia-odwyer/photon-node: pi's image-resize wasm host locates
+//    photon_rs_bg.wasm with __dirname — bundled, that resolves nowhere and
+//    every image an agent reads silently degrades to "[Image omitted…]".
+//    Lazily imported; resolves from the image's node_modules.
+//  - *.node native addons load via the filesystem by design.
+const externalImport =
+  /^@anthropic-ai\/claude-agent-sdk(?:\/|$)|^@silvia-odwyer\/photon-node(?:\/|$)|\.node$/;
 
 const externalNodeModules = {
-  name: "external-node-modules",
+  name: "external-unbundleables",
   setup(build) {
     build.onResolve({ filter: /.*/ }, (args) => {
-      if (!shouldExternalize(args.path)) return undefined;
+      if (!externalImport.test(args.path)) return undefined;
       return { path: args.path, external: true };
     });
   },
@@ -53,3 +59,22 @@ await Promise.all([
     outfile: "dist/runtime/main.mjs",
   }),
 ]);
+
+// Self-check: the deliberate externals must survive as import specifiers in
+// the emitted runtime bundle. If a refactor inlines one, image reads (photon
+// wasm) or the Anthropic backend (SDK subprocess layout) break SILENTLY at
+// turn time — nothing a boot probe can see — so fail the build instead.
+{
+  const { readFileSync } = await import("node:fs");
+  const emitted = readFileSync("dist/runtime/main.mjs", "utf8");
+  for (const specifier of [
+    "@anthropic-ai/claude-agent-sdk",
+    "@silvia-odwyer/photon-node",
+  ]) {
+    if (!emitted.includes(`"${specifier}"`)) {
+      throw new Error(
+        `bundle self-check: ${specifier} was inlined instead of staying external`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## The finding (profiled live in the Kata guest)

A pool worker's ~15s start-to-listen was **~10s of Node module resolution**: the engine bundle (`selfhost/bundle.mjs`) externalized *every* npm package, so each VM boot re-resolved the whole dependency graph from `node_modules` over the guest filesystem. CPU profile top frames: `getPackageScopeConfig`, `internalModuleStat`, file `open/read/close`. The same code as one self-contained file evaluates in **~0.3s** (0.44s with `--enable-source-maps`), verified for **both** server and turn modes via /health.

Expected effect in staging: worker replacement ~20s → **~10s**, which halves the buffer fleet the autoscaler must keep and shrinks the burst window (#331).

## What stays external (each for a hard reason)
- `@anthropic-ai/claude-agent-sdk` — spawns the `claude` subprocess from its package dir; lazily imported; cloud never reaches it.
- `@silvia-odwyer/photon-node` — pi's image-resize wasm host locates `photon_rs_bg.wasm` via `__dirname`; bundled, every image an agent reads silently degrades to "[Image omitted…]" (**caught in adversarial review** — invisible to boot probes). The build now **self-checks** both externals survived and fails otherwise.
- `*.node` native addons.

## Verified
- esbuild: zero warnings/errors; no un-analyzable dynamic requires in the graph (metafile audit).
- The image keeps `node_modules`, so externals (and any stray specifier) resolve exactly as before.
- Host + runtime + domain suites green (runtime: 1398 tests); Biome clean.
- Unaffected: desktop sidecar (bun-compiled separately), per-turn Cloud Run image (source-run).
- Known cosmetic: pi self-locates version/name against the root package.json inside the bundle (user-agent strings only; its config keys are unaffected — documented in review).

## Rollout safety
Merging builds the engine image and rolls **staging only** (`engine-pod-published` → `cloud/roll-engine-staging.yml`). **Prod requires the explicit `engine-pod-v*` tag** — nothing here can reach prod on merge. After the staging roll I'll re-measure replacement and re-run the burst storm.