### PR TITLE
fix(ci): engine-pod image filter covers every Dockerfile build input

### DIFF
--- a/.github/workflows/engine-pod-image.yml
+++ b/.github/workflows/engine-pod-image.yml
@@ -103,9 +103,11 @@ jobs:
           if [ -n "$BASE" ] && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
               && git fetch --depth=1 origin "$BASE" 2>/dev/null; then
             if git diff --name-only "$BASE" "${{ github.sha }}" -- \
-                selfhost/Dockerfile packages/protocol packages/runtime-client \
-                packages/domain packages/runtime packages/host ui/agent-schemas \
-                pnpm-lock.yaml .github/workflows/engine-pod-image.yml | grep -q .; then
+                selfhost/Dockerfile selfhost/bundle.mjs packages/protocol \
+                packages/runtime-client packages/domain packages/runtime \
+                packages/host packages/agentstore-contract ui/agent-schemas \
+                patches package.json pnpm-lock.yaml pnpm-workspace.yaml \
+                .github/workflows/engine-pod-image.yml | grep -q .; then
               BUILD=true
             else
               BUILD=false


### PR DESCRIPTION
The engine-pod image workflow skips the build when a push touches none of its path filter. The filter listed only a subset of the files the Dockerfile actually consumes: a change to `selfhost/bundle.mjs` (the bundler script itself), `patches/`, `packages/agentstore-contract`, `package.json`, or `pnpm-workspace.yaml` silently skipped the rebuild, so main and the published engine image diverged.

Concretely: #1414 changed only `selfhost/bundle.mjs`; its merge skipped the build (`build=false`), so the bundling change never produced an image until a manual `workflow_dispatch`.

The filter now matches the Dockerfile's COPY set exactly.