### PR TITLE
feat(app): navigation stack with browser history sync

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -42,6 +42,7 @@ import { shouldAllowNativeContextMenu } from "./lib/context-menu";
 import { newEngineActive } from "./lib/engine";
 import { isIdentityConfigured } from "./lib/identity";
 import { logger } from "./lib/logger";
+import { useNavHistorySync } from "./lib/nav-history";
 import {
   clearUser as clearSentryUser,
   setUser as setSentryUser,
@@ -90,6 +91,10 @@ export default function App() {
   // Turn an `houston://store/install` deep link (desktop) or `?install=<slug>`
   // web param into a seeded import wizard once the shell is live.
   useStoreInstallDeepLink();
+  // Mirror the ui store's nav stack into browser history (back/forward walk
+  // the app). The one history writer besides the deep-link param strip above,
+  // which preserves `history.state` — the two cannot fight.
+  useNavHistorySync();
 
   // NOTE: install identity, `install_created`, `session_started`, and theme
   // load run in <StartupEffects> at the top of the tree (main.tsx), NOT here.

--- a/app/src/components/shell/use-workspace-view-guards.ts
+++ b/app/src/components/shell/use-workspace-view-guards.ts
@@ -69,7 +69,9 @@ export function useWorkspaceViewGuards(gates: {
     });
     boot.current = step.state;
     if (step.action === "open-home-team" && team !== null) {
-      openTeamView(team.id, "mission-control");
+      // A REDIRECT, not a place the user chose: replacing keeps the transient
+      // boot Inbox off the nav stack, so browser back can't land on it.
+      openTeamView(team.id, "mission-control", { nav: "replace" });
     }
   }, [openTeamView, teams, viewMode, workspaceId]);
 
@@ -87,8 +89,10 @@ export function useWorkspaceViewGuards(gates: {
     });
     if (action !== "go-home") return;
     const team = homeTeam(teams);
-    if (team === null) setViewMode(INBOX_VIEW_ID);
-    else openTeamView(team.id, "mission-control");
+    // Replace, not push: a dead view sent home must not stay reachable via
+    // the browser back button (backing into it would just bounce home again).
+    if (team === null) setViewMode(INBOX_VIEW_ID, { nav: "replace" });
+    else openTeamView(team.id, "mission-control", { nav: "replace" });
   }, [
     activeTeamId,
     openTeamView,

--- a/app/src/lib/nav-history.ts
+++ b/app/src/lib/nav-history.ts
@@ -1,0 +1,146 @@
+/**
+ * The nav stack's browser-history mirror — the ONLY code in the app allowed to
+ * touch `history` (pushState/popstate). Screens never call pushState; they
+ * navigate through the ui store, this layer echoes the stack into the browser,
+ * and the browser's back/forward come back in through `popstate`.
+ *
+ * The URL never changes (there is no router): every history entry shares the
+ * page's URL and carries only a stack index in its state. That is what keeps
+ * this layer compatible with the one pre-existing history call —
+ * `store-deeplink-ingress.ts` strips `?install=`/`?creator=` with a
+ * `replaceState` that passes `window.history.state` through, so the index
+ * survives in either order.
+ *
+ * Refresh: the in-memory stack re-boots to a single entry while the browser
+ * keeps the old session's entries below the current one. Their indices no
+ * longer mean anything, so `navApplyHistory` clamps them onto the fresh stack
+ * (they all decay to the root) and the next in-app push truncates them —
+ * graceful, never a crash. Forward is the same mechanism in the other
+ * direction: popped entries stay on the stack, so a forward `popstate` re-lands
+ * on a real entry.
+ */
+
+import { useEffect } from "react";
+import { useUIStore } from "../stores/ui.ts";
+import type { NavEntry } from "./nav-stack.ts";
+
+/** Namespaced so foreign state (or a pre-refresh entry) is recognizably ours. */
+const NAV_STATE_KEY = "__houstonNavIndex";
+
+/** The stack index a history entry's state carries, or null if not ours. */
+export function readNavIndex(state: unknown): number | null {
+  if (typeof state !== "object" || state === null) return null;
+  const value = (state as Record<string, unknown>)[NAV_STATE_KEY];
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+function withNavIndex(base: unknown, index: number): Record<string, unknown> {
+  const carried =
+    typeof base === "object" && base !== null
+      ? (base as Record<string, unknown>)
+      : {};
+  return { ...carried, [NAV_STATE_KEY]: index };
+}
+
+/** What the mirror compares between store notifications. */
+export interface NavSnapshot {
+  index: number;
+  stack: readonly NavEntry[];
+}
+
+export type SyncStep =
+  | { op: "push"; index: number }
+  | { op: "replace"; index: number }
+  | { op: "go"; delta: number };
+
+/**
+ * The store→history echo, pure for unit tests. A pop leaves the stack array's
+ * identity intact (see `navigated`), which is what tells a real retreat
+ * (mirror with `go`, so the browser's own back stack retreats too) apart from
+ * a rebuild like `reset()` (mirror with `replace` — the browser's deeper
+ * entries can't be deleted, so they decay via the clamp instead).
+ */
+export function syncPlan(
+  prev: NavSnapshot,
+  next: NavSnapshot,
+): SyncStep | null {
+  if (next.stack === prev.stack && next.index === prev.index) return null;
+  if (next.index > prev.index) return { op: "push", index: next.index };
+  if (next.index < prev.index && next.stack === prev.stack)
+    return { op: "go", delta: next.index - prev.index };
+  return { op: "replace", index: next.index };
+}
+
+/**
+ * Wire the mirror: brand the current history entry with the current stack
+ * index, echo every stack change out, and feed every `popstate` back into the
+ * store. Returns an unsubscribe.
+ */
+export function installNavHistorySync(): () => void {
+  window.history.replaceState(
+    withNavIndex(window.history.state, useUIStore.getState().navIndex),
+    "",
+  );
+
+  let prev: NavSnapshot = {
+    index: useUIStore.getState().navIndex,
+    stack: useUIStore.getState().navStack,
+  };
+  // True while a popstate is being applied to the store: the browser already
+  // moved, so the resulting store change must not be echoed back out (a `go`
+  // here would move the browser a second time).
+  let applyingFromHistory = false;
+  // Echoed `go` traversals whose popstate has not landed yet. Their popstate
+  // must be IGNORED, not applied: the store already sits at the target, and a
+  // traversal is processed asynchronously — a push that lands in between (the
+  // archived → active handoff pops the panel level and re-pushes it in one
+  // breath) shifts which entry the traversal resolves to, so applying its
+  // event would yank the store to a place the user never went (and close the
+  // panel the handoff just reopened).
+  let pendingTraversals = 0;
+
+  const unsubscribe = useUIStore.subscribe((s) => {
+    const next: NavSnapshot = { index: s.navIndex, stack: s.navStack };
+    const step = applyingFromHistory ? null : syncPlan(prev, next);
+    prev = next;
+    if (step === null) return;
+    if (step.op === "push") {
+      window.history.pushState(withNavIndex(null, step.index), "");
+    } else if (step.op === "replace") {
+      window.history.replaceState(
+        withNavIndex(window.history.state, step.index),
+        "",
+      );
+    } else {
+      pendingTraversals += 1;
+      window.history.go(step.delta);
+    }
+  });
+
+  const onPopState = (event: PopStateEvent) => {
+    if (pendingTraversals > 0) {
+      // Our own echo completing (see above), never a user's back/forward.
+      pendingTraversals -= 1;
+      return;
+    }
+    applyingFromHistory = true;
+    try {
+      useUIStore.getState().navApplyHistory(readNavIndex(event.state) ?? 0);
+    } finally {
+      applyingFromHistory = false;
+    }
+  };
+  window.addEventListener("popstate", onPopState);
+
+  return () => {
+    unsubscribe();
+    window.removeEventListener("popstate", onPopState);
+  };
+}
+
+/** Mount-once hook form for `App`. */
+export function useNavHistorySync(): void {
+  useEffect(() => installNavHistorySync(), []);
+}

--- a/app/src/lib/nav-stack.ts
+++ b/app/src/lib/nav-stack.ts
@@ -1,0 +1,165 @@
+/**
+ * The app's navigation stack: an explicit push-stack of screen-level locations
+ * (tab → team board → chat panel), modeled in the ui store and mirrored into
+ * the browser history by `lib/nav-history.ts` so back/forward (and Android's
+ * hardware back) walk the app instead of leaving it.
+ *
+ * There is deliberately NO router: an entry is a snapshot of the store fields
+ * that say where the user is, not a URL. The one-shot handoff fields
+ * (`activityPanelId`, `pendingRoutineChat`, …) are excluded on purpose — they
+ * are messages between surfaces, not places, and replaying one on back would
+ * re-fire its side effect.
+ *
+ * Everything here is pure so the stack semantics are unit-testable; the store
+ * (`stores/ui.ts`) is the only caller of `navigated`, and the history sync
+ * layer is the only code in the app allowed to touch `history`.
+ */
+
+import type { SettingsSectionId } from "./settings-sections";
+import type { TeamSectionId } from "./teams-model.ts";
+import { INBOX_VIEW_ID } from "./top-level-views.ts";
+
+/** One place the user has been, at screen granularity. */
+export interface NavEntry {
+  viewMode: string;
+  settingsSection: SettingsSectionId | null;
+  activeTeamId: string | null;
+  teamSection: TeamSectionId | null;
+  teamAgentFilter: string | null;
+  teamAgentFocus: boolean;
+  teamSettingsFocus: boolean;
+  /**
+   * Whether the shell detail panel (the chat) is open over the view. A panel
+   * level can be POPPED (back closes the chat) but not re-entered: the panel
+   * is derived from a surface's live selection, which a popped entry no longer
+   * holds — forward into a panel entry restores the view and leaves the panel
+   * closed.
+   */
+  panelOpen: boolean;
+}
+
+/** The stack plus the cursor: entries above `navIndex` are the forward set. */
+export interface NavState {
+  navStack: NavEntry[];
+  navIndex: number;
+}
+
+/**
+ * How a navigation lands on the stack:
+ * - `push`: a new place (rail click, drill-in, panel open).
+ * - `replace`: a redirect — the current entry never counts as a place the user
+ *   chose (boot's Inbox→home hop, the dead-view guard's go-home).
+ * - `retreat`: a "back"-flavored transition (Escape, a back bar, panel close).
+ *   It POPS when the previous entry already is the destination, so the browser
+ *   history retreats with the UI; anywhere else it replaces, because a close
+ *   is not a new place and pushing it would make browser-back "reopen" what
+ *   the user just dismissed.
+ */
+export type NavMode = "push" | "replace" | "retreat";
+
+/** The store fields a {@link NavEntry} snapshots. */
+export interface NavSourceFields {
+  viewMode: string;
+  settingsSection: SettingsSectionId | null;
+  activeTeamId: string | null;
+  teamSection: TeamSectionId | null;
+  teamAgentFilter: string | null;
+  teamAgentFocus: boolean;
+  teamSettingsFocus: boolean;
+  missionPanelOpen: boolean;
+}
+
+export function navEntryOf(s: NavSourceFields): NavEntry {
+  return {
+    viewMode: s.viewMode,
+    settingsSection: s.settingsSection,
+    activeTeamId: s.activeTeamId,
+    teamSection: s.teamSection,
+    teamAgentFilter: s.teamAgentFilter,
+    teamAgentFocus: s.teamAgentFocus,
+    teamSettingsFocus: s.teamSettingsFocus,
+    panelOpen: s.missionPanelOpen,
+  };
+}
+
+export function sameNavEntry(a: NavEntry, b: NavEntry): boolean {
+  return (
+    a.viewMode === b.viewMode &&
+    a.settingsSection === b.settingsSection &&
+    a.activeTeamId === b.activeTeamId &&
+    a.teamSection === b.teamSection &&
+    a.teamAgentFilter === b.teamAgentFilter &&
+    a.teamAgentFocus === b.teamAgentFocus &&
+    a.teamSettingsFocus === b.teamSettingsFocus &&
+    a.panelOpen === b.panelOpen
+  );
+}
+
+/**
+ * The entry's fields as a store write, minus `panelOpen`: the panel is owned
+ * by surface claims (`detail-panel-owners.ts`), so applying an entry writes the
+ * view fields and lets the caller close the panel through its owner.
+ */
+export function viewFieldsOf(entry: NavEntry): Omit<NavEntry, "panelOpen"> {
+  const { panelOpen: _panelOpen, ...fields } = entry;
+  return fields;
+}
+
+/**
+ * The boot stack: one entry, the Inbox — the same honest landing the store's
+ * initial `viewMode` names. A refresh re-boots to this single entry on
+ * purpose (`viewMode` is deliberately not persisted); pre-refresh history
+ * entries decay to it (`nav-history.ts`).
+ */
+export function initialNavState(): NavState {
+  return {
+    navStack: [
+      navEntryOf({
+        viewMode: INBOX_VIEW_ID,
+        settingsSection: null,
+        activeTeamId: null,
+        teamSection: null,
+        teamAgentFilter: null,
+        teamAgentFocus: false,
+        teamSettingsFocus: false,
+        missionPanelOpen: false,
+      }),
+    ],
+    navIndex: 0,
+  };
+}
+
+/**
+ * Fold a navigation write into the stack: returns `partial` untouched when the
+ * resulting location is the one already current (a re-click is not a move),
+ * otherwise `partial` plus the updated stack per {@link NavMode}. A push
+ * truncates the forward set, exactly as the browser's own `pushState` will.
+ */
+export function navigated<P extends object>(
+  s: NavSourceFields & NavState,
+  partial: P,
+  mode: NavMode,
+): P | (P & NavState) {
+  const resulting = navEntryOf({ ...s, ...partial });
+  const current = s.navStack[s.navIndex];
+  if (sameNavEntry(resulting, current)) return partial;
+  if (mode === "push") {
+    return {
+      ...partial,
+      navStack: [...s.navStack.slice(0, s.navIndex + 1), resulting],
+      navIndex: s.navIndex + 1,
+    };
+  }
+  if (mode === "retreat") {
+    const previous = s.navIndex > 0 ? s.navStack[s.navIndex - 1] : null;
+    if (previous !== null && sameNavEntry(previous, resulting)) {
+      // The stack array is deliberately UNCHANGED on a pop: the history sync
+      // layer distinguishes a pop (mirror with `history.go`) from a rebuild
+      // (mirror with `replaceState`) by the array's identity.
+      return { ...partial, navStack: s.navStack, navIndex: s.navIndex - 1 };
+    }
+  }
+  const navStack = s.navStack.slice();
+  navStack[s.navIndex] = resulting;
+  return { ...partial, navStack, navIndex: s.navIndex };
+}

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -2,6 +2,13 @@ import type { PortableUploadPreviewResponse } from "@houston-ai/engine-client";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { setPanelOwner } from "../components/shell/detail-panel-owners.ts";
+import {
+  initialNavState,
+  type NavEntry,
+  type NavMode,
+  navigated,
+  viewFieldsOf,
+} from "../lib/nav-stack.ts";
 import type { SettingsSectionId } from "../lib/settings-sections";
 import { TEAM_VIEW_ID, type TeamSectionId } from "../lib/teams-model.ts";
 import { INBOX_VIEW_ID } from "../lib/top-level-views.ts";
@@ -198,7 +205,24 @@ interface UIState {
   workspaceSectionCollapsed: boolean;
   /** File shown by the global preview dialog, or null when closed. */
   filePreview: FilePreviewTarget | null;
-  setViewMode: (mode: string) => void;
+  /**
+   * The navigation stack (`lib/nav-stack.ts`): every screen-level location the
+   * user has visited, with `navIndex` as the cursor. The nav-aware actions
+   * below fold their writes in (`navigated`), and `lib/nav-history.ts` mirrors
+   * the pair into browser history — the ONLY code that touches `history` — so
+   * back/forward walk the app. Not persisted: a refresh re-boots to one entry.
+   */
+  navStack: NavEntry[];
+  navIndex: number;
+  /** Pop one level — the programmatic equivalent of the browser back button. */
+  navBack: () => void;
+  /**
+   * Jump the stack to `index` (clamped) and apply that entry, closing the
+   * detail panel through its owner when the entry has none. For the history
+   * sync layer's popstate handler and {@link UIState.navBack} only.
+   */
+  navApplyHistory: (index: number) => void;
+  setViewMode: (mode: string, opts?: { nav?: NavMode }) => void;
   /**
    * Open a team view: the ONE writer of `viewMode` + `activeTeamId` +
    * `teamSection` (+ `teamAgentFilter`), so the view is never half-set. It is
@@ -212,6 +236,8 @@ interface UIState {
       agentFilter?: string | null;
       agentFocus?: boolean;
       teamSettingsFocus?: boolean;
+      /** `replace` for redirects (boot, dead-view guard); default `push`. */
+      nav?: NavMode;
     },
   ) => void;
   setTeamAgentFilter: (agentId: string | null) => void;
@@ -328,6 +354,9 @@ const initialUIState = {
   teamAgentFilter: null,
   teamAgentFocus: false,
   teamSettingsFocus: false,
+  // The single-entry boot stack; its root mirrors the initial view fields
+  // above (pinned by app/tests/ui-store-nav.test.ts).
+  ...initialNavState(),
 } satisfies Partial<UIState>;
 
 let toastCounter = 0;
@@ -337,28 +366,64 @@ const toastTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 export const useUIStore = create<UIState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       ...initialUIState,
 
-      setViewMode: (viewMode) => set({ viewMode }),
+      navBack: () => get().navApplyHistory(get().navIndex - 1),
+      navApplyHistory: (index) => {
+        const s = get();
+        const clamped = Math.max(0, Math.min(index, s.navStack.length - 1));
+        if (clamped === s.navIndex) return;
+        const entry = s.navStack[clamped];
+        set({ navIndex: clamped, ...viewFieldsOf(entry) });
+        // The panel closes through its OWNER (deselect and all), outside the
+        // write above: the closer's own store writes then find the stack
+        // already at the panel-less entry, so they fold in as no-ops instead
+        // of double-popping. An entry WITH a panel can't reopen it — the
+        // selection it derived from is gone (see NavEntry.panelOpen).
+        if (!entry.panelOpen && get().missionPanelOpen) {
+          const close = get().onPanelClose;
+          if (close) close();
+          else get().closeMissionPanel();
+        }
+      },
+      setViewMode: (viewMode, opts) =>
+        set((s) => navigated(s, { viewMode }, opts?.nav ?? "push")),
       openTeamView: (activeTeamId, teamSection, opts) => {
         const teamAgentFilter = opts?.agentFilter ?? null;
         const teamAgentFocus =
           opts?.agentFocus === true && teamAgentFilter !== null;
-        set({
-          viewMode: TEAM_VIEW_ID,
-          activeTeamId,
-          teamSection,
-          teamAgentFilter,
-          teamAgentFocus,
-          teamSettingsFocus:
-            !teamAgentFocus && opts?.teamSettingsFocus === true,
-        });
+        set((s) =>
+          navigated(
+            s,
+            {
+              viewMode: TEAM_VIEW_ID,
+              activeTeamId,
+              teamSection,
+              teamAgentFilter,
+              teamAgentFocus,
+              teamSettingsFocus:
+                !teamAgentFocus && opts?.teamSettingsFocus === true,
+            },
+            opts?.nav ?? "push",
+          ),
+        );
       },
       setTeamAgentFilter: (teamAgentFilter) => set({ teamAgentFilter }),
-      setSettingsSection: (settingsSection) => set({ settingsSection }),
+      // Drilling INTO a section is a new place; back to the index is a
+      // "back" (pops when the index is where the user came from).
+      setSettingsSection: (settingsSection) =>
+        set((s) =>
+          navigated(
+            s,
+            { settingsSection },
+            settingsSection === null ? "retreat" : "push",
+          ),
+        ),
       openSettings: (settingsSection) =>
-        set({ viewMode: "settings", settingsSection }),
+        set((s) =>
+          navigated(s, { viewMode: "settings", settingsSection }, "push"),
+        ),
       setActivityPanelId: (activityPanelId, options) =>
         set({
           activityPanelId,
@@ -441,13 +506,23 @@ export const useUIStore = create<UIState>()(
             open,
           );
           if (missionPanelOwners === s.missionPanelOwners) return s;
-          return {
-            missionPanelOwners,
-            missionPanelOpen: missionPanelOwners.length > 0,
-          };
+          const missionPanelOpen = missionPanelOwners.length > 0;
+          const partial = { missionPanelOwners, missionPanelOpen };
+          // Only the panel's open/shut TRANSITIONS are navigation (a second
+          // claim on an open panel is not a move): opening pushes a level the
+          // back button can pop, the last release retreats it.
+          if (missionPanelOpen === s.missionPanelOpen) return partial;
+          return navigated(s, partial, missionPanelOpen ? "push" : "retreat");
         }),
       closeMissionPanel: () =>
-        set({ missionPanelOwners: [], missionPanelOpen: false }),
+        set((s) => {
+          const partial = { missionPanelOwners: [], missionPanelOpen: false };
+          // Same retreat as the last owner's release: closing the panel is a
+          // "back" when the previous entry is this view without it.
+          return s.missionPanelOpen
+            ? navigated(s, partial, "retreat")
+            : partial;
+        }),
       setMobileSidebarOpen: (mobileSidebarOpen) => set({ mobileSidebarOpen }),
       setPendingRoutineChat: (pendingRoutineChat) =>
         set({ pendingRoutineChat }),

--- a/app/tests/nav-history-plan.test.ts
+++ b/app/tests/nav-history-plan.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readNavIndex, syncPlan } from "../src/lib/nav-history.ts";
+import { navEntryOf } from "../src/lib/nav-stack.ts";
+
+// PRODUCT-1557: the store→history echo, decided by a pure plan so the mirror's
+// three verbs (pushState / replaceState / go) are testable without a browser.
+
+const entry = (viewMode: string) =>
+  navEntryOf({
+    viewMode,
+    settingsSection: null,
+    activeTeamId: null,
+    teamSection: null,
+    teamAgentFilter: null,
+    teamAgentFocus: false,
+    teamSettingsFocus: false,
+    missionPanelOpen: false,
+  });
+
+describe("syncPlan", () => {
+  it("ignores store changes that did not move the stack", () => {
+    const stack = [entry("inbox")];
+    assert.equal(syncPlan({ index: 0, stack }, { index: 0, stack }), null);
+  });
+
+  it("echoes a push as pushState at the new index", () => {
+    const prev = [entry("inbox")];
+    const next = [...prev, entry("settings")];
+    assert.deepEqual(
+      syncPlan({ index: 0, stack: prev }, { index: 1, stack: next }),
+      { op: "push", index: 1 },
+    );
+  });
+
+  it("echoes a pop (same array, cursor back) as history.go", () => {
+    const stack = [entry("inbox"), entry("settings")];
+    assert.deepEqual(syncPlan({ index: 1, stack }, { index: 0, stack }), {
+      op: "go",
+      delta: -1,
+    });
+  });
+
+  it("echoes an in-place swap as replaceState", () => {
+    const prev = [entry("inbox")];
+    const next = [entry("team")];
+    assert.deepEqual(
+      syncPlan({ index: 0, stack: prev }, { index: 0, stack: next }),
+      { op: "replace", index: 0 },
+    );
+  });
+
+  it("echoes a rebuild (reset: cursor back, NEW array) as replaceState", () => {
+    // The browser's deeper entries can't be deleted, so a rebuild re-brands
+    // the current one and lets the stale entries decay via the clamp.
+    const prev = [entry("inbox"), entry("settings")];
+    const next = [entry("inbox")];
+    assert.deepEqual(
+      syncPlan({ index: 1, stack: prev }, { index: 0, stack: next }),
+      { op: "replace", index: 0 },
+    );
+  });
+});
+
+describe("readNavIndex", () => {
+  it("reads our namespaced index and rejects everything else", () => {
+    assert.equal(readNavIndex({ __houstonNavIndex: 3 }), 3);
+    assert.equal(readNavIndex({ __houstonNavIndex: -1 }), null);
+    assert.equal(readNavIndex({ __houstonNavIndex: "3" }), null);
+    assert.equal(readNavIndex({ other: 3 }), null);
+    assert.equal(readNavIndex(null), null);
+    assert.equal(readNavIndex(undefined), null);
+  });
+});

--- a/app/tests/nav-stack.test.ts
+++ b/app/tests/nav-stack.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  initialNavState,
+  type NavSourceFields,
+  type NavState,
+  navEntryOf,
+  navigated,
+  sameNavEntry,
+  viewFieldsOf,
+} from "../src/lib/nav-stack.ts";
+
+// PRODUCT-1557: the nav stack's pure semantics. The store folds every
+// navigation write through `navigated`; these tests pin how each NavMode
+// lands on the stack without involving zustand or the browser.
+
+const at = (viewMode: string, panelOpen = false): NavSourceFields => ({
+  viewMode,
+  settingsSection: null,
+  activeTeamId: null,
+  teamSection: null,
+  teamAgentFilter: null,
+  teamAgentFocus: false,
+  teamSettingsFocus: false,
+  missionPanelOpen: panelOpen,
+});
+
+/** A source state sitting on `stack[index]`, ready for `navigated`. */
+const state = (
+  fields: NavSourceFields,
+  nav: NavState,
+): NavSourceFields & NavState => ({ ...fields, ...nav });
+
+describe("navigated push", () => {
+  it("appends the resulting location and advances the cursor", () => {
+    const s = state(at("inbox"), initialNavState());
+    const out = navigated(s, { viewMode: "settings" }, "push");
+    assert.ok("navStack" in out);
+    assert.equal(out.navIndex, 1);
+    assert.equal(out.navStack.length, 2);
+    assert.ok(sameNavEntry(out.navStack[1], navEntryOf(at("settings"))));
+  });
+
+  it("re-navigating to the current location is not a move", () => {
+    const s = state(at("inbox"), initialNavState());
+    const out = navigated(s, { viewMode: "inbox" }, "push");
+    assert.equal("navStack" in out, false);
+  });
+
+  it("truncates the forward set, like the browser's own pushState", () => {
+    const stack = [navEntryOf(at("inbox")), navEntryOf(at("settings"))];
+    const s = state(at("inbox"), { navStack: stack, navIndex: 0 });
+    const out = navigated(s, { viewMode: "skills" }, "push");
+    assert.ok("navStack" in out);
+    assert.deepEqual(
+      out.navStack.map((e) => e.viewMode),
+      ["inbox", "skills"],
+    );
+    assert.equal(out.navIndex, 1);
+  });
+});
+
+describe("navigated replace", () => {
+  it("swaps the current entry without growing the stack", () => {
+    const s = state(at("inbox"), initialNavState());
+    const out = navigated(s, { viewMode: "team" }, "replace");
+    assert.ok("navStack" in out);
+    assert.equal(out.navIndex, 0);
+    assert.equal(out.navStack.length, 1);
+    assert.equal(out.navStack[0].viewMode, "team");
+  });
+});
+
+describe("navigated retreat", () => {
+  it("pops when the previous entry is the destination, keeping the array", () => {
+    const stack = [navEntryOf(at("team")), navEntryOf(at("team", true))];
+    const s = state(at("team", true), { navStack: stack, navIndex: 1 });
+    const out = navigated(s, { missionPanelOpen: false }, "retreat");
+    assert.ok("navStack" in out);
+    assert.equal(out.navIndex, 0);
+    // Identity preserved on a pop: the history mirror relies on it to tell a
+    // retreat (echo with history.go) from a rebuild (echo with replaceState).
+    assert.equal(out.navStack, stack);
+  });
+
+  it("replaces when the previous entry is somewhere else", () => {
+    // Deep link straight into a Settings section from the team board: the
+    // in-UI back to the index retreats WITHIN the surface, so browser back
+    // still leaves it for the board.
+    const stack = [
+      navEntryOf(at("team")),
+      navEntryOf({ ...at("settings"), settingsSection: "shortcuts" }),
+    ];
+    const s = state(
+      { ...at("settings"), settingsSection: "shortcuts" },
+      {
+        navStack: stack,
+        navIndex: 1,
+      },
+    );
+    const out = navigated(s, { settingsSection: null }, "retreat");
+    assert.ok("navStack" in out);
+    assert.equal(out.navIndex, 1);
+    assert.equal(out.navStack.length, 2);
+    assert.equal(out.navStack[1].settingsSection, null);
+    assert.equal(out.navStack[0].viewMode, "team");
+  });
+
+  it("replaces at the root, where there is nothing to pop to", () => {
+    const s = state(at("team", true), {
+      navStack: [navEntryOf(at("team", true))],
+      navIndex: 0,
+    });
+    const out = navigated(s, { missionPanelOpen: false }, "retreat");
+    assert.ok("navStack" in out);
+    assert.equal(out.navIndex, 0);
+    assert.equal(out.navStack[0].panelOpen, false);
+  });
+});
+
+describe("entry plumbing", () => {
+  it("snapshots missionPanelOpen as the entry's panel level", () => {
+    assert.equal(navEntryOf(at("team", true)).panelOpen, true);
+  });
+
+  it("viewFieldsOf never writes the derived panel flag back", () => {
+    assert.equal(
+      "panelOpen" in viewFieldsOf(navEntryOf(at("team", true))),
+      false,
+    );
+    assert.equal(viewFieldsOf(navEntryOf(at("team"))).viewMode, "team");
+  });
+
+  it("boots as a single Inbox entry, matching the store's initial view", () => {
+    const nav = initialNavState();
+    assert.equal(nav.navIndex, 0);
+    assert.equal(nav.navStack.length, 1);
+    assert.ok(sameNavEntry(nav.navStack[0], navEntryOf(at("inbox"))));
+  });
+});

--- a/app/tests/ui-store-nav.test.ts
+++ b/app/tests/ui-store-nav.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { navEntryOf } from "../src/lib/nav-stack.ts";
+import { useUIStore } from "../src/stores/ui.ts";
+
+// PRODUCT-1557: the ui store's nav-aware actions. Every navigation write folds
+// into the stack (push / replace / retreat), navBack walks it back the way a
+// browser back button would, and the panel level closes through its owner.
+
+afterEach(() => useUIStore.getState().reset());
+
+const views = () => {
+  const s = useUIStore.getState();
+  return s.navStack.map((e) => e.viewMode);
+};
+
+describe("nav-aware actions", () => {
+  it("keeps the stack root coherent with the store's initial view fields", () => {
+    const s = useUIStore.getState();
+    assert.deepEqual(s.navStack[0], navEntryOf(s));
+    assert.equal(s.navIndex, 0);
+  });
+
+  it("pushes on view changes and dedupes a re-click", () => {
+    const s = useUIStore.getState();
+    s.setViewMode("skills");
+    s.setViewMode("skills");
+    assert.deepEqual(views(), ["inbox", "skills"]);
+    assert.equal(useUIStore.getState().navIndex, 1);
+  });
+
+  it("replaces on a redirect, keeping the transient view off the stack", () => {
+    // The boot rule: Inbox → first team's Mission Control is not a place the
+    // user chose, so browser back must not land on the boot Inbox.
+    useUIStore
+      .getState()
+      .openTeamView("team-a", "mission-control", { nav: "replace" });
+    assert.deepEqual(views(), ["team"]);
+    assert.equal(useUIStore.getState().navIndex, 0);
+  });
+
+  it("settings drill-in pushes; back to the index pops", () => {
+    const s = useUIStore.getState();
+    s.openSettings(null);
+    s.setSettingsSection("shortcuts");
+    assert.equal(useUIStore.getState().navIndex, 2);
+    s.setSettingsSection(null);
+    const after = useUIStore.getState();
+    assert.equal(after.navIndex, 1);
+    assert.equal(after.settingsSection, null);
+    assert.equal(after.navStack.length, 3);
+  });
+
+  it("panel open pushes a level; the last owner's release pops it", () => {
+    const s = useUIStore.getState();
+    s.openTeamView("team-a", "mission-control", { nav: "replace" });
+    s.setMissionPanelOwner("board", true);
+    let now = useUIStore.getState();
+    assert.equal(now.navIndex, 1);
+    assert.equal(now.navStack[1].panelOpen, true);
+
+    s.setMissionPanelOwner("board", false);
+    now = useUIStore.getState();
+    assert.equal(now.navIndex, 0);
+    assert.equal(now.missionPanelOpen, false);
+  });
+
+  it("a second claim on an already-open panel is not a move", () => {
+    const s = useUIStore.getState();
+    s.setMissionPanelOwner("board", true);
+    s.setMissionPanelOwner("routines", true);
+    assert.equal(useUIStore.getState().navIndex, 1);
+    s.setMissionPanelOwner("routines", false);
+    // Still one owner left: the panel stays open, the stack stays put.
+    const now = useUIStore.getState();
+    assert.equal(now.navIndex, 1);
+    assert.equal(now.missionPanelOpen, true);
+  });
+
+  it("closeMissionPanel retreats the panel level like the owner release", () => {
+    const s = useUIStore.getState();
+    s.setMissionPanelOwner("board", true);
+    s.closeMissionPanel();
+    const now = useUIStore.getState();
+    assert.equal(now.navIndex, 0);
+    assert.deepEqual(now.missionPanelOwners, []);
+  });
+});
+
+describe("navBack / navApplyHistory", () => {
+  it("navBack restores the previous entry's view fields", () => {
+    const s = useUIStore.getState();
+    s.openTeamView("team-a", "mission-control", { nav: "replace" });
+    s.openSettings("shortcuts");
+    s.navBack();
+    const now = useUIStore.getState();
+    assert.equal(now.viewMode, "team");
+    assert.equal(now.activeTeamId, "team-a");
+    assert.equal(now.navIndex, 0);
+    // The popped entry stays on the stack: forward can re-land on it.
+    assert.equal(now.navStack.length, 2);
+  });
+
+  it("navApplyHistory jumps forward onto a still-stacked entry", () => {
+    const s = useUIStore.getState();
+    s.setViewMode("skills");
+    s.navBack();
+    s.navApplyHistory(1);
+    const now = useUIStore.getState();
+    assert.equal(now.viewMode, "skills");
+    assert.equal(now.navIndex, 1);
+  });
+
+  it("clamps a stale index (a pre-refresh history entry) onto the stack", () => {
+    useUIStore.getState().navApplyHistory(7);
+    assert.equal(useUIStore.getState().navIndex, 0);
+    useUIStore.getState().setViewMode("skills");
+    useUIStore.getState().navApplyHistory(-3);
+    assert.equal(useUIStore.getState().navIndex, 0);
+    assert.equal(useUIStore.getState().viewMode, "inbox");
+  });
+
+  it("closes an open panel through its registered owner on back", () => {
+    const s = useUIStore.getState();
+    s.openTeamView("team-a", "mission-control", { nav: "replace" });
+    s.setMissionPanelOwner("board", true);
+    // The board's closer deselects, which releases the claim — modeled here.
+    let closed = 0;
+    s.setOnPanelClose(() => {
+      closed += 1;
+      useUIStore.getState().setMissionPanelOwner("board", false);
+    });
+
+    useUIStore.getState().navBack();
+
+    const now = useUIStore.getState();
+    assert.equal(closed, 1);
+    assert.equal(now.missionPanelOpen, false);
+    // The closer's own release found the stack already at the panel-less
+    // entry, so it folded in as a no-op instead of double-popping.
+    assert.equal(now.navIndex, 0);
+  });
+
+  it("falls back to closeMissionPanel when no closer is registered", () => {
+    const s = useUIStore.getState();
+    s.setMissionPanelOwner("setup-chat", true);
+    s.navBack();
+    const now = useUIStore.getState();
+    assert.equal(now.missionPanelOpen, false);
+    assert.deepEqual(now.missionPanelOwners, []);
+    assert.equal(now.navIndex, 0);
+  });
+
+  it("reset returns the stack to the single boot entry", () => {
+    const s = useUIStore.getState();
+    s.setViewMode("skills");
+    s.setMissionPanelOwner("board", true);
+    useUIStore.getState().reset();
+    const now = useUIStore.getState();
+    assert.equal(now.navStack.length, 1);
+    assert.equal(now.navIndex, 0);
+    assert.equal(now.navStack[0].viewMode, "inbox");
+  });
+});

--- a/packages/web/e2e/mobile/nav-back.spec.ts
+++ b/packages/web/e2e/mobile/nav-back.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "../support/fixtures";
+
+/**
+ * Hardware/browser back on a phone: on Android
+ * (and in an installed PWA) back is the primary way out of a screen, so it
+ * must pop the app's navigation stack — here the full-screen chat overlay —
+ * instead of leaving the app.
+ */
+
+test("back closes the full-screen chat instead of leaving the app", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByText("Plan a trip to Tokyo").tap();
+  await expect(page.getByText("Task: Plan a trip to Tokyo")).toBeVisible();
+
+  await page.goBack();
+  await expect(page.getByTestId("mission-panel")).toBeHidden();
+  // Still in the app, on the board the chat covered.
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+});

--- a/packages/web/e2e/nav-history.spec.ts
+++ b/packages/web/e2e/nav-history.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "./support/fixtures";
+import { navRow, screen } from "./support/team-nav";
+
+/**
+ * The navigation stack's browser-history sync: the app
+ * has no router, but every screen-level move mirrors into `history`, so the
+ * browser's back/forward buttons (and Android's hardware back, covered by the
+ * mobile project) walk the app instead of leaving it.
+ */
+
+test("browser back and forward walk the app's screens", async ({ page }) => {
+  await page.goto("/");
+  // Boot's Inbox→home redirect REPLACES, so the stack starts on the board.
+  await expect(screen(page)).toHaveAttribute("data-screen", "team");
+
+  await navRow(page, "inbox").click();
+  await expect(screen(page)).toHaveAttribute("data-screen", "inbox");
+  await navRow(page, "settings").click();
+  await expect(screen(page)).toHaveAttribute("data-screen", "settings");
+
+  await page.goBack();
+  await expect(screen(page)).toHaveAttribute("data-screen", "inbox");
+  await page.goBack();
+  await expect(screen(page)).toHaveAttribute("data-screen", "team");
+
+  await page.goForward();
+  await expect(screen(page)).toHaveAttribute("data-screen", "inbox");
+});
+
+test("browser back closes the chat panel before leaving the board", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await screen(page).getByText("Plan a trip to Tokyo").click();
+  await expect(page.getByTestId("mission-panel")).toBeVisible();
+
+  await page.goBack();
+  await expect(page.getByTestId("mission-panel")).toBeHidden();
+  await expect(screen(page)).toHaveAttribute("data-screen", "team");
+  // The board itself is still on the glass, not blanked by the pop.
+  await expect(screen(page).getByText("Plan a trip to Tokyo")).toBeVisible();
+});
+
+test("browser back retreats a Settings drill-in to the index", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await navRow(page, "settings").click();
+  await screen(page).getByText("Keyboard shortcuts").click();
+  await expect(
+    screen(page).getByRole("button", { name: "Settings" }),
+  ).toBeVisible();
+
+  await page.goBack();
+  // Back on the index: the drill-in rows are the screen again.
+  await expect(screen(page).getByText("Keyboard shortcuts")).toBeVisible();
+  await expect(screen(page)).toHaveAttribute("data-screen", "settings");
+
+  await page.goBack();
+  await expect(screen(page)).toHaveAttribute("data-screen", "team");
+});
+
+test("a reload re-boots to a single-entry stack and keeps navigating", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await navRow(page, "inbox").click();
+  await expect(screen(page)).toHaveAttribute("data-screen", "inbox");
+
+  // viewMode is deliberately not persisted: a refresh lands back on home
+  // with a fresh one-entry stack — and navigation still works from there.
+  await page.reload();
+  await expect(screen(page)).toHaveAttribute("data-screen", "team");
+  await navRow(page, "settings").click();
+  await expect(screen(page)).toHaveAttribute("data-screen", "settings");
+  await page.goBack();
+  await expect(screen(page)).toHaveAttribute("data-screen", "team");
+});


### PR DESCRIPTION
PRODUCT-1557 — PR 2 of the responsiveness overhaul.

## What

The app has no router and previously had zero history integration: browser back exited the SPA. This adds an explicit navigation stack in the ui store, mirrored into browser history, so back/forward (and Android's hardware back, once the mobile shell lands) walk the app. Always-on, desktop included. The URL never changes.

- `app/src/lib/nav-stack.ts` — pure stack semantics. An entry snapshots the screen-level location (viewMode, settings section, team params, detail-panel level). `navigated()` folds every store write in as **push** (rail clicks, drill-ins, panel open), **replace** (boot / dead-view guard redirects — transient screens never become back targets), or **retreat** (settings back bar, panel close: pops when the previous entry is the destination, else replaces, so back can never "reopen" what was just dismissed).
- `app/src/stores/ui.ts` — `navStack`/`navIndex` plus `navBack`/`navApplyHistory`; the nav actions (`setViewMode`, `openTeamView`, `openSettings`, `setSettingsSection`, `setMissionPanelOwner`, `closeMissionPanel`) are nav-aware. Not persisted; `reset()` re-roots the stack. One-shot handoff fields stay out of entries by design.
- `app/src/lib/nav-history.ts` — the ONLY code touching `history`. Echoes stack changes as pushState/replaceState/go (pop vs rebuild told apart by stack-array identity) and applies `popstate` back with index clamping, so a refresh re-boots to a single-entry stack and stale pre-refresh entries decay to the root. Self-echoed `go()` traversals are counted and their popstates ignored: a traversal resolves asynchronously, and a push landing in between (the archived → active handoff pops the panel level and re-pushes it in one breath) would otherwise make the stale popstate close the panel the handoff just reopened.
- Compatible with the one pre-existing history call: the `?install=`/`?creator=` strip in `store-deeplink-ingress.ts` passes `history.state` through, so the branded index survives in either order.

## Tests

- `app/tests/nav-stack.test.ts` — push/replace/retreat semantics, forward-set truncation, boot root.
- `app/tests/ui-store-nav.test.ts` — store behavior: dedupe, redirects, settings drill-in/back, panel push/pop, owner-routed close on back, clamping, reset.
- `app/tests/nav-history-plan.test.ts` — the store→history echo plan + state-key parsing.
- `packages/web/e2e/nav-history.spec.ts` — desktop back/forward across screens, back closing the chat panel, settings drill-in retreat, reload re-boot.
- `packages/web/e2e/mobile/nav-back.spec.ts` — hardware back closes the full-screen chat instead of leaving the app (Pixel 7 project).

## Checks

`pnpm check` · `cd app && pnpm tsgo --noEmit && pnpm test` (3793 pass) · `pnpm check-locales` · `pnpm check:parity` · `pnpm check:boundaries` · `pnpm --filter houston-web test:e2e` — 310 passed locally; the one failure is `sidebar-dnd.spec.ts:72`, a pre-existing local-env failure that also fails on pristine main (CI is the arbiter).

Desktop rendering is untouched: no visual or layout changes, state and history plumbing only.