### PR TITLE
feat(runtime): per-turn grant unlocks host-proxying tools on pooled turns

### DIFF
--- a/packages/host/src/routes/integrations-fanout.test.ts
+++ b/packages/host/src/routes/integrations-fanout.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { FakeIntegrationProvider } from "../integrations/fake";
+import { IntegrationRegistry } from "../integrations/registry";
+import { executeIntegration, searchIntegrations } from "./integrations-fanout";
+
+test("search fan-out keeps healthy provider results", async () => {
+  const failed = new FakeIntegrationProvider({ id: "failed" });
+  failed.throwSearchExecute = new Error("offline");
+  const healthy = new FakeIntegrationProvider({
+    id: "healthy",
+    actions: [
+      {
+        action: "SLACK_SEND_MESSAGE",
+        toolkit: "slack",
+        description: "Send a message",
+      },
+    ],
+  });
+  const result = await searchIntegrations({
+    registry: new IntegrationRegistry([failed, healthy]),
+    userId: "user",
+    query: "message",
+  });
+  expect(result.items.map((item) => item.action)).toEqual([
+    "SLACK_SEND_MESSAGE",
+  ]);
+});
+
+test("execute routes tools-prefixed actions to custom", async () => {
+  const custom = new FakeIntegrationProvider({ id: "custom" });
+  const composio = new FakeIntegrationProvider({ id: "composio" });
+  const result = await executeIntegration({
+    registry: new IntegrationRegistry([composio, custom]),
+    userId: "user",
+    action: "tools.acme.owner.default.run",
+    params: { value: 1 },
+    acting: { actingAs: "turn-token" },
+  });
+  expect(result).toEqual({
+    successful: true,
+    data: { action: "tools.acme.owner.default.run", params: { value: 1 } },
+  });
+  expect(custom.lastActing).toEqual({ actingAs: "turn-token" });
+  expect(composio.lastActing).toBeUndefined();
+});

--- a/packages/host/src/routes/integrations-fanout.ts
+++ b/packages/host/src/routes/integrations-fanout.ts
@@ -1,0 +1,121 @@
+import { CUSTOM_ACTION_PREFIX } from "../integrations/custom/provider";
+import type { ActingContext } from "../integrations/provider";
+import type { IntegrationRegistry } from "../integrations/registry";
+import {
+  type ActionResult,
+  IntegrationSigninRequiredError,
+  type ToolMatch,
+} from "../integrations/types";
+
+/** Resolve the provider that owns an action when callers omit one. */
+export function providerForAction(
+  registry: IntegrationRegistry,
+  action: string,
+): string {
+  const ids = registry.ids();
+  if (action.startsWith(CUSTOM_ACTION_PREFIX) && ids.includes("custom")) {
+    return "custom";
+  }
+  return ids.find((id) => id !== "custom") ?? ids[0] ?? "custom";
+}
+
+/** Inputs for a provider-fan-out integration search. */
+export interface IntegrationSearchInput {
+  registry: IntegrationRegistry;
+  userId: string;
+  query: string;
+  acting?: ActingContext;
+  app?: string;
+  provider?: string;
+  fatalFailure?: (error: unknown) => boolean;
+}
+
+/** Merged integration search results and scope-fallback signals. */
+export interface IntegrationSearchOutput {
+  items: ToolMatch[];
+  unscopedFallback?: true;
+  scopeIgnored?: true;
+}
+
+/** Search selected providers and preserve healthy results across partial failure. */
+export async function searchIntegrations(
+  input: IntegrationSearchInput,
+): Promise<IntegrationSearchOutput> {
+  const providerIds = input.provider ? [input.provider] : input.registry.ids();
+  const fanOut = async (scope: string | undefined) => {
+    const settled = await Promise.allSettled(
+      providerIds.map((id) =>
+        input.registry
+          .get(id)
+          .search(input.userId, input.query, input.acting, scope),
+      ),
+    );
+    const fulfilled = settled.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value] : [],
+    );
+    const failures = settled.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    const fatal = failures.find((error) => input.fatalFailure?.(error));
+    if (fatal) throw fatal;
+    return {
+      items: fulfilled.flatMap((result) => result.items),
+      scopes: fulfilled.flatMap((result) =>
+        result.scope ? [result.scope] : [],
+      ),
+      failures,
+    };
+  };
+
+  let { items, scopes, failures } = await fanOut(input.app);
+  const scopeIgnored = input.app !== undefined && scopes.includes("ignored");
+  let unscopedFallback = false;
+  if (
+    input.app &&
+    !scopeIgnored &&
+    items.length === 0 &&
+    failures.length === 0
+  ) {
+    ({ items, failures } = await fanOut(undefined));
+    unscopedFallback = items.length > 0;
+  }
+  if (items.length === 0 && failures.length > 0) {
+    throw (
+      failures.find(
+        (error) => error instanceof IntegrationSigninRequiredError,
+      ) ?? failures[0]
+    );
+  }
+  return {
+    items,
+    ...(unscopedFallback ? { unscopedFallback: true } : {}),
+    ...(scopeIgnored ? { scopeIgnored: true } : {}),
+  };
+}
+
+/** Inputs for one provider-selected integration action. */
+export interface IntegrationExecuteInput {
+  registry: IntegrationRegistry;
+  userId: string;
+  action: string;
+  params: Record<string, unknown>;
+  acting?: ActingContext;
+  account?: string;
+  provider?: string;
+}
+
+/** Execute an action once through its selected provider. */
+export async function executeIntegration(
+  input: IntegrationExecuteInput,
+): Promise<ActionResult> {
+  const provider = input.registry.get(
+    input.provider ?? providerForAction(input.registry, input.action),
+  );
+  return provider.execute(
+    input.userId,
+    input.action,
+    input.params,
+    input.acting,
+    input.account,
+  );
+}

--- a/packages/host/src/routes/integrations-sandbox.ts
+++ b/packages/host/src/routes/integrations-sandbox.ts
@@ -1,6 +1,4 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { CUSTOM_ACTION_PREFIX } from "../integrations/custom/provider";
-import type { IntegrationRegistry } from "../integrations/registry";
 import { IntegrationSigninRequiredError } from "../integrations/types";
 import type { CredentialVault, WorkspaceStore } from "../ports";
 import { bearer, header, json, optionalTrimmed, readJson } from "./http";
@@ -9,6 +7,9 @@ import {
   relayIntegrationUpstreamError,
   signinRequired,
 } from "./integrations";
+import { executeIntegration, searchIntegrations } from "./integrations-fanout";
+
+export { providerForAction } from "./integrations-fanout";
 
 /**
  * Which provider owns an action the runtime tool passed with no explicit
@@ -17,17 +18,6 @@ import {
  * non-custom provider (Composio's slug convention), falling back to whatever
  * is registered.
  */
-export function providerForAction(
-  registry: IntegrationRegistry,
-  action: string,
-): string {
-  const ids = registry.ids();
-  if (action.startsWith(CUSTOM_ACTION_PREFIX) && ids.includes("custom")) {
-    return "custom";
-  }
-  return ids.find((id) => id !== "custom") ?? ids[0] ?? "custom";
-}
-
 /**
  * The RUNTIME-facing integrations proxy (`/sandbox/integrations/*`, authed by
  * the per-sandbox HMAC token): the agent's `integration_search` /
@@ -108,59 +98,18 @@ export async function handleSandboxIntegrations(
       // Optional `app`: the agent's HARD scope when the task names an app —
       // each provider returns only that app's actions (PRODUCT-1274).
       const app = optionalTrimmed(body.app);
-      const providerIds = explicit ? [explicit] : registry.ids();
-      // Fan out and merge. One provider failing must not hide another's
-      // results (desktop signed out: the gateway adapter throws while the
-      // key-free custom provider still answers) — but an ALL-empty merge with
-      // a signin failure underneath must still surface THAT, or the runtime
-      // would render the wrong speech act ("no such app" instead of the
-      // sign-in card).
-      const fanOut = async (scope: string | undefined) => {
-        const settled = await Promise.allSettled(
-          providerIds.map((id) =>
-            registry.get(id).search(ws.ownerUserId, query, acting, scope),
-          ),
-        );
-        const fulfilled = settled.flatMap((s) =>
-          s.status === "fulfilled" ? [s.value] : [],
-        );
-        return {
-          items: fulfilled.flatMap((r) => r.items),
-          scopes: fulfilled.flatMap((r) => (r.scope ? [r.scope] : [])),
-          failures: settled.flatMap((s) =>
-            s.status === "rejected" ? [s.reason] : [],
-          ),
-        };
-      };
-      let { items, scopes, failures } = await fanOut(app);
-      // A provider that IGNORED the scope (a remote upstream predating the
-      // contract) may have merged in UNSCOPED items: no retry (it would serve
-      // the same unscoped result again), but the flag tells the runtime tool
-      // the results are not certainly the named app's — and that an empty
-      // result proves nothing about the app existing.
-      const scopeIgnored = app !== undefined && scopes.includes("ignored");
-      // A scope NO provider resolved (a typo, a guess) merges to empty — a
-      // resolved scope always yields at least the app's toolkit row. Retry
-      // unscoped ONCE, here and only here: a provider falling back on its own
-      // would pollute the merge with unscoped noise ranked ahead of another
-      // provider's correctly scoped hits. The flag tells the runtime tool the
-      // results are NOT the named app's.
-      let unscopedFallback = false;
-      if (app && !scopeIgnored && items.length === 0 && failures.length === 0) {
-        ({ items, failures } = await fanOut(undefined));
-        unscopedFallback = items.length > 0;
-      }
-      if (items.length === 0 && failures.length > 0) {
-        throw (
-          failures.find((f) => f instanceof IntegrationSigninRequiredError) ??
-          failures[0]
-        );
-      }
-      json(res, 200, {
-        items,
-        ...(unscopedFallback ? { unscopedFallback: true } : {}),
-        ...(scopeIgnored ? { scopeIgnored: true } : {}),
-      });
+      json(
+        res,
+        200,
+        await searchIntegrations({
+          registry,
+          userId: ws.ownerUserId,
+          query,
+          acting,
+          app,
+          provider: explicit ?? undefined,
+        }),
+      );
       return true;
     }
 
@@ -170,9 +119,6 @@ export async function handleSandboxIntegrations(
       json(res, 400, { error: "missing 'action'" });
       return true;
     }
-    const provider = registry.get(
-      explicit ?? providerForAction(registry, action),
-    );
     const params =
       body.params && typeof body.params === "object"
         ? (body.params as Record<string, unknown>)
@@ -191,7 +137,15 @@ export async function handleSandboxIntegrations(
     json(
       res,
       200,
-      await provider.execute(ws.ownerUserId, action, params, acting, account),
+      await executeIntegration({
+        registry,
+        userId: ws.ownerUserId,
+        action,
+        params,
+        acting,
+        account,
+        provider: explicit ?? undefined,
+      }),
     );
     return true;
   } catch (err) {

--- a/packages/host/src/routes/learning-write.test.ts
+++ b/packages/host/src/routes/learning-write.test.ts
@@ -1,0 +1,67 @@
+import { loadLearnings, saveActivities, saveLearnings } from "@houston/domain";
+import { expect, test } from "vitest";
+import { MemoryVfs } from "../vfs";
+import { appendLearningChecked } from "./learning-write";
+
+const ROOT = "Personal/Helper";
+
+test("appendLearningChecked stamps provenance and keeps existing learnings", async () => {
+  const vfs = new MemoryVfs();
+  await saveLearnings(vfs, ROOT, [
+    { id: "old", text: "Existing", created_at: "2020-01-01T00:00:00.000Z" },
+  ]);
+  await saveActivities(vfs, ROOT, [
+    {
+      id: "mission-1",
+      title: "Renewals",
+      description: "",
+      status: "running",
+      session_key: "conversation-1",
+    },
+  ]);
+
+  const result = await appendLearningChecked(vfs, ROOT, {
+    id: "new",
+    text: "  Renewals happen on Mondays.  ",
+    nowIso: "2026-08-27T12:00:00.000Z",
+    taughtBy: { user_id: "user-1", name: "Ada" },
+    conversationId: "conversation-1",
+  });
+
+  expect(result).toMatchObject({
+    learning: {
+      id: "new",
+      text: "Renewals happen on Mondays.",
+      taught_by: { user_id: "user-1", name: "Ada" },
+      mission_id: "mission-1",
+      mission_title: "Renewals",
+    },
+  });
+  expect((await loadLearnings(vfs, ROOT)).items.map((item) => item.id)).toEqual(
+    ["old", "new"],
+  );
+});
+
+test("appendLearningChecked deduplicates a retried append by id", async () => {
+  const vfs = new MemoryVfs();
+  const input = {
+    id: "stable",
+    text: "Keep this once",
+    nowIso: "2026-08-27T12:00:00.000Z",
+  };
+  await appendLearningChecked(vfs, ROOT, input);
+  await appendLearningChecked(vfs, ROOT, input);
+  expect((await loadLearnings(vfs, ROOT)).items).toHaveLength(1);
+});
+
+test("appendLearningChecked rejects empty text without writing", async () => {
+  const vfs = new MemoryVfs();
+  expect(
+    await appendLearningChecked(vfs, ROOT, {
+      id: "new",
+      text: "  ",
+      nowIso: "2026-08-27T12:00:00.000Z",
+    }),
+  ).toEqual({ error: "missing 'text'" });
+  expect((await loadLearnings(vfs, ROOT)).items).toEqual([]);
+});

--- a/packages/host/src/routes/learning-write.ts
+++ b/packages/host/src/routes/learning-write.ts
@@ -1,0 +1,67 @@
+import {
+  loadActivities,
+  loadLearnings,
+  saveLearnings,
+  type TextStore,
+} from "@houston/domain";
+import type { Learning } from "@houston/protocol";
+import { withDocLock } from "./doc-lock";
+
+/** Stable inputs for an idempotent learning append. */
+export interface AppendLearningInput {
+  id: string;
+  text: string;
+  nowIso: string;
+  taughtBy?: Learning["taught_by"];
+  conversationId?: string;
+}
+
+/** Append one validated learning without replacing existing memory. */
+export async function appendLearningChecked(
+  store: TextStore,
+  root: string,
+  input: AppendLearningInput,
+): Promise<{ learning: Learning } | { error: string }> {
+  const text = input.text.trim();
+  if (!text) return { error: "missing 'text'" };
+
+  const mission = await learningMission(store, root, input.conversationId);
+  const learning: Learning = {
+    id: input.id,
+    text,
+    created_at: input.nowIso,
+    ...(input.taughtBy ? { taught_by: input.taughtBy } : {}),
+    ...mission,
+  };
+  return withDocLock(`${root}#learnings`, async () => {
+    const { items } = await loadLearnings(store, root);
+    const existing = items.find((item) => item.id === learning.id);
+    if (existing) return { learning: existing };
+    await saveLearnings(store, root, [...items, learning]);
+    return { learning };
+  });
+}
+
+async function learningMission(
+  store: TextStore,
+  root: string,
+  conversationId: string | undefined,
+): Promise<{ mission_id?: string; mission_title?: string }> {
+  if (!conversationId) return {};
+  try {
+    const { items } = await loadActivities(store, root);
+    const activity = items.find(
+      (item) =>
+        item.session_key === conversationId ||
+        `activity-${item.id}` === conversationId,
+    );
+    if (!activity) return {};
+    return {
+      mission_id: activity.id,
+      ...(activity.title ? { mission_title: activity.title } : {}),
+    };
+  } catch (error) {
+    console.error(`[learnings] mission lookup failed for ${root}:`, error);
+    return {};
+  }
+}

--- a/packages/host/src/routes/learnings-sandbox.ts
+++ b/packages/host/src/routes/learnings-sandbox.ts
@@ -1,20 +1,14 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import {
-  loadActivities,
-  loadLearnings,
-  saveLearnings,
-  type TextStore,
-} from "@houston/domain";
-import type { HoustonEvent, Learning } from "@houston/protocol";
+import type { HoustonEvent } from "@houston/protocol";
 import { ACTING_AS_HEADER, actingAuthorFromHeader } from "../auth/acting";
 import type { EventHub } from "../events/hub";
 import type { WorkspacePaths } from "../paths";
 import type { CredentialVault, WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
 import { DEFAULT_PATHS } from "./agent-authz";
-import { withDocLock } from "./doc-lock";
 import { bearer, header, json, readJson } from "./http";
+import { appendLearningChecked } from "./learning-write";
 
 /** The header the runtime's `save_learning` tool carries the turn's conversation
  *  id on, so the mission a learning came from can be resolved. Provenance only —
@@ -124,76 +118,22 @@ export async function handleSandboxLearnings(
     ? (actingAuthorFromHeader(req.headers[ACTING_AS_HEADER]) ??
       (actingUser ? { user_id: actingUser } : null))
     : null;
-  const mission = await resolveMission(
-    vfs,
-    root,
-    header(req, CONVERSATION_ID_HEADER),
-  );
-
-  const learning: Learning = {
+  const result = await appendLearningChecked(vfs, root, {
     id: randomUUID(),
     text,
-    created_at: new Date().toISOString(),
-    // Spread-when-present: absent provenance writes NO key, so a single-player
-    // learnings.json stays byte-identical in shape to today's.
-    ...(taughtBy ? { taught_by: taughtBy } : {}),
-    ...mission,
-  };
-
-  // Merge-save: read what is there, append, write the whole set back — so a
-  // second save never clobbers the first. Under the per-doc lock (see
-  // doc-lock.ts) because the read-modify-write is only merge-safe when it is
-  // ATOMIC: two saves from different conversations on the same pod, or a save
-  // racing the Memory tab's whole-file PUT (agent-data.ts, same key), would
-  // otherwise both load the same base list and the last write would win.
-  await withDocLock(`${root}#learnings`, async () => {
-    const { items } = await loadLearnings(vfs, root);
-    await saveLearnings(vfs, root, [...items, learning]);
+    nowIso: new Date().toISOString(),
+    ...(taughtBy ? { taughtBy } : {}),
+    conversationId: header(req, CONVERSATION_ID_HEADER),
   });
+  if ("error" in result) {
+    json(res, 400, { error: result.error });
+    return true;
+  }
   // React on the SAME channel a UI or file-watcher write does; scope to the
   // workspace owner, exactly as the agent-data learnings PUT does.
   const event: HoustonEvent = { type: "LearningsChanged", agentPath: agent.id };
   deps.events?.emit(ws.ownerUserId, event);
 
-  json(res, 201, learning);
+  json(res, 201, result.learning);
   return true;
-}
-
-/**
- * The mission a conversation belongs to, as the learning's mission keys, or an
- * empty object when there is no id / no match / the read failed.
- *
- * Matching uses the SAME convention as per-mission attribution
- * (`activity-attribution.ts`): a mission's `session_key` IS the turn's
- * conversation id, with `activity-<id>` as the fallback for missions whose key
- * was never persisted separately.
- *
- * `mission_title` is denormalized on purpose: the mission may later be renamed
- * or deleted, and a learning that reads "from a mission that no longer exists"
- * is worse than one that keeps the title it was taught under. Renderers prefer
- * the live title looked up by `mission_id` and fall back to this.
- */
-async function resolveMission(
-  store: TextStore,
-  root: string,
-  conversationId: string | undefined,
-): Promise<{ mission_id?: string; mission_title?: string }> {
-  if (!conversationId) return {};
-  try {
-    const { items } = await loadActivities(store, root);
-    const activity = items.find(
-      (a) =>
-        a.session_key === conversationId ||
-        `activity-${a.id}` === conversationId,
-    );
-    if (!activity) return {};
-    return {
-      mission_id: activity.id,
-      ...(activity.title ? { mission_title: activity.title } : {}),
-    };
-  } catch (err) {
-    // Provenance is metadata: never cost the user their learning over it.
-    console.error(`[learnings] mission lookup failed for ${root}:`, err);
-    return {};
-  }
 }

--- a/packages/host/src/routes/routine-write.test.ts
+++ b/packages/host/src/routes/routine-write.test.ts
@@ -32,6 +32,16 @@ test("creating a second task keeps the first (merge-safe, not a wholesale write)
   expect(new Set(items.map((r) => r.id)).size).toBe(2);
 });
 
+test("a caller-supplied id makes a retried create idempotent", async () => {
+  const vfs = new MemoryVfs();
+  const opts = { ...OPTS, id: "stable-id" };
+  await createRoutineChecked(vfs, ROOT, WS, daily("A"), opts);
+  await createRoutineChecked(vfs, ROOT, WS, daily("A"), opts);
+
+  const { items } = await loadRoutines(vfs, ROOT);
+  expect(items.map((routine) => routine.id)).toEqual(["stable-id"]);
+});
+
 test("updating by id changes that task in place and touches no other", async () => {
   const vfs = new MemoryVfs();
   const a = await createRoutineChecked(vfs, ROOT, WS, daily("A"), OPTS);

--- a/packages/host/src/routes/routine-write.ts
+++ b/packages/host/src/routes/routine-write.ts
@@ -77,6 +77,8 @@ export interface RoutineWriteOptions {
   triggersEnabled: boolean;
   /** ISO clock the caller supplies (domain stays pure). */
   nowIso: string;
+  /** Stable id supplied when an optimistic write may be retried. */
+  id?: string;
 }
 
 /**
@@ -123,7 +125,7 @@ export async function createRoutineChecked(
     const { items } = await loadRoutines(vfs, root);
     const routine = createRoutine(
       input,
-      crypto.randomUUID(),
+      opts.id ?? crypto.randomUUID(),
       opts.nowIso,
       opts.createdBy,
     );

--- a/packages/host/src/routes/skills-sandbox-search.ts
+++ b/packages/host/src/routes/skills-sandbox-search.ts
@@ -1,6 +1,4 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { CommunitySkill } from "@houston/protocol";
-import type { CommunityDirectory } from "../skills/community";
 import { json, readJson } from "./http";
 import {
   communityDirectory,
@@ -8,6 +6,7 @@ import {
   previewDirectory,
 } from "./skills-directory";
 import type { SandboxSkillsDeps } from "./skills-sandbox";
+import { searchCommunitySkills } from "./skills-search";
 
 /**
  * The SEARCH half of `/sandbox/skills/*` — the agent's `find_skills` tool (see
@@ -27,61 +26,8 @@ import type { SandboxSkillsDeps } from "./skills-sandbox";
  * installs each. Visibility is bounded by {@link RESULT_LIMIT} alone; every hit
  * inside it ships, described or not.
  */
-const ENRICH_LIMIT = 10;
-
-/**
- * How many merged hits come back. skills.sh answers EVERY search with 100 rows
- * whether or not any of them are relevant (a nonsense query still returns 100),
- * so the deep tail is noise by construction and merging three queries could
- * otherwise put 300 rows in the model's context. This keeps the union of all
- * queries well past the head — the rank-6 misses that motivated the cap fix —
- * without spending thousands of tokens on rows nobody would ever pick.
- */
-const RESULT_LIMIT = 60;
-
 /** At most this many queries per call; each is one spaced skills.sh request. */
 const MAX_QUERIES = 3;
-
-/** What the agent gets back per hit — the search row plus the description the
- *  recommendation actually rests on. */
-interface FoundSkill {
-  skillId: string;
-  source: string;
-  name: string;
-  installs: number;
-  description?: string;
-}
-
-/**
- * Run each query and fold the result lists into one ranked list.
- *
- * A skill keeps its BEST position across the queries, so a rank-1 hit for the
- * phrasing that happened to match stays rank 1 in the merge instead of being
- * diluted by the queries that missed it — that is the entire point of asking
- * for several phrasings. Ties (the common case, since every query has its own
- * rank 1) break toward install count, which is the one quality signal the search
- * rows carry. Queries run concurrently; `CommunityDirectory` serializes the
- * actual outbound requests through its own global spacing, so this cannot
- * burst past the rate limit.
- */
-async function mergeSearches(
-  directory: Pick<CommunityDirectory, "search">,
-  queries: string[],
-): Promise<CommunitySkill[]> {
-  const lists = await Promise.all(queries.map((q) => directory.search(q)));
-  const best = new Map<string, { hit: CommunitySkill; rank: number }>();
-  for (const list of lists) {
-    list.forEach((hit, rank) => {
-      const key = `${hit.source}#${hit.skillId}`;
-      const seen = best.get(key);
-      if (!seen || rank < seen.rank) best.set(key, { hit, rank });
-    });
-  }
-  return [...best.values()]
-    .sort((a, b) => a.rank - b.rank || b.hit.installs - a.hit.installs)
-    .slice(0, RESULT_LIMIT)
-    .map((e) => e.hit);
-}
 
 /**
  * Run every query, merge the results, and return them ranked, with the top
@@ -115,7 +61,7 @@ export async function searchAction(
     ? body.queries
         .filter((q: unknown): q is string => typeof q === "string")
         .map((q: string) => q.trim())
-        .filter(Boolean)
+        .filter((query: string) => query.length > 0)
         .slice(0, MAX_QUERIES)
     : [];
   if (!queries.length) {
@@ -123,38 +69,15 @@ export async function searchAction(
     return;
   }
   try {
-    const hits = await mergeSearches(
-      deps.directory ?? communityDirectory,
+    const result = await searchCommunitySkills(
+      {
+        directory: deps.directory ?? communityDirectory,
+        previews: deps.previews ?? previewDirectory,
+        fetchImpl,
+      },
       queries,
     );
-    const enriched = await Promise.all(
-      hits.map(async (hit, rank): Promise<FoundSkill> => {
-        const base: FoundSkill = {
-          skillId: hit.skillId,
-          source: hit.source,
-          name: hit.name,
-          installs: hit.installs,
-        };
-        // Past the enrichment budget the hit still ships — ranked, named, and
-        // installable — just without a fetched description.
-        if (rank >= ENRICH_LIMIT) return base;
-        try {
-          const preview = await (deps.previews ?? previewDirectory).preview(
-            fetchImpl,
-            hit.source,
-            hit.skillId,
-          );
-          return preview.description
-            ? { ...base, description: preview.description }
-            : base;
-        } catch {
-          // Best-effort by design (see above): one unreachable SKILL.md must
-          // not cost the user the whole answer.
-          return base;
-        }
-      }),
-    );
-    json(res, 200, { skills: enriched });
+    json(res, 200, result);
   } catch (err) {
     failSkill(res, err);
   }

--- a/packages/host/src/routes/skills-search.test.ts
+++ b/packages/host/src/routes/skills-search.test.ts
@@ -1,0 +1,66 @@
+import type { CommunitySkill } from "@houston/protocol";
+import { expect, test } from "vitest";
+import { searchCommunitySkills } from "./skills-search";
+
+const hit = (skillId: string, installs: number): CommunitySkill => ({
+  id: `source/repo/${skillId}`,
+  skillId,
+  source: "source/repo",
+  name: skillId,
+  installs,
+});
+
+test("searchCommunitySkills keeps each skill's best rank and enriches results", async () => {
+  const byQuery: Record<string, CommunitySkill[]> = {
+    broad: [hit("filler", 10), hit("winner", 500)],
+    exact: [hit("winner", 500), hit("other", 20)],
+  };
+  const result = await searchCommunitySkills(
+    {
+      directory: { search: async (query) => byQuery[query] ?? [] },
+      previews: {
+        preview: async (_fetch, _source, skillId) => ({
+          title: null,
+          description: `Description for ${skillId}`,
+          image: null,
+          category: null,
+          tags: [],
+          integrations: [],
+          content: null,
+        }),
+      },
+      fetchImpl: fetch,
+    },
+    ["broad", "exact"],
+  );
+
+  expect(result.skills.map((skill) => skill.skillId)).toEqual([
+    "winner",
+    "filler",
+    "other",
+  ]);
+  expect(result.skills[0]?.description).toBe("Description for winner");
+});
+
+test("searchCommunitySkills keeps a hit when its preview fails", async () => {
+  const result = await searchCommunitySkills(
+    {
+      directory: { search: async () => [hit("still-visible", 1)] },
+      previews: {
+        preview: async () => {
+          throw new Error("gone");
+        },
+      },
+      fetchImpl: fetch,
+    },
+    ["query"],
+  );
+  expect(result.skills).toEqual([
+    {
+      skillId: "still-visible",
+      source: "source/repo",
+      name: "still-visible",
+      installs: 1,
+    },
+  ]);
+});

--- a/packages/host/src/routes/skills-search.ts
+++ b/packages/host/src/routes/skills-search.ts
@@ -1,0 +1,76 @@
+import type { CommunitySkill } from "@houston/protocol";
+import type { CommunityDirectory } from "../skills/community";
+import type { PreviewDirectory } from "../skills/preview";
+
+const ENRICH_LIMIT = 10;
+const RESULT_LIMIT = 60;
+
+/** Directory result enriched with the fields exposed to the agent. */
+export interface FoundSkill {
+  skillId: string;
+  source: string;
+  name: string;
+  installs: number;
+  description?: string;
+}
+
+/** External seams used by community skill search and preview enrichment. */
+export interface SkillsSearchDeps {
+  directory: Pick<CommunityDirectory, "search">;
+  previews: Pick<PreviewDirectory, "preview">;
+  fetchImpl: typeof fetch;
+}
+
+async function mergeSearches(
+  directory: SkillsSearchDeps["directory"],
+  queries: string[],
+): Promise<CommunitySkill[]> {
+  const lists = await Promise.all(
+    queries.map((query) => directory.search(query)),
+  );
+  const best = new Map<string, { hit: CommunitySkill; rank: number }>();
+  for (const list of lists) {
+    list.forEach((hit, rank) => {
+      const key = `${hit.source}#${hit.skillId}`;
+      const seen = best.get(key);
+      if (!seen || rank < seen.rank) best.set(key, { hit, rank });
+    });
+  }
+  return [...best.values()]
+    .sort((a, b) => a.rank - b.rank || b.hit.installs - a.hit.installs)
+    .slice(0, RESULT_LIMIT)
+    .map(({ hit }) => hit);
+}
+
+/** Merge multiple catalog searches by best rank and enrich their leading hits. */
+export async function searchCommunitySkills(
+  deps: SkillsSearchDeps,
+  queries: string[],
+): Promise<{ skills: FoundSkill[] }> {
+  const hits = await mergeSearches(deps.directory, queries);
+  const skills = await Promise.all(
+    hits.map(async (hit, rank): Promise<FoundSkill> => {
+      const base: FoundSkill = {
+        skillId: hit.skillId,
+        source: hit.source,
+        name: hit.name,
+        installs: hit.installs,
+      };
+      if (rank >= ENRICH_LIMIT) return base;
+      try {
+        const preview = await deps.previews.preview(
+          deps.fetchImpl,
+          hit.source,
+          hit.skillId,
+        );
+        return preview.description
+          ? { ...base, description: preview.description }
+          : base;
+      } catch {
+        // Preview enrichment is optional; the ranked result remains useful.
+        return base;
+      }
+    }),
+  );
+  return { skills };
+}

--- a/packages/host/src/routes/skills-search.ts
+++ b/packages/host/src/routes/skills-search.ts
@@ -19,14 +19,16 @@ export interface SkillsSearchDeps {
   directory: Pick<CommunityDirectory, "search">;
   previews: Pick<PreviewDirectory, "preview">;
   fetchImpl: typeof fetch;
+  signal?: AbortSignal | null;
 }
 
 async function mergeSearches(
   directory: SkillsSearchDeps["directory"],
   queries: string[],
+  opts: Pick<SkillsSearchDeps, "fetchImpl" | "signal">,
 ): Promise<CommunitySkill[]> {
   const lists = await Promise.all(
-    queries.map((query) => directory.search(query)),
+    queries.map((query) => directory.search(query, opts)),
   );
   const best = new Map<string, { hit: CommunitySkill; rank: number }>();
   for (const list of lists) {
@@ -47,7 +49,7 @@ export async function searchCommunitySkills(
   deps: SkillsSearchDeps,
   queries: string[],
 ): Promise<{ skills: FoundSkill[] }> {
-  const hits = await mergeSearches(deps.directory, queries);
+  const hits = await mergeSearches(deps.directory, queries, deps);
   const skills = await Promise.all(
     hits.map(async (hit, rank): Promise<FoundSkill> => {
       const base: FoundSkill = {

--- a/packages/host/src/skills/community.ts
+++ b/packages/host/src/skills/community.ts
@@ -42,6 +42,12 @@ export interface CommunityDirectoryOptions {
   popularFreshTtlMs?: number;
 }
 
+/** Per-request overrides that preserve process-wide cache and rate spacing. */
+export interface CommunitySearchOptions {
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal | null;
+}
+
 const realSleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
@@ -73,7 +79,11 @@ export class CommunityDirectory {
     this.popularFreshTtlMs = opts.popularFreshTtlMs ?? POPULAR_FRESH_TTL_MS;
   }
 
-  async search(query: string): Promise<CommunitySkill[]> {
+  /** Search with shared cache/spacing and optional request-scoped I/O. */
+  async search(
+    query: string,
+    opts: CommunitySearchOptions = {},
+  ): Promise<CommunitySkill[]> {
     const trimmed = query.trim();
     if ([...trimmed].length < 2) return [];
     const key = trimmed.toLowerCase();
@@ -84,10 +94,11 @@ export class CommunityDirectory {
 
     await this.waitForRequestSlot();
     try {
-      const skills = await this.fetchSearch(trimmed);
+      const skills = await this.fetchSearch(trimmed, opts.fetchImpl);
       this.entries.set(key, { skills, fetchedAt: this.now() });
       return skills;
     } catch (err) {
+      if (opts.signal?.aborted) throw opts.signal.reason ?? err;
       const stale = this.entries.get(key);
       if (stale && this.now() - stale.fetchedAt <= this.staleTtlMs) {
         console.warn(
@@ -130,11 +141,14 @@ export class CommunityDirectory {
   }
 
   /** One search round-trip. Retries once after a delay on HTTP 429. */
-  private async fetchSearch(query: string): Promise<CommunitySkill[]> {
+  private async fetchSearch(
+    query: string,
+    fetchOverride?: typeof fetch,
+  ): Promise<CommunitySkill[]> {
     for (let attempt = 0; ; attempt++) {
       let res: Response;
       try {
-        res = await this.fetchImpl(
+        res = await (fetchOverride ?? this.fetchImpl)(
           `${this.endpoint}?q=${encodeURIComponent(query)}`,
           { headers: { "User-Agent": "houston-skills/1.0" } },
         );

--- a/packages/host/src/skills/remote.test.ts
+++ b/packages/host/src/skills/remote.test.ts
@@ -146,6 +146,32 @@ test("community search returns stale cache when skills.sh rate limits", async ()
   expect(skills[0]?.id).toBe("owner/repo/writing");
 });
 
+test("community search never turns cancellation into a stale-cache success", async () => {
+  const clock = fakeClock();
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    freshTtlMs: 0,
+    fetchImpl: fakeFetch(() => jsonRes({ skills: [SKILL_HIT] })),
+  });
+  await dir.search("writing");
+  clock.state.t += 1;
+  const controller = new AbortController();
+  controller.abort(new Error("search cancelled"));
+  const cancelledFetch: typeof fetch = async (_input, init) => {
+    init?.signal?.throwIfAborted();
+    throw new Error("missing signal");
+  };
+
+  await expect(
+    dir.search("writing", {
+      fetchImpl: cancelledFetch,
+      signal: controller.signal,
+    }),
+  ).rejects.toThrow("search cancelled");
+});
+
 test("community search maps a persistent 429 to rate_limited when no cache", async () => {
   const clock = fakeClock();
   const dir = new CommunityDirectory({

--- a/packages/runtime-client/src/object-sync/http-store-download.ts
+++ b/packages/runtime-client/src/object-sync/http-store-download.ts
@@ -1,0 +1,33 @@
+import { randomUUID } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, rename, rm } from "node:fs/promises";
+import { dirname } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import type { ReadResult } from "./object-store";
+
+/** Atomically land one successful object GET and retain its generation. */
+export async function downloadFile(
+  response: Response,
+  key: string,
+  destFile: string,
+): Promise<ReadResult> {
+  if (!response.body) {
+    throw new Error(`object store GET ${key} returned no response body`);
+  }
+  await mkdir(dirname(destFile), { recursive: true });
+  const tempFile = `${destFile}.${randomUUID()}.tmp`;
+  try {
+    await pipeline(
+      Readable.fromWeb(response.body as NodeReadableStream),
+      createWriteStream(tempFile),
+    );
+    await rename(tempFile, destFile);
+  } catch (error) {
+    await rm(tempFile, { force: true });
+    throw error;
+  }
+  const generation = response.headers.get("X-Houston-Generation");
+  return generation && generation !== "0" ? { generation } : {};
+}

--- a/packages/runtime-client/src/object-sync/http-store-options.ts
+++ b/packages/runtime-client/src/object-sync/http-store-options.ts
@@ -1,0 +1,17 @@
+/** Construction options for an agent-scoped HTTP object store. */
+export interface HttpObjectStoreOptions {
+  /** Full agent-scoped base URL ending in `/v1/pod/store/<org>/<agent>`. */
+  baseUrl: string;
+  token: string;
+  /** Shared routes additionally bind the pod token to its own agent slug. */
+  agentSlug?: string;
+  fetchImpl?: typeof fetch;
+  /** One delay per retry of a transient failure; override to speed up tests. */
+  retryDelaysMs?: number[];
+  /** Stable for this engine boot and sent only after a fencing token is seen. */
+  bootId?: string;
+  /** Mutable lease token shared by every agent-prefix request in this boot. */
+  fence?: { token?: string };
+  /** Per-conversation mutation authority for a pooled worker turn. */
+  claim?: { token: string; bootId: string; conversationId: string };
+}

--- a/packages/runtime-client/src/object-sync/http-store.test.ts
+++ b/packages/runtime-client/src/object-sync/http-store.test.ts
@@ -440,6 +440,22 @@ test("retries download and still writes the file atomically", async () => {
   expect(readdirSync(join(dir, "nested"))).toEqual(["dest.txt"]);
 });
 
+test("versioned download returns the object generation header", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "http-object-store-versioned-"));
+  const destination = join(dir, "dest.txt");
+  const store = retryStore(
+    async () =>
+      new Response("payload", {
+        headers: { "X-Houston-Generation": "17" },
+      }),
+  );
+
+  await expect(
+    store.downloadVersioned("file.txt", destination),
+  ).resolves.toEqual({ generation: "17" });
+  expect(readFileSync(destination, "utf8")).toBe("payload");
+});
+
 test("a 413 PUT surfaces as the typed ObjectTooLargeError, with no retry", async () => {
   let calls = 0;
   const fetchImpl: typeof fetch = async () => {

--- a/packages/runtime-client/src/object-sync/http-store.ts
+++ b/packages/runtime-client/src/object-sync/http-store.ts
@@ -1,34 +1,18 @@
-import { randomUUID } from "node:crypto";
-import { createWriteStream } from "node:fs";
-import { mkdir, rename, rm } from "node:fs/promises";
-import { dirname } from "node:path";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
-import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { downloadFile } from "./http-store-download";
 import { objectStoreResponseError } from "./http-store-errors";
+import type { HttpObjectStoreOptions } from "./http-store-options";
 import { uploadFile } from "./http-store-upload";
 import { type ObjectMetadata, parseObjectManifest } from "./object-manifest";
-import type { ObjectStore, WriteOptions, WriteResult } from "./object-store";
+import type {
+  ObjectStore,
+  ReadResult,
+  WriteOptions,
+  WriteResult,
+} from "./object-store";
 import { type FetchRetryOptions, fetchWithRetry } from "./retry";
 
+export type { HttpObjectStoreOptions } from "./http-store-options";
 export { STREAM_UPLOAD_THRESHOLD_BYTES } from "./http-store-upload";
-
-export interface HttpObjectStoreOptions {
-  /** Full agent-scoped base URL ending in `/v1/pod/store/<org>/<agent>`. */
-  baseUrl: string;
-  token: string;
-  /** Shared routes additionally bind the pod token to its own agent slug. */
-  agentSlug?: string;
-  fetchImpl?: typeof fetch;
-  /** One delay per retry of a transient failure; override to speed up tests. */
-  retryDelaysMs?: number[];
-  /** Stable for this engine boot and sent only after a fencing token is seen. */
-  bootId?: string;
-  /** Mutable lease token shared by every agent-prefix request in this boot. */
-  fence?: { token?: string };
-  /** Per-conversation mutation authority for a pooled worker turn. */
-  claim?: { token: string; bootId: string; conversationId: string };
-}
 
 export class HttpObjectStore implements ObjectStore {
   private readonly baseUrl: string;
@@ -81,27 +65,17 @@ export class HttpObjectStore implements ObjectStore {
   }
 
   async download(key: string, destFile: string): Promise<void> {
+    await this.downloadVersioned(key, destFile);
+  }
+
+  /** Download one object and preserve the generation from its GET response. */
+  async downloadVersioned(key: string, destFile: string): Promise<ReadResult> {
     const res = await this.fetch(this.objectUrl(key), {
       headers: this.authHeaders(),
     });
     this.captureFence(res);
     if (!res.ok) throw await objectStoreResponseError(res, "GET", key);
-    if (!res.body) {
-      throw new Error(`object store GET ${key} returned no response body`);
-    }
-
-    await mkdir(dirname(destFile), { recursive: true });
-    const tempFile = `${destFile}.${randomUUID()}.tmp`;
-    try {
-      await pipeline(
-        Readable.fromWeb(res.body as NodeReadableStream),
-        createWriteStream(tempFile),
-      );
-      await rename(tempFile, destFile);
-    } catch (err) {
-      await rm(tempFile, { force: true });
-      throw err;
-    }
+    return downloadFile(res, key, destFile);
   }
 
   async upload(

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -18,7 +18,12 @@ export type {
   ManifestObjectStore,
   ObjectMetadata,
 } from "./object-manifest";
-export type { ObjectStore, WriteOptions, WriteResult } from "./object-store";
+export type {
+  ObjectStore,
+  ReadResult,
+  WriteOptions,
+  WriteResult,
+} from "./object-store";
 export {
   LocalDirStore,
   ObjectNotFoundError,
@@ -36,3 +41,4 @@ export type {
 } from "./shared-mirror";
 export { probeSharedMirror, syncSharedMirror } from "./shared-mirror";
 export type { SharedMirrorFileState } from "./shared-mirror-files";
+export { mergeDocumentBodies } from "./sync-back-doc-merge";

--- a/packages/runtime-client/src/object-sync/object-store.ts
+++ b/packages/runtime-client/src/object-sync/object-store.ts
@@ -17,6 +17,8 @@ export interface ObjectStore {
     prefix?: string,
   ): Promise<import("./object-manifest").ObjectMetadata[]>;
   download(key: string, destFile: string): Promise<void>;
+  /** Download one object and return metadata from the same read response. */
+  downloadVersioned?(key: string, destFile: string): Promise<ReadResult>;
   upload(
     srcFile: string,
     key: string,
@@ -29,6 +31,11 @@ export interface ObjectStore {
 export interface WriteOptions {
   /** `0` means create-only. */
   ifGenerationMatch?: string;
+}
+
+/** Metadata captured atomically with an object download. */
+export interface ReadResult {
+  generation?: string;
 }
 
 export interface WriteResult {

--- a/packages/runtime-client/src/object-sync/sync-back-conflicts.test.ts
+++ b/packages/runtime-client/src/object-sync/sync-back-conflicts.test.ts
@@ -1,0 +1,142 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { expect, test } from "vitest";
+import { fileSha256 } from "./file-hash";
+import type { ObjectMetadata } from "./object-manifest";
+import { type ObjectStore, StoreConflictError } from "./object-store";
+import { syncBack } from "./sync-back";
+
+async function conflictingUpload(
+  relativePath: string,
+  localBody: string,
+  remoteBody: string,
+) {
+  const root = await mkdtemp(join(tmpdir(), "sync-back-conflict-"));
+  const local = join(root, ...relativePath.split("/"));
+  await mkdir(dirname(local), { recursive: true });
+  await writeFile(local, localBody);
+  const preconditions: Array<string | undefined> = [];
+  let uploadedBody = "";
+  let downloads = 0;
+  let uploads = 0;
+  const store: ObjectStore = {
+    list: async () => [relativePath],
+    manifest: async (): Promise<ObjectMetadata[]> => [
+      {
+        key: relativePath,
+        size: remoteBody.length,
+        md5: "",
+        updated: "2026-08-27T00:00:00.000Z",
+        generation: "2",
+      },
+    ],
+    download: async (_key, dest) => {
+      downloads += 1;
+      await writeFile(dest, remoteBody);
+    },
+    upload: async (source, key, options) => {
+      uploads += 1;
+      preconditions.push(options?.ifGenerationMatch);
+      if (uploads === 1) throw new StoreConflictError(key, "stale");
+      uploadedBody = await readFile(source, "utf8");
+      return { generation: "3" };
+    },
+    delete: async () => undefined,
+  };
+  const result = await syncBack(
+    store,
+    "",
+    root,
+    new Map([[relativePath, { hash: "before", generation: "1" }]]),
+    { generations: true },
+  );
+  return {
+    downloads: () => downloads,
+    local,
+    preconditions,
+    result,
+    uploadedBody: () => uploadedBody,
+  };
+}
+
+test("a routines conflict keeps remote routines the pod lacks", async () => {
+  const relativePath = ".houston/routines/routines.json";
+  const local = [{ id: "shared", name: "Local", prompt: "updated" }];
+  const remote = [
+    { id: "remote", name: "Remote", prompt: "remote" },
+    { id: "shared", name: "Stale", prompt: "stale" },
+  ];
+  const state = await conflictingUpload(
+    relativePath,
+    JSON.stringify(local),
+    JSON.stringify(remote),
+  );
+
+  expect(JSON.parse(state.uploadedBody())).toEqual([remote[0], ...local]);
+  expect(JSON.parse(await readFile(state.local, "utf8"))).toEqual([
+    remote[0],
+    ...local,
+  ]);
+  expect(state.preconditions).toEqual(["1", "2"]);
+  expect(state.result.uploaded).toEqual([relativePath]);
+  const { size } = await stat(state.local);
+  expect(state.result.manifest.get(relativePath)?.hash).toBe(
+    await fileSha256(state.local, size),
+  );
+});
+
+test("a learnings conflict keeps remote learnings the pod lacks", async () => {
+  const relativePath =
+    "workspaces/Personal/Bob/.houston/learnings/learnings.json";
+  const local = [{ id: "shared", text: "Local" }];
+  const remote = [
+    { id: "remote", text: "Remote" },
+    { id: "shared", text: "Stale" },
+  ];
+  const state = await conflictingUpload(
+    relativePath,
+    JSON.stringify(local),
+    JSON.stringify(remote),
+  );
+
+  expect(JSON.parse(state.uploadedBody())).toEqual([remote[0], ...local]);
+  expect(JSON.parse(await readFile(state.local, "utf8"))).toEqual([
+    remote[0],
+    ...local,
+  ]);
+});
+
+test("a custom definitions conflict keeps remote slugs the pod lacks", async () => {
+  const relativePath = "custom-integrations.json";
+  const local = { version: 1, items: [{ slug: "shared", name: "Local" }] };
+  const remote = {
+    version: 1,
+    items: [
+      { slug: "remote", name: "Remote" },
+      { slug: "shared", name: "Stale" },
+    ],
+  };
+  const state = await conflictingUpload(
+    relativePath,
+    JSON.stringify(local),
+    JSON.stringify(remote),
+  );
+  const expected = { version: 1, items: [remote.items[0], ...local.items] };
+
+  expect(JSON.parse(state.uploadedBody())).toEqual(expected);
+  expect(JSON.parse(await readFile(state.local, "utf8"))).toEqual(expected);
+});
+
+test("an ordinary file conflict keeps local last-writer-wins behavior", async () => {
+  const state = await conflictingUpload(
+    "workspaces/Personal/Bob/notes.txt",
+    "pod edit",
+    "remote edit",
+  );
+
+  expect(state.uploadedBody()).toBe("pod edit");
+  expect(await readFile(state.local, "utf8")).toBe("pod edit");
+  expect(state.downloads()).toBe(0);
+  expect(state.preconditions).toEqual(["1", "2"]);
+});

--- a/packages/runtime-client/src/object-sync/sync-back-conflicts.ts
+++ b/packages/runtime-client/src/object-sync/sync-back-conflicts.ts
@@ -6,6 +6,7 @@ import {
   StoreConflictError,
   type WriteOptions,
 } from "./object-store";
+import { mergeSyncBackDocument } from "./sync-back-doc-merge";
 
 /** Lazily fetched remote generations shared across one sync pass. */
 export type RefreshManifest = () =>
@@ -50,6 +51,7 @@ export async function uploadChangedObject(opts: {
   store: ObjectStore;
   abs: string;
   key: string;
+  relativePath: string;
   hash: string;
   previous?: HydrateManifestEntry;
   generationAware: boolean;
@@ -93,11 +95,20 @@ export async function uploadChangedObject(opts: {
       };
     }
     try {
+      const mergedHash = await mergeSyncBackDocument({
+        store: opts.store,
+        abs: opts.abs,
+        key: opts.key,
+        relativePath: opts.relativePath,
+      });
       const result = await opts.store.upload(opts.abs, opts.key, {
         ifGenerationMatch: retryGeneration,
       });
       return {
-        entry: { hash: opts.hash, generation: result?.generation },
+        entry: {
+          hash: mergedHash ?? opts.hash,
+          generation: result?.generation,
+        },
         uploaded: true,
       };
     } catch (retryError) {

--- a/packages/runtime-client/src/object-sync/sync-back-doc-merge.ts
+++ b/packages/runtime-client/src/object-sync/sync-back-doc-merge.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "node:crypto";
+import { readFile, rm, stat, writeFile } from "node:fs/promises";
+import { fileSha256 } from "./file-hash";
+import type { ObjectStore } from "./object-store";
+
+const ROUTINES_DOC = ".houston/routines/routines.json";
+const LEARNINGS_DOC = ".houston/learnings/learnings.json";
+const CUSTOM_DEFINITIONS = "custom-integrations.json";
+
+function isPath(relativePath: string, documentPath: string): boolean {
+  return (
+    relativePath === documentPath || relativePath.endsWith(`/${documentPath}`)
+  );
+}
+
+function arrayIdentity(relativePath: string): string | undefined {
+  return isPath(relativePath, ROUTINES_DOC) ||
+    isPath(relativePath, LEARNINGS_DOC)
+    ? "id"
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function identity(value: unknown, field: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const candidate = value[field];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function objectDocument(value: unknown, relativePath: string) {
+  if (!isRecord(value)) {
+    throw new Error(`${relativePath} is not an object`);
+  }
+  return value;
+}
+
+function mergeArrayDocument(
+  remote: unknown,
+  local: unknown,
+  field: string,
+  relativePath: string,
+): unknown[] {
+  if (!Array.isArray(remote) || !Array.isArray(local)) {
+    throw new Error(`${relativePath} is not an array`);
+  }
+  const localIds = new Set(
+    local.map((item) => identity(item, field)).filter((id) => id !== undefined),
+  );
+  return [
+    ...remote.filter((item) => {
+      const id = identity(item, field);
+      return id === undefined || !localIds.has(id);
+    }),
+    ...local,
+  ];
+}
+
+function mergeDocument(
+  relativePath: string,
+  localBody: string,
+  remoteBody: string,
+): string | undefined {
+  const field = arrayIdentity(relativePath);
+  const remote = JSON.parse(remoteBody) as unknown;
+  const local = JSON.parse(localBody) as unknown;
+  if (field) {
+    const merged = mergeArrayDocument(remote, local, field, relativePath);
+    return `${JSON.stringify(merged, null, 2)}\n`;
+  }
+  if (relativePath !== CUSTOM_DEFINITIONS) return undefined;
+  const remoteShape = objectDocument(remote, relativePath);
+  const localShape = objectDocument(local, relativePath);
+  if (remoteShape.version !== 1 || localShape.version !== 1) {
+    throw new Error(`${relativePath} has an unsupported version`);
+  }
+  const merged = {
+    ...remoteShape,
+    ...localShape,
+    items: mergeArrayDocument(
+      remoteShape.items,
+      localShape.items,
+      "slug",
+      relativePath,
+    ),
+  };
+  return `${JSON.stringify(merged, null, 2)}\n`;
+}
+
+/** Merge a conflict-sensitive document and replace its local copy. */
+export async function mergeSyncBackDocument(opts: {
+  store: ObjectStore;
+  abs: string;
+  key: string;
+  relativePath: string;
+}): Promise<string | undefined> {
+  if (
+    !arrayIdentity(opts.relativePath) &&
+    opts.relativePath !== CUSTOM_DEFINITIONS
+  ) {
+    return undefined;
+  }
+  const localBody = await readFile(opts.abs, "utf8");
+  const remoteTemp = `${opts.abs}.${randomUUID()}.remote.tmp`;
+  try {
+    await opts.store.download(opts.key, remoteTemp);
+    const remoteBody = await readFile(remoteTemp, "utf8");
+    const merged = mergeDocument(opts.relativePath, localBody, remoteBody);
+    if (merged === undefined) return undefined;
+    await writeFile(opts.abs, merged);
+    const { size } = await stat(opts.abs);
+    return fileSha256(opts.abs, size);
+  } finally {
+    await rm(remoteTemp, { force: true });
+  }
+}

--- a/packages/runtime-client/src/object-sync/sync-back-doc-merge.ts
+++ b/packages/runtime-client/src/object-sync/sync-back-doc-merge.ts
@@ -58,19 +58,20 @@ function mergeArrayDocument(
   ];
 }
 
-function mergeDocument(
+/** Merge local document entries into a refreshed remote document. */
+export function mergeDocumentBodies(
   relativePath: string,
   localBody: string,
   remoteBody: string,
 ): string | undefined {
   const field = arrayIdentity(relativePath);
+  if (!field && relativePath !== CUSTOM_DEFINITIONS) return undefined;
   const remote = JSON.parse(remoteBody) as unknown;
   const local = JSON.parse(localBody) as unknown;
   if (field) {
     const merged = mergeArrayDocument(remote, local, field, relativePath);
     return `${JSON.stringify(merged, null, 2)}\n`;
   }
-  if (relativePath !== CUSTOM_DEFINITIONS) return undefined;
   const remoteShape = objectDocument(remote, relativePath);
   const localShape = objectDocument(local, relativePath);
   if (remoteShape.version !== 1 || localShape.version !== 1) {
@@ -107,7 +108,11 @@ export async function mergeSyncBackDocument(opts: {
   try {
     await opts.store.download(opts.key, remoteTemp);
     const remoteBody = await readFile(remoteTemp, "utf8");
-    const merged = mergeDocument(opts.relativePath, localBody, remoteBody);
+    const merged = mergeDocumentBodies(
+      opts.relativePath,
+      localBody,
+      remoteBody,
+    );
     if (merged === undefined) return undefined;
     await writeFile(opts.abs, merged);
     const { size } = await stat(opts.abs);

--- a/packages/runtime-client/src/object-sync/sync-back.ts
+++ b/packages/runtime-client/src/object-sync/sync-back.ts
@@ -141,6 +141,7 @@ export async function syncBack(
       store,
       abs,
       key,
+      relativePath: rel,
       hash,
       previous,
       generationAware,

--- a/packages/runtime/src/backends/claude/backend-mcp.test.ts
+++ b/packages/runtime/src/backends/claude/backend-mcp.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { Options } from "@anthropic-ai/claude-agent-sdk";
 import { expect, test, vi } from "vitest";
 import type { ToolSelection } from "../../session/tool-selection";
+import { httpSandboxFetch } from "../../session/tools/sandbox-fetch";
 import type { ResolvedModel } from "../types";
 import { createClaudeBackend } from "./backend";
 
@@ -46,8 +47,7 @@ const model: ResolvedModel = {
 
 async function runTurn(
   integrations?: {
-    baseUrl: string;
-    sandboxToken: string;
+    call: ReturnType<typeof httpSandboxFetch>;
   },
   mode?: "execute" | "plan" | "auto",
 ): Promise<Options> {
@@ -75,8 +75,7 @@ async function runTurn(
 
 test("backend options carry the houston MCP server and its allowlist", async () => {
   const options = await runTurn({
-    baseUrl: "http://host.local",
-    sandboxToken: "tok",
+    call: httpSandboxFetch("http://host.local", "tok"),
   });
   expect(options.mcpServers?.houston).toBeDefined();
   expect(h.capturedMcp?.name).toBe("houston");
@@ -108,7 +107,7 @@ test("plan mode builds the MCP server WITHOUT integrations — ask_user + plan_r
   // tools (they act on the user's connected apps), leaving ask_user plus the
   // plan-only plan_ready presentation tool.
   const options = await runTurn(
-    { baseUrl: "http://host.local", sandboxToken: "tok" },
+    { call: httpSandboxFetch("http://host.local", "tok") },
     "plan",
   );
   expect(options.mcpServers?.houston).toBeDefined();
@@ -130,7 +129,7 @@ test("auto mode builds the MCP with integrations ON and ask_user OFF", async () 
   // HOU-853) but drops ask_user so the agent never waits on the user's
   // judgment.
   const options = await runTurn(
-    { baseUrl: "http://host.local", sandboxToken: "tok" },
+    { call: httpSandboxFetch("http://host.local", "tok") },
     "auto",
   );
   expect(options.mcpServers?.houston).toBeDefined();

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../session/interaction";
 import { makeAskUserTool } from "../../session/tools/ask-user";
 import { makeIntegrationTools } from "../../session/tools/integrations";
+import { httpSandboxFetch } from "../../session/tools/sandbox-fetch";
 import {
   buildHoustonMcpServer,
   HOUSTON_MCP_SERVER_NAME,
@@ -19,7 +20,9 @@ import {
 import { type ClaudeQuery, ClaudeSession } from "./session";
 import type { SessionsStore } from "./sessions-store";
 
-const INTEGRATIONS = { baseUrl: "http://host.local", sandboxToken: "tok" };
+const INTEGRATIONS = {
+  call: httpSandboxFetch("http://host.local", "tok"),
+};
 
 /**
  * Build the MCP server with a fake `createSdkMcpServer` that captures the adapted
@@ -27,7 +30,7 @@ const INTEGRATIONS = { baseUrl: "http://host.local", sandboxToken: "tok" };
  * real SDK (and without spawning any subprocess).
  */
 function build(
-  integrations?: { baseUrl: string; sandboxToken: string },
+  integrations?: { call: ReturnType<typeof httpSandboxFetch> },
   mode?: "execute" | "plan" | "auto",
 ): {
   mcp: HoustonMcp;

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -26,6 +26,7 @@ import { makeMissionTools } from "./tools/missions";
 import { makePlanReadyTool } from "./tools/plan-ready";
 import { makeReadMissionTool } from "./tools/read-mission";
 import { makeRunCodeTool } from "./tools/run-code";
+import { httpSandboxFetch } from "./tools/sandbox-fetch";
 import { makeSaveLearningTool } from "./tools/save-learning";
 import { makeSaveRoutineTool } from "./tools/save-routine";
 import { makeSuggestActionsTool } from "./tools/suggest-actions";
@@ -78,76 +79,55 @@ const suggestReusableTool = makeSuggestReusableTool();
 // of the two. See conversation-cache-tools.test.ts, which pins that parity.
 const suggestActionsTool = makeSuggestActionsTool();
 
+const sandboxCall =
+  config.controlPlaneUrl && config.sandboxToken
+    ? httpSandboxFetch(config.controlPlaneUrl, config.sandboxToken)
+    : null;
+const hostReachable = sandboxCall !== null;
+
 // Integration tools (Composio, platform mode): available whenever this runtime
 // can reach its host with a sandbox token (server mode — local desktop +
 // standing pods). They hold no credential; they proxy to /sandbox/integrations
 // and the host (or its cloud gateway) acts as the user's Composio user_id.
-const integrationTools =
-  config.controlPlaneUrl && config.sandboxToken
-    ? makeIntegrationTools({
-        baseUrl: config.controlPlaneUrl,
-        sandboxToken: config.sandboxToken,
-      })
-    : [];
+const integrationTools = sandboxCall
+  ? makeIntegrationTools({ call: sandboxCall })
+  : [];
 
 // Custom-integration setup tools (HOU-550): same reachability gate and trust
 // posture — they proxy to /sandbox/integrations/custom/* and hold no secret.
-const customIntegrationTools =
-  config.controlPlaneUrl && config.sandboxToken
-    ? makeCustomIntegrationTools({
-        baseUrl: config.controlPlaneUrl,
-        sandboxToken: config.sandboxToken,
-      })
-    : [];
-
-// Whether this runtime can reach its host with a sandbox token (server mode:
-// local desktop + standing pods). Gates the host-proxying tools below.
-const hostReachable = Boolean(config.controlPlaneUrl && config.sandboxToken);
+const customIntegrationTools = sandboxCall
+  ? makeCustomIntegrationTools({ call: sandboxCall })
+  : [];
 
 // The merge-safe scheduled-task write tool: proxies to /sandbox/routines/save so
 // the agent never overwrites routines.json wholesale. Same reachability gate as
 // the integration tools, but NOT tied to a Composio key — scheduled tasks exist
 // on every deployment.
-const saveRoutineTool = hostReachable
-  ? makeSaveRoutineTool({
-      baseUrl: config.controlPlaneUrl,
-      sandboxToken: config.sandboxToken,
-    })
+const saveRoutineTool = sandboxCall
+  ? makeSaveRoutineTool({ call: sandboxCall })
   : null;
 
 // The merge-safe memory write tool: proxies to /sandbox/learnings/save so the
 // agent never rewrites learnings.json wholesale AND the host can stamp the
 // learning's provenance (who taught it, which mission it came from) from the
 // turn's acting identity + conversation id. Same reachability gate as above.
-const saveLearningTool = hostReachable
-  ? makeSaveLearningTool({
-      baseUrl: config.controlPlaneUrl,
-      sandboxToken: config.sandboxToken,
-    })
+const saveLearningTool = sandboxCall
+  ? makeSaveLearningTool({ call: sandboxCall })
   : null;
 
 // The mission-board tools (PRODUCT-1244): start_mission / list_missions /
 // update_mission_status proxy to /sandbox/missions/* with the same trust
 // posture as save_routine; read_mission reads this runtime's own transcript
 // store in-process. All four ride the host-reachability gate together.
-const missionTools = hostReachable
-  ? [
-      ...makeMissionTools({
-        baseUrl: config.controlPlaneUrl,
-        sandboxToken: config.sandboxToken,
-      }),
-      makeReadMissionTool(),
-    ]
+const missionTools = sandboxCall
+  ? [...makeMissionTools({ call: sandboxCall }), makeReadMissionTool()]
   : [];
 
 // The open-skills-directory tools: proxy to /sandbox/skills/* so the agent can
 // answer "is there a skill for X?" itself and add the one the user picks. Same
 // reachability gate as above — the directory lives behind the host.
-const skillDirectoryTools = hostReachable
-  ? makeSkillDirectoryTools({
-      baseUrl: config.controlPlaneUrl,
-      sandboxToken: config.sandboxToken,
-    })
+const skillDirectoryTools = sandboxCall
+  ? makeSkillDirectoryTools({ call: sandboxCall })
   : [];
 
 const toolSelection = buildToolSelection({
@@ -224,13 +204,7 @@ registerBackend(
     // SAME integrations gate as the pi path above: present only when this
     // runtime can reach its host with a sandbox token, so the Claude backend's
     // in-process MCP server exposes the identical integration tool set.
-    integrations:
-      config.controlPlaneUrl && config.sandboxToken
-        ? {
-            baseUrl: config.controlPlaneUrl,
-            sandboxToken: config.sandboxToken,
-          }
-        : undefined,
+    integrations: sandboxCall ? { call: sandboxCall } : undefined,
   }),
 );
 

--- a/packages/runtime/src/session/tools/custom-integrations.ts
+++ b/packages/runtime/src/session/tools/custom-integrations.ts
@@ -6,6 +6,7 @@ import {
   makeRequestCredentialTool,
   REQUEST_CREDENTIAL_TOOL_NAME,
 } from "./request-credential";
+import type { SandboxFetch } from "./sandbox-fetch";
 
 export { REQUEST_CREDENTIAL_TOOL_NAME };
 
@@ -76,8 +77,7 @@ const AddParams = Type.Object({
 type AddParams = Static<typeof AddParams>;
 
 export interface CustomIntegrationToolOptions {
-  baseUrl: string;
-  sandboxToken: string;
+  call: SandboxFetch;
 }
 
 interface DetectResponse {
@@ -103,18 +103,15 @@ interface AddResponse {
 }
 
 export function makeCustomIntegrationTools(opts: CustomIntegrationToolOptions) {
-  const base = opts.baseUrl.replace(/\/$/, "");
-
   async function post<T>(
     path: "detect" | "add" | "remove" | "status",
     body: unknown,
     signal: AbortSignal | undefined,
   ): Promise<T> {
-    const res = await fetch(`${base}/sandbox/integrations/custom/${path}`, {
+    const res = await opts.call(`/sandbox/integrations/custom/${path}`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${opts.sandboxToken}`,
       },
       body: JSON.stringify(body),
       signal,
@@ -266,11 +263,10 @@ export function makeCustomIntegrationTools(opts: CustomIntegrationToolOptions) {
       // tool refuses with guidance); any other failure relays like the
       // sibling calls so the model hears the real reason.
       async status(slug, signal) {
-        const res = await fetch(`${base}/sandbox/integrations/custom/status`, {
+        const res = await opts.call("/sandbox/integrations/custom/status", {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            authorization: `Bearer ${opts.sandboxToken}`,
           },
           body: JSON.stringify({ slug }),
           signal,

--- a/packages/runtime/src/session/tools/find-skills.test.ts
+++ b/packages/runtime/src/session/tools/find-skills.test.ts
@@ -7,6 +7,7 @@ import {
   makeInstallSkillTool,
   SKILL_DIRECTORY_TOOL_NAMES,
 } from "./find-skills";
+import { httpSandboxFetch } from "./sandbox-fetch";
 
 /**
  * find_skills / install_skill are thin proxies to the host's /sandbox/skills/*
@@ -47,7 +48,7 @@ function mockFetch(reply: () => { status?: number; body?: unknown }) {
   return calls;
 }
 
-const OPTS = { baseUrl: "http://host/", sandboxToken: "sb-token" };
+const OPTS = { call: httpSandboxFetch("http://host/", "sb-token") };
 const find = makeFindSkillsTool(OPTS);
 const install = makeInstallSkillTool(OPTS);
 const CTX = {} as ExtensionContext;

--- a/packages/runtime/src/session/tools/find-skills.ts
+++ b/packages/runtime/src/session/tools/find-skills.ts
@@ -1,5 +1,6 @@
 import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
+import type { SandboxFetch } from "./sandbox-fetch";
 
 /**
  * The agent's tools for the OPEN SKILLS DIRECTORY (skills.sh): find a skill for
@@ -52,9 +53,7 @@ const InstallSkillParams = Type.Object({
 type InstallSkillParams = Static<typeof InstallSkillParams>;
 
 export interface SkillDirectoryToolOptions {
-  baseUrl: string;
-  /** The per-sandbox HMAC token (HOUSTON_SANDBOX_TOKEN). */
-  sandboxToken: string;
+  call: SandboxFetch;
 }
 
 interface FoundSkill {
@@ -78,12 +77,10 @@ async function post<T>(
   signal: AbortSignal | undefined,
   toolName: string,
 ): Promise<T> {
-  const base = opts.baseUrl.replace(/\/$/, "");
-  const res = await fetch(`${base}/sandbox/skills/${route}`, {
+  const res = await opts.call(`/sandbox/skills/${route}`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      authorization: `Bearer ${opts.sandboxToken}`,
     },
     body: JSON.stringify(body),
     signal,

--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../interaction";
 import { runWithTurnMode } from "../turn-mode-context";
 import { makeIntegrationTools } from "./integrations";
+import { httpSandboxFetch } from "./sandbox-fetch";
 
 /**
  * The agent's integration tools are thin proxies to the host's
@@ -49,8 +50,7 @@ function mockFetch(
 }
 
 const [search, execute, requestConnection] = makeIntegrationTools({
-  baseUrl: "https://host.test/",
-  sandboxToken: "sb-tok",
+  call: httpSandboxFetch("https://host.test/", "sb-tok"),
 });
 if (!search || !execute || !requestConnection)
   throw new Error("expected three integration tools");
@@ -416,6 +416,20 @@ test("a 409 (signed out) queues a signin step and tells the model to end its tur
       },
     ],
   });
+});
+
+test("an expired turn grant refuses without queuing signin or suggesting retry", async () => {
+  mockFetch(() => ({
+    status: 401,
+    body: { error: "turn grant expired", code: "grant_expired" },
+  }));
+  const holder = newInteractionHolder();
+  const failure = runWithInteractionCapture(holder, () =>
+    run(execute, { action: "GMAIL_SEND_EMAIL" }),
+  );
+  await expect(failure).rejects.toThrow(/access expired/i);
+  await expect(failure).rejects.toThrow(/Do not retry/i);
+  expect(holder.pending).toBeUndefined();
 });
 
 test("a 503 (not set up) is an honest, closed message and queues nothing", async () => {

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -4,6 +4,7 @@ import { currentActingContext } from "../acting-context";
 import { recordConnection, recordSignin } from "../interaction";
 import { assertNotPlanMode } from "../live-mode-gate";
 import { searchEmptyText, searchLeadNote } from "./integrations-search-notes";
+import type { SandboxFetch } from "./sandbox-fetch";
 
 /**
  * The agent's window into the user's connected third-party apps (Gmail, Google
@@ -156,10 +157,7 @@ const NO_AGENT_ACCESS_GUIDANCE =
   "The user does not have access to this agent, so its connected apps cannot be used for them. Tell the user plainly that someone who manages this agent needs to give them access to it in this agent's Settings, under People. Do not retry until they confirm they have access, do not call request_connection, and never imply Houston lacks the app or that something is broken.";
 
 export interface IntegrationToolOptions {
-  /** The host control-plane base URL (HOUSTON_CONTROL_PLANE_URL). */
-  baseUrl: string;
-  /** The per-sandbox HMAC token (HOUSTON_SANDBOX_TOKEN). */
-  sandboxToken: string;
+  call: SandboxFetch;
 }
 
 /**
@@ -247,8 +245,6 @@ interface ActionResult {
 
 /** Both integration tools, or `[]` when the host can't be reached (no creds). */
 export function makeIntegrationTools(opts: IntegrationToolOptions) {
-  const base = opts.baseUrl.replace(/\/$/, "");
-
   async function post<T>(
     path: "search" | "execute",
     body: unknown,
@@ -259,11 +255,10 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
     // (chat.ts wraps the turn), so it's present only when this turn received one —
     // absent otherwise, preserving the act-as-owner behavior.
     const acting = currentActingContext();
-    const res = await fetch(`${base}/sandbox/integrations/${path}`, {
+    const res = await opts.call(`/sandbox/integrations/${path}`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${opts.sandboxToken}`,
         ...(acting?.actingAs ? { "x-houston-acting-as": acting.actingAs } : {}),
         ...(acting?.actingUser
           ? { "x-houston-acting-user": acting.actingUser }
@@ -307,6 +302,11 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
         });
         throw new Error(
           "The user is signed out of Houston, so connected apps can't act for them yet. A sign-in card has been queued in the interaction flow. Queue any request_connection you still need (it will follow the sign-in step), then end your turn. Do NOT tell the user to open Settings — Houston sends you a message automatically once they're signed in.",
+        );
+      }
+      if (code === "grant_expired") {
+        throw new Error(
+          "This turn's connected-app access expired before the action could run. Do not retry it in this turn, especially if it may have changed external data. Tell the user plainly that connected apps are temporarily unavailable and ask them to send a new message to continue.",
         );
       }
       // integrations_not_configured (503): connected apps are not set up in this

--- a/packages/runtime/src/session/tools/missions.ts
+++ b/packages/runtime/src/session/tools/missions.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from "typebox";
 import { currentActingContext } from "../acting-context";
 import { currentConversationId } from "../conversation-context";
 import { currentTurnModel, type TurnModel } from "../turn-model-context";
+import type { SandboxFetch } from "./sandbox-fetch";
 import { CONVERSATION_ID_HEADER } from "./save-learning";
 
 /**
@@ -66,9 +67,7 @@ const UpdateMissionStatusParams = Type.Object({
 type UpdateMissionStatusParams = Static<typeof UpdateMissionStatusParams>;
 
 export interface MissionToolOptions {
-  baseUrl: string;
-  /** The per-sandbox HMAC token (HOUSTON_SANDBOX_TOKEN). */
-  sandboxToken: string;
+  call: SandboxFetch;
 }
 
 /**
@@ -99,8 +98,6 @@ export function missionPin(
 }
 
 export function makeMissionTools(opts: MissionToolOptions) {
-  const base = opts.baseUrl.replace(/\/$/, "");
-
   /** Shared authed call; forwards the acting identity + this conversation's id
    *  so the host can stamp attribution and enforce the self/depth guards. */
   async function call(
@@ -111,11 +108,10 @@ export function makeMissionTools(opts: MissionToolOptions) {
   ): Promise<unknown> {
     const acting = currentActingContext();
     const conversationId = currentConversationId();
-    const res = await fetch(`${base}/sandbox/missions${path}`, {
+    const res = await opts.call(`/sandbox/missions${path}`, {
       method,
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${opts.sandboxToken}`,
         ...(acting?.actingAs ? { "x-houston-acting-as": acting.actingAs } : {}),
         ...(acting?.actingUser
           ? { "x-houston-acting-user": acting.actingUser }

--- a/packages/runtime/src/session/tools/sandbox-fetch.test.ts
+++ b/packages/runtime/src/session/tools/sandbox-fetch.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { httpSandboxFetch } from "./sandbox-fetch";
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("httpSandboxFetch preserves the server-mode request and adds sandbox auth", async () => {
+  const signal = new AbortController().signal;
+  const seen: Array<{ url: string; init?: RequestInit }> = [];
+  vi.stubGlobal(
+    "fetch",
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push({ url: String(input), init });
+      return new Response("ok");
+    },
+  );
+
+  const call = httpSandboxFetch("https://host.test/", "sb-token");
+  await call("/sandbox/example", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-houston-acting-as": "acting-v1.value",
+    },
+    body: '{"value":1}',
+    signal,
+  });
+
+  expect(seen).toEqual([
+    {
+      url: "https://host.test/sandbox/example",
+      init: {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-houston-acting-as": "acting-v1.value",
+          authorization: "Bearer sb-token",
+        },
+        body: '{"value":1}',
+        signal,
+      },
+    },
+  ]);
+});

--- a/packages/runtime/src/session/tools/sandbox-fetch.ts
+++ b/packages/runtime/src/session/tools/sandbox-fetch.ts
@@ -1,0 +1,21 @@
+/** Turn-local transport used by tools that call `/sandbox/*` routes. */
+export type SandboxFetch = (
+  path: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/** Server-mode adapter over the host's HTTP sandbox routes. */
+export function httpSandboxFetch(
+  baseUrl: string,
+  sandboxToken: string,
+): SandboxFetch {
+  const base = baseUrl.replace(/\/+$/, "");
+  return (path, init) =>
+    fetch(`${base}${path}`, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        authorization: `Bearer ${sandboxToken}`,
+      },
+    });
+}

--- a/packages/runtime/src/session/tools/save-learning.test.ts
+++ b/packages/runtime/src/session/tools/save-learning.test.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { afterEach, expect, test } from "vitest";
 import { runWithActingContext } from "../acting-context";
 import { runWithConversationId } from "../conversation-context";
+import { httpSandboxFetch } from "./sandbox-fetch";
 import {
   CONVERSATION_ID_HEADER,
   makeSaveLearningTool,
@@ -48,8 +49,7 @@ function mockFetch(reply: () => { status?: number; body?: unknown }) {
 }
 
 const tool = makeSaveLearningTool({
-  baseUrl: "https://host.test/",
-  sandboxToken: "sb-tok",
+  call: httpSandboxFetch("https://host.test/", "sb-tok"),
 });
 const ctx = {} as unknown as ExtensionContext;
 const run = (params: unknown) =>

--- a/packages/runtime/src/session/tools/save-learning.ts
+++ b/packages/runtime/src/session/tools/save-learning.ts
@@ -2,6 +2,7 @@ import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
 import { currentActingContext } from "../acting-context";
 import { currentConversationId } from "../conversation-context";
+import type { SandboxFetch } from "./sandbox-fetch";
 
 /**
  * The agent's structured tool to SAVE a learning (a stable fact or preference
@@ -35,9 +36,7 @@ const SaveLearningParams = Type.Object({
 type SaveLearningParams = Static<typeof SaveLearningParams>;
 
 export interface SaveLearningToolOptions {
-  baseUrl: string;
-  /** The per-sandbox HMAC token (HOUSTON_SANDBOX_TOKEN). */
-  sandboxToken: string;
+  call: SandboxFetch;
 }
 
 /** What the host echoes back on a successful save. */
@@ -46,8 +45,6 @@ interface SavedLearning {
 }
 
 export function makeSaveLearningTool(opts: SaveLearningToolOptions) {
-  const base = opts.baseUrl.replace(/\/$/, "");
-
   return defineTool({
     name: SAVE_LEARNING_TOOL_NAME,
     label: "Remember this",
@@ -67,11 +64,10 @@ export function makeSaveLearningTool(opts: SaveLearningToolOptions) {
       // the host then simply stamps nothing.
       const acting = currentActingContext();
       const conversationId = currentConversationId();
-      const res = await fetch(`${base}/sandbox/learnings/save`, {
+      const res = await opts.call("/sandbox/learnings/save", {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${opts.sandboxToken}`,
           ...(acting?.actingAs
             ? { "x-houston-acting-as": acting.actingAs }
             : {}),

--- a/packages/runtime/src/session/tools/save-routine.test.ts
+++ b/packages/runtime/src/session/tools/save-routine.test.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { afterEach, expect, test } from "vitest";
 import { runWithActingContext } from "../acting-context";
 import { runWithConversationId } from "../conversation-context";
+import { httpSandboxFetch } from "./sandbox-fetch";
 import {
   makeSaveRoutineTool,
   ROUTINE_RUN_SAVE_REFUSAL,
@@ -47,8 +48,7 @@ function mockFetch(reply: () => { status?: number; body?: unknown }) {
 }
 
 const tool = makeSaveRoutineTool({
-  baseUrl: "https://host.test/",
-  sandboxToken: "sb-tok",
+  call: httpSandboxFetch("https://host.test/", "sb-tok"),
 });
 const ctx = {} as unknown as ExtensionContext;
 const run = (params: unknown) =>

--- a/packages/runtime/src/session/tools/save-routine.ts
+++ b/packages/runtime/src/session/tools/save-routine.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from "typebox";
 import { currentActingContext } from "../acting-context";
 import { currentConversationId } from "../conversation-context";
 import { currentTurnMode } from "../turn-mode-context";
+import type { SandboxFetch } from "./sandbox-fetch";
 
 /**
  * The agent's structured tool to CREATE or UPDATE a scheduled task (a Routine).
@@ -108,9 +109,7 @@ const SaveRoutineParams = Type.Object({
 type SaveRoutineParams = Static<typeof SaveRoutineParams>;
 
 export interface SaveRoutineToolOptions {
-  baseUrl: string;
-  /** The per-sandbox HMAC token (HOUSTON_SANDBOX_TOKEN). */
-  sandboxToken: string;
+  call: SandboxFetch;
 }
 
 /**
@@ -139,8 +138,6 @@ interface SavedRoutine {
 }
 
 export function makeSaveRoutineTool(opts: SaveRoutineToolOptions) {
-  const base = opts.baseUrl.replace(/\/$/, "");
-
   return defineTool({
     name: SAVE_ROUTINE_TOOL_NAME,
     label: "Save a scheduled task",
@@ -161,11 +158,10 @@ export function makeSaveRoutineTool(opts: SaveRoutineToolOptions) {
       // tools. Turn-scoped; absent outside a turn.
       const acting = currentActingContext();
       const auto = currentTurnMode() === "auto";
-      const res = await fetch(`${base}/sandbox/routines/save`, {
+      const res = await opts.call("/sandbox/routines/save", {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${opts.sandboxToken}`,
           ...(acting?.actingAs
             ? { "x-houston-acting-as": acting.actingAs }
             : {}),

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -281,6 +281,7 @@ export async function executeTurn(
         heartbeat,
         outcome,
         transcript,
+        ...(turnSandbox ? { views: turnSandbox.views() } : {}),
       });
       outcome = durable.outcome;
       emit(
@@ -303,9 +304,11 @@ export async function executeTurn(
   } finally {
     try {
       await turnSandbox?.dispose().catch((error: unknown) => {
-        console.error(
-          `[turn] sandbox dispose failed (${error instanceof Error ? error.name : typeof error})`,
-        );
+        const detail =
+          error instanceof Error
+            ? `${error.name}: ${error.message}`
+            : typeof error;
+        console.error(`[turn] sandbox dispose failed (${detail})`);
       });
     } finally {
       try {

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -23,8 +23,9 @@ import {
   settleRoutineTurn,
 } from "./turn-routine";
 import { createTurnModelRuntime } from "./turn-runtime";
+import { makeTurnSandboxFetch } from "./turn-sandbox";
 import { runPiTurn, type TurnOutcome } from "./turn-session";
-import { resolveTurnStore } from "./turn-store";
+import { poolIdentity, resolveTurnStore } from "./turn-store";
 import { turnSetupErrorFrame, turnTerminalFrame } from "./turn-terminal";
 import { createTurnTranscript } from "./turn-transcript";
 import type { TurnRequest } from "./types";
@@ -48,6 +49,7 @@ export async function executeTurn(
   if (!turn.claim) req.on("close", () => abort.abort());
   const turnId = turn.turnId ?? crypto.randomUUID();
   let heartbeat: ReturnType<typeof startClaimHeartbeat> | null = null;
+  let turnSandbox: ReturnType<typeof makeTurnSandboxFetch> | null = null;
   let closeSse: (() => void) | undefined;
   try {
     const resolved = resolveTurnStore(turn, deps.store, {
@@ -84,6 +86,22 @@ export async function executeTurn(
     });
     timings.t_hydrated = performance.now();
     const { dataDir } = filesystem;
+    if (turn.grant && turn.hostToken) {
+      const identity = poolIdentity(turn.gcsPrefix);
+      turnSandbox = makeTurnSandboxFetch({
+        grant: turn.grant,
+        hostToken: turn.hostToken,
+        store: resolved.store,
+        prefix: resolved.prefix,
+        filesystem,
+        workspaceId: turn.workspaceId,
+        conversationId: turn.conversationId,
+        ...(turn.actingAs ? { actingAs: turn.actingAs } : {}),
+        orgSlug: identity.org,
+        agentSlug: identity.agent,
+        ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+      });
+    }
     const authPath = join(dataDir, "auth.json");
     if (turn.credential) {
       applyServedCredential(authPath, turn.credential);
@@ -214,7 +232,13 @@ export async function executeTurn(
               () =>
                 run(
                   filesystem,
-                  piTurnRequest(effectiveTurn, turnId, emit, abort.signal),
+                  piTurnRequest(
+                    effectiveTurn,
+                    turnId,
+                    emit,
+                    abort.signal,
+                    turnSandbox ? { call: turnSandbox.call } : undefined,
+                  ),
                 ),
             ),
           );
@@ -278,13 +302,21 @@ export async function executeTurn(
     sse.send(turnSetupErrorFrame(error, turnId));
   } finally {
     try {
-      await heartbeat?.stop();
+      await turnSandbox?.dispose().catch((error: unknown) => {
+        console.error(
+          `[turn] sandbox dispose failed (${error instanceof Error ? error.name : typeof error})`,
+        );
+      });
     } finally {
-      releaseConversation(scope, turn.conversationId);
       try {
-        await rm(root, { recursive: true, force: true });
+        await heartbeat?.stop();
       } finally {
-        closeSse?.();
+        releaseConversation(scope, turn.conversationId);
+        try {
+          await rm(root, { recursive: true, force: true });
+        } finally {
+          closeSse?.();
+        }
       }
     }
   }

--- a/packages/runtime/src/turn/op-scope.ts
+++ b/packages/runtime/src/turn/op-scope.ts
@@ -1,5 +1,4 @@
 import { posix } from "node:path";
-import { agentScopeIncludes } from "./turn-agent-scope";
 import type { TurnFilesystem } from "./turn-filesystem";
 
 /**
@@ -21,7 +20,12 @@ export type OpInclude = (relativePath: string) => boolean;
  *  accept) — never the runtime tree (conversations, sessions, auth), which
  *  stays conversation-scoped. Mirrors the pod-store's ops-claim scope. */
 export function agentRouteScope(workspaceRel: string): OpInclude {
-  return (relativePath) => agentScopeIncludes(relativePath, workspaceRel);
+  // Deliberately WIDER than the turn predicate (turn-agent-scope): an op runs
+  // under the serialized agent-ops claim, which the store grants the whole
+  // non-runtime tree; a turn claim gets only its own doc files.
+  const root = `${workspaceRel}/`;
+  const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
+  return (rel) => rel.startsWith(root) && !rel.startsWith(runtime);
 }
 
 /** One conversation's file + sessions. */

--- a/packages/runtime/src/turn/op-scope.ts
+++ b/packages/runtime/src/turn/op-scope.ts
@@ -1,4 +1,5 @@
 import { posix } from "node:path";
+import { agentScopeIncludes } from "./turn-agent-scope";
 import type { TurnFilesystem } from "./turn-filesystem";
 
 /**
@@ -20,9 +21,7 @@ export type OpInclude = (relativePath: string) => boolean;
  *  accept) — never the runtime tree (conversations, sessions, auth), which
  *  stays conversation-scoped. Mirrors the pod-store's ops-claim scope. */
 export function agentRouteScope(workspaceRel: string): OpInclude {
-  const root = `${workspaceRel}/`;
-  const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
-  return (rel) => rel.startsWith(root) && !rel.startsWith(runtime);
+  return (relativePath) => agentScopeIncludes(relativePath, workspaceRel);
 }
 
 /** One conversation's file + sessions. */

--- a/packages/runtime/src/turn/parse-turn-request.ts
+++ b/packages/runtime/src/turn/parse-turn-request.ts
@@ -1,7 +1,7 @@
 import { normalizeTurnMode, parseMentions } from "@houston/protocol";
 import type { ServedCredential } from "../auth/auth-file";
 import { assertRoutineEventBounds } from "./parse-routine-events";
-import type { TurnRequest } from "./types";
+import type { TurnGrant, TurnGrantScope, TurnRequest } from "./types";
 
 const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const PREFIX = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/;
@@ -27,6 +27,52 @@ function exactKeys(
 
 function nonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+const GRANT_SCOPES: readonly TurnGrantScope[] = [
+  "integrations",
+  "agent-writes",
+];
+
+function parseGrant(value: unknown): TurnGrant {
+  const grant = record(value, "grant");
+  exactKeys(grant, ["url", "token", "expires", "scopes"], "grant");
+  if (
+    !nonEmpty(grant.url) ||
+    !nonEmpty(grant.token) ||
+    typeof grant.expires !== "number" ||
+    !Number.isSafeInteger(grant.expires) ||
+    grant.expires <= 0 ||
+    !Array.isArray(grant.scopes)
+  ) {
+    throw new Error("invalid 'grant'");
+  }
+  let origin: URL;
+  try {
+    origin = new URL(grant.url);
+  } catch {
+    throw new Error("invalid 'grant'");
+  }
+  if (
+    (origin.protocol !== "http:" && origin.protocol !== "https:") ||
+    origin.username !== "" ||
+    origin.password !== "" ||
+    origin.pathname !== "/" ||
+    origin.search !== "" ||
+    origin.hash !== ""
+  ) {
+    throw new Error("invalid 'grant'");
+  }
+  return {
+    url: origin.origin,
+    token: grant.token,
+    expires: grant.expires,
+    scopes: grant.scopes.filter(
+      (scope): scope is TurnGrantScope =>
+        typeof scope === "string" &&
+        GRANT_SCOPES.includes(scope as TurnGrantScope),
+    ),
+  };
 }
 
 /** Validate an untyped body into a TurnRequest. Throws with the real reason. */
@@ -133,6 +179,11 @@ export function parseTurnRequest(body: unknown): TurnRequest {
   if (Boolean(claim) !== Boolean(b.hostToken)) {
     throw new Error("claim and hostToken must be configured together");
   }
+  const grant = b.grant === undefined ? undefined : parseGrant(b.grant);
+  if (grant && !claim) throw new Error("grant requires a claim");
+  if (grant && b.shadow === true) {
+    throw new Error("shadow turn cannot carry a grant");
+  }
   let routine: TurnRequest["routine"];
   if (b.routine !== undefined) {
     const parsed = record(b.routine, "routine");
@@ -202,5 +253,6 @@ export function parseTurnRequest(body: unknown): TurnRequest {
       typeof b.turnlogSeqStart === "number" ? b.turnlogSeqStart : undefined,
     routine,
     claim,
+    grant,
   };
 }

--- a/packages/runtime/src/turn/pi-turn-request.test.ts
+++ b/packages/runtime/src/turn/pi-turn-request.test.ts
@@ -48,3 +48,33 @@ test("no pin and no credential leaves the provider unattributed", () => {
     piTurnRequest({ ...base, credential: null }, "t1", emit, signal).provider,
   ).toBe("");
 });
+
+test("only grant scopes and the sandbox closure reach the pi request", () => {
+  const call = async () => Response.json({});
+  const turn = piTurnRequest(
+    {
+      ...base,
+      claim: {
+        id: "claim",
+        bootId: "boot",
+        token: "claim-secret",
+        heartbeatUrl: "https://gateway.test/heartbeat",
+      },
+      hostToken: "host-secret",
+      grant: {
+        url: "https://gateway.test",
+        token: "grant-secret",
+        expires: 2_000_000_000,
+        scopes: ["integrations"],
+      },
+    },
+    "t1",
+    emit,
+    signal,
+    { call },
+  );
+  expect(turn.grant).toEqual({ scopes: ["integrations"] });
+  expect(turn.sandbox?.call).toBe(call);
+  expect(JSON.stringify(turn)).not.toContain("grant-secret");
+  expect(JSON.stringify(turn)).not.toContain("host-secret");
+});

--- a/packages/runtime/src/turn/pi-turn-request.ts
+++ b/packages/runtime/src/turn/pi-turn-request.ts
@@ -1,4 +1,5 @@
 import type { WireFrame } from "@houston/runtime-client";
+import type { SandboxFetch } from "../session/tools/sandbox-fetch";
 import type { PiTurnRequest } from "./turn-session";
 import type { TurnRequest } from "./types";
 
@@ -8,6 +9,7 @@ export function piTurnRequest(
   turnId: string,
   emit: (frame: WireFrame) => void,
   signal: AbortSignal,
+  sandbox?: { call: SandboxFetch },
 ): PiTurnRequest {
   return {
     conversationId: turn.conversationId,
@@ -27,6 +29,8 @@ export function piTurnRequest(
     displayText: turn.displayText,
     mentions: turn.mentions,
     author: turn.actingAs,
+    ...(turn.grant ? { grant: { scopes: turn.grant.scopes } } : {}),
+    ...(sandbox ? { sandbox } : {}),
     // Either context field present means "use these" (each defaults to ""),
     // mirroring the long-lived server's message-send contract.
     ...(turn.workspaceContext !== undefined || turn.userContext !== undefined

--- a/packages/runtime/src/turn/pool-leaks.test.ts
+++ b/packages/runtime/src/turn/pool-leaks.test.ts
@@ -11,6 +11,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterAll, expect, test } from "vitest";
+import { poolBashEnv } from "../session/tools/pool-bash";
+import type { runPiTurn } from "./turn-session";
 
 const scratch = mkdtempSync(join(tmpdir(), "houston-pool-leaks-"));
 process.env.HOUSTON_MODE = "turn";
@@ -224,4 +226,101 @@ test("alternating agents leave no credential, conversation, auth, root, or confi
   expect(await store.list("ws/w1")).not.toContainEqual(
     expect.stringMatching(/auth\.json$/),
   );
+});
+
+function treeText(root: string): string {
+  const values: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else values.push(readFileSync(path, "utf8"));
+    }
+  };
+  walk(root);
+  return values.join("\n");
+}
+
+test("a granted turn keeps every operational secret out of pi, tools, bash, and the hydrated tree", async () => {
+  const secrets = {
+    grant: "grant-secret-never-persist",
+    host: "host-secret-never-persist",
+    worker: "worker-secret-never-persist",
+    storeUrl: "https://store.internal.test",
+  };
+  const childEnv = poolBashEnv({
+    PATH: process.env.PATH,
+    HOUSTON_POOL_WORKER_TOKEN: secrets.worker,
+    HOUSTON_POOL_STORE_URL: secrets.storeUrl,
+    HOUSTON_HOST_TOKEN: secrets.host,
+    HOUSTON_TURN_GRANT: secrets.grant,
+  });
+  for (const secret of Object.values(secrets)) {
+    expect(JSON.stringify(childEnv)).not.toContain(secret);
+  }
+  expect(Object.values(process.env)).not.toContain(secrets.grant);
+  expect(Object.values(process.env)).not.toContain(secrets.host);
+
+  let observed = false;
+  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+    const serialized = JSON.stringify(turn);
+    expect(serialized).not.toContain(secrets.grant);
+    expect(serialized).not.toContain(secrets.host);
+    const toolResponse = await turn.sandbox?.call(
+      "/sandbox/integrations/search",
+      { method: "POST", body: JSON.stringify({ query: "email" }) },
+    );
+    expect(await toolResponse?.text()).not.toMatch(
+      new RegExp(Object.values(secrets).join("|")),
+    );
+    const hydrated = treeText(join(filesystem.workspaceDir, "../../.."));
+    for (const secret of Object.values(secrets)) {
+      expect(hydrated).not.toContain(secret);
+    }
+    observed = true;
+    return {};
+  };
+  const granted = createTurnServer({
+    store,
+    token: "",
+    runTurn,
+    fetchImpl: async (input) =>
+      String(input).includes("/heartbeat")
+        ? new Response(null, { status: 204 })
+        : Response.json({ error: "expired" }, { status: 401 }),
+  });
+  const url = await listen(granted);
+  const response = await fetch(`${url}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      workspaceId: "w1",
+      agentId: "agent-s",
+      conversationId: "granted-cid",
+      text: "hello",
+      gcsPrefix: "ws/w1/agent-s",
+      credential: {
+        provider: "openai-compatible",
+        access: "model-access",
+        expires: Date.now() + 60_000,
+        kind: "api_key",
+      },
+      hostToken: secrets.host,
+      claim: {
+        id: "claim-granted",
+        bootId: "boot-granted",
+        token: "claim-secret-never-persist",
+        heartbeatUrl: "https://gateway.test/heartbeat",
+      },
+      grant: {
+        url: "https://gateway.test",
+        token: secrets.grant,
+        expires: 2_000_000_000,
+        scopes: ["integrations", "agent-writes"],
+      },
+    }),
+  });
+  expect(response.status).toBe(200);
+  await response.text();
+  expect(observed).toBe(true);
 });

--- a/packages/runtime/src/turn/turn-agent-scope.test.ts
+++ b/packages/runtime/src/turn/turn-agent-scope.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { agentScopeIncludes } from "./turn-agent-scope";
+
+const ROOT = "workspaces/Personal/Bob";
+
+test.each([
+  `${ROOT}/.houston/routines/routines.json`,
+  `${ROOT}/.houston/learnings/learnings.json`,
+  "custom-integrations.json",
+  `${ROOT}/.agents/skills/example/SKILL.md`,
+  `${ROOT}/notes.md`,
+])("agent scope includes %s", (path) => {
+  expect(agentScopeIncludes(path, ROOT)).toBe(true);
+});
+
+test.each([
+  `${ROOT}/.houston/runtime/settings.json`,
+  `${ROOT}/.houston/runtime/conversations/c1.json`,
+  "workspaces/Personal/Alice/notes.md",
+])("agent scope excludes %s", (path) => {
+  expect(agentScopeIncludes(path, ROOT)).toBe(false);
+});

--- a/packages/runtime/src/turn/turn-agent-scope.test.ts
+++ b/packages/runtime/src/turn/turn-agent-scope.test.ts
@@ -16,6 +16,8 @@ test.each([
 test.each([
   `${ROOT}/.houston/runtime/settings.json`,
   `${ROOT}/.houston/runtime/conversations/c1.json`,
+  `${ROOT}/.houston/docs/activity/activity.json`,
+  `${ROOT}/.houston/routines/other.json`,
   "workspaces/Personal/Alice/notes.md",
 ])("agent scope excludes %s", (path) => {
   expect(agentScopeIncludes(path, ROOT)).toBe(false);

--- a/packages/runtime/src/turn/turn-agent-scope.ts
+++ b/packages/runtime/src/turn/turn-agent-scope.ts
@@ -1,0 +1,12 @@
+import { posix } from "node:path";
+
+/** Files an agent-level mutation may own without entering turn runtime state. */
+export function agentScopeIncludes(
+  relativePath: string,
+  workspaceRel: string,
+): boolean {
+  if (relativePath === "custom-integrations.json") return true;
+  const root = `${workspaceRel}/`;
+  const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
+  return relativePath.startsWith(root) && !relativePath.startsWith(runtime);
+}

--- a/packages/runtime/src/turn/turn-agent-scope.ts
+++ b/packages/runtime/src/turn/turn-agent-scope.ts
@@ -1,12 +1,25 @@
 import { posix } from "node:path";
 
-/** Files an agent-level mutation may own without entering turn runtime state. */
+/**
+ * Files an agent-level mutation may own from a claimed turn. Mirrors the
+ * store's turn-claim object scope EXACTLY — any path admitted here but
+ * rejected server-side would be attempted at sync and 403'd (a silent
+ * partial sync), so the two rules must not drift: ordinary workspace files,
+ * the two turn-owned doc files, and the store-root custom-integration
+ * definitions. Every other `.houston` family (docs, runtime, settings)
+ * belongs to other writers.
+ */
 export function agentScopeIncludes(
   relativePath: string,
   workspaceRel: string,
 ): boolean {
   if (relativePath === "custom-integrations.json") return true;
   const root = `${workspaceRel}/`;
-  const runtime = `${posix.join(workspaceRel, ".houston", "runtime")}/`;
-  return relativePath.startsWith(root) && !relativePath.startsWith(runtime);
+  if (!relativePath.startsWith(root)) return false;
+  const internal = `${posix.join(workspaceRel, ".houston")}/`;
+  if (!relativePath.startsWith(internal)) return true;
+  const rest = relativePath.slice(internal.length);
+  return (
+    rest === "routines/routines.json" || rest === "learnings/learnings.json"
+  );
 }

--- a/packages/runtime/src/turn/turn-changed-events.test.ts
+++ b/packages/runtime/src/turn/turn-changed-events.test.ts
@@ -15,10 +15,12 @@ describe("changedEventTypes", () => {
         "workspaces/Houston/Agent/.houston/routines/routines.json",
         "workspaces/Houston/Agent/.houston/config/config.json",
         "workspaces/Houston/Agent/.houston/learnings/learnings.json",
+        "custom-integrations.json",
       ]),
     ).toEqual([
       "ActivityChanged",
       "ConfigChanged",
+      "CustomIntegrationsChanged",
       "LearningsChanged",
       "RoutineRunsChanged",
       "RoutinesChanged",
@@ -56,8 +58,7 @@ describe("changedEventTypes", () => {
     ).toEqual([]);
     // The canonical classifier (agentFileEventType) is prefix-based, so this
     // agent's own activity SCHEMA file maps to ActivityChanged — a rare, safe
-    // over-fire (a refetch), never a miss. Claimed turns never sync .houston
-    // internals anyway (claimedTurnIncludes excludes them).
+    // over-fire (a refetch), never a miss.
     expect(
       changedEventTypes(layout, [
         "workspaces/Houston/Agent/.houston/activity/activity.schema.json",

--- a/packages/runtime/src/turn/turn-changed-events.ts
+++ b/packages/runtime/src/turn/turn-changed-events.ts
@@ -2,6 +2,7 @@ import { agentFileEventType } from "@houston/domain";
 import type { HoustonEvent } from "@houston/protocol";
 
 type AgentEventType = Extract<HoustonEvent, { agentPath: string }>["type"];
+type TurnChangedEventType = AgentEventType | "CustomIntegrationsChanged";
 
 /**
  * The domain events a pool turn's durable writes imply, derived from the
@@ -23,12 +24,14 @@ type AgentEventType = Extract<HoustonEvent, { agentPath: string }>["type"];
 export function changedEventTypes(
   layout: { workspaceRel: string; dataRel: string },
   keys: readonly string[],
-): AgentEventType[] {
+): TurnChangedEventType[] {
   const workspacePrefix = `${layout.workspaceRel}/`;
   const dataPrefix = `${layout.dataRel}/`;
-  const out = new Set<AgentEventType>();
+  const out = new Set<TurnChangedEventType>();
   for (const key of keys) {
-    if (key.startsWith(workspacePrefix)) {
+    if (key === "custom-integrations.json") {
+      out.add("CustomIntegrationsChanged");
+    } else if (key.startsWith(workspacePrefix)) {
       const type = agentFileEventType(key.slice(workspacePrefix.length));
       if (type) out.add(type);
     } else if (

--- a/packages/runtime/src/turn/turn-custom-context.ts
+++ b/packages/runtime/src/turn/turn-custom-context.ts
@@ -1,0 +1,64 @@
+import { join } from "node:path";
+import type { CustomIntegrationManager } from "@houston/host/src/integrations/custom/manager";
+import type { CustomIntegrationProvider } from "@houston/host/src/integrations/custom/provider";
+import type { TurnFilesystem } from "./turn-filesystem";
+
+const CUSTOM_DEFS_FILE = "custom-integrations.json";
+
+/** Per-turn custom-integration manager, provider, and owned resources. */
+export interface TurnCustomContext {
+  manager: CustomIntegrationManager;
+  provider: CustomIntegrationProvider;
+  dispose: () => Promise<void>;
+}
+
+/** Build a custom-integration context over the hydrated definitions and remote secrets. */
+export async function createTurnCustomContext(opts: {
+  filesystem: TurnFilesystem;
+  grantUrl: string;
+  hostToken: string;
+  orgSlug: string;
+  agentSlug: string;
+  fetchImpl?: typeof fetch;
+}): Promise<TurnCustomContext> {
+  await opts.filesystem.vfs.readBytes(CUSTOM_DEFS_FILE);
+  const [
+    { CustomExecutorHost },
+    { CustomIntegrationManager },
+    { CustomIntegrationProvider },
+    { RemoteCustomSecretStore },
+    { FileCustomIntegrationStore },
+  ] = await Promise.all([
+    import("@houston/host/src/integrations/custom/executor-host"),
+    import("@houston/host/src/integrations/custom/manager"),
+    import("@houston/host/src/integrations/custom/provider"),
+    import("@houston/host/src/integrations/custom/secrets"),
+    import("@houston/host/src/integrations/custom/store"),
+  ]);
+  const store = new FileCustomIntegrationStore(
+    join(opts.filesystem.storeRoot, CUSTOM_DEFS_FILE),
+  );
+  const secrets = new RemoteCustomSecretStore({
+    baseUrl: opts.grantUrl,
+    orgSlug: opts.orgSlug,
+    agentSlug: opts.agentSlug,
+    podToken: opts.hostToken,
+    ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+  });
+  const executor = new CustomExecutorHost(secrets, () => store.list());
+  const manager = new CustomIntegrationManager(
+    store,
+    secrets,
+    executor,
+    () => undefined,
+    {},
+  );
+  return {
+    manager,
+    provider: new CustomIntegrationProvider(store, executor),
+    dispose: () => executor.reset(),
+  };
+}
+
+/** Store-relative custom-integration definitions document. */
+export const customDefinitionsFile = CUSTOM_DEFS_FILE;

--- a/packages/runtime/src/turn/turn-doc-cas.test.ts
+++ b/packages/runtime/src/turn/turn-doc-cas.test.ts
@@ -1,10 +1,20 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
+  fileSha256,
   type ObjectMetadata,
+  ObjectNotFoundError,
   type ObjectStore,
   StoreConflictError,
+  syncBack,
 } from "@houston/runtime-client/object-sync";
 import { expect, test } from "vitest";
 import { mutateTurnDocument, TurnDocConflictError } from "./turn-doc-cas";
@@ -95,7 +105,161 @@ test("three generation conflicts become a typed conflict", async () => {
   ).rejects.toBeInstanceOf(TurnDocConflictError);
 });
 
-test("a declined mutation refreshes ownership without uploading", async () => {
+test("a terminal conflict restores the pre-call file before final sync", async () => {
+  const state = await fixture(3);
+  const before = "pre-call bytes";
+  await mkdir(dirname(state.local), { recursive: true });
+  await writeFile(state.local, before);
+  state.filesystem.manifest.set(state.relativePath, {
+    hash: await fileSha256(state.local, before.length),
+    generation: "1",
+  });
+
+  await expect(
+    mutateTurnDocument({
+      ...state,
+      apply: async () => writeFile(state.local, "failed mutation"),
+    }),
+  ).rejects.toBeInstanceOf(TurnDocConflictError);
+
+  expect(await readFile(state.local, "utf8")).toBe(before);
+  const finalSync = await syncBack(
+    state.store,
+    state.prefix,
+    state.filesystem.storeRoot,
+    state.filesystem.manifest,
+    { generations: true },
+  );
+  expect(finalSync.uploaded).toEqual([]);
+  expect((await stat(state.local)).size).toBe(before.length);
+});
+
+test("an upload failure restores the pre-call file before final sync", async () => {
+  const state = await fixture(0);
+  const before = "pre-call bytes";
+  await mkdir(dirname(state.local), { recursive: true });
+  await writeFile(state.local, before);
+  state.filesystem.manifest.set(state.relativePath, {
+    hash: await fileSha256(state.local, before.length),
+    generation: "1",
+  });
+  state.store.upload = async () => {
+    throw new Error("store unavailable");
+  };
+
+  await expect(
+    mutateTurnDocument({
+      ...state,
+      apply: async () => writeFile(state.local, "failed mutation"),
+    }),
+  ).rejects.toThrow("store unavailable");
+
+  expect(await readFile(state.local, "utf8")).toBe(before);
+  const finalSync = await syncBack(
+    state.store,
+    state.prefix,
+    state.filesystem.storeRoot,
+    state.filesystem.manifest,
+    { generations: true },
+  );
+  expect(finalSync.uploaded).toEqual([]);
+});
+
+test("refresh merges same-turn local routines with remote before applying", async () => {
+  const root = await mkdtemp(join(tmpdir(), "turn-cas-merge-"));
+  const relativePath =
+    "workspaces/Personal/Bob/.houston/routines/routines.json";
+  const local = join(root, ...relativePath.split("/"));
+  const handEdited = { id: "hand", name: "Hand edit" };
+  const remoteOnly = { id: "remote", name: "Remote" };
+  const saved = { id: "saved", name: "Saved" };
+  await mkdir(dirname(local), { recursive: true });
+  await writeFile(local, JSON.stringify([handEdited]));
+  let remote = JSON.stringify([remoteOnly]);
+  const store: ObjectStore = {
+    list: async () => [relativePath],
+    manifest: async () => {
+      throw new Error("single-object reads must not list the manifest");
+    },
+    download: async () => {
+      throw new Error("versioned download must be used");
+    },
+    downloadVersioned: async (_key, dest) => {
+      await writeFile(dest, remote);
+      return { generation: "2" };
+    },
+    upload: async (source) => {
+      remote = await readFile(source, "utf8");
+      return { generation: "3" };
+    },
+    delete: async () => undefined,
+  };
+  const filesystem = {
+    storeRoot: root,
+    manifest: new Map([
+      [
+        relativePath,
+        {
+          hash: await fileSha256(local, (await stat(local)).size),
+          generation: "1",
+        },
+      ],
+    ]),
+    immediateWrites: new Set<string>(),
+  } as TurnFilesystem;
+
+  await mutateTurnDocument({
+    store,
+    prefix: "",
+    filesystem,
+    relativePath,
+    apply: async () => {
+      const routines = JSON.parse(await readFile(local, "utf8")) as unknown[];
+      await writeFile(local, JSON.stringify([...routines, saved]));
+    },
+  });
+
+  expect(JSON.parse(remote)).toEqual([remoteOnly, handEdited, saved]);
+});
+
+test("a store without refresh capability stops after its first conflict", async () => {
+  const state = await fixture(0);
+  delete state.store.manifest;
+  let uploads = 0;
+  state.store.upload = async (_source, key) => {
+    uploads += 1;
+    throw new StoreConflictError(key, "stale");
+  };
+
+  await expect(
+    mutateTurnDocument({
+      ...state,
+      apply: async () => {
+        await mkdir(dirname(state.local), { recursive: true });
+        await writeFile(state.local, "mutation");
+      },
+    }),
+  ).rejects.toBeInstanceOf(TurnDocConflictError);
+  expect(uploads).toBe(1);
+});
+
+test("a vanished remote object cannot leave a sync-visible temp file", async () => {
+  const state = await fixture(0);
+  state.store.download = async (key, dest) => {
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, "partial");
+    throw new ObjectNotFoundError(key, "vanished");
+  };
+  state.store.upload = async () => ({ generation: "2" });
+  await mutateTurnDocument({
+    ...state,
+    apply: async () => writeFile(state.local, "mutation"),
+  });
+
+  expect(await readdir(dirname(state.local))).toEqual(["doc.json"]);
+});
+
+test("a declined mutation restores the pre-call state without uploading", async () => {
   const state = await fixture(0);
   const upload = state.store.upload;
   let uploads = 0;
@@ -110,7 +274,8 @@ test("a declined mutation refreshes ownership without uploading", async () => {
   });
   expect(result).toEqual({ error: "invalid" });
   expect(uploads).toBe(0);
-  expect(state.filesystem.manifest.get(state.relativePath)?.generation).toBe(
-    "1",
-  );
+  expect(state.filesystem.manifest.has(state.relativePath)).toBe(false);
+  await expect(readFile(state.local, "utf8")).rejects.toMatchObject({
+    code: "ENOENT",
+  });
 });

--- a/packages/runtime/src/turn/turn-doc-cas.test.ts
+++ b/packages/runtime/src/turn/turn-doc-cas.test.ts
@@ -1,0 +1,116 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  type ObjectMetadata,
+  type ObjectStore,
+  StoreConflictError,
+} from "@houston/runtime-client/object-sync";
+import { expect, test } from "vitest";
+import { mutateTurnDocument, TurnDocConflictError } from "./turn-doc-cas";
+import type { TurnFilesystem } from "./turn-filesystem";
+
+async function fixture(conflicts: number) {
+  const root = await mkdtemp(join(tmpdir(), "turn-cas-"));
+  const relativePath = "workspaces/Personal/Bob/doc.json";
+  const local = join(root, ...relativePath.split("/"));
+  let remote = JSON.stringify({ values: ["remote"] });
+  let generation = 1;
+  let uploads = 0;
+  const store: ObjectStore = {
+    list: async () => [relativePath],
+    manifest: async (): Promise<ObjectMetadata[]> => [
+      {
+        key: relativePath,
+        size: remote.length,
+        md5: "",
+        updated: "2026-01-01T00:00:00.000Z",
+        generation: String(generation),
+      },
+    ],
+    download: async (_key, dest) => {
+      await mkdir(dirname(dest), { recursive: true });
+      await writeFile(dest, remote);
+    },
+    upload: async (src, key, options) => {
+      uploads += 1;
+      if (uploads <= conflicts) {
+        remote = JSON.stringify({ values: ["concurrent"] });
+        generation += 1;
+        throw new StoreConflictError(key, "stale");
+      }
+      expect(options?.ifGenerationMatch).toBe(String(generation));
+      remote = await readFile(src, "utf8");
+      generation += 1;
+      return { generation: String(generation) };
+    },
+    delete: async () => undefined,
+  };
+  const filesystem = {
+    storeRoot: root,
+    manifest: new Map(),
+    immediateWrites: new Set<string>(),
+  } as TurnFilesystem;
+  return {
+    store,
+    prefix: "",
+    filesystem,
+    relativePath,
+    local,
+    getRemote: () => remote,
+  };
+}
+
+test("a generation conflict re-reads and re-applies the mutation", async () => {
+  const state = await fixture(1);
+  await mutateTurnDocument({
+    ...state,
+    apply: async () => {
+      const doc = JSON.parse(await readFile(state.local, "utf8")) as {
+        values: string[];
+      };
+      await writeFile(
+        state.local,
+        JSON.stringify({ values: [...doc.values, "ours"] }),
+      );
+    },
+  });
+
+  expect(JSON.parse(state.getRemote())).toEqual({
+    values: ["concurrent", "ours"],
+  });
+  expect(state.filesystem.manifest.get(state.relativePath)?.generation).toBe(
+    "3",
+  );
+  expect(state.filesystem.immediateWrites).toContain(state.relativePath);
+});
+
+test("three generation conflicts become a typed conflict", async () => {
+  const state = await fixture(3);
+  await expect(
+    mutateTurnDocument({
+      ...state,
+      apply: async () => undefined,
+    }),
+  ).rejects.toBeInstanceOf(TurnDocConflictError);
+});
+
+test("a declined mutation refreshes ownership without uploading", async () => {
+  const state = await fixture(0);
+  const upload = state.store.upload;
+  let uploads = 0;
+  state.store.upload = async (...args) => {
+    uploads += 1;
+    return upload(...args);
+  };
+  const result = await mutateTurnDocument({
+    ...state,
+    apply: async () => ({ error: "invalid" }),
+    shouldCommit: () => false,
+  });
+  expect(result).toEqual({ error: "invalid" });
+  expect(uploads).toBe(0);
+  expect(state.filesystem.manifest.get(state.relativePath)?.generation).toBe(
+    "1",
+  );
+});

--- a/packages/runtime/src/turn/turn-doc-cas.ts
+++ b/packages/runtime/src/turn/turn-doc-cas.ts
@@ -1,11 +1,14 @@
-import { mkdir, rm, stat } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, posix } from "node:path";
 import {
   fileSha256,
+  mergeDocumentBodies,
   ObjectNotFoundError,
   type ObjectStore,
   StoreConflictError,
 } from "@houston/runtime-client/object-sync";
+import { restoreTurnDocument, snapshotTurnDocument } from "./turn-doc-state";
 import type { TurnFilesystem } from "./turn-filesystem";
 
 const MAX_ATTEMPTS = 3;
@@ -36,38 +39,72 @@ function remoteKey(prefix: string, relativePath: string): string {
 
 async function refreshDocument<T>(
   opts: TurnDocCasOptions<T>,
-): Promise<string | undefined> {
-  if (!opts.store.manifest) {
-    return opts.filesystem.manifest.get(opts.relativePath)?.generation;
-  }
+): Promise<{ generation?: string; refreshable: boolean }> {
   const key = remoteKey(opts.prefix, opts.relativePath);
-  const object = (await opts.store.manifest(opts.prefix)).find(
-    (entry) => entry.key === key,
-  );
   const local = join(
     opts.filesystem.storeRoot,
     ...opts.relativePath.split("/"),
   );
-  if (!object) {
-    await rm(local, { force: true });
-    opts.filesystem.manifest.delete(opts.relativePath);
-    return undefined;
-  }
-  await mkdir(dirname(local), { recursive: true });
+  let localBody: string | undefined;
   try {
-    await opts.store.download(key, local);
+    localBody = await readFile(local, "utf8");
   } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  let generation: string | undefined;
+  const versionedRead = opts.store.downloadVersioned !== undefined;
+  const remoteTemp = `${local}.${randomUUID()}.remote.tmp`;
+  try {
+    if (opts.store.downloadVersioned) {
+      generation = (await opts.store.downloadVersioned(key, remoteTemp))
+        .generation;
+    } else if (opts.store.manifest) {
+      const object = (await opts.store.manifest(opts.prefix)).find(
+        (entry) => entry.key === key,
+      );
+      if (!object) {
+        opts.filesystem.manifest.delete(opts.relativePath);
+        return { refreshable: true };
+      }
+      generation = object.generation;
+      await opts.store.download(key, remoteTemp);
+    } else {
+      return {
+        generation: opts.filesystem.manifest.get(opts.relativePath)?.generation,
+        refreshable: false,
+      };
+    }
+  } catch (error) {
+    await rm(remoteTemp, { force: true });
     if (!(error instanceof ObjectNotFoundError)) throw error;
-    await rm(local, { force: true });
     opts.filesystem.manifest.delete(opts.relativePath);
-    return undefined;
+    return { refreshable: true };
+  }
+  try {
+    await mkdir(dirname(local), { recursive: true });
+    if (localBody !== undefined) {
+      const remoteBody = await readFile(remoteTemp, "utf8");
+      const merged = mergeDocumentBodies(
+        opts.relativePath,
+        localBody,
+        remoteBody,
+      );
+      await writeFile(local, merged ?? remoteBody);
+    } else {
+      await writeFile(local, await readFile(remoteTemp));
+    }
+  } finally {
+    await rm(remoteTemp, { force: true });
   }
   const info = await stat(local);
   opts.filesystem.manifest.set(opts.relativePath, {
     hash: await fileSha256(local, info.size),
-    generation: object.generation,
+    generation,
   });
-  return object.generation;
+  return {
+    generation,
+    refreshable: !versionedRead || generation !== undefined,
+  };
 }
 
 /** Re-read, re-apply, and generation-guard one document mutation up to three times. */
@@ -79,24 +116,59 @@ export async function mutateTurnDocument<T>(
     opts.filesystem.storeRoot,
     ...opts.relativePath.split("/"),
   );
-  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
-    const generation = await refreshDocument(opts);
-    const result = await opts.apply();
-    if (opts.shouldCommit && !opts.shouldCommit(result)) return result;
-    const info = await stat(local);
-    try {
-      const uploaded = await opts.store.upload(local, key, {
-        ifGenerationMatch: generation ?? "0",
-      });
-      opts.filesystem.manifest.set(opts.relativePath, {
-        hash: await fileSha256(local, info.size),
-        generation: uploaded?.generation ?? generation,
-      });
-      opts.filesystem.immediateWrites.add(opts.relativePath);
-      return result;
-    } catch (error) {
-      if (!(error instanceof StoreConflictError)) throw error;
+  const original = await snapshotTurnDocument(
+    opts.filesystem,
+    opts.relativePath,
+    local,
+  );
+  try {
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+      const refreshed = await refreshDocument(opts);
+      const beforeAttempt = await snapshotTurnDocument(
+        opts.filesystem,
+        opts.relativePath,
+        local,
+      );
+      const result = await opts.apply();
+      if (opts.shouldCommit && !opts.shouldCommit(result)) {
+        await restoreTurnDocument(
+          opts.filesystem,
+          opts.relativePath,
+          local,
+          original,
+        );
+        return result;
+      }
+      const info = await stat(local);
+      try {
+        const uploaded = await opts.store.upload(local, key, {
+          ifGenerationMatch: refreshed.generation ?? "0",
+        });
+        opts.filesystem.manifest.set(opts.relativePath, {
+          hash: await fileSha256(local, info.size),
+          generation: uploaded?.generation ?? refreshed.generation,
+        });
+        opts.filesystem.immediateWrites.add(opts.relativePath);
+        return result;
+      } catch (error) {
+        if (!(error instanceof StoreConflictError)) throw error;
+        await restoreTurnDocument(
+          opts.filesystem,
+          opts.relativePath,
+          local,
+          beforeAttempt,
+        );
+        if (!refreshed.refreshable) break;
+      }
     }
+    throw new TurnDocConflictError(opts.relativePath);
+  } catch (error) {
+    await restoreTurnDocument(
+      opts.filesystem,
+      opts.relativePath,
+      local,
+      original,
+    );
+    throw error;
   }
-  throw new TurnDocConflictError(opts.relativePath);
 }

--- a/packages/runtime/src/turn/turn-doc-cas.ts
+++ b/packages/runtime/src/turn/turn-doc-cas.ts
@@ -1,0 +1,102 @@
+import { mkdir, rm, stat } from "node:fs/promises";
+import { dirname, join, posix } from "node:path";
+import {
+  fileSha256,
+  ObjectNotFoundError,
+  type ObjectStore,
+  StoreConflictError,
+} from "@houston/runtime-client/object-sync";
+import type { TurnFilesystem } from "./turn-filesystem";
+
+const MAX_ATTEMPTS = 3;
+
+/** A document remained concurrently modified across every bounded CAS attempt. */
+export class TurnDocConflictError extends Error {
+  readonly code = "document_conflict";
+
+  constructor(readonly relativePath: string) {
+    super(`document changed during this turn: ${relativePath}`);
+    this.name = "TurnDocConflictError";
+  }
+}
+
+/** Dependencies and mutation callback for one guarded document write. */
+export interface TurnDocCasOptions<T> {
+  store: ObjectStore;
+  prefix: string;
+  filesystem: TurnFilesystem;
+  relativePath: string;
+  apply: () => Promise<T>;
+  shouldCommit?: (result: T) => boolean;
+}
+
+function remoteKey(prefix: string, relativePath: string): string {
+  return prefix ? posix.join(prefix, relativePath) : relativePath;
+}
+
+async function refreshDocument<T>(
+  opts: TurnDocCasOptions<T>,
+): Promise<string | undefined> {
+  if (!opts.store.manifest) {
+    return opts.filesystem.manifest.get(opts.relativePath)?.generation;
+  }
+  const key = remoteKey(opts.prefix, opts.relativePath);
+  const object = (await opts.store.manifest(opts.prefix)).find(
+    (entry) => entry.key === key,
+  );
+  const local = join(
+    opts.filesystem.storeRoot,
+    ...opts.relativePath.split("/"),
+  );
+  if (!object) {
+    await rm(local, { force: true });
+    opts.filesystem.manifest.delete(opts.relativePath);
+    return undefined;
+  }
+  await mkdir(dirname(local), { recursive: true });
+  try {
+    await opts.store.download(key, local);
+  } catch (error) {
+    if (!(error instanceof ObjectNotFoundError)) throw error;
+    await rm(local, { force: true });
+    opts.filesystem.manifest.delete(opts.relativePath);
+    return undefined;
+  }
+  const info = await stat(local);
+  opts.filesystem.manifest.set(opts.relativePath, {
+    hash: await fileSha256(local, info.size),
+    generation: object.generation,
+  });
+  return object.generation;
+}
+
+/** Re-read, re-apply, and generation-guard one document mutation up to three times. */
+export async function mutateTurnDocument<T>(
+  opts: TurnDocCasOptions<T>,
+): Promise<T> {
+  const key = remoteKey(opts.prefix, opts.relativePath);
+  const local = join(
+    opts.filesystem.storeRoot,
+    ...opts.relativePath.split("/"),
+  );
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    const generation = await refreshDocument(opts);
+    const result = await opts.apply();
+    if (opts.shouldCommit && !opts.shouldCommit(result)) return result;
+    const info = await stat(local);
+    try {
+      const uploaded = await opts.store.upload(local, key, {
+        ifGenerationMatch: generation ?? "0",
+      });
+      opts.filesystem.manifest.set(opts.relativePath, {
+        hash: await fileSha256(local, info.size),
+        generation: uploaded?.generation ?? generation,
+      });
+      opts.filesystem.immediateWrites.add(opts.relativePath);
+      return result;
+    } catch (error) {
+      if (!(error instanceof StoreConflictError)) throw error;
+    }
+  }
+  throw new TurnDocConflictError(opts.relativePath);
+}

--- a/packages/runtime/src/turn/turn-doc-state.ts
+++ b/packages/runtime/src/turn/turn-doc-state.ts
@@ -1,0 +1,49 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { TurnFilesystem } from "./turn-filesystem";
+
+/** Local bytes and sync bookkeeping restored when a guarded write fails. */
+export interface TurnDocumentSnapshot {
+  bytes?: Buffer;
+  entry?: { hash: string; generation?: string };
+  immediate: boolean;
+}
+
+/** Capture a document before a mutation or retry attempt. */
+export async function snapshotTurnDocument(
+  filesystem: TurnFilesystem,
+  relativePath: string,
+  local: string,
+): Promise<TurnDocumentSnapshot> {
+  let bytes: Buffer | undefined;
+  try {
+    bytes = await readFile(local);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const entry = filesystem.manifest.get(relativePath);
+  return {
+    bytes,
+    ...(entry ? { entry: { ...entry } } : {}),
+    immediate: filesystem.immediateWrites.has(relativePath),
+  };
+}
+
+/** Restore a captured document and its sync bookkeeping exactly. */
+export async function restoreTurnDocument(
+  filesystem: TurnFilesystem,
+  relativePath: string,
+  local: string,
+  snapshot: TurnDocumentSnapshot,
+): Promise<void> {
+  if (snapshot.bytes) {
+    await mkdir(dirname(local), { recursive: true });
+    await writeFile(local, snapshot.bytes);
+  } else {
+    await rm(local, { force: true });
+  }
+  if (snapshot.entry) filesystem.manifest.set(relativePath, snapshot.entry);
+  else filesystem.manifest.delete(relativePath);
+  if (snapshot.immediate) filesystem.immediateWrites.add(relativePath);
+  else filesystem.immediateWrites.delete(relativePath);
+}

--- a/packages/runtime/src/turn/turn-durability.test.ts
+++ b/packages/runtime/src/turn/turn-durability.test.ts
@@ -66,6 +66,10 @@ async function claimedTurn(docPutStatus: number) {
 
 test("a durable turn names the conversation and board as changed", async () => {
   const { deps, turn, filesystem, resolved } = await claimedTurn(200);
+  filesystem.immediateWrites.add(
+    `${workspaceRel}/.houston/routines/routines.json`,
+  );
+  filesystem.immediateWrites.add("custom-integrations.json");
   const result = await finishTurnDurability({
     deps,
     turn,
@@ -76,7 +80,12 @@ test("a durable turn names the conversation and board as changed", async () => {
     transcript: null,
   });
   expect(result.outcome).toEqual({});
-  expect(result.changed).toEqual(["ActivityChanged", "ConversationsChanged"]);
+  expect(result.changed).toEqual([
+    "ActivityChanged",
+    "ConversationsChanged",
+    "CustomIntegrationsChanged",
+    "RoutinesChanged",
+  ]);
 });
 
 test("a family whose doc projection failed is not announced", async () => {

--- a/packages/runtime/src/turn/turn-durability.test.ts
+++ b/packages/runtime/src/turn/turn-durability.test.ts
@@ -39,10 +39,17 @@ async function claimedTurn(docPutStatus: number) {
     ".houston/activity/activity.json",
     '[{"id":"a1","title":"Plan","status":"running"}]',
   );
-  const fetchImpl = (async (_url: unknown, init?: RequestInit) =>
-    init?.method === "PUT"
+  const requests: Array<{ url: string; method: string; body?: string }> = [];
+  const fetchImpl = (async (url: unknown, init?: RequestInit) => {
+    requests.push({
+      url: String(url),
+      method: init?.method ?? "GET",
+      ...(typeof init?.body === "string" ? { body: init.body } : {}),
+    });
+    return init?.method === "PUT"
       ? new Response("{}", { status: docPutStatus })
-      : Response.json({ revision: 1 })) as typeof fetch;
+      : Response.json({ revision: 1 });
+  }) as typeof fetch;
   const deps = {
     poolStoreUrl: "https://store.example",
     fetchImpl,
@@ -61,6 +68,7 @@ async function claimedTurn(docPutStatus: number) {
     turn,
     filesystem,
     resolved: { store, prefix: "ws/w1/agent-1" },
+    requests,
   };
 }
 
@@ -103,4 +111,48 @@ test("a family whose doc projection failed is not announced", async () => {
   });
   expect(result.outcome.error).toMatch(/board doc publish failed/);
   expect(result.changed).toEqual(["ConversationsChanged"]);
+});
+
+test("turn tool mutations publish the skills and custom definition views", async () => {
+  const { deps, turn, filesystem, resolved, requests } = await claimedTurn(200);
+  filesystem.immediateWrites.add(
+    `${workspaceRel}/.agents/skills/example/SKILL.md`,
+  );
+  filesystem.immediateWrites.add("custom-integrations.json");
+  const result = await finishTurnDurability({
+    deps,
+    turn,
+    filesystem,
+    resolved,
+    heartbeat: null,
+    outcome: {},
+    transcript: null,
+    views: {
+      skills: { items: [{ name: "example" }], diagnostics: [] },
+      customDefinitions: { items: [{ slug: "example" }] },
+    },
+  });
+
+  const viewPuts = requests.filter(
+    (request) =>
+      request.method === "PUT" &&
+      /\/(skills|custom_definitions)$/.test(request.url),
+  );
+  expect(viewPuts).toEqual([
+    {
+      url: "https://store.example/v1/pod/docs/w1/agent-1/skills",
+      method: "PUT",
+      body: JSON.stringify({
+        doc: { items: [{ name: "example" }], diagnostics: [] },
+      }),
+    },
+    {
+      url: "https://store.example/v1/pod/docs/w1/agent-1/custom_definitions",
+      method: "PUT",
+      body: JSON.stringify({ doc: { items: [{ slug: "example" }] } }),
+    },
+  ]);
+  expect(result.changed).toEqual(
+    expect.arrayContaining(["SkillsChanged", "CustomIntegrationsChanged"]),
+  );
 });

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -12,12 +12,14 @@ import {
   turnActivityKey,
   turnRoutineRunsKey,
 } from "./turn-filesystem";
+import type { TurnSandboxViews } from "./turn-sandbox";
 import type { TurnOutcome } from "./turn-session";
 import type { ResolvedTurnStore } from "./turn-store";
 import type {
   TranscriptPublishResult,
   TurnTranscript,
 } from "./turn-transcript";
+import { publishTurnSandboxViews } from "./turn-view-publish";
 import type { TurnRequest } from "./types";
 
 interface TurnDurabilityOptions {
@@ -29,6 +31,7 @@ interface TurnDurabilityOptions {
   outcome: TurnOutcome;
   /** The turn's transcript publisher (created at turn start; null = none). */
   transcript: TurnTranscript | null;
+  views?: TurnSandboxViews;
 }
 
 export interface TurnDurabilityResult {
@@ -129,6 +132,15 @@ export async function finishTurnDurability(
       `transcript publish failed: ${published.error}`,
     );
     without("ConversationsChanged");
+  }
+  for (const family of await publishTurnSandboxViews(
+    opts.deps,
+    opts.turn,
+    opts.views,
+  )) {
+    without(
+      family === "skills" ? "SkillsChanged" : "CustomIntegrationsChanged",
+    );
   }
 
   const activityChanged = uploaded.includes(

--- a/packages/runtime/src/turn/turn-durability.ts
+++ b/packages/runtime/src/turn/turn-durability.ts
@@ -77,6 +77,7 @@ export async function finishTurnDurability(
     changed = changedEventTypes(opts.filesystem, [
       ...uploaded,
       ...synced.deleted,
+      ...opts.filesystem.immediateWrites,
     ]);
   } catch (error) {
     // A fenced object write means the claim was adopted mid-sync: report it

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -11,6 +11,7 @@ import {
   type ObjectStore,
   syncBack,
 } from "@houston/runtime-client/object-sync";
+import { agentScopeIncludes } from "./turn-agent-scope";
 import {
   layoutSkeleton,
   resolveTurnLayout,
@@ -36,6 +37,8 @@ export interface TurnFilesystem extends TurnLayout {
   /** The store's generation capability as the LISTING showed it. A filtered
    *  or lazy manifest may be empty and cannot answer this on its own. */
   generationAware: boolean;
+  /** Tool-call-time CAS writes already durable before the final sync pass. */
+  immediateWrites: Set<string>;
 }
 
 /**
@@ -92,6 +95,7 @@ export async function prepareTurnFilesystem(opts: {
       vfs,
       listedObjects: objects.length,
       generationAware: vfs.generationAware,
+      immediateWrites: new Set(),
     };
   }
   let manifest: HydrateManifest;
@@ -120,6 +124,7 @@ export async function prepareTurnFilesystem(opts: {
     vfs: new FsVfs(storeRoot),
     listedObjects: listed.rels.length,
     generationAware: listed.generationAware,
+    immediateWrites: new Set(),
   };
 }
 
@@ -148,16 +153,12 @@ export function claimedTurnIncludes(
   const session = posix.join(dataRel, "sessions", conversationId);
   const activity = turnActivityKey(workspaceRel);
   const runs = turnRoutineRunsKey(workspaceRel);
-  const workspaceFiles = `${workspaceRel}/`;
-  const internal = posix.join(workspaceRel, ".houston");
   return (relativePath) =>
     relativePath === conversation ||
     relativePath.startsWith(`${session}/`) ||
     relativePath === activity ||
     relativePath === runs ||
-    (relativePath.startsWith(workspaceFiles) &&
-      relativePath !== internal &&
-      !relativePath.startsWith(`${internal}/`));
+    agentScopeIncludes(relativePath, workspaceRel);
 }
 
 /** Store-relative mission-board object granted to a claimed turn. */

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -131,13 +131,13 @@ test.each([
       "utf8",
     ),
   ).toBe('[{"id":"a1","title":"Plan","status":"running"}]');
-  // Workspace files are the turn's deliverable: they sync. `.houston/`
-  // internals beyond the explicit grants stay out of scope.
+  // Agent-owned files sync, including structured docs; only runtime state stays
+  // conversation-scoped.
   expect(keys).toContain(`ws/w1/agent-1/${workspaceRel}/result.txt`);
-  expect(keys).not.toContain(
+  expect(keys).toContain(
     `ws/w1/agent-1/${workspaceRel}/.houston/activity/activity.schema.json`,
   );
-  expect(keys).not.toContain(
+  expect(keys).toContain(
     `ws/w1/agent-1/${workspaceRel}/.houston/routines/routines.json`,
   );
   // The landed writes name the events other tabs need: the conversation, the
@@ -147,13 +147,15 @@ test.each([
   expect(emitted.at(-1)).toMatchObject({
     type: "done",
     data: {
-      poolWritesOutOfScope: 2,
-      changed: ["ActivityChanged", "ConversationsChanged", "FilesChanged"],
+      changed: [
+        "ActivityChanged",
+        "ConversationsChanged",
+        "FilesChanged",
+        "RoutinesChanged",
+      ],
     },
   });
-  expect(log).toHaveBeenCalledWith(
-    "[turn] pool_writes_out_of_scope=2 prefix=ws/w1/agent-1 conversation=c1",
-  );
+  expect(log).not.toHaveBeenCalled();
   log.mockRestore();
 });
 

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -134,7 +134,9 @@ test.each([
   // Agent-owned files sync, including structured docs; only runtime state stays
   // conversation-scoped.
   expect(keys).toContain(`ws/w1/agent-1/${workspaceRel}/result.txt`);
-  expect(keys).toContain(
+  // The schema sidecar is .houston-internal and NOT turn-owned: the store's
+  // turn-claim scope rejects it, so the sync must not attempt it.
+  expect(keys).not.toContain(
     `ws/w1/agent-1/${workspaceRel}/.houston/activity/activity.schema.json`,
   );
   expect(keys).toContain(
@@ -155,7 +157,11 @@ test.each([
       ],
     },
   });
-  expect(log).not.toHaveBeenCalled();
+  // The out-of-scope schema write is skipped AND logged — silent to the user,
+  // never to us.
+  expect(log).toHaveBeenCalledWith(
+    expect.stringContaining("pool_writes_out_of_scope=1"),
+  );
   log.mockRestore();
 });
 

--- a/packages/runtime/src/turn/turn-sandbox-custom.test.ts
+++ b/packages/runtime/src/turn/turn-sandbox-custom.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "vitest";
+import type { TurnCustomContext } from "./turn-custom-context";
+import type { TurnSandboxDeps } from "./turn-sandbox";
+import { makeTurnCustomRoutes } from "./turn-sandbox-custom";
+
+// SAFETY: these tests exercise only the detect and pre-mutation add branches.
+const context = {
+  manager: {
+    detect: async () => ({
+      kind: "mcp" as const,
+      name: "Example",
+      requiresAuthentication: true,
+      requiresOAuth: true,
+      oauthSupported: false,
+    }),
+  },
+} as unknown as TurnCustomContext;
+
+const route = makeTurnCustomRoutes(
+  // SAFETY: OAuth declines return before any sandbox dependency is read.
+  {} as TurnSandboxDeps,
+  async () => context,
+  async () => undefined,
+  () => undefined,
+);
+
+test("OAuth detection directs the model to an awake app connection", async () => {
+  const response = await route("/sandbox/integrations/custom/detect", {
+    url: "https://mcp.example.test",
+  });
+  expect(response.status).toBe(503);
+  expect(await response.json()).toMatchObject({
+    code: "oauth_requires_awake_assistant",
+    error: expect.stringMatching(/open this assistant.*keep it awake/i),
+  });
+});
+
+test("custom add validates its shape before declining OAuth", async () => {
+  const response = await route("/sandbox/integrations/custom/add", {
+    kind: "openapi",
+    name: "Example",
+    url: "https://example.test/openapi.json",
+    auth: "oauth",
+  });
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({
+    error: "auth 'oauth' is only supported for MCP servers",
+  });
+});
+
+test("valid MCP OAuth add directs the model to an awake app connection", async () => {
+  const response = await route("/sandbox/integrations/custom/add", {
+    kind: "mcp",
+    name: "Example",
+    endpoint: "https://mcp.example.test",
+    auth: "oauth",
+  });
+  expect(response.status).toBe(503);
+  expect(await response.json()).toMatchObject({
+    code: "oauth_requires_awake_assistant",
+    error: expect.stringContaining("Do not ask for an API key"),
+  });
+});

--- a/packages/runtime/src/turn/turn-sandbox-custom.ts
+++ b/packages/runtime/src/turn/turn-sandbox-custom.ts
@@ -1,0 +1,87 @@
+import { parseAddInput } from "@houston/host/src/routes/custom-integrations";
+import type { TurnCustomContext } from "./turn-custom-context";
+import { customDefinitionsFile } from "./turn-custom-context";
+import { mutateTurnDocument } from "./turn-doc-cas";
+import type { TurnSandboxDeps } from "./turn-sandbox";
+
+const oauthDecline = (): Response =>
+  Response.json(
+    {
+      error:
+        "This connection uses browser sign-in. Ask the user to open this assistant in the Houston app and keep it awake while they connect the service. Do not ask for an API key.",
+      code: "oauth_requires_awake_assistant",
+    },
+    { status: 503 },
+  );
+
+/** Build custom-integration routes over signal-scoped executor contexts. */
+export function makeTurnCustomRoutes(
+  deps: TurnSandboxDeps,
+  getCustom: (signal?: AbortSignal | null) => Promise<TurnCustomContext>,
+  resetCustom: () => Promise<void>,
+  definitionsChanged: (view: unknown) => void,
+) {
+  return async (
+    path: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal | null,
+  ): Promise<Response> => {
+    const action = path.split("/").at(-1);
+    if (action === "detect") {
+      if (typeof body.url !== "string" || !body.url.trim()) {
+        return Response.json({ error: "missing 'url'" }, { status: 400 });
+      }
+      const result = await (await getCustom(signal)).manager.detect(
+        body.url.trim(),
+      );
+      return result.requiresOAuth
+        ? oauthDecline()
+        : Response.json(result, { status: 200 });
+    }
+    if (action === "status") {
+      if (typeof body.slug !== "string" || !body.slug.trim()) {
+        return Response.json({ error: "missing 'slug'" }, { status: 400 });
+      }
+      const slug = body.slug.trim();
+      const view = (await (await getCustom(signal)).manager.list()).find(
+        (item) => item.slug === slug,
+      );
+      return view
+        ? Response.json(view, { status: 200 })
+        : Response.json(
+            { error: `no custom integration '${slug}'`, code: "not_found" },
+            { status: 404 },
+          );
+    }
+    const input = action === "add" ? parseAddInput(body) : null;
+    if (typeof input === "string") {
+      return Response.json({ error: input }, { status: 400 });
+    }
+    if (action === "add" && input?.auth === "oauth") return oauthDecline();
+    if (
+      action === "remove" &&
+      (typeof body.slug !== "string" || !body.slug.trim())
+    ) {
+      return Response.json({ error: "missing 'slug'" }, { status: 400 });
+    }
+    await resetCustom();
+    const result = await mutateTurnDocument({
+      ...deps,
+      relativePath: customDefinitionsFile,
+      apply: async () => {
+        const context = await getCustom(signal);
+        try {
+          if (action === "add" && input) return context.manager.add(input);
+          await context.manager.remove((body.slug as string).trim());
+          return { ok: true };
+        } finally {
+          await resetCustom();
+        }
+      },
+    });
+    definitionsChanged({
+      items: await (await getCustom(signal)).manager.list(),
+    });
+    return Response.json(result, { status: 200 });
+  };
+}

--- a/packages/runtime/src/turn/turn-sandbox-integrations.ts
+++ b/packages/runtime/src/turn/turn-sandbox-integrations.ts
@@ -1,0 +1,112 @@
+import type {
+  ActingContext,
+  ProviderSearchResult,
+} from "@houston/host/src/integrations/provider";
+import { IntegrationRegistry } from "@houston/host/src/integrations/registry";
+import { RemoteIntegrationProvider } from "@houston/host/src/integrations/remote";
+import {
+  type ActionResult,
+  IntegrationSigninRequiredError,
+} from "@houston/host/src/integrations/types";
+import {
+  executeIntegration,
+  searchIntegrations,
+} from "@houston/host/src/routes/integrations-fanout";
+import type { TurnCustomContext } from "./turn-custom-context";
+import type { TurnSandboxDeps } from "./turn-sandbox";
+
+/** The gateway no longer accepts this turn's short-lived authority. */
+export class TurnGrantExpiredError extends Error {}
+
+class GrantRemoteProvider extends RemoteIntegrationProvider {
+  override async search(
+    userId: string,
+    query: string,
+    acting?: ActingContext,
+    app?: string,
+  ): Promise<ProviderSearchResult> {
+    try {
+      return await super.search(userId, query, acting, app);
+    } catch (error) {
+      if (error instanceof IntegrationSigninRequiredError) {
+        throw new TurnGrantExpiredError();
+      }
+      throw error;
+    }
+  }
+
+  override async execute(
+    userId: string,
+    action: string,
+    params: Record<string, unknown>,
+    acting?: ActingContext,
+    account?: string,
+  ): Promise<ActionResult> {
+    try {
+      return await super.execute(userId, action, params, acting, account);
+    } catch (error) {
+      if (error instanceof IntegrationSigninRequiredError) {
+        throw new TurnGrantExpiredError();
+      }
+      throw error;
+    }
+  }
+}
+
+/** Build the Composio/custom integration routes used by the turn facade. */
+export function makeTurnIntegrationRoutes(
+  deps: TurnSandboxDeps,
+  fetchImpl: typeof fetch,
+  getCustom: () => Promise<TurnCustomContext>,
+) {
+  const gateway = new GrantRemoteProvider({
+    id: "composio",
+    upstreamUrl: deps.grant.url,
+    token: () => null,
+    fetch: fetchImpl,
+  });
+  return async (path: string, body: Record<string, unknown>) => {
+    if (path.endsWith("/search")) {
+      if (typeof body.query !== "string") {
+        return Response.json({ error: "missing 'query'" }, { status: 400 });
+      }
+      const registry = new IntegrationRegistry([
+        gateway,
+        (await getCustom()).provider,
+      ]);
+      const app = typeof body.app === "string" ? body.app.trim() : "";
+      return Response.json(
+        await searchIntegrations({
+          registry,
+          userId: deps.workspaceId,
+          query: body.query,
+          acting: { actingAs: deps.grant.token },
+          ...(app ? { app } : {}),
+          fatalFailure: (error) => error instanceof TurnGrantExpiredError,
+        }),
+      );
+    }
+    if (typeof body.action !== "string") {
+      return Response.json({ error: "missing 'action'" }, { status: 400 });
+    }
+    const registry = new IntegrationRegistry([
+      gateway,
+      (await getCustom()).provider,
+    ]);
+    const params =
+      body.params && typeof body.params === "object"
+        ? (body.params as Record<string, unknown>)
+        : {};
+    const account = typeof body.account === "string" ? body.account : "";
+    return Response.json(
+      await executeIntegration({
+        registry,
+        userId: deps.workspaceId,
+        action: body.action,
+        params,
+        acting: { actingAs: deps.grant.token },
+        ...(account ? { account } : {}),
+      }),
+    );
+  };
+}

--- a/packages/runtime/src/turn/turn-sandbox-integrations.ts
+++ b/packages/runtime/src/turn/turn-sandbox-integrations.ts
@@ -14,6 +14,7 @@ import {
 } from "@houston/host/src/routes/integrations-fanout";
 import type { TurnCustomContext } from "./turn-custom-context";
 import type { TurnSandboxDeps } from "./turn-sandbox";
+import { fetchWithTurnSignal } from "./turn-sandbox-signal";
 
 /** The gateway no longer accepts this turn's short-lived authority. */
 export class TurnGrantExpiredError extends Error {}
@@ -57,56 +58,74 @@ class GrantRemoteProvider extends RemoteIntegrationProvider {
 export function makeTurnIntegrationRoutes(
   deps: TurnSandboxDeps,
   fetchImpl: typeof fetch,
-  getCustom: () => Promise<TurnCustomContext>,
+  getCustom: (signal?: AbortSignal | null) => Promise<TurnCustomContext>,
 ) {
-  const gateway = new GrantRemoteProvider({
-    id: "composio",
-    upstreamUrl: deps.grant.url,
-    token: () => null,
-    fetch: fetchImpl,
-  });
-  return async (path: string, body: Record<string, unknown>) => {
-    if (path.endsWith("/search")) {
-      if (typeof body.query !== "string") {
-        return Response.json({ error: "missing 'query'" }, { status: 400 });
+  return async (
+    path: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal | null,
+  ) => {
+    const gateway = new GrantRemoteProvider({
+      id: "composio",
+      upstreamUrl: deps.grant.url,
+      token: () => null,
+      fetch: fetchWithTurnSignal(fetchImpl, signal),
+    });
+    try {
+      if (path.endsWith("/search")) {
+        if (typeof body.query !== "string") {
+          return Response.json({ error: "missing 'query'" }, { status: 400 });
+        }
+        const registry = new IntegrationRegistry([
+          gateway,
+          (await getCustom(signal)).provider,
+        ]);
+        const app = typeof body.app === "string" ? body.app.trim() : "";
+        return Response.json(
+          await searchIntegrations({
+            registry,
+            userId: deps.workspaceId,
+            query: body.query,
+            acting: { actingAs: deps.grant.token },
+            ...(app ? { app } : {}),
+            fatalFailure: (error) =>
+              error instanceof TurnGrantExpiredError ||
+              signal?.aborted === true,
+          }),
+        );
+      }
+      if (typeof body.action !== "string") {
+        return Response.json({ error: "missing 'action'" }, { status: 400 });
       }
       const registry = new IntegrationRegistry([
         gateway,
-        (await getCustom()).provider,
+        (await getCustom(signal)).provider,
       ]);
-      const app = typeof body.app === "string" ? body.app.trim() : "";
+      const params =
+        body.params && typeof body.params === "object"
+          ? (body.params as Record<string, unknown>)
+          : {};
+      const account = typeof body.account === "string" ? body.account : "";
       return Response.json(
-        await searchIntegrations({
+        await executeIntegration({
           registry,
           userId: deps.workspaceId,
-          query: body.query,
+          action: body.action,
+          params,
           acting: { actingAs: deps.grant.token },
-          ...(app ? { app } : {}),
-          fatalFailure: (error) => error instanceof TurnGrantExpiredError,
+          ...(account ? { account } : {}),
         }),
       );
+    } catch (error) {
+      if (
+        error instanceof TurnGrantExpiredError &&
+        deps.grant.expires > Date.now() / 1000 + 60
+      ) {
+        console.error(
+          "[turn-sandbox] integrations gateway rejected a grant before its advertised expiry; check gateway grant verification",
+        );
+      }
+      throw error;
     }
-    if (typeof body.action !== "string") {
-      return Response.json({ error: "missing 'action'" }, { status: 400 });
-    }
-    const registry = new IntegrationRegistry([
-      gateway,
-      (await getCustom()).provider,
-    ]);
-    const params =
-      body.params && typeof body.params === "object"
-        ? (body.params as Record<string, unknown>)
-        : {};
-    const account = typeof body.account === "string" ? body.account : "";
-    return Response.json(
-      await executeIntegration({
-        registry,
-        userId: deps.workspaceId,
-        action: body.action,
-        params,
-        acting: { actingAs: deps.grant.token },
-        ...(account ? { account } : {}),
-      }),
-    );
   };
 }

--- a/packages/runtime/src/turn/turn-sandbox-signal.ts
+++ b/packages/runtime/src/turn/turn-sandbox-signal.ts
@@ -1,0 +1,12 @@
+/** Bind a tool call's cancellation signal to every fetch started on its behalf. */
+export function fetchWithTurnSignal(
+  fetchImpl: typeof fetch,
+  signal?: AbortSignal | null,
+): typeof fetch {
+  if (!signal) return fetchImpl;
+  return (input, init) =>
+    fetchImpl(input, {
+      ...init,
+      signal: init?.signal ? AbortSignal.any([signal, init.signal]) : signal,
+    });
+}

--- a/packages/runtime/src/turn/turn-sandbox-writes.ts
+++ b/packages/runtime/src/turn/turn-sandbox-writes.ts
@@ -24,6 +24,7 @@ export interface TurnWriteRoutesDeps {
   conversationId: string;
   actingAs?: { userId: string; name?: string };
   fetchImpl: typeof fetch;
+  signal?: AbortSignal | null;
 }
 
 const json = (status: number, body: unknown): Response =>
@@ -37,6 +38,9 @@ async function saveRoutine(
   const creating = typeof id !== "string" || id === "";
   const stableId = creating ? randomUUID() : id;
   const nowIso = new Date().toISOString();
+  // Turn requests do not carry the account timezone, and the agent-scoped
+  // store cannot read account preferences. Pooled cron validation therefore
+  // keeps the null-zone fallback until dispatch includes that context.
   const result = await mutateTurnDocument({
     ...deps,
     relativePath: docKey(deps.filesystem.workspaceRel, "routines"),
@@ -129,6 +133,7 @@ export async function handleTurnWriteRoute(
           directory: communityDirectory,
           previews: previewDirectory,
           fetchImpl: deps.fetchImpl,
+          ...(deps.signal ? { signal: deps.signal } : {}),
         },
         queries,
       ),

--- a/packages/runtime/src/turn/turn-sandbox-writes.ts
+++ b/packages/runtime/src/turn/turn-sandbox-writes.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import { docKey } from "@houston/domain";
+import { appendLearningChecked } from "@houston/host/src/routes/learning-write";
+import {
+  createRoutineChecked,
+  updateRoutineChecked,
+} from "@houston/host/src/routes/routine-write";
+import {
+  communityDirectory,
+  previewDirectory,
+} from "@houston/host/src/routes/skills-directory";
+import { searchCommunitySkills } from "@houston/host/src/routes/skills-search";
+import { installCommunitySkill } from "@houston/host/src/skills/install";
+import type { ObjectStore } from "@houston/runtime-client/object-sync";
+import { mutateTurnDocument } from "./turn-doc-cas";
+import type { TurnFilesystem } from "./turn-filesystem";
+
+/** Turn-local storage, identity, and network seams for agent-owned writes. */
+export interface TurnWriteRoutesDeps {
+  store: ObjectStore;
+  prefix: string;
+  filesystem: TurnFilesystem;
+  workspaceId: string;
+  conversationId: string;
+  actingAs?: { userId: string; name?: string };
+  fetchImpl: typeof fetch;
+}
+
+const json = (status: number, body: unknown): Response =>
+  Response.json(body, { status });
+
+async function saveRoutine(
+  deps: TurnWriteRoutesDeps,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const { id, ...fields } = body;
+  const creating = typeof id !== "string" || id === "";
+  const stableId = creating ? randomUUID() : id;
+  const nowIso = new Date().toISOString();
+  const result = await mutateTurnDocument({
+    ...deps,
+    relativePath: docKey(deps.filesystem.workspaceRel, "routines"),
+    shouldCommit: (outcome) => "routine" in outcome,
+    apply: () =>
+      creating
+        ? createRoutineChecked(
+            deps.filesystem.vfs,
+            deps.filesystem.workspaceRel,
+            deps.workspaceId,
+            fields,
+            {
+              triggersEnabled: true,
+              nowIso,
+              id: stableId,
+              createdBy: deps.actingAs?.userId,
+            },
+          )
+        : updateRoutineChecked(
+            deps.filesystem.vfs,
+            deps.filesystem.workspaceRel,
+            deps.workspaceId,
+            stableId,
+            fields,
+            {
+              triggersEnabled: true,
+              nowIso,
+              actorSub: deps.actingAs?.userId,
+            },
+          ),
+  });
+  if ("notFound" in result)
+    return json(404, { error: `no routine with id '${id}'` });
+  if ("error" in result) return json(400, { error: result.error });
+  return json(creating ? 201 : 200, result.routine);
+}
+
+async function saveLearning(
+  deps: TurnWriteRoutesDeps,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const id = randomUUID();
+  const nowIso = new Date().toISOString();
+  const result = await mutateTurnDocument({
+    ...deps,
+    relativePath: docKey(deps.filesystem.workspaceRel, "learnings"),
+    shouldCommit: (outcome) => "learning" in outcome,
+    apply: () =>
+      appendLearningChecked(deps.filesystem.vfs, deps.filesystem.workspaceRel, {
+        id,
+        text: typeof body.text === "string" ? body.text : "",
+        nowIso,
+        ...(deps.actingAs
+          ? {
+              taughtBy: {
+                user_id: deps.actingAs.userId,
+                ...(deps.actingAs.name ? { name: deps.actingAs.name } : {}),
+              },
+            }
+          : {}),
+        conversationId: deps.conversationId,
+      }),
+  });
+  return "error" in result
+    ? json(400, { error: result.error })
+    : json(201, result.learning);
+}
+
+/** Handle a routine, learning, or skill route, or return null when unmatched. */
+export async function handleTurnWriteRoute(
+  path: string,
+  body: Record<string, unknown>,
+  deps: TurnWriteRoutesDeps,
+): Promise<Response | null> {
+  if (path === "/sandbox/routines/save") return saveRoutine(deps, body);
+  if (path === "/sandbox/learnings/save") return saveLearning(deps, body);
+  if (path === "/sandbox/skills/search") {
+    const queries = Array.isArray(body.queries)
+      ? body.queries
+          .filter((query): query is string => typeof query === "string")
+          .map((query) => query.trim())
+          .filter((query) => query.length > 0)
+          .slice(0, 3)
+      : [];
+    if (queries.length === 0) return json(400, { error: "missing 'queries'" });
+    return json(
+      200,
+      await searchCommunitySkills(
+        {
+          directory: communityDirectory,
+          previews: previewDirectory,
+          fetchImpl: deps.fetchImpl,
+        },
+        queries,
+      ),
+    );
+  }
+  if (path === "/sandbox/skills/install") {
+    if (typeof body.source !== "string" || typeof body.skillId !== "string") {
+      return json(400, { error: "missing 'source' or 'skillId'" });
+    }
+    const slug = await installCommunitySkill(
+      deps.fetchImpl,
+      deps.filesystem.vfs,
+      deps.filesystem.workspaceRel,
+      body.source,
+      body.skillId,
+    );
+    return json(201, { slug, path: `.agents/skills/${slug}/SKILL.md` });
+  }
+  return null;
+}

--- a/packages/runtime/src/turn/turn-sandbox.test.ts
+++ b/packages/runtime/src/turn/turn-sandbox.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FsVfs } from "@houston/host/src/vfs";
+import type { ObjectStore } from "@houston/runtime-client/object-sync";
+import { expect, test, vi } from "vitest";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { makeTurnSandboxFetch } from "./turn-sandbox";
+
+async function fixture(fetchImpl: typeof fetch = fetch) {
+  const root = await mkdtemp(join(tmpdir(), "turn-sandbox-"));
+  const store: ObjectStore = {
+    list: async () => [],
+    manifest: async () => [],
+    download: async () => undefined,
+    upload: async () => ({ generation: "1" }),
+    delete: async () => undefined,
+  };
+  const filesystem = {
+    kind: "standing" as const,
+    storeRoot: root,
+    workspaceRel: "workspaces/Personal/Bob",
+    workspaceDir: join(root, "workspaces/Personal/Bob"),
+    dataRel: "workspaces/Personal/Bob/.houston/runtime",
+    dataDir: join(root, "workspaces/Personal/Bob/.houston/runtime"),
+    manifest: new Map(),
+    vfs: new FsVfs(root),
+    listedObjects: 0,
+    generationAware: true,
+    immediateWrites: new Set(),
+  } satisfies TurnFilesystem;
+  return makeTurnSandboxFetch({
+    grant: {
+      url: "https://gateway.test",
+      token: "grant-secret",
+      expires: 2_000_000_000,
+      scopes: ["integrations", "agent-writes"],
+    },
+    hostToken: "host-secret",
+    store,
+    prefix: "",
+    filesystem,
+    workspaceId: "w1",
+    conversationId: "c1",
+    orgSlug: "org",
+    agentSlug: "agent",
+    fetchImpl,
+  });
+}
+
+const post = (
+  call: ReturnType<typeof makeTurnSandboxFetch>["call"],
+  path: string,
+  body: unknown,
+) => call(path, { method: "POST", body: JSON.stringify(body) });
+
+test.each([
+  ["/sandbox/integrations/search", {}],
+  ["/sandbox/integrations/execute", {}],
+  ["/sandbox/integrations/custom/detect", {}],
+  ["/sandbox/integrations/custom/add", { auth: "oauth" }],
+  ["/sandbox/integrations/custom/remove", {}],
+  ["/sandbox/integrations/custom/status", {}],
+  ["/sandbox/routines/save", {}],
+  ["/sandbox/learnings/save", {}],
+  ["/sandbox/skills/search", {}],
+  ["/sandbox/skills/install", {}],
+])("routes %s through the turn facade", async (path, body) => {
+  const sandbox = await fixture();
+  const response = await post(sandbox.call, path, body);
+  expect(response.status).not.toBe(404);
+  await sandbox.dispose();
+});
+
+test("gateway authorization uses the grant and a 401 becomes grant_expired", async () => {
+  const calls: { url: string; authorization: string | null }[] = [];
+  const sandbox = await fixture(async (input, init) => {
+    calls.push({
+      url: String(input),
+      authorization: new Headers(init?.headers).get("authorization"),
+    });
+    return Response.json({ error: "expired" }, { status: 401 });
+  });
+  const response = await post(sandbox.call, "/sandbox/integrations/search", {
+    query: "email",
+  });
+  expect(response.status).toBe(401);
+  expect(await response.json()).toEqual({
+    error: "turn grant expired",
+    code: "grant_expired",
+  });
+  expect(calls).toEqual([
+    {
+      url: "https://gateway.test/v1/integrations/composio/search",
+      authorization: "Bearer grant-secret",
+    },
+  ]);
+  await sandbox.dispose();
+});
+
+test("a gateway 403 body relays verbatim", async () => {
+  const sandbox = await fixture(async () =>
+    Response.json(
+      { error: "blocked", code: "toolkit_not_allowed" },
+      { status: 403 },
+    ),
+  );
+  const response = await post(sandbox.call, "/sandbox/integrations/execute", {
+    action: "GMAIL_SEND_EMAIL",
+    params: {},
+  });
+  expect(response.status).toBe(403);
+  expect(await response.json()).toEqual({
+    error: "blocked",
+    code: "toolkit_not_allowed",
+  });
+  await sandbox.dispose();
+});
+
+test("tools-prefixed execute stays in the custom executor", async () => {
+  const gateway = vi.fn<typeof fetch>();
+  const sandbox = await fixture(gateway);
+  const response = await post(sandbox.call, "/sandbox/integrations/execute", {
+    action: "tools.example.owner.default.doThing",
+    params: {},
+  });
+  expect(response.status).toBe(200);
+  expect(gateway).not.toHaveBeenCalled();
+  await sandbox.dispose();
+});

--- a/packages/runtime/src/turn/turn-sandbox.test.ts
+++ b/packages/runtime/src/turn/turn-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FsVfs } from "@houston/host/src/vfs";
@@ -29,7 +29,7 @@ async function fixture(fetchImpl: typeof fetch = fetch) {
     generationAware: true,
     immediateWrites: new Set(),
   } satisfies TurnFilesystem;
-  return makeTurnSandboxFetch({
+  const sandbox = makeTurnSandboxFetch({
     grant: {
       url: "https://gateway.test",
       token: "grant-secret",
@@ -46,6 +46,7 @@ async function fixture(fetchImpl: typeof fetch = fetch) {
     agentSlug: "agent",
     fetchImpl,
   });
+  return { ...sandbox, root };
 }
 
 const post = (
@@ -73,6 +74,7 @@ test.each([
 });
 
 test("gateway authorization uses the grant and a 401 becomes grant_expired", async () => {
+  const warning = vi.spyOn(console, "error").mockImplementation(() => {});
   const calls: { url: string; authorization: string | null }[] = [];
   const sandbox = await fixture(async (input, init) => {
     calls.push({
@@ -95,6 +97,52 @@ test("gateway authorization uses the grant and a 401 becomes grant_expired", asy
       authorization: "Bearer grant-secret",
     },
   ]);
+  expect(warning).toHaveBeenCalledWith(
+    expect.stringContaining("before its advertised expiry"),
+  );
+  warning.mockRestore();
+  await sandbox.dispose();
+});
+
+test("aborting a tool call aborts its pending gateway request", async () => {
+  const sandbox = await fixture(
+    (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) reject(signal.reason);
+        else signal?.addEventListener("abort", () => reject(signal.reason));
+      }),
+  );
+  const controller = new AbortController();
+  const pending = sandbox.call("/sandbox/integrations/search", {
+    method: "POST",
+    body: JSON.stringify({ query: "email" }),
+    signal: controller.signal,
+  });
+  controller.abort(new Error("tool call cancelled"));
+
+  await expect(pending).rejects.toThrow("tool call cancelled");
+  await sandbox.dispose();
+});
+
+test("aborting a skill search aborts its pending directory request", async () => {
+  const sandbox = await fixture(
+    (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) reject(signal.reason);
+        else signal?.addEventListener("abort", () => reject(signal.reason));
+      }),
+  );
+  const controller = new AbortController();
+  const pending = sandbox.call("/sandbox/skills/search", {
+    method: "POST",
+    body: JSON.stringify({ queries: ["abort-signal-test"] }),
+    signal: controller.signal,
+  });
+  controller.abort(new Error("skill search cancelled"));
+
+  await expect(pending).rejects.toThrow("skill search cancelled");
   await sandbox.dispose();
 });
 
@@ -126,5 +174,96 @@ test("tools-prefixed execute stays in the custom executor", async () => {
   });
   expect(response.status).toBe(200);
   expect(gateway).not.toHaveBeenCalled();
+  await sandbox.dispose();
+});
+
+test("OAuth start is not exposed by the pooled facade", async () => {
+  const sandbox = await fixture();
+  const response = await post(
+    sandbox.call,
+    "/sandbox/integrations/custom/oauth/start",
+    {},
+  );
+  expect(response.status).toBe(404);
+  await sandbox.dispose();
+});
+
+test("skill installs capture the updated asleep-read view", async () => {
+  const sandbox = await fixture(
+    async () =>
+      new Response("---\nname: example\ndescription: test\n---\nbody\n"),
+  );
+  const response = await post(sandbox.call, "/sandbox/skills/install", {
+    source: "owner/repo",
+    skillId: "example",
+  });
+  expect(response.status).toBe(201);
+  expect(sandbox.views().skills).toMatchObject({
+    items: [{ name: "example", description: "test" }],
+  });
+  await sandbox.dispose();
+});
+
+test("custom definition writes capture the updated asleep-read view", async () => {
+  const sandbox = await fixture();
+  await writeFile(
+    join(sandbox.root, "custom-integrations.json"),
+    JSON.stringify({
+      version: 1,
+      items: [
+        {
+          kind: "mcp",
+          slug: "example",
+          name: "Example",
+          endpoint: "https://mcp.example.test",
+          auth: "credential",
+          addedAtMs: 1,
+        },
+      ],
+    }),
+  );
+  const response = await post(
+    sandbox.call,
+    "/sandbox/integrations/custom/remove",
+    { slug: "example" },
+  );
+  expect(response.status).toBe(200);
+  expect(sandbox.views().customDefinitions).toEqual({ items: [] });
+  await sandbox.dispose();
+});
+
+test("skill failures preserve the host route error taxonomy", async () => {
+  const sandbox = await fixture();
+  const response = await post(sandbox.call, "/sandbox/skills/install", {
+    source: "not a repo",
+    skillId: "example",
+  });
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({
+    error: {
+      code: "BAD_REQUEST",
+      message: "not a repo",
+      kind: "invalid_repo_source",
+      details: { kind: "invalid_repo_source" },
+    },
+  });
+  await sandbox.dispose();
+});
+
+test("unknown skill failures relay their message with a 502", async () => {
+  const sandbox = await fixture(
+    async () =>
+      new Response("---\nname: example\ndescription: test\n---\nbody\n"),
+  );
+  await rm(sandbox.root, { recursive: true });
+  await writeFile(sandbox.root, "not a directory");
+  const response = await post(sandbox.call, "/sandbox/skills/install", {
+    source: "owner/repo",
+    skillId: "example",
+  });
+  expect(response.status).toBe(502);
+  expect(await response.json()).toMatchObject({
+    error: expect.stringContaining("ENOTDIR"),
+  });
   await sandbox.dispose();
 });

--- a/packages/runtime/src/turn/turn-sandbox.ts
+++ b/packages/runtime/src/turn/turn-sandbox.ts
@@ -1,0 +1,173 @@
+import { CustomIntegrationError } from "@houston/host/src/integrations/custom/types";
+import { IntegrationUpstreamError } from "@houston/host/src/integrations/types";
+import { parseAddInput } from "@houston/host/src/routes/custom-integrations";
+import type { ObjectStore } from "@houston/runtime-client/object-sync";
+import type { SandboxFetch } from "../session/tools/sandbox-fetch";
+import {
+  createTurnCustomContext,
+  customDefinitionsFile,
+  type TurnCustomContext,
+} from "./turn-custom-context";
+import { mutateTurnDocument, TurnDocConflictError } from "./turn-doc-cas";
+import type { TurnFilesystem } from "./turn-filesystem";
+import {
+  makeTurnIntegrationRoutes,
+  TurnGrantExpiredError,
+} from "./turn-sandbox-integrations";
+import { handleTurnWriteRoute } from "./turn-sandbox-writes";
+import type { TurnGrant } from "./types";
+
+/** Dependencies captured by a single turn's sandbox routing closure. */
+export interface TurnSandboxDeps {
+  grant: TurnGrant;
+  hostToken: string;
+  store: ObjectStore;
+  prefix: string;
+  filesystem: TurnFilesystem;
+  workspaceId: string;
+  conversationId: string;
+  actingAs?: { userId: string; name?: string };
+  orgSlug: string;
+  agentSlug: string;
+  fetchImpl?: typeof fetch;
+}
+
+const json = (status: number, body: unknown): Response =>
+  Response.json(body, { status });
+
+function customStatus(error: CustomIntegrationError): number {
+  return error.code === "not_found"
+    ? 404
+    : error.code === "duplicate_slug"
+      ? 409
+      : 400;
+}
+
+/** Build the `/sandbox/*` facade available only for this granted turn. */
+export function makeTurnSandboxFetch(deps: TurnSandboxDeps): {
+  call: SandboxFetch;
+  dispose: () => Promise<void>;
+} {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  let custom: TurnCustomContext | null = null;
+  const getCustom = async () => {
+    custom ??= await createTurnCustomContext({
+      ...deps,
+      grantUrl: deps.grant.url,
+      fetchImpl,
+    });
+    return custom;
+  };
+  const resetCustom = async () => {
+    await custom?.dispose();
+    custom = null;
+  };
+  const integrations = makeTurnIntegrationRoutes(deps, fetchImpl, getCustom);
+
+  const customRoute = async (path: string, body: Record<string, unknown>) => {
+    const action = path.split("/").at(-1);
+    if (action === "detect") {
+      if (typeof body.url !== "string" || !body.url.trim())
+        return json(400, { error: "missing 'url'" });
+      return json(
+        200,
+        await (await getCustom()).manager.detect(body.url.trim()),
+      );
+    }
+    if (action === "status") {
+      if (typeof body.slug !== "string" || !body.slug.trim())
+        return json(400, { error: "missing 'slug'" });
+      const slug = body.slug.trim();
+      const view = (await (await getCustom()).manager.list()).find(
+        (item) => item.slug === slug,
+      );
+      return view
+        ? json(200, view)
+        : json(404, {
+            error: `no custom integration '${slug}'`,
+            code: "not_found",
+          });
+    }
+    if (action === "add" && body.auth === "oauth") {
+      return json(503, { error: "the pod serves this one" });
+    }
+    const input = action === "add" ? parseAddInput(body) : null;
+    if (typeof input === "string") return json(400, { error: input });
+    if (
+      action === "remove" &&
+      (typeof body.slug !== "string" || !body.slug.trim())
+    ) {
+      return json(400, { error: "missing 'slug'" });
+    }
+    await resetCustom();
+    const result = await mutateTurnDocument({
+      ...deps,
+      relativePath: customDefinitionsFile,
+      apply: async () => {
+        const context = await getCustom();
+        try {
+          if (action === "add" && input) {
+            return context.manager.add(input);
+          }
+          return context.manager
+            .remove((body.slug as string).trim())
+            .then(() => ({ ok: true }));
+        } finally {
+          await resetCustom();
+        }
+      },
+    });
+    return json(200, result);
+  };
+
+  const call: SandboxFetch = async (path, init) => {
+    if ((init?.method ?? "GET") !== "POST")
+      return json(405, { error: "method not allowed" });
+    let body: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(
+        typeof init?.body === "string" ? init.body : "{}",
+      );
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+        throw new Error();
+      body = parsed as Record<string, unknown>;
+    } catch {
+      return json(400, { error: "invalid JSON body" });
+    }
+    try {
+      if (/^\/sandbox\/integrations\/(search|execute)$/.test(path))
+        return await integrations(path, body);
+      if (
+        /^\/sandbox\/integrations\/custom\/(detect|add|remove|status)$/.test(
+          path,
+        )
+      )
+        return await customRoute(path, body);
+      const write = await handleTurnWriteRoute(path, body, {
+        ...deps,
+        fetchImpl,
+      });
+      return write ?? json(404, { error: "unknown sandbox route" });
+    } catch (error) {
+      if (error instanceof TurnGrantExpiredError)
+        return json(401, {
+          error: "turn grant expired",
+          code: "grant_expired",
+        });
+      if (error instanceof IntegrationUpstreamError)
+        return json(error.status, error.body);
+      if (error instanceof CustomIntegrationError)
+        return json(customStatus(error), {
+          error: error.message,
+          code: error.code,
+        });
+      if (error instanceof TurnDocConflictError)
+        return json(409, { error: error.message, code: error.code });
+      console.error(
+        `[turn-sandbox] request failed (${error instanceof Error ? error.name : typeof error})`,
+      );
+      return json(500, { error: "sandbox request failed" });
+    }
+  };
+  return { call, dispose: resetCustom };
+}

--- a/packages/runtime/src/turn/turn-sandbox.ts
+++ b/packages/runtime/src/turn/turn-sandbox.ts
@@ -1,19 +1,21 @@
+import { loadSkills } from "@houston/domain";
 import { CustomIntegrationError } from "@houston/host/src/integrations/custom/types";
 import { IntegrationUpstreamError } from "@houston/host/src/integrations/types";
-import { parseAddInput } from "@houston/host/src/routes/custom-integrations";
+import { SkillRemoteError } from "@houston/host/src/skills/remote-error";
 import type { ObjectStore } from "@houston/runtime-client/object-sync";
 import type { SandboxFetch } from "../session/tools/sandbox-fetch";
 import {
   createTurnCustomContext,
-  customDefinitionsFile,
   type TurnCustomContext,
 } from "./turn-custom-context";
-import { mutateTurnDocument, TurnDocConflictError } from "./turn-doc-cas";
+import { TurnDocConflictError } from "./turn-doc-cas";
 import type { TurnFilesystem } from "./turn-filesystem";
+import { makeTurnCustomRoutes } from "./turn-sandbox-custom";
 import {
   makeTurnIntegrationRoutes,
   TurnGrantExpiredError,
 } from "./turn-sandbox-integrations";
+import { fetchWithTurnSignal } from "./turn-sandbox-signal";
 import { handleTurnWriteRoute } from "./turn-sandbox-writes";
 import type { TurnGrant } from "./types";
 
@@ -32,6 +34,12 @@ export interface TurnSandboxDeps {
   fetchImpl?: typeof fetch;
 }
 
+/** Mutation-derived views published after the turn's object sync lands. */
+export interface TurnSandboxViews {
+  skills?: unknown;
+  customDefinitions?: unknown;
+}
+
 const json = (status: number, body: unknown): Response =>
   Response.json(body, { status });
 
@@ -43,82 +51,63 @@ function customStatus(error: CustomIntegrationError): number {
       : 400;
 }
 
+function skillFailure(error: unknown): Response {
+  if (!(error instanceof SkillRemoteError)) {
+    return json(502, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  const code =
+    error.httpStatus === 400
+      ? "BAD_REQUEST"
+      : error.httpStatus === 404
+        ? "NOT_FOUND"
+        : "UNAVAILABLE";
+  return json(error.httpStatus, {
+    error: {
+      code,
+      message: error.message,
+      kind: error.kind,
+      details: { kind: error.kind },
+    },
+  });
+}
+
 /** Build the `/sandbox/*` facade available only for this granted turn. */
 export function makeTurnSandboxFetch(deps: TurnSandboxDeps): {
   call: SandboxFetch;
   dispose: () => Promise<void>;
+  views: () => TurnSandboxViews;
 } {
   const fetchImpl = deps.fetchImpl ?? fetch;
-  let custom: TurnCustomContext | null = null;
-  const getCustom = async () => {
-    custom ??= await createTurnCustomContext({
+  const views: TurnSandboxViews = {};
+  const custom = new Map<AbortSignal | null, TurnCustomContext>();
+  const getCustom = async (signal?: AbortSignal | null) => {
+    const key = signal ?? null;
+    const existing = custom.get(key);
+    if (existing) return existing;
+    const context = await createTurnCustomContext({
       ...deps,
       grantUrl: deps.grant.url,
-      fetchImpl,
+      fetchImpl: fetchWithTurnSignal(fetchImpl, signal),
     });
-    return custom;
+    custom.set(key, context);
+    return context;
   };
   const resetCustom = async () => {
-    await custom?.dispose();
-    custom = null;
+    const contexts = [...custom.values()];
+    custom.clear();
+    await Promise.all(contexts.map((context) => context.dispose()));
   };
   const integrations = makeTurnIntegrationRoutes(deps, fetchImpl, getCustom);
-
-  const customRoute = async (path: string, body: Record<string, unknown>) => {
-    const action = path.split("/").at(-1);
-    if (action === "detect") {
-      if (typeof body.url !== "string" || !body.url.trim())
-        return json(400, { error: "missing 'url'" });
-      return json(
-        200,
-        await (await getCustom()).manager.detect(body.url.trim()),
-      );
-    }
-    if (action === "status") {
-      if (typeof body.slug !== "string" || !body.slug.trim())
-        return json(400, { error: "missing 'slug'" });
-      const slug = body.slug.trim();
-      const view = (await (await getCustom()).manager.list()).find(
-        (item) => item.slug === slug,
-      );
-      return view
-        ? json(200, view)
-        : json(404, {
-            error: `no custom integration '${slug}'`,
-            code: "not_found",
-          });
-    }
-    if (action === "add" && body.auth === "oauth") {
-      return json(503, { error: "the pod serves this one" });
-    }
-    const input = action === "add" ? parseAddInput(body) : null;
-    if (typeof input === "string") return json(400, { error: input });
-    if (
-      action === "remove" &&
-      (typeof body.slug !== "string" || !body.slug.trim())
-    ) {
-      return json(400, { error: "missing 'slug'" });
-    }
-    await resetCustom();
-    const result = await mutateTurnDocument({
-      ...deps,
-      relativePath: customDefinitionsFile,
-      apply: async () => {
-        const context = await getCustom();
-        try {
-          if (action === "add" && input) {
-            return context.manager.add(input);
-          }
-          return context.manager
-            .remove((body.slug as string).trim())
-            .then(() => ({ ok: true }));
-        } finally {
-          await resetCustom();
-        }
-      },
-    });
-    return json(200, result);
-  };
+  const customRoute = makeTurnCustomRoutes(
+    deps,
+    getCustom,
+    resetCustom,
+    (view) => {
+      views.customDefinitions = view;
+    },
+  );
 
   const call: SandboxFetch = async (path, init) => {
     if ((init?.method ?? "GET") !== "POST")
@@ -136,19 +125,27 @@ export function makeTurnSandboxFetch(deps: TurnSandboxDeps): {
     }
     try {
       if (/^\/sandbox\/integrations\/(search|execute)$/.test(path))
-        return await integrations(path, body);
+        return await integrations(path, body, init?.signal);
       if (
         /^\/sandbox\/integrations\/custom\/(detect|add|remove|status)$/.test(
           path,
         )
       )
-        return await customRoute(path, body);
+        return await customRoute(path, body, init?.signal);
       const write = await handleTurnWriteRoute(path, body, {
         ...deps,
-        fetchImpl,
+        fetchImpl: fetchWithTurnSignal(fetchImpl, init?.signal),
+        ...(init?.signal ? { signal: init.signal } : {}),
       });
+      if (write?.ok && path === "/sandbox/skills/install") {
+        views.skills = await loadSkills(
+          deps.filesystem.vfs,
+          deps.filesystem.workspaceRel,
+        );
+      }
       return write ?? json(404, { error: "unknown sandbox route" });
     } catch (error) {
+      if (init?.signal?.aborted) throw init.signal.reason ?? error;
       if (error instanceof TurnGrantExpiredError)
         return json(401, {
           error: "turn grant expired",
@@ -163,11 +160,14 @@ export function makeTurnSandboxFetch(deps: TurnSandboxDeps): {
         });
       if (error instanceof TurnDocConflictError)
         return json(409, { error: error.message, code: error.code });
-      console.error(
-        `[turn-sandbox] request failed (${error instanceof Error ? error.name : typeof error})`,
-      );
+      if (path.startsWith("/sandbox/skills/")) return skillFailure(error);
+      const detail =
+        error instanceof Error
+          ? `${error.name}: ${error.message}`
+          : typeof error;
+      console.error(`[turn-sandbox] request failed (${detail})`);
       return json(500, { error: "sandbox request failed" });
     }
   };
-  return { call, dispose: resetCustom };
+  return { call, dispose: resetCustom, views: () => ({ ...views }) };
 }

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -36,16 +36,14 @@ import {
   planReadyFallback,
   runWithInteractionCapture,
 } from "../session/interaction";
-import {
-  buildToolSelection,
-  turnCodeExecutionMode,
-} from "../session/tool-selection";
+import { turnCodeExecutionMode } from "../session/tool-selection";
 import { makeAskUserTool } from "../session/tools/ask-user";
 import { makeClampedFileTools } from "../session/tools/clamped-fs";
 import { makeIdTokenProvider } from "../session/tools/gcp-id-token";
 import { makePlanReadyTool } from "../session/tools/plan-ready";
 import { makePoolBashTool } from "../session/tools/pool-bash";
 import { makeRunCodeTool } from "../session/tools/run-code";
+import type { SandboxFetch } from "../session/tools/sandbox-fetch";
 import type { ProvidedContext } from "../session/workspace-context";
 import {
   appendAssistantMessageAt,
@@ -53,6 +51,8 @@ import {
   loadConversation,
 } from "../store/conversation-file";
 import { createTurnModelRuntime } from "./turn-runtime";
+import { buildTurnHostTools, buildTurnToolSelection } from "./turn-toolset";
+import type { TurnGrantScope } from "./types";
 
 /**
  * One pi turn against resolved hydrated directories. Unlike chat.ts (one
@@ -70,8 +70,7 @@ export interface TurnOutcome {
   /**
    * What the model ended the turn waiting on the user for (ask_user), if
    * anything. The per-turn SERVER carries it on the clean terminal `done` frame
-   * it sends after sync-back — never on an error. request_connection isn't
-   * available here (integrations are off in cloud turn mode).
+   * it sends after sync-back, never on an error.
    */
   pendingInteraction?: PendingInteraction;
 }
@@ -120,6 +119,10 @@ export interface PiTurnRequest {
   author?: MessageAuthor;
   /** Gateway-provided workspace/user context for the session prompt. */
   context?: ProvidedContext;
+  /** Non-secret capability scopes copied from the parsed turn grant. */
+  grant?: { scopes: TurnGrantScope[] };
+  /** Turn-local routing closure; it owns all grant-bearing calls. */
+  sandbox?: { call: SandboxFetch };
 }
 
 export interface PiTurnDirectories {
@@ -196,21 +199,11 @@ export async function runPiTurn(
       pin?.model,
     );
 
-    const toolSelection = buildToolSelection({
-      codeExecution: turnCodeExecutionMode(
-        config.codeExecution,
-        config.poolSingleUse,
-      ),
-      integrations: false,
-      // The retired stateless per-turn cloud runtime has no sandbox routine,
-      // learning, or skills route wired (it syncs the whole workspace prefix),
-      // so every host-proxying tool is off here — the standing per-agent pods
-      // run in server mode with them on.
-      saveRoutine: false,
-      saveLearning: false,
-      skillDirectory: false,
-    });
-    const sandbox = toolSelection.includeRunCode
+    const toolSelection = buildTurnToolSelection(
+      turn,
+      turnCodeExecutionMode(config.codeExecution, config.poolSingleUse),
+    );
+    const codeSandbox = toolSelection.includeRunCode
       ? makeRunCodeTool({
           baseUrl: config.codeSandboxUrl,
           token: config.codeSandboxToken,
@@ -263,14 +256,14 @@ export async function runPiTurn(
           sharedRoots: config.sharedSkillsDir ? [config.sharedSkillsDir] : [],
         }),
         // ask_user is available in every mode (holds no credential); its name is
-        // already in toolSelection.toolNames. request_connection is NOT — it is
-        // gated with the integration tools, which are off in cloud turn mode.
+        // already in toolSelection.toolNames.
         makeAskUserTool(),
         // plan_ready is registered always but name-gated to Plan mode by
         // toolNamesForMode (harmless in execute/auto — pi exposes it only when
         // its name is in the mode's allowlist).
         makePlanReadyTool(),
-        ...(sandbox ? [sandbox] : []),
+        ...(codeSandbox ? [codeSandbox] : []),
+        ...buildTurnHostTools(turn),
         // When local bash is enabled (single-use pool worker), shadow pi's
         // built-in bash with one whose child env is scrubbed to a non-secret
         // allowlist — pi's default copies process.env, which here carries the

--- a/packages/runtime/src/turn/turn-toolset.test.ts
+++ b/packages/runtime/src/turn/turn-toolset.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "vitest";
+import { toolNamesForMode } from "../session/tool-selection";
+import type { PiTurnRequest } from "./turn-session";
+import { buildTurnHostTools, buildTurnToolSelection } from "./turn-toolset";
+
+const base = (scopes?: PiTurnRequest["grant"]): PiTurnRequest => ({
+  conversationId: "c1",
+  text: "hello",
+  provider: "openai",
+  emit: () => undefined,
+  signal: undefined,
+  turnId: "t1",
+  ...(scopes
+    ? { grant: scopes, sandbox: { call: async () => Response.json({}) } }
+    : {}),
+});
+
+test.each([
+  {
+    scopes: ["integrations"] as const,
+    names: [
+      "integration_search",
+      "integration_execute",
+      "custom_integration_detect",
+      "custom_integration_add",
+      "custom_integration_remove",
+      "request_credential",
+    ],
+  },
+  {
+    scopes: ["agent-writes"] as const,
+    names: ["save_routine", "save_learning", "find_skills", "install_skill"],
+  },
+])("$scopes gates both names and registered objects", ({ scopes, names }) => {
+  const turn = base({ scopes: [...scopes] });
+  const selected = buildTurnToolSelection(turn, "disabled").toolNames;
+  const registered = buildTurnHostTools(turn).map((tool) => tool.name);
+  for (const name of names) {
+    expect(selected).toContain(name);
+    expect(registered).toContain(name);
+  }
+});
+
+test("an absent grant preserves the host-proxying all-off set", () => {
+  const turn = base();
+  const names = buildTurnToolSelection(turn, "disabled").toolNames;
+  expect(names).toEqual([
+    "read",
+    "ls",
+    "grep",
+    "find",
+    "edit",
+    "write",
+    "ask_user",
+    "suggest_reusable",
+    "suggest_actions",
+  ]);
+  expect(buildTurnHostTools(turn)).toEqual([]);
+});
+
+test("plan mode strips granted acting and write tools", () => {
+  const turn = base({ scopes: ["integrations", "agent-writes"] });
+  const selected = buildTurnToolSelection(turn, "disabled").toolNames;
+  expect(toolNamesForMode("plan", selected)).toEqual([
+    "read",
+    "ls",
+    "grep",
+    "find",
+    "ask_user",
+    "plan_ready",
+  ]);
+});

--- a/packages/runtime/src/turn/turn-toolset.ts
+++ b/packages/runtime/src/turn/turn-toolset.ts
@@ -1,0 +1,60 @@
+import type { PiBackendDeps } from "../backends/pi/backend";
+import {
+  buildToolSelection,
+  type CodeExecutionMode,
+  type ToolSelection,
+} from "../session/tool-selection";
+import { makeCustomIntegrationTools } from "../session/tools/custom-integrations";
+import { makeSkillDirectoryTools } from "../session/tools/find-skills";
+import { makeIntegrationTools } from "../session/tools/integrations";
+import { makeSaveLearningTool } from "../session/tools/save-learning";
+import { makeSaveRoutineTool } from "../session/tools/save-routine";
+import type { PiTurnRequest } from "./turn-session";
+
+function capabilities(turn: PiTurnRequest) {
+  const scopes = new Set(turn.grant?.scopes ?? []);
+  const callable = turn.sandbox !== undefined;
+  return {
+    integrations: callable && scopes.has("integrations"),
+    agentWrites: callable && scopes.has("agent-writes"),
+  };
+}
+
+/** Build the turn's name allowlist from non-secret grant scopes. */
+export function buildTurnToolSelection(
+  turn: PiTurnRequest,
+  codeExecution: CodeExecutionMode,
+): ToolSelection {
+  const enabled = capabilities(turn);
+  return buildToolSelection({
+    codeExecution,
+    integrations: enabled.integrations,
+    saveRoutine: enabled.agentWrites,
+    saveLearning: enabled.agentWrites,
+    skillDirectory: enabled.agentWrites,
+    missions: false,
+  });
+}
+
+/** Register only the host-proxying tool objects admitted by grant scopes. */
+export function buildTurnHostTools(
+  turn: PiTurnRequest,
+): PiBackendDeps["customTools"] {
+  if (!turn.sandbox) return [];
+  const enabled = capabilities(turn);
+  return [
+    ...(enabled.integrations
+      ? [
+          ...makeIntegrationTools({ call: turn.sandbox.call }),
+          ...makeCustomIntegrationTools({ call: turn.sandbox.call }),
+        ]
+      : []),
+    ...(enabled.agentWrites
+      ? [
+          makeSaveRoutineTool({ call: turn.sandbox.call }),
+          makeSaveLearningTool({ call: turn.sandbox.call }),
+          ...makeSkillDirectoryTools({ call: turn.sandbox.call }),
+        ]
+      : []),
+  ];
+}

--- a/packages/runtime/src/turn/turn-view-publish.ts
+++ b/packages/runtime/src/turn/turn-view-publish.ts
@@ -1,0 +1,65 @@
+import type { TurnServerDeps } from "./server-types";
+import { publish } from "./turn-activity-doc";
+import type { TurnSandboxViews } from "./turn-sandbox";
+import { poolIdentity } from "./turn-store";
+import type { TurnRequest } from "./types";
+
+type TurnViewFamily = "skills" | "custom_definitions";
+
+/** Publish mutation-derived views so claimed turns update asleep reads. */
+export async function publishTurnSandboxViews(
+  deps: TurnServerDeps,
+  turn: TurnRequest & { turnId: string },
+  views: TurnSandboxViews | undefined,
+): Promise<TurnViewFamily[]> {
+  if (!views || turn.shadow || !turn.claim || !turn.hostToken) return [];
+  const baseUrl = deps.poolStoreUrl ?? process.env.HOUSTON_POOL_STORE_URL;
+  if (!baseUrl) return [];
+  const { org, agent } = poolIdentity(turn.gcsPrefix);
+  const documents: Array<{ family: TurnViewFamily; doc: unknown }> = [];
+  if (views.skills !== undefined) {
+    documents.push({ family: "skills", doc: views.skills });
+  }
+  if (views.customDefinitions !== undefined) {
+    documents.push({
+      family: "custom_definitions",
+      doc: views.customDefinitions,
+    });
+  }
+  const failures: Array<{ family: TurnViewFamily; error: string }> = [];
+  for (const { family, doc } of documents) {
+    try {
+      const result = await publish(
+        {
+          family,
+          baseUrl,
+          org,
+          agent,
+          conversationId: turn.conversationId,
+          hostToken: turn.hostToken,
+          claim: { token: turn.claim.token, bootId: turn.claim.bootId },
+          fetchImpl: deps.fetchImpl ?? fetch,
+          ...(deps.activityDocRetryDelaysMs
+            ? { retryDelaysMs: deps.activityDocRetryDelaysMs }
+            : {}),
+        },
+        doc,
+      );
+      if ("error" in result) failures.push({ family, error: result.error });
+      if ("disabled" in result) {
+        failures.push({ family, error: result.reason });
+      }
+    } catch (error) {
+      failures.push({
+        family,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  for (const failure of failures) {
+    console.error(
+      `[turn] ${failure.family} view publish failed after durable sync: ${failure.error}`,
+    );
+  }
+  return failures.map((failure) => failure.family);
+}

--- a/packages/runtime/src/turn/types.test.ts
+++ b/packages/runtime/src/turn/types.test.ts
@@ -164,3 +164,79 @@ test("parseTurnRequest carries the turn's pinned provider; junk reads as absent"
   expect(parseTurnRequest({ ...BASE, provider: "" }).provider).toBeUndefined();
   expect(parseTurnRequest({ ...BASE, provider: 5 }).provider).toBeUndefined();
 });
+
+const CLAIMED = {
+  ...BASE,
+  hostToken: "host-secret",
+  claim: {
+    id: "claim-1",
+    bootId: "boot-1",
+    token: "claim-secret",
+    heartbeatUrl: "https://gateway.test/heartbeat",
+  },
+};
+
+test("parseTurnRequest leaves an absent grant absent", () => {
+  expect(parseTurnRequest(CLAIMED).grant).toBeUndefined();
+});
+
+test("parseTurnRequest accepts and normalizes a claimed turn grant", () => {
+  expect(
+    parseTurnRequest({
+      ...CLAIMED,
+      grant: {
+        url: "https://gateway.test:8443/",
+        token: "acting-v1.secret",
+        expires: 1_900_000_000,
+        scopes: ["integrations", "future-scope", "agent-writes"],
+      },
+    }).grant,
+  ).toEqual({
+    url: "https://gateway.test:8443",
+    token: "acting-v1.secret",
+    expires: 1_900_000_000,
+    scopes: ["integrations", "agent-writes"],
+  });
+});
+
+test.each([
+  ["a malformed URL", { url: "not a url" }],
+  ["a non-http URL", { url: "ftp://gateway.test" }],
+  ["URL credentials", { url: "https://user:password@gateway.test" }],
+  ["a URL path", { url: "https://gateway.test/internal" }],
+  ["a URL query", { url: "https://gateway.test?x=1" }],
+  ["a URL hash", { url: "https://gateway.test#x" }],
+  ["an empty token", { token: "" }],
+  ["a zero expiry", { expires: 0 }],
+  ["a fractional expiry", { expires: 1.5 }],
+  ["a non-array scope list", { scopes: "integrations" }],
+  ["an extra key", { extra: true }],
+])("rejects a grant with %s", (_case, override) => {
+  expect(() =>
+    parseTurnRequest({
+      ...CLAIMED,
+      grant: {
+        url: "https://gateway.test",
+        token: "acting-v1.secret",
+        expires: 1_900_000_000,
+        scopes: ["integrations"],
+        ...override,
+      },
+    }),
+  ).toThrow("invalid 'grant'");
+});
+
+test("a grant requires a claim and is refused on a shadow turn", () => {
+  const grant = {
+    url: "https://gateway.test",
+    token: "acting-v1.secret",
+    expires: 1_900_000_000,
+    scopes: ["integrations"],
+  };
+  expect(() => parseTurnRequest({ ...BASE, grant })).toThrow(
+    "grant requires a claim",
+  );
+  expect(() => parseTurnRequest({ ...CLAIMED, shadow: true, grant })).toThrow(
+    "shadow turn cannot carry a grant",
+  );
+});

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -1,6 +1,17 @@
 import type { ChatMessage, TurnMode } from "@houston/protocol";
 import type { ServedCredential } from "../auth/auth-file";
 
+/** Independently deployable authority carried by a per-turn grant. */
+export type TurnGrantScope = "integrations" | "agent-writes";
+
+/** Parsed short-lived authority for host-proxying tools. */
+export interface TurnGrant {
+  url: string;
+  token: string;
+  expires: number;
+  scopes: TurnGrantScope[];
+}
+
 /**
  * The self-contained turn request the control plane sends. Everything a turn
  * needs rides in: identity (for the GCS prefix), the user's text, and the
@@ -96,4 +107,6 @@ export interface TurnRequest {
     token: string;
     heartbeatUrl: string;
   };
+  /** Secret turn-local authority. Never log, export, persist, or put in env. */
+  grant?: TurnGrant;
 }


### PR DESCRIPTION
Pooled turns previously ran with every host-proxying tool disabled: no integrations, no custom tools, no save_routine/save_learning, no skill directory — and ordinary workspace-file deliverables written during a pooled turn were rejected at sync-back. This PR gives pooled turns full tool parity with standing pods.

## How

- The turn envelope may now carry a per-turn `grant` (origin + token + scopes, short-TTL, minted by the dispatcher alongside the existing claim). The parser validates it strictly (origin-only URL, unknown scopes dropped, requires a claim, refused on shadow turns).
- New `SandboxFetch` seam: the six host-proxying tool factories now take a transport closure instead of `{baseUrl, sandboxToken}`. Server mode binds the existing HTTP transport — byte-identical behavior. Pooled turns bind an in-process façade.
- The façade routes Composio search/execute to the gateway's existing integration routes under the grant token (per-agent allowlist enforced server-side, identically to standing pods); custom integrations, routine/learning saves, and skill search/install run in-process against extracted host cores.
- Doc writes (`routines.json`, `learnings.json`, `custom-integrations.json`) happen at tool-call time with generation-CAS (3-attempt re-read/re-apply, typed conflict error). The standing pod's sync-back now merges these docs by id/slug on generation conflict instead of re-uploading its own bytes — closing the wake-window race where a pod hydrated mid-turn could clobber a pooled save.
- The turn's sync scope now admits workspace files and exactly the turn-owned doc files, mirroring the server-side authorization.
- The grant lives only in the parsed request and closures — never env, config, disk, logs, or tool results; leak tests pin that end-to-end (bash child env, process.env, hydrated tree, tool output).
- `oauth/start` stays pod-only; mission tools stay off on pooled turns.

## Tests

Parser matrix, routing-table coverage for all sandbox paths, CAS conflict/retry, scope-gated tool names AND registered objects (absent grant = today's exact all-off set), widened-sync-scope matrix, doc-merge regression tests, secret-leak pins. Runtime/host/domain/runtime-client suites green; Biome and boundary checks clean.
