### PR TITLE
fix(app): language pick persists across restarts (PRODUCT-1564)

### DIFF
--- a/packages/web/src/engine-adapter/client/workspaces-mixin.ts
+++ b/packages/web/src/engine-adapter/client/workspaces-mixin.ts
@@ -92,10 +92,18 @@ export function WorkspacesMixin<TBase extends BaseCtor>(Base: TBase) {
         throw new Error("Deleting a team needs the hosted gateway.");
       await deleteOrg(this.ctx.cp, slug);
     }
+    // Persist the language pick as the account-level `locale` preference. The
+    // workspace id is ignored on purpose: the personal row is the synthetic
+    // "default" (no server workspace behind the gateway to PATCH), and on the
+    // host the workspace PATCH writes the same `locale` preference key this PUT
+    // does — one preference either way. Writing it here (instead of the old
+    // return-only stub) is what makes the pick survive a restart: the boot path
+    // reads `/v1/preferences/locale` (PRODUCT-1564).
     async setWorkspaceLocale(
       _id: string,
       locale: string | null,
     ): Promise<Workspace> {
+      await this.ctx.sdk.preferences.set("locale", locale);
       const { provider, model } = await this.ctx.activeOld();
       return { ...syntheticWorkspace(provider, model), locale };
     }

--- a/packages/web/tests/account-preferences.test.ts
+++ b/packages/web/tests/account-preferences.test.ts
@@ -185,3 +185,23 @@ test("locale, legal_acceptance and the migration flag are account keys", async (
     "http://host/v1/preferences/migration_reconnect_dismissed",
   ]);
 });
+
+// PRODUCT-1564: the Settings language pick goes through `setWorkspaceLocale`.
+// The adapter used to return a synthetic workspace WITHOUT persisting anything,
+// so the language reverted to the engine's stored preference on the next boot.
+// The pick must land on the account `locale` preference — the key the boot
+// path (`useLocalePreference`) reads back.
+test("setWorkspaceLocale persists the pick as the account locale preference", async () => {
+  stubFetch(json(200, { value: "pt" }));
+
+  const ws = await client(true).setWorkspaceLocale("default", "pt");
+
+  expect(ws.locale).toBe("pt");
+  expect(calls.filter((c) => c.url.includes("/v1/preferences/"))).toEqual([
+    {
+      url: "http://host/v1/preferences/locale",
+      method: "PUT",
+      body: JSON.stringify({ value: "pt" }),
+    },
+  ]);
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -538,7 +538,9 @@ export class HoustonClient {
    * the workspace record, so every client of this engine shares the value.
    */
   setWorkspaceLocale(id: string, locale: string | null): Promise<Workspace> {
-    return this.request("PATCH", `/workspaces/${this.seg(id)}/locale`, {
+    // The host's workspace-settings route is `PATCH /workspaces/:id` (locale is
+    // the one mutable field); a `/locale` suffix 404s, so the pick never lands.
+    return this.request("PATCH", `/workspaces/${this.seg(id)}`, {
       locale,
     });
   }

--- a/ui/engine-client/tests/client-workspace-locale.test.ts
+++ b/ui/engine-client/tests/client-workspace-locale.test.ts
@@ -1,0 +1,69 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { HoustonClient } from "../src/client.ts";
+
+/**
+ * PRODUCT-1564: the language pick must actually land on the host. The host's
+ * workspace-settings route is `PATCH /v1/workspaces/:id` (locale is the one
+ * mutable field); the client used to PATCH a `/locale` suffix that no host
+ * serves, so the pick 404'd and the language reverted on the next boot. A
+ * capturing `fetchImpl` pins the exact wire request.
+ */
+
+interface Captured {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+function makeClient(responseBody: unknown = {}): {
+  client: HoustonClient;
+  calls: Captured[];
+} {
+  const calls: Captured[] = [];
+  const client = new HoustonClient({
+    baseUrl: "http://127.0.0.1:9999",
+    token: "tok",
+    retry: { maxAttempts: 1, baseDelayMs: 1, maxDelayMs: 1, deadlineMs: 50 },
+    fetchImpl: async (url, init) => {
+      calls.push({
+        method: init?.method ?? "GET",
+        url: String(url),
+        body:
+          typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+      });
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { client, calls };
+}
+
+const WS = {
+  id: "ws-1",
+  name: "Houston",
+  isDefault: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  locale: "es",
+};
+
+describe("HoustonClient — setWorkspaceLocale", () => {
+  it("PATCHes /workspaces/:id (the route the host serves) with {locale}", async () => {
+    const { client, calls } = makeClient(WS);
+    const got = await client.setWorkspaceLocale("ws-1", "es");
+    strictEqual(calls.length, 1);
+    strictEqual(calls[0].method, "PATCH");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/workspaces/ws-1");
+    deepStrictEqual(calls[0].body, { locale: "es" });
+    deepStrictEqual(got, WS);
+  });
+
+  it("clears the override with an explicit null", async () => {
+    const { client, calls } = makeClient({ ...WS, locale: null });
+    await client.setWorkspaceLocale("ws-1", null);
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/workspaces/ws-1");
+    deepStrictEqual(calls[0].body, { locale: null });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1564: changing the language applied for the session but reverted to the previous language on the next launch — the pick never reached the engine, so boot re-applied the stored locale.

Two broken write paths behind the Settings language selector (`setWorkspaceLocale`):

- **ui/engine-client**: the client PATCHed `/v1/workspaces/:id/locale`, a route no host serves — the TS host's workspace-settings route is `PATCH /v1/workspaces/:id` (locale is its one mutable field). Verified live: the `/locale` path answers `404 {"error":"not found"}`. The client now PATCHes the route the host implements (the same one `@houston/runtime-client` already uses).
- **packages/web engine-adapter**: `setWorkspaceLocale` was a pure stub — it echoed a synthetic workspace with the locale set and persisted nothing, so the in-session switch silently evaporated. It now writes the account-level `locale` preference (`PUT /v1/preferences/locale`) — on the host that's the same preference key the workspace wire shape (`toWire`) and the boot path (`useLocalePreference`) read back, and it's the route the hosted gateway serves.

## Repro (before)

1. Open the app, go to Settings → Language, switch to Español.
2. UI switches to Spanish; a confirmation toast shows.
3. Quit and reopen the app.
4. UI is back in the previous language.

## Verify (after)

1. Settings → Language → Español; UI switches.
2. Quit and reopen: UI boots in Spanish (engine preference `locale` = `es`; on a local host, `GET /v1/preferences/locale` returns `{"value":"es"}`).
3. Same round trip on the web surface.

## Tests

- `ui/engine-client/tests/client-workspace-locale.test.ts` pins the wire request (`PATCH /v1/workspaces/:id` with `{locale}`, set + clear).
- `packages/web/tests/account-preferences.test.ts` pins the adapter persisting the pick via `PUT /v1/preferences/locale`.
- Full gates: engine-client suite (2 pre-existing flaky failures also fail on pristine `main`, unrelated: `store-catalog`/`client-retry`), `houston-web` 423 unit tests, workspace typecheck + Tauri shim parity, Biome — all green.