### PR TITLE
feat(runtime): anthropic pooled turns run the Claude Agent SDK in the worker

### DIFF
--- a/.github/workflows/engine-pod-image.yml
+++ b/.github/workflows/engine-pod-image.yml
@@ -149,6 +149,8 @@ jobs:
             -f selfhost/Dockerfile \
             -t "$SHA_TAG" -t "$POC_TAG" \
             .
+          docker run --rm --entrypoint sh "$SHA_TAG" -c \
+            'set -- /app/node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-linux-x64@*/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude; test -x "$1"'
           docker push "$SHA_TAG"
           docker push "$POC_TAG"
           # Resolve the immutable digest of the pushed image for the roll below.

--- a/.github/workflows/engine-pod-image.yml
+++ b/.github/workflows/engine-pod-image.yml
@@ -149,8 +149,22 @@ jobs:
             -f selfhost/Dockerfile \
             -t "$SHA_TAG" -t "$POC_TAG" \
             .
-          docker run --rm --entrypoint sh "$SHA_TAG" -c \
-            'set -- /app/node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-linux-x64@*/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude; test -x "$1"'
+          docker run --rm --entrypoint sh "$SHA_TAG" -c '
+            ARCH=$(node -p "process.arch")
+            case "$ARCH" in
+              x64|arm64) ;;
+              *) echo "ERROR: unsupported engine image architecture: $ARCH" >&2; exit 1 ;;
+            esac
+            BINARY="/app/dist/runtime/node_modules/@anthropic-ai/claude-agent-sdk-linux-${ARCH}/claude"
+            if [ ! -e "$BINARY" ]; then
+              echo "ERROR: Claude Agent SDK binary is missing for image architecture $ARCH: $BINARY" >&2
+              exit 1
+            fi
+            if [ ! -x "$BINARY" ]; then
+              echo "ERROR: Claude Agent SDK binary is not executable: $BINARY" >&2
+              exit 1
+            fi
+          '
           docker push "$SHA_TAG"
           docker push "$POC_TAG"
           # Resolve the immutable digest of the pushed image for the roll below.

--- a/packages/host/src/routes/portable-anonymize.ts
+++ b/packages/host/src/routes/portable-anonymize.ts
@@ -40,6 +40,8 @@ export async function runPortableAnonymize(
     vfs: Vfs;
     root: string;
     ai?: AnonymizeAiRunner;
+    /** Errors this surface must handle outside the patterns fallback. */
+    rethrowAiError?: (error: unknown) => boolean;
     /** Surface-specific `aiError` copy when no runner exists at all. */
     aiUnavailableReason?: string;
   },
@@ -82,6 +84,7 @@ export async function runPortableAnonymize(
       redactSecrets,
     );
   } catch (e) {
+    if (deps.rethrowAiError?.(e)) throw e;
     return {
       ...(await anonymizeContent(content, redactSecrets)),
       aiError: e instanceof Error ? e.message : String(e),

--- a/packages/runtime/src/backends/backend-contract.test.ts
+++ b/packages/runtime/src/backends/backend-contract.test.ts
@@ -1,45 +1,39 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  createSdkMcpServer,
+  SDKMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { WireEvent } from "@houston/runtime-client";
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
+import { writeAuthFile } from "../auth/auth-file";
+import { createTurnBackend } from "../turn/turn-backend";
+import type { ClaudeQuery } from "./claude/session";
 import type {
   CreateSessionOptions,
   HarnessBackend,
   HarnessSession,
 } from "./types";
 
-/**
- * The provider-agnostic HarnessBackend contract. Any backend (pi today, another
- * provider's harness tomorrow) must honor these guarantees, so the server and the
- * cloud runtime can drive it blind. Exercised here against a scripted fake so the
- * contract is pinned independent of pi — a real backend that violates it (e.g.
- * throwing from prompt instead of emitting a provider_error, or delivering after
- * unsubscribe) is a contract break, caught by re-running this suite over it.
- */
-
-/** A scripted fake session: `prompt` delivers `script` in order, resolving only
- *  after the terminal event. Provider failures ride the stream, never a throw. */
 class FakeSession implements HarnessSession {
-  private listeners = new Set<(e: WireEvent) => void>();
+  private listeners = new Set<(event: WireEvent) => void>();
   private disposed = false;
-  aborts = 0;
 
   constructor(private readonly script: readonly WireEvent[]) {}
 
-  subscribe(listener: (e: WireEvent) => void): () => void {
+  subscribe(listener: (event: WireEvent) => void): () => void {
     this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
+    return () => this.listeners.delete(listener);
   }
   async prompt(): Promise<void> {
-    for (const e of this.script) {
-      // Yield between frames so delivery is asynchronous, like a real stream.
+    for (const event of this.script) {
       await Promise.resolve();
-      for (const l of this.listeners) l(e);
+      for (const listener of this.listeners) listener(event);
     }
   }
-  async abort(): Promise<void> {
-    this.aborts++;
-  }
+  async abort(): Promise<void> {}
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
@@ -53,16 +47,7 @@ class FakeSession implements HarnessSession {
   }
 }
 
-function fakeBackend(script: readonly WireEvent[]): HarnessBackend {
-  return {
-    id: "fake",
-    async createSession(_opts: CreateSessionOptions): Promise<HarnessSession> {
-      return new FakeSession(script);
-    },
-  };
-}
-
-const SCRIPT: readonly WireEvent[] = [
+const FAKE_EVENTS: readonly WireEvent[] = [
   { type: "text", data: "one " },
   { type: "text", data: "two" },
   {
@@ -72,58 +57,162 @@ const SCRIPT: readonly WireEvent[] = [
   { type: "done", data: null },
 ];
 
-async function open(
-  script: readonly WireEvent[] = SCRIPT,
-): Promise<HarnessSession> {
-  return fakeBackend(script).createSession({
+function fakeBackend(): HarnessBackend {
+  return {
+    id: "fake",
+    async createSession(): Promise<HarnessSession> {
+      return new FakeSession(FAKE_EVENTS);
+    },
+  };
+}
+
+const CLAUDE_MESSAGES: SDKMessage[] = [
+  {
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "one " },
+    },
+    session_id: "s1",
+    parent_tool_use_id: null,
+  } as unknown as SDKMessage,
+  {
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "two" },
+    },
+    session_id: "s1",
+    parent_tool_use_id: null,
+  } as unknown as SDKMessage,
+  {
+    type: "result",
+    subtype: "success",
+    usage: { input_tokens: 10, output_tokens: 2 },
+    session_id: "s1",
+  } as unknown as SDKMessage,
+];
+
+const CLAUDE_EVENTS: readonly WireEvent[] = [
+  { type: "text", data: "one " },
+  { type: "text", data: "two" },
+  {
+    type: "usage",
+    data: { context_tokens: 10, output_tokens: 2, cached_tokens: 0 },
+  },
+];
+
+async function openClaudeSession(): Promise<HarnessSession> {
+  const turnRoot = mkdtempSync(join(tmpdir(), "claude-contract-"));
+  const workspaceDir = join(turnRoot, "store", "workspace");
+  const dataDir = join(turnRoot, "store", "data");
+  mkdirSync(workspaceDir, { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
+  writeAuthFile(join(dataDir, "auth.json"), {
+    anthropic: {
+      type: "oauth",
+      access: "sk-ant-oat01-contract",
+      refresh: "",
+      expires: Date.now() + 60_000,
+    },
+  });
+  const query: ClaudeQuery = async function* () {
+    for (const message of CLAUDE_MESSAGES) {
+      await Promise.resolve();
+      yield message;
+    }
+  };
+  const createMcp = ((input: { name: string }) => ({
+    type: "sdk",
+    name: input.name,
+    instance: {},
+  })) as typeof createSdkMcpServer;
+  const backend = createTurnBackend("anthropic", {
+    directories: { workspaceDir, dataDir, turnRoot },
+    turn: {
+      conversationId: "c1",
+      text: "go",
+      provider: "anthropic",
+      emit: () => undefined,
+      signal: undefined,
+      turnId: "t1",
+    },
+    modelRuntime: {} as ModelRuntime,
+    toolSelection: { toolNames: [], includeRunCode: false },
+    codeSandbox: null,
+    systemPrompt: "system",
+    claudeSdk: { query, createSdkMcpServer: createMcp },
+  });
+  return backend.createSession({
     conversationId: "c1",
-    model: { provider: "fake", id: "m1", contextWindow: 1000 },
+    model: {
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      contextWindow: 200_000,
+    },
   });
 }
 
-test("events are delivered to the subscriber in order", async () => {
-  const session = await open();
-  const seen: WireEvent[] = [];
-  session.subscribe((e) => seen.push(e));
+function backendContract(input: {
+  name: string;
+  open: () => Promise<HarnessSession>;
+  expected: readonly WireEvent[];
+}): void {
+  describe(input.name, () => {
+    test("events are delivered to the subscriber in order", async () => {
+      const session = await input.open();
+      const seen: WireEvent[] = [];
+      session.subscribe((event) => seen.push(event));
+      await session.prompt("go");
+      expect(seen).toEqual(input.expected);
+    });
 
-  await session.prompt("go");
+    test("unsubscribe stops delivery", async () => {
+      const session = await input.open();
+      const seen: WireEvent[] = [];
+      const unsubscribe = session.subscribe((event) => seen.push(event));
+      unsubscribe();
+      await session.prompt("go");
+      expect(seen).toEqual([]);
+    });
 
-  expect(seen).toEqual(SCRIPT);
+    test("prompt resolves only after the whole stream is delivered", async () => {
+      const session = await input.open();
+      const seen: WireEvent[] = [];
+      session.subscribe((event) => seen.push(event));
+      await session.prompt("go");
+      expect(seen).toEqual(input.expected);
+    });
+
+    test("abort before any prompt is safe", async () => {
+      const session = await input.open();
+      await expect(session.abort()).resolves.toBeUndefined();
+    });
+
+    test("dispose is idempotent", async () => {
+      const session = await input.open();
+      expect(() => {
+        session.dispose();
+        session.dispose();
+      }).not.toThrow();
+    });
+  });
+}
+
+backendContract({
+  name: "scripted backend contract",
+  open: () =>
+    fakeBackend().createSession({
+      conversationId: "c1",
+      model: { provider: "fake", id: "m1", contextWindow: 1_000 },
+    } satisfies CreateSessionOptions),
+  expected: FAKE_EVENTS,
 });
 
-test("unsubscribe stops delivery", async () => {
-  const session = await open();
-  const seen: WireEvent[] = [];
-  const unsub = session.subscribe((e) => seen.push(e));
-  unsub();
-
-  await session.prompt("go");
-
-  expect(seen).toEqual([]);
-});
-
-test("prompt resolves only after the terminal frame has been delivered", async () => {
-  const session = await open();
-  const seen: WireEvent[] = [];
-  session.subscribe((e) => seen.push(e));
-
-  await session.prompt("go");
-
-  // By the time prompt() resolves, the whole script (ending in the terminal
-  // `done`) has already been delivered — no frame arrives after settlement.
-  expect(seen.at(-1)).toEqual({ type: "done", data: null });
-  expect(seen).toHaveLength(SCRIPT.length);
-});
-
-test("abort before any prompt is safe (no throw)", async () => {
-  const session = await open();
-  await expect(session.abort()).resolves.toBeUndefined();
-});
-
-test("dispose is idempotent", async () => {
-  const session = await open();
-  expect(() => {
-    session.dispose();
-    session.dispose();
-  }).not.toThrow();
+backendContract({
+  name: "turn-mode Claude backend contract",
+  open: openClaudeSession,
+  expected: CLAUDE_EVENTS,
 });

--- a/packages/runtime/src/backends/claude/auth-cli.ts
+++ b/packages/runtime/src/backends/claude/auth-cli.ts
@@ -78,7 +78,9 @@ export function readProbeOutcome(
  * `readProbeOutcome`.
  */
 export function spawnStatusProbe(): Promise<ProbeAnswer> {
-  const env = buildClaudeEnv(claudeLoginConfigDir(), undefined);
+  const env = buildClaudeEnv(undefined, {
+    configDir: claudeLoginConfigDir(),
+  });
   return new Promise<ProbeAnswer>((resolve, reject) => {
     execFile(
       claudeBinary(),
@@ -102,7 +104,9 @@ export function spawnStatusProbe(): Promise<ProbeAnswer> {
  * is no bundled binary to log out with, and nothing was ever cached through it.
  */
 export function spawnClaudeLogout(): Promise<void> {
-  const env = buildClaudeEnv(claudeLoginConfigDir(), undefined);
+  const env = buildClaudeEnv(undefined, {
+    configDir: claudeLoginConfigDir(),
+  });
   return new Promise<void>((resolve, reject) => {
     execFile(
       claudeBinary(),

--- a/packages/runtime/src/backends/claude/backend-mcp.test.ts
+++ b/packages/runtime/src/backends/claude/backend-mcp.test.ts
@@ -7,6 +7,7 @@ import type { ToolSelection } from "../../session/tool-selection";
 import { httpSandboxFetch } from "../../session/tools/sandbox-fetch";
 import type { ResolvedModel } from "../types";
 import { createClaudeBackend } from "./backend";
+import { serverClaudeLayout } from "./paths";
 
 /**
  * Verify the Claude backend WIRES the in-process MCP server into the SDK options:
@@ -56,7 +57,7 @@ async function runTurn(
   const root = mkdtempSync(join(tmpdir(), "houston-mcp-test-"));
   const backend = createClaudeBackend({
     workspaceDir: root,
-    dataDir: join(root, "data"),
+    layout: serverClaudeLayout(join(root, "data")),
     readToken: () => undefined,
     toolSelection,
     systemPrompt: "system",

--- a/packages/runtime/src/backends/claude/backend.test.ts
+++ b/packages/runtime/src/backends/claude/backend.test.ts
@@ -11,7 +11,7 @@ import {
   type ClaudeToken,
   createClaudeBackend,
 } from "./backend";
-import { claudeLoginConfigDir } from "./paths";
+import { claudeLoginConfigDir, serverClaudeLayout } from "./paths";
 
 // Capture the deps the backend hands a session WITHOUT running the SDK: the
 // whole point of the scope guard is that a refused turn never builds an env at
@@ -56,7 +56,7 @@ const oauth: ClaudeToken = { kind: "oauth-token", value: "sk-ant-oat01-x" };
 const apiKey: ClaudeToken = { kind: "api-key", value: "sk-ant-api03-x" };
 
 test("buildClaudeEnv pins the isolated config dir", () => {
-  const env = buildClaudeEnv("/data/cfg", oauth);
+  const env = buildClaudeEnv(oauth, { configDir: "/data/cfg" });
   expect(env.CLAUDE_CONFIG_DIR).toBe("/data/cfg");
 });
 
@@ -65,7 +65,7 @@ test("an OAuth token scrubs a stale ambient ANTHROPIC_API_KEY", () => {
   // OAuth subscription token. The subprocess must carry ONLY the OAuth token.
   process.env.ANTHROPIC_API_KEY = "stale-host-key";
   process.env.ANTHROPIC_AUTH_TOKEN = "stale-alias";
-  const env = buildClaudeEnv("/cfg", oauth);
+  const env = buildClaudeEnv(oauth, { configDir: "/cfg" });
   expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-x");
   expect(env.ANTHROPIC_API_KEY).toBeUndefined();
   expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
@@ -74,7 +74,7 @@ test("an OAuth token scrubs a stale ambient ANTHROPIC_API_KEY", () => {
 test("an API key scrubs a stale ambient OAuth token", () => {
   process.env.CLAUDE_CODE_OAUTH_TOKEN = "stale-oauth";
   process.env.ANTHROPIC_AUTH_TOKEN = "stale-alias";
-  const env = buildClaudeEnv("/cfg", apiKey);
+  const env = buildClaudeEnv(apiKey, { configDir: "/cfg" });
   expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-api03-x");
   expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
   expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
@@ -84,14 +84,14 @@ test("no connected token clears every ambient credential var", () => {
   process.env.ANTHROPIC_API_KEY = "stale-host-key";
   process.env.CLAUDE_CODE_OAUTH_TOKEN = "stale-oauth";
   process.env.ANTHROPIC_AUTH_TOKEN = "stale-alias";
-  const env = buildClaudeEnv("/cfg", undefined);
+  const env = buildClaudeEnv(undefined, { configDir: "/cfg" });
   expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
   expect(env.ANTHROPIC_API_KEY).toBeUndefined();
   expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
 });
 
 test("operational ambient env (PATH) is preserved", () => {
-  const env = buildClaudeEnv("/cfg", oauth);
+  const env = buildClaudeEnv(oauth, { configDir: "/cfg" });
   expect(env.PATH).toBe(process.env.PATH);
 });
 
@@ -104,7 +104,7 @@ test("the Windows Git Bash override reaches the subprocess", () => {
   process.env.CLAUDE_CODE_GIT_BASH_PATH =
     "C:\\Program Files\\Git\\bin\\bash.exe";
   try {
-    const env = buildClaudeEnv("/cfg", oauth);
+    const env = buildClaudeEnv(oauth, { configDir: "/cfg" });
     expect(env.CLAUDE_CODE_GIT_BASH_PATH).toBe(
       "C:\\Program Files\\Git\\bin\\bash.exe",
     );
@@ -127,7 +127,7 @@ test("the username (USER/LOGNAME) reaches the subprocess", () => {
   process.env.USER = "jane";
   process.env.LOGNAME = "jane";
   try {
-    const env = buildClaudeEnv("/cfg", oauth);
+    const env = buildClaudeEnv(oauth, { configDir: "/cfg" });
     expect(env.USER).toBe("jane");
     expect(env.LOGNAME).toBe("jane");
   } finally {
@@ -156,7 +156,7 @@ test("Houston host secrets never reach the subprocess env", () => {
   );
   Object.assign(process.env, secrets);
   try {
-    const env = buildClaudeEnv("/cfg", oauth);
+    const env = buildClaudeEnv(oauth, { configDir: "/cfg" });
     for (const key of Object.keys(secrets)) {
       expect(env[key]).toBeUndefined();
     }
@@ -200,7 +200,7 @@ function backendDeps(readToken: ClaudeBackendDeps["readToken"]) {
   const workspaceDir = mkdtempSync(join(tmpdir(), "claude-backend-scope-"));
   return {
     workspaceDir,
-    dataDir: workspaceDir,
+    layout: serverClaudeLayout(workspaceDir),
     readToken,
     toolSelection: { toolNames: [], includeRunCode: false },
     systemPrompt: "houston",
@@ -283,7 +283,9 @@ test("browser-login path: shared config dir, NO token env (SDK reads the cached 
   const prevHome = process.env.HOUSTON_HOME;
   process.env.HOUSTON_HOME = "/home/x/.houston";
   try {
-    const env = buildClaudeEnv(claudeLoginConfigDir(), undefined);
+    const env = buildClaudeEnv(undefined, {
+      configDir: claudeLoginConfigDir(),
+    });
     expect(env.CLAUDE_CONFIG_DIR).toBe("/home/x/.houston/claude-login");
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -217,6 +217,7 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         sessionsStore,
         model: toSdkModel(opts.model.id),
         thinkingLevel: opts.thinkingLevel,
+        freshRetryPromptPrefix: opts.freshRetryPromptPrefix,
         refreshAuth,
         // WHICH token the subprocess env carries, for the revoked-token
         // report (PRODUCT-1319) — updated by refreshAuth on every prompt so it

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -1,4 +1,7 @@
-import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  createSdkMcpServer,
+  Options,
+} from "@anthropic-ai/claude-agent-sdk";
 import type { ToolSelection } from "../../session/tool-selection";
 import type { IntegrationToolOptions } from "../../session/tools/integrations";
 import type {
@@ -8,13 +11,14 @@ import type {
 } from "../types";
 import { resolveClaudeExecutable } from "./binary-path";
 import { buildClaudeEnv } from "./claude-env";
-import { buildHoustonMcpServer, HOUSTON_MCP_SERVER_NAME } from "./custom-tools";
-import { toSdkModel } from "./model";
-import { claudeLoginConfigDir } from "./paths";
 import {
-  anthropicCredentialStorageDir,
-  assertAnthropicScopeCredential,
-} from "./scope-guard";
+  type BridgedPiTool,
+  buildHoustonMcpServer,
+  HOUSTON_MCP_SERVER_NAME,
+} from "./custom-tools";
+import { toSdkModel } from "./model";
+import type { ClaudeLayout } from "./paths";
+import { assertAnthropicScopeCredential } from "./scope-guard";
 import { type ClaudeQuery, ClaudeSession } from "./session";
 import { createSessionsStore } from "./sessions-store";
 import { buildSystemPrompt } from "./system-prompt";
@@ -36,7 +40,7 @@ export type ClaudeToken =
 /** Everything the Claude backend needs to open a session. */
 export interface ClaudeBackendDeps {
   workspaceDir: string;
-  dataDir: string;
+  layout: ClaudeLayout;
   /** The current Anthropic credential, or undefined when none is connected. */
   readToken: () => ClaudeToken | undefined;
   /** Houston's active tool selection (its code-execution mode gates Bash). */
@@ -53,6 +57,13 @@ export interface ClaudeBackendDeps {
    * → only `ask_user` (which holds no credential and makes no network call).
    */
   integrations?: IntegrationToolOptions;
+  /** Prebuilt turn tools replace the long-lived server's default set. */
+  tools?: BridgedPiTool[];
+  /** External SDK adapter for tests that must not spawn a process. */
+  sdk?: {
+    query: ClaudeQuery;
+    createSdkMcpServer: typeof createSdkMcpServer;
+  };
 }
 
 /** Thrown when the optional Claude Agent SDK is not present in this build. */
@@ -108,7 +119,8 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
       let query: ClaudeQuery;
       let houstonMcp: ReturnType<typeof buildHoustonMcpServer>;
       try {
-        const sdk = await import("@anthropic-ai/claude-agent-sdk");
+        const sdk =
+          deps.sdk ?? (await import("@anthropic-ai/claude-agent-sdk"));
         query = sdk.query as ClaudeQuery;
         // Build the in-process MCP server that exposes Houston's custom tools to
         // the subprocess. Built here (not at module load) so the optional SDK's
@@ -116,6 +128,7 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         houstonMcp = buildHoustonMcpServer({
           createSdkMcpServer: sdk.createSdkMcpServer,
           integrations: deps.integrations,
+          tools: deps.tools,
           // The mode does the tool filtering (via `toolNamesForMode`), mirroring
           // the pi path: plan withholds the acting integration tools and keeps
           // only `ask_user`; auto is the inverse — it drops the blocking tools
@@ -145,14 +158,13 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         const fresh = deps.readToken();
         assertAnthropicScopeCredential(fresh);
         return {
-          env: buildClaudeEnv(
-            claudeLoginConfigDir(),
-            fresh,
-            // Personal scope: the CLI's credential store moves off the shared
-            // dir, so a mid-turn 401 cannot recover onto the team credential.
-            // Team scope: undefined, i.e. unchanged (see `./scope-guard`).
-            anthropicCredentialStorageDir(deps.dataDir),
-          ),
+          env: buildClaudeEnv(fresh, {
+            configDir: deps.layout.configDir,
+            // A disposable turn supplies this directly. The long-lived layout
+            // resolves it lazily inside the prompt's acting-context scope.
+            credentialStorageDir: deps.layout.credentialStorageDir,
+            homeDir: deps.layout.homeDir,
+          }),
           accessDigest: fresh?.accessDigest,
         };
       };
@@ -186,10 +198,11 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         permissionMode: "default",
       };
 
-      const sessionsStore = createSessionsStore(
-        deps.dataDir,
-        deps.workspaceDir,
-      );
+      const sessionsStore = createSessionsStore({
+        configDir: deps.layout.configDir,
+        sessionsFile: deps.layout.sessionsFile,
+        cwd: deps.workspaceDir,
+      });
       // A cross-backend rebuild (opts.fresh) must NOT resume a stale SDK
       // session from before the conversation left this backend: the history
       // arrives as a transcript replay on the first prompt (HOU-951), and the

--- a/packages/runtime/src/backends/claude/claude-env.test.ts
+++ b/packages/runtime/src/backends/claude/claude-env.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, expect, test } from "vitest";
+import { buildClaudeEnv } from "./claude-env";
+
+const savedHome = process.env.HOME;
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+});
+
+test("an explicit home overrides the ambient HOME", () => {
+  process.env.HOME = "/ambient";
+
+  const env = buildClaudeEnv(undefined, {
+    configDir: "/config",
+    homeDir: "/turn/home",
+  });
+
+  expect(env.HOME).toBe("/turn/home");
+  expect(env.CLAUDE_CONFIG_DIR).toBe("/config");
+});
+
+test("the credential store remains optional and must be absolute", () => {
+  expect(
+    buildClaudeEnv(undefined, {
+      configDir: "/config",
+      credentialStorageDir: "/turn/credentials",
+    }).CLAUDE_SECURESTORAGE_CONFIG_DIR,
+  ).toBe("/turn/credentials");
+  expect(() =>
+    buildClaudeEnv(undefined, {
+      configDir: "/config",
+      credentialStorageDir: "relative",
+    }),
+  ).toThrow(/absolute path/);
+});

--- a/packages/runtime/src/backends/claude/claude-env.ts
+++ b/packages/runtime/src/backends/claude/claude-env.ts
@@ -129,9 +129,12 @@ function tokenEnv(token: ClaudeToken | undefined): Record<string, string> {
  * byte-identical to before that guard existed.
  */
 export function buildClaudeEnv(
-  configDir: string,
   token: ClaudeToken | undefined,
-  credentialStorageDir?: string,
+  opts: {
+    configDir: string;
+    credentialStorageDir?: string;
+    homeDir?: string;
+  },
 ): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
@@ -139,18 +142,19 @@ export function buildClaudeEnv(
       env[key] = value;
     }
   }
-  env.CLAUDE_CONFIG_DIR = configDir;
-  if (credentialStorageDir !== undefined) {
+  env.CLAUDE_CONFIG_DIR = opts.configDir;
+  if (opts.homeDir !== undefined) env.HOME = opts.homeDir;
+  if (opts.credentialStorageDir !== undefined) {
     // The CLI reads an EMPTY `CLAUDE_SECURESTORAGE_CONFIG_DIR` as `~/.houston`'s
     // neighbour `~/.claude` — the machine user's PERSONAL credential (trap #2) —
     // and a RELATIVE one against the subprocess cwd, which is the agent's
     // workspace, so credential material would land in user-visible files. Both
     // are worse than the leak this var closes, so neither is accepted.
-    if (!isAbsolute(credentialStorageDir))
+    if (!isAbsolute(opts.credentialStorageDir))
       throw new Error(
-        `the Claude credential store must be an absolute path, got "${credentialStorageDir}"`,
+        `the Claude credential store must be an absolute path, got "${opts.credentialStorageDir}"`,
       );
-    env.CLAUDE_SECURESTORAGE_CONFIG_DIR = credentialStorageDir;
+    env.CLAUDE_SECURESTORAGE_CONFIG_DIR = opts.credentialStorageDir;
   }
   // Belt-and-braces: the credential keys are not in the allowlist, but assert the
   // invariant so a future allowlist edit can never re-admit an ambient one.

--- a/packages/runtime/src/backends/claude/cleanup.ts
+++ b/packages/runtime/src/backends/claude/cleanup.ts
@@ -1,3 +1,4 @@
+import { serverClaudeLayout } from "./paths";
 import { createSessionsStore } from "./sessions-store";
 
 /**
@@ -15,5 +16,6 @@ export function cleanupClaudeConversation(
   dataDir: string,
   conversationId: string,
 ): void {
-  createSessionsStore(dataDir).purge(conversationId);
+  const layout = serverClaudeLayout(dataDir);
+  createSessionsStore(layout).purge(conversationId);
 }

--- a/packages/runtime/src/backends/claude/credential-recovery-scope.test.ts
+++ b/packages/runtime/src/backends/claude/credential-recovery-scope.test.ts
@@ -11,7 +11,11 @@ import {
   type ClaudeToken,
   createClaudeBackend,
 } from "./backend";
-import { claudeCredentialsFile, claudeLoginConfigDir } from "./paths";
+import {
+  claudeCredentialsFile,
+  claudeLoginConfigDir,
+  serverClaudeLayout,
+} from "./paths";
 import { anthropicCredentialStorageDir } from "./scope-guard";
 import type { ClaudeQuery } from "./session";
 import { titleWithClaude } from "./title";
@@ -145,7 +149,7 @@ function backendDeps(): ClaudeBackendDeps {
   const workspaceDir = mkdtempSync(join(tmpdir(), "claude-401-ws-"));
   return {
     workspaceDir,
-    dataDir,
+    layout: serverClaudeLayout(dataDir),
     readToken: () => memberToken,
     toolSelection: { toolNames: [], includeRunCode: false },
     systemPrompt: "houston",
@@ -273,12 +277,18 @@ test("a non-absolute credential store is refused (it would resolve inside the wo
   // The CLI resolves a relative value against the subprocess cwd — the agent's
   // workspace — and an EMPTY one against `~/.claude`, the machine user's PERSONAL
   // credential (trap #2). Both are worse than the leak this closes.
-  expect(() => buildClaudeEnv("/cfg", memberToken, "auth-users/x")).toThrow(
-    /must be an absolute path/,
-  );
-  expect(() => buildClaudeEnv("/cfg", memberToken, "")).toThrow(
-    /must be an absolute path/,
-  );
+  expect(() =>
+    buildClaudeEnv(memberToken, {
+      configDir: "/cfg",
+      credentialStorageDir: "auth-users/x",
+    }),
+  ).toThrow(/must be an absolute path/);
+  expect(() =>
+    buildClaudeEnv(memberToken, {
+      configDir: "/cfg",
+      credentialStorageDir: "",
+    }),
+  ).toThrow(/must be an absolute path/);
 });
 
 test("an ambient CLAUDE_SECURESTORAGE_CONFIG_DIR never reaches the subprocess", async () => {

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -10,8 +10,10 @@ import {
 } from "../../session/interaction";
 import { makeAskUserTool } from "../../session/tools/ask-user";
 import { makeIntegrationTools } from "../../session/tools/integrations";
+import { makePlanReadyTool } from "../../session/tools/plan-ready";
 import { httpSandboxFetch } from "../../session/tools/sandbox-fetch";
 import {
+  type BridgedPiTool,
   buildHoustonMcpServer,
   HOUSTON_MCP_SERVER_NAME,
   type HoustonMcp,
@@ -32,6 +34,7 @@ const INTEGRATIONS = {
 function build(
   integrations?: { call: ReturnType<typeof httpSandboxFetch> },
   mode?: "execute" | "plan" | "auto",
+  explicitTools?: BridgedPiTool[],
 ): {
   mcp: HoustonMcp;
   tools: SdkMcpToolDefinition[];
@@ -52,6 +55,7 @@ function build(
     createSdkMcpServer: fakeCreate,
     integrations,
     mode,
+    tools: explicitTools,
   });
   return { mcp, tools: capturedTools, serverName: capturedName };
 }
@@ -318,6 +322,20 @@ test("the allowlist always matches the exposed tool set", () => {
   expect(mcp.allowedTools).toEqual(
     tools.map((t) => `mcp__${HOUSTON_MCP_SERVER_NAME}__${t.name}`),
   );
+});
+
+test("an explicit tool list replaces the server defaults and remains mode-filtered", () => {
+  const explicit = [
+    makeAskUserTool(),
+    makePlanReadyTool(),
+  ] as unknown as BridgedPiTool[];
+
+  expect(
+    build(INTEGRATIONS, undefined, explicit).tools.map((t) => t.name),
+  ).toEqual(["ask_user"]);
+  expect(
+    build(INTEGRATIONS, "plan", explicit).tools.map((t) => t.name),
+  ).toEqual(["ask_user", "plan_ready"]);
 });
 
 // --- naming ----------------------------------------------------------------

--- a/packages/runtime/src/backends/claude/custom-tools.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.ts
@@ -78,6 +78,8 @@ export interface HoustonMcpInput {
    * + `integration_execute` are built; absent → only `ask_user` is.
    */
   integrations?: IntegrationToolOptions;
+  /** An already grant-scoped tool set for a disposable turn runtime. */
+  tools?: BridgedPiTool[];
   /**
    * The turn's execution mode, applied as the SAME tool filter the pi path uses
    * (`toolNamesForMode`): "plan" keeps `ask_user` + `plan_ready` (the acting
@@ -101,7 +103,7 @@ export interface HoustonMcpInput {
  * `unknown` so heterogeneous tools share one adapter, and the SDK-validated args
  * are handed straight through.
  */
-interface BridgedPiTool {
+export interface BridgedPiTool {
   name: string;
   description: string;
   parameters: TSchema;
@@ -120,6 +122,8 @@ interface BridgedPiTool {
  * is safe. Cast once here rather than threading a real context the SDK path has
  * no way to supply.
  */
+// SAFETY: every tool admitted to this bridge ignores ExtensionContext and gets
+// its request scope from AsyncLocalStorage, as documented on BridgedPiTool.
 const NOOP_CTX = {} as ExtensionContext;
 
 /**
@@ -136,36 +140,42 @@ export function buildHoustonMcpServer(input: HoustonMcpInput): HoustonMcp {
   // is handed, so we filter the tool OBJECTS to the mode's allowed names. The
   // variance between a concrete pi `ToolDefinition<S>` and the widened adapter
   // shape is bridged by one documented assertion at this single boundary.
-  const built = [
-    makeAskUserTool(),
-    // plan_ready is in the built set but name-gated by `toolNamesForMode`: it
-    // survives only on a plan turn (filtered out of execute/auto below).
-    makePlanReadyTool(),
-    // suggest_reusable is the inverse gating: name-kept in execute/auto, filtered
-    // out of plan by `toolNamesForMode`.
-    makeSuggestReusableTool(),
-    makeSuggestActionsTool(),
-    // save_routine reaches the host with the SAME sandbox token the integration
-    // tools use (present ⟺ host reachable). It reaches execute/auto but never
-    // plan — the same reach as suggest_reusable, applied by `toolNamesForMode`.
-    ...(input.integrations ? [makeSaveRoutineTool(input.integrations)] : []),
-    // save_learning reaches the host with the SAME sandbox token, and has the
-    // same reach as save_routine: execute/auto, never plan.
-    ...(input.integrations ? [makeSaveLearningTool(input.integrations)] : []),
-    // The mission-board tools (PRODUCT-1244) ride the same host-reachability
-    // gate and the same execute/auto reach; read_mission is in-process but is
-    // useless without list_missions, so it shares the gate.
-    ...(input.integrations
-      ? [...makeMissionTools(input.integrations), makeReadMissionTool()]
-      : []),
-    // find_skills + install_skill reach the host with the SAME sandbox token,
-    // and have the same reach as save_routine: execute/auto, never plan.
-    ...(input.integrations ? makeSkillDirectoryTools(input.integrations) : []),
-    ...(input.integrations ? makeIntegrationTools(input.integrations) : []),
-    ...(input.integrations
-      ? makeCustomIntegrationTools(input.integrations)
-      : []),
-  ] as unknown as BridgedPiTool[];
+  const built =
+    input.tools ??
+    ([
+      makeAskUserTool(),
+      // plan_ready is in the built set but name-gated by `toolNamesForMode`: it
+      // survives only on a plan turn (filtered out of execute/auto below).
+      makePlanReadyTool(),
+      // suggest_reusable is the inverse gating: name-kept in execute/auto, filtered
+      // out of plan by `toolNamesForMode`.
+      makeSuggestReusableTool(),
+      makeSuggestActionsTool(),
+      // save_routine reaches the host with the SAME sandbox token the integration
+      // tools use (present ⟺ host reachable). It reaches execute/auto but never
+      // plan — the same reach as suggest_reusable, applied by `toolNamesForMode`.
+      ...(input.integrations ? [makeSaveRoutineTool(input.integrations)] : []),
+      // save_learning reaches the host with the SAME sandbox token, and has the
+      // same reach as save_routine: execute/auto, never plan.
+      ...(input.integrations ? [makeSaveLearningTool(input.integrations)] : []),
+      // The mission-board tools ride the same host-reachability
+      // gate and the same execute/auto reach; read_mission is in-process but is
+      // useless without list_missions, so it shares the gate.
+      ...(input.integrations
+        ? [...makeMissionTools(input.integrations), makeReadMissionTool()]
+        : []),
+      // find_skills + install_skill reach the host with the SAME sandbox token,
+      // and have the same reach as save_routine: execute/auto, never plan.
+      ...(input.integrations
+        ? makeSkillDirectoryTools(input.integrations)
+        : []),
+      ...(input.integrations ? makeIntegrationTools(input.integrations) : []),
+      ...(input.integrations
+        ? makeCustomIntegrationTools(input.integrations)
+        : []),
+      // SAFETY: Houston's tool implementations satisfy BridgedPiTool at runtime;
+      // the assertion only widens their heterogeneous TypeBox parameter types.
+    ] as unknown as BridgedPiTool[]);
   const allowed = new Set(
     toolNamesForMode(
       input.mode,

--- a/packages/runtime/src/backends/claude/one-shot.ts
+++ b/packages/runtime/src/backends/claude/one-shot.ts
@@ -75,11 +75,10 @@ export async function oneShotWithClaude(
   const pathToClaudeCodeExecutable = resolveClaudeExecutable();
   const options: Options = {
     cwd: p.workspaceDir,
-    env: buildClaudeEnv(
-      claudeLoginConfigDir(),
-      token,
-      anthropicCredentialStorageDir(p.dataDir),
-    ),
+    env: buildClaudeEnv(token, {
+      configDir: claudeLoginConfigDir(),
+      credentialStorageDir: anthropicCredentialStorageDir(p.dataDir),
+    }),
     ...(pathToClaudeCodeExecutable ? { pathToClaudeCodeExecutable } : {}),
     settingSources: [],
     allowedTools: [],

--- a/packages/runtime/src/backends/claude/paths.ts
+++ b/packages/runtime/src/backends/claude/paths.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { anthropicCredentialStorageDir } from "./scope-guard";
 
 /**
  * The on-disk layout for the Claude Agent SDK backend, in ONE place so every
@@ -76,4 +77,25 @@ export function claudeBaseDir(dataDir: string): string {
 /** The conversationId → SDK session_id map file (per agent). */
 export function claudeSessionsFile(dataDir: string): string {
   return join(claudeBaseDir(dataDir), "sessions.json");
+}
+
+/** Explicit filesystem locations consumed by the Claude backend. */
+export interface ClaudeLayout {
+  configDir: string;
+  sessionsFile: string;
+  credentialStorageDir?: string;
+  homeDir?: string;
+}
+
+/** The established shared-login layout for the long-lived runtime. */
+export function serverClaudeLayout(dataDir: string): ClaudeLayout {
+  return {
+    configDir: claudeLoginConfigDir(),
+    sessionsFile: claudeSessionsFile(dataDir),
+    // Evaluated inside the prompt's acting-context scope, not when the
+    // long-lived backend is registered at module load.
+    get credentialStorageDir() {
+      return anthropicCredentialStorageDir(dataDir);
+    },
+  };
 }

--- a/packages/runtime/src/backends/claude/session.test.ts
+++ b/packages/runtime/src/backends/claude/session.test.ts
@@ -100,6 +100,7 @@ function make(deps: {
   store?: SessionsStore;
   model?: string;
   refreshAuth?: () => { env: Record<string, string>; accessDigest?: string };
+  freshRetryPromptPrefix?: string;
 }): ClaudeSession {
   return new ClaudeSession({
     query: deps.query,
@@ -108,6 +109,7 @@ function make(deps: {
     sessionsStore: deps.store ?? fakeStore(),
     model: deps.model ?? "claude-sonnet-4-6",
     refreshAuth: deps.refreshAuth ?? (() => ({ env: {} })),
+    freshRetryPromptPrefix: deps.freshRetryPromptPrefix,
   });
 }
 
@@ -310,6 +312,32 @@ test("a resume the SDK rejects as unknown retries fresh: mapping dropped, no pha
   expect(events.some((e) => e.type === "provider_error")).toBe(false);
   expect(events.some((e) => e.type === "text")).toBe(true);
   expect(store.setCalls).toContainEqual(["c1", "sess-new"]);
+});
+
+test("a dangling-resume retry prefixes the fresh prompt with canonical history", async () => {
+  const prompts: string[] = [];
+  let call = 0;
+  const query: ClaudeQuery = (params) => {
+    prompts.push(params.prompt);
+    call++;
+    if (call === 1)
+      return throwingQuery(
+        new Error("No conversation found with session ID: sess-gone"),
+      )(params);
+    return arrayQuery([usageMsg("sess-new")])(params);
+  };
+  const session = make({
+    query,
+    store: fakeStore("sess-gone"),
+    freshRetryPromptPrefix: "[canonical replay]\n",
+  });
+
+  await session.prompt("current prompt");
+
+  expect(prompts).toEqual([
+    "current prompt",
+    "[canonical replay]\ncurrent prompt",
+  ]);
 });
 
 test("the same SDK error WITHOUT a resume surfaces normally (no retry loop)", async () => {

--- a/packages/runtime/src/backends/claude/session.ts
+++ b/packages/runtime/src/backends/claude/session.ts
@@ -37,6 +37,8 @@ export interface ClaudeSessionDeps {
   /** Initial SDK model string. */
   model: string;
   thinkingLevel?: ThinkingLevel;
+  /** Canonical history used only when a rejected resume must retry fresh. */
+  freshRetryPromptPrefix?: string;
   /**
    * Re-read the stored credential and rebuild the subprocess env from it.
    * Called at the start of EVERY prompt (PRODUCT-1355): each `query()` spawns
@@ -141,7 +143,11 @@ export class ClaudeSession implements HarnessSession {
     console.warn(
       `[claude] resume for conversation ${this.deps.conversationId} was rejected by the SDK; starting a fresh session`,
     );
-    await this.runAttempt(text, undefined, auth.env);
+    await this.runAttempt(
+      `${this.deps.freshRetryPromptPrefix ?? ""}${text}`,
+      undefined,
+      auth.env,
+    );
   }
 
   /**

--- a/packages/runtime/src/backends/claude/sessions-store.test.ts
+++ b/packages/runtime/src/backends/claude/sessions-store.test.ts
@@ -2,7 +2,9 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -148,6 +150,32 @@ test("a transcript already under the current cwd slug is returned without moving
 
   expect(store.resolveResume("c1")).toBe("sess-1");
   expect(existsSync(join(slugDir, "sess-1.jsonl"))).toBe(true);
+});
+
+test("duplicate transcripts relocate the newest copy by mtime", () => {
+  const cwd = "/ws/Personal/current";
+  const store = sessionsStore(dataDir(), cwd);
+  store.setSessionId("c1", "sess-1");
+  const oldDir = join(claudeProjectsDir(), "a-old");
+  const newDir = join(claudeProjectsDir(), "z-new");
+  mkdirSync(oldDir, { recursive: true });
+  mkdirSync(newDir, { recursive: true });
+  const oldCopy = join(oldDir, "sess-1.jsonl");
+  const newCopy = join(newDir, "sess-1.jsonl");
+  writeFileSync(oldCopy, "old");
+  writeFileSync(newCopy, "new");
+  utimesSync(oldCopy, new Date(1_000), new Date(1_000));
+  utimesSync(newCopy, new Date(2_000), new Date(2_000));
+
+  expect(store.resolveResume("c1")).toBe("sess-1");
+
+  const current = join(
+    claudeProjectsDir(),
+    "-ws-Personal-current",
+    "sess-1.jsonl",
+  );
+  expect(readFileSync(current, "utf8")).toBe("new");
+  expect(existsSync(oldCopy)).toBe(true);
 });
 
 test("without a cwd (purge-only store) resolveResume never relocates", () => {

--- a/packages/runtime/src/backends/claude/sessions-store.test.ts
+++ b/packages/runtime/src/backends/claude/sessions-store.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import { claudeProjectsDir } from "./paths";
+import { claudeProjectsDir, serverClaudeLayout } from "./paths";
 import { createSessionsStore } from "./sessions-store";
 
 // The transcript `projects` tree is SHARED (under CLAUDE_CONFIG_DIR =
@@ -30,6 +30,13 @@ function dataDir(): string {
   return mkdtempSync(join(tmpdir(), "claude-data-"));
 }
 
+function sessionsStore(dataDir: string, cwd?: string) {
+  return createSessionsStore({
+    ...serverClaudeLayout(dataDir),
+    ...(cwd ? { cwd } : {}),
+  });
+}
+
 /** Write a fake SDK transcript for `sessionId` under the SHARED projects dir. */
 function writeTranscript(sessionId: string): void {
   const projects = join(claudeProjectsDir(), "proj");
@@ -39,20 +46,20 @@ function writeTranscript(sessionId: string): void {
 
 test("set / get round-trips and persists across store instances", () => {
   const dir = dataDir();
-  createSessionsStore(dir).setSessionId("c1", "sess-1");
-  expect(createSessionsStore(dir).getSessionId("c1")).toBe("sess-1");
+  sessionsStore(dir).setSessionId("c1", "sess-1");
+  expect(sessionsStore(dir).getSessionId("c1")).toBe("sess-1");
 });
 
 test("the sessions file is written with mode 0600", () => {
   const dir = dataDir();
-  createSessionsStore(dir).setSessionId("c1", "sess-1");
+  sessionsStore(dir).setSessionId("c1", "sess-1");
   const mode = statSync(join(dir, "backends", "claude", "sessions.json")).mode;
   expect(mode & 0o777).toBe(0o600);
 });
 
 test("remove forgets a mapping", () => {
   const dir = dataDir();
-  const store = createSessionsStore(dir);
+  const store = sessionsStore(dir);
   store.setSessionId("c1", "sess-1");
   store.remove("c1");
   expect(store.getSessionId("c1")).toBeUndefined();
@@ -60,20 +67,20 @@ test("remove forgets a mapping", () => {
 
 test("resolveResume returns the id when its transcript exists", () => {
   const dir = dataDir();
-  const store = createSessionsStore(dir);
+  const store = sessionsStore(dir);
   store.setSessionId("c1", "sess-1");
   writeTranscript("sess-1");
   expect(store.resolveResume("c1")).toBe("sess-1");
 });
 
 test("resolveResume with no mapping returns undefined", () => {
-  expect(createSessionsStore(dataDir()).resolveResume("nope")).toBeUndefined();
+  expect(sessionsStore(dataDir()).resolveResume("nope")).toBeUndefined();
 });
 
 test("a missing transcript warns, drops the mapping, and starts fresh", () => {
   const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
   const dir = dataDir();
-  const store = createSessionsStore(dir);
+  const store = sessionsStore(dir);
   store.setSessionId("c1", "sess-gone");
   // No transcript on disk → resume is impossible.
   expect(store.resolveResume("c1")).toBeUndefined();
@@ -84,7 +91,7 @@ test("a missing transcript warns, drops the mapping, and starts fresh", () => {
 
 test("purge drops the mapping AND deletes the transcript", () => {
   const dir = dataDir();
-  const store = createSessionsStore(dir);
+  const store = sessionsStore(dir);
   store.setSessionId("c1", "sess-1");
   writeTranscript("sess-1");
   const transcript = join(claudeProjectsDir(), "proj", "sess-1.jsonl");
@@ -99,14 +106,14 @@ test("purge drops the mapping AND deletes the transcript", () => {
 test("purge is a no-op for a conversation that never ran on this backend", () => {
   const dir = dataDir();
   // No mapping, no transcript, no config dir at all → must not throw.
-  expect(() => createSessionsStore(dir).purge("never")).not.toThrow();
+  expect(() => sessionsStore(dir).purge("never")).not.toThrow();
 });
 
 test("a corrupt sessions.json degrades to empty rather than throwing", () => {
   const dir = dataDir();
   mkdirSync(join(dir, "backends", "claude"), { recursive: true });
   writeFileSync(join(dir, "backends", "claude", "sessions.json"), "{not json");
-  expect(createSessionsStore(dir).getSessionId("c1")).toBeUndefined();
+  expect(sessionsStore(dir).getSessionId("c1")).toBeUndefined();
 });
 
 test("a transcript stranded under a stale cwd slug is relocated so the SDK can resume it (HOU-892)", () => {
@@ -115,7 +122,7 @@ test("a transcript stranded under a stale cwd slug is relocated so the SDK can r
   // must move it into the CURRENT cwd's slug dir — preserving the conversation —
   // rather than declaring it resumable and letting the SDK reject the id.
   const cwd = "/ws/Personal/new name";
-  const store = createSessionsStore(dataDir(), cwd);
+  const store = sessionsStore(dataDir(), cwd);
   store.setSessionId("c1", "sess-1");
   writeTranscript("sess-1"); // lands under the unrelated "proj" slug dir
 
@@ -133,7 +140,7 @@ test("a transcript stranded under a stale cwd slug is relocated so the SDK can r
 
 test("a transcript already under the current cwd slug is returned without moving", () => {
   const cwd = "/ws/Personal/agent";
-  const store = createSessionsStore(dataDir(), cwd);
+  const store = sessionsStore(dataDir(), cwd);
   store.setSessionId("c1", "sess-1");
   const slugDir = join(claudeProjectsDir(), "-ws-Personal-agent");
   mkdirSync(slugDir, { recursive: true });
@@ -144,7 +151,7 @@ test("a transcript already under the current cwd slug is returned without moving
 });
 
 test("without a cwd (purge-only store) resolveResume never relocates", () => {
-  const store = createSessionsStore(dataDir());
+  const store = sessionsStore(dataDir());
   store.setSessionId("c1", "sess-1");
   writeTranscript("sess-1");
   expect(store.resolveResume("c1")).toBe("sess-1");
@@ -157,8 +164,8 @@ test("without a cwd (purge-only store) resolveResume never relocates", () => {
 test("two agents' transcripts under the shared projects dir don't collide", () => {
   // Different per-agent data dirs, DIFFERENT session ids → each resolves only
   // its own transcript even though the projects tree is shared.
-  const a = createSessionsStore(dataDir());
-  const b = createSessionsStore(dataDir());
+  const a = sessionsStore(dataDir());
+  const b = sessionsStore(dataDir());
   a.setSessionId("c", "sess-a");
   b.setSessionId("c", "sess-b");
   writeTranscript("sess-a");

--- a/packages/runtime/src/backends/claude/sessions-store.ts
+++ b/packages/runtime/src/backends/claude/sessions-store.ts
@@ -8,7 +8,6 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import { claudeBaseDir, claudeProjectsDir, claudeSessionsFile } from "./paths";
 
 // NOTE on isolation: `sessions.json` (the conversationId → session_id map) lives
 // per-agent under `dataDir`, but the transcript `projects` tree is SHARED (it
@@ -58,13 +57,15 @@ export interface SessionsStore {
  * `resolveResume` can relocate a transcript stranded under a stale cwd slug;
  * without it (e.g. the purge-only cleanup path) relocation is skipped.
  */
-export function createSessionsStore(
-  dataDir: string,
-  cwd?: string,
-): SessionsStore {
-  const baseDir = claudeBaseDir(dataDir);
-  const filePath = claudeSessionsFile(dataDir);
-  const projectsDir = claudeProjectsDir();
+export function createSessionsStore(input: {
+  configDir: string;
+  sessionsFile: string;
+  cwd?: string;
+}): SessionsStore {
+  const baseDir = dirname(input.sessionsFile);
+  const filePath = input.sessionsFile;
+  const projectsDir = join(input.configDir, "projects");
+  const { cwd } = input;
   const currentSlugDir = cwd
     ? join(projectsDir, sdkProjectSlug(cwd))
     : undefined;

--- a/packages/runtime/src/backends/claude/sessions-store.ts
+++ b/packages/runtime/src/backends/claude/sessions-store.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
@@ -168,12 +169,17 @@ function locateTranscript(
   if (!existsSync(projectsDir)) return undefined;
   const file = `${sessionId}.jsonl`;
   const top = join(projectsDir, file);
-  if (existsSync(top)) return top;
+  const candidates = existsSync(top) ? [top] : [];
   for (const entry of readdirSync(projectsDir)) {
     const nested = join(projectsDir, entry, file);
-    if (existsSync(nested)) return nested;
+    if (existsSync(nested)) candidates.push(nested);
   }
-  return undefined;
+  return candidates
+    .map((path) => ({ path, mtimeMs: statSync(path).mtimeMs }))
+    .sort(
+      (left, right) =>
+        right.mtimeMs - left.mtimeMs || left.path.localeCompare(right.path),
+    )[0]?.path;
 }
 
 /**

--- a/packages/runtime/src/backends/types.ts
+++ b/packages/runtime/src/backends/types.ts
@@ -93,6 +93,11 @@ export interface CreateSessionOptions {
    * said on the other backend in between.
    */
   fresh?: boolean;
+  /**
+   * Canonical history to prepend only if a backend-native resume is rejected
+   * and the backend retries the current prompt as a fresh session.
+   */
+  freshRetryPromptPrefix?: string;
 }
 
 /** A pluggable turn-execution backend for a provider. */

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -116,14 +116,6 @@ async function start(): Promise<Server> {
     // restart guard into a silent no-op and surface only as burned claims.
     // Only the not-yet-spent path needs this (a spent pod never serves again).
     if (config.poolSingleUse && !spent) assertMarkerWritable();
-    if (config.poolSingleUse && !spent) {
-      const { probeClaudeWorkerBinary } = await import("./turn/claude-worker");
-      try {
-        probeClaudeWorkerBinary();
-      } catch (error) {
-        logger.error("Claude Agent SDK worker binary probe failed:", error);
-      }
-    }
     const registrationConfig = await loadWorkerRegistrationConfig();
     const admission = new AdmissionLimiter(turnConcurrency());
     workerRegistration =
@@ -157,6 +149,13 @@ async function start(): Promise<Server> {
     // registering would silently reopen that cross-tenant window — see the cloud
     // pool_workers boot_id clear (internal/store/poolworkers.go).
     await workerRegistration?.start();
+    const { startClaudeWorkerBoot } = await import("./turn/claude-worker");
+    startClaudeWorkerBoot({
+      profile: config.poolSingleUse && !spent ? "single-use" : "multi-turn",
+      root: config.dataDir,
+      report: (error) =>
+        logger.error("Claude Agent SDK worker boot task failed:", error),
+    });
     try {
       await new Promise<void>((resolve, reject) => {
         const failed = (error: Error) => reject(error);

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -116,6 +116,14 @@ async function start(): Promise<Server> {
     // restart guard into a silent no-op and surface only as burned claims.
     // Only the not-yet-spent path needs this (a spent pod never serves again).
     if (config.poolSingleUse && !spent) assertMarkerWritable();
+    if (config.poolSingleUse && !spent) {
+      const { probeClaudeWorkerBinary } = await import("./turn/claude-worker");
+      try {
+        probeClaudeWorkerBinary();
+      } catch (error) {
+        logger.error("Claude Agent SDK worker binary probe failed:", error);
+      }
+    }
     const registrationConfig = await loadWorkerRegistrationConfig();
     const admission = new AdmissionLimiter(turnConcurrency());
     workerRegistration =

--- a/packages/runtime/src/session/chat.test.ts
+++ b/packages/runtime/src/session/chat.test.ts
@@ -73,6 +73,7 @@ const { subscribe } = await import("./bus");
 const { createSessionsStore } = await import(
   "../backends/claude/sessions-store"
 );
+const { serverClaudeLayout } = await import("../backends/claude/paths");
 
 afterAll(() => vi.restoreAllMocks());
 
@@ -134,14 +135,16 @@ test("disposeConversation with deleteSessions purges the anthropic SDK session m
   // A conversation that ran on the Claude backend has a sessions.json mapping;
   // deleting the conversation must drop it too, not just pi's transcript dir.
   const dataDir = process.env.HOUSTON_DATA_DIR as string;
-  const store = createSessionsStore(dataDir);
+  const store = createSessionsStore(serverClaudeLayout(dataDir));
   store.setSessionId("conv-anthropic", "sess-xyz");
   expect(store.getSessionId("conv-anthropic")).toBe("sess-xyz");
 
   await disposeConversation("conv-anthropic", { deleteSessions: true });
 
   expect(
-    createSessionsStore(dataDir).getSessionId("conv-anthropic"),
+    createSessionsStore(serverClaudeLayout(dataDir)).getSessionId(
+      "conv-anthropic",
+    ),
   ).toBeUndefined();
 });
 

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -2,6 +2,7 @@ import { DEFAULT_TURN_MODE, type TurnMode } from "@houston/protocol";
 import { resolveModel } from "../ai/providers";
 import { authStorage, modelRuntime } from "../auth/storage";
 import { createClaudeBackend } from "../backends/claude/backend";
+import { serverClaudeLayout } from "../backends/claude/paths";
 import { readAnthropicToken } from "../backends/claude/read-token";
 import { createPiBackend } from "../backends/pi/backend";
 import {
@@ -196,7 +197,7 @@ registerBackend(
   "anthropic",
   createClaudeBackend({
     workspaceDir: config.workspaceDir,
-    dataDir: config.dataDir,
+    layout: serverClaudeLayout(config.dataDir),
     readToken: () => readAnthropicToken(authStorage),
     toolSelection,
     systemPrompt: config.systemPrompt || SYSTEM_PROMPT,

--- a/packages/runtime/src/turn/claude-worker.test.ts
+++ b/packages/runtime/src/turn/claude-worker.test.ts
@@ -1,5 +1,8 @@
-import { expect, test } from "vitest";
-import { probeClaudeWorkerBinary } from "./claude-worker";
+import { expect, test, vi } from "vitest";
+import {
+  probeClaudeWorkerBinary,
+  startClaudeWorkerBoot,
+} from "./claude-worker";
 
 function stats(isFile: boolean): { isFile(): boolean } {
   return { isFile: () => isFile };
@@ -27,4 +30,60 @@ test("the worker probe rejects a non-file path", () => {
       stat: () => stats(false),
     }),
   ).toThrow("Claude Agent SDK binary is not a file");
+});
+
+test("boot probes and warms exactly once for a live single-use worker", async () => {
+  const probe = vi.fn(() => "/app/sdk/claude");
+  const warm = vi.fn(async () => undefined);
+  const report = vi.fn();
+
+  startClaudeWorkerBoot({
+    profile: "single-use",
+    root: "/data",
+    probe,
+    warm,
+    report,
+  });
+  await vi.waitFor(() => expect(warm).toHaveBeenCalledTimes(1));
+
+  expect(probe).toHaveBeenCalledTimes(1);
+  expect(warm).toHaveBeenCalledWith("/data", "/app/sdk/claude");
+  expect(report).not.toHaveBeenCalled();
+});
+
+test.each([
+  "multi-turn",
+  "server",
+] as const)("%s boot never probes or warms Claude", async (profile) => {
+  const probe = vi.fn(() => "/app/sdk/claude");
+  const warm = vi.fn(async () => undefined);
+
+  startClaudeWorkerBoot({
+    profile,
+    root: "/data",
+    probe,
+    warm,
+    report: vi.fn(),
+  });
+  await Promise.resolve();
+
+  expect(probe).not.toHaveBeenCalled();
+  expect(warm).not.toHaveBeenCalled();
+});
+
+test("a boot warm failure is reported without rejecting boot", async () => {
+  const report = vi.fn();
+
+  expect(() =>
+    startClaudeWorkerBoot({
+      profile: "single-use",
+      root: "/data",
+      probe: () => "/app/sdk/claude",
+      warm: async () => {
+        throw new Error("warm failed");
+      },
+      report,
+    }),
+  ).not.toThrow();
+  await vi.waitFor(() => expect(report).toHaveBeenCalledTimes(1));
 });

--- a/packages/runtime/src/turn/claude-worker.test.ts
+++ b/packages/runtime/src/turn/claude-worker.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { probeClaudeWorkerBinary } from "./claude-worker";
+
+function stats(isFile: boolean): { isFile(): boolean } {
+  return { isFile: () => isFile };
+}
+
+test("the worker probe returns a present SDK platform binary", () => {
+  expect(
+    probeClaudeWorkerBinary({
+      resolveBinary: () => "/app/sdk/claude",
+      stat: () => stats(true),
+    }),
+  ).toBe("/app/sdk/claude");
+});
+
+test("the worker probe fails loudly when the platform binary is absent", () => {
+  expect(() => probeClaudeWorkerBinary({ resolveBinary: () => null })).toThrow(
+    "Claude Agent SDK binary is unavailable",
+  );
+});
+
+test("the worker probe rejects a non-file path", () => {
+  expect(() =>
+    probeClaudeWorkerBinary({
+      resolveBinary: () => "/app/sdk/claude",
+      stat: () => stats(false),
+    }),
+  ).toThrow("Claude Agent SDK binary is not a file");
+});

--- a/packages/runtime/src/turn/claude-worker.ts
+++ b/packages/runtime/src/turn/claude-worker.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { resolveClaudeCliBinary } from "../auth/anthropic-cli-binary";
+import { buildClaudeEnv } from "../backends/claude/claude-env";
+
+/** Replaceable filesystem seams for the worker binary probe. */
+export interface ClaudeWorkerProbeDeps {
+  resolveBinary?: () => string | null;
+  stat?: (path: string) => { isFile(): boolean };
+}
+
+/** Resolve and stat the SDK platform binary used by pooled workers. */
+export function probeClaudeWorkerBinary(
+  deps: ClaudeWorkerProbeDeps = {},
+): string {
+  const binary = (deps.resolveBinary ?? resolveClaudeCliBinary)();
+  if (!binary) throw new Error("Claude Agent SDK binary is unavailable");
+  const stats = (deps.stat ?? statSync)(binary);
+  if (!stats.isFile())
+    throw new Error(`Claude Agent SDK binary is not a file: ${binary}`);
+  return binary;
+}
+
+let warmup: Promise<void> | undefined;
+
+/** Page the Claude binary into the worker cache once, with no credential. */
+export function warmClaudeWorker(root: string): Promise<void> {
+  warmup ??= runWarmup(root).catch((error) => {
+    warmup = undefined;
+    throw error;
+  });
+  return warmup;
+}
+
+async function runWarmup(root: string): Promise<void> {
+  const binary = probeClaudeWorkerBinary();
+  const warmDir = join(root, "claude-warm");
+  await mkdir(warmDir, { recursive: true });
+  const env = buildClaudeEnv(undefined, {
+    configDir: warmDir,
+    homeDir: warmDir,
+  });
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(binary, ["--version"], { env, stdio: "ignore" });
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("Claude Agent SDK binary warmup timed out"));
+    }, 10_000);
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(
+            `Claude Agent SDK binary warmup exited with ${signal ?? code}`,
+          ),
+        );
+    });
+  });
+}

--- a/packages/runtime/src/turn/claude-worker.ts
+++ b/packages/runtime/src/turn/claude-worker.ts
@@ -11,10 +11,26 @@ export interface ClaudeWorkerProbeDeps {
   stat?: (path: string) => { isFile(): boolean };
 }
 
+export type ClaudeWorkerProfile = "single-use" | "multi-turn" | "server";
+
+/** Boot-only seams that keep the worker profile policy unit-testable. */
+export interface ClaudeWorkerBootDeps {
+  profile: ClaudeWorkerProfile;
+  root: string;
+  probe?: () => string;
+  warm?: (root: string, binary: string) => Promise<void>;
+  report: (error: unknown) => void;
+}
+
 /** Resolve and stat the SDK platform binary used by pooled workers. */
 export function probeClaudeWorkerBinary(
   deps: ClaudeWorkerProbeDeps = {},
 ): string {
+  // Without HOUSTON_CLAUDE_BIN, resolveClaudeCliBinary starts resolution from
+  // the SDK module and selects the same platform package the SDK self-resolves
+  // at query time. On Node WITH that explicit override, probe/warm intentionally
+  // use the override while the SDK still self-resolves because its executable
+  // option is Bun-only; that is the sole known resolution skew.
   const binary = (deps.resolveBinary ?? resolveClaudeCliBinary)();
   if (!binary) throw new Error("Claude Agent SDK binary is unavailable");
   const stats = (deps.stat ?? statSync)(binary);
@@ -23,19 +39,36 @@ export function probeClaudeWorkerBinary(
   return binary;
 }
 
+/** Start the single-use worker's Claude probe and warmup without blocking boot. */
+export function startClaudeWorkerBoot(deps: ClaudeWorkerBootDeps): void {
+  if (deps.profile !== "single-use") return;
+  const probe = deps.probe ?? probeClaudeWorkerBinary;
+  let binary: string;
+  try {
+    binary = probe();
+  } catch (error) {
+    deps.report(error);
+    return;
+  }
+  const warm = deps.warm ?? warmClaudeWorker;
+  void Promise.resolve()
+    .then(() => warm(deps.root, binary))
+    .catch(deps.report);
+}
+
 let warmup: Promise<void> | undefined;
 
 /** Page the Claude binary into the worker cache once, with no credential. */
-export function warmClaudeWorker(root: string): Promise<void> {
-  warmup ??= runWarmup(root).catch((error) => {
+export function warmClaudeWorker(root: string, binary?: string): Promise<void> {
+  warmup ??= runWarmup(root, binary).catch((error) => {
     warmup = undefined;
     throw error;
   });
   return warmup;
 }
 
-async function runWarmup(root: string): Promise<void> {
-  const binary = probeClaudeWorkerBinary();
+async function runWarmup(root: string, resolvedBinary?: string): Promise<void> {
+  const binary = resolvedBinary ?? probeClaudeWorkerBinary();
   const warmDir = join(root, "claude-warm");
   await mkdir(warmDir, { recursive: true });
   const env = buildClaudeEnv(undefined, {

--- a/packages/runtime/src/turn/execute-op.ts
+++ b/packages/runtime/src/turn/execute-op.ts
@@ -14,6 +14,7 @@ import type { HoustonEvent } from "@houston/protocol";
 import { syncBack } from "@houston/runtime-client/object-sync";
 import { startClaimHeartbeat } from "./claim-heartbeat";
 import { applyOp, type OpResult } from "./op-apply";
+import { WorkerOpDeclinedError } from "./op-provider-guard";
 import { opTranscriptMirror } from "./op-transcript";
 import { parseOpRequest } from "./parse-op-request";
 import type { TurnServerDeps } from "./server-types";
@@ -124,7 +125,11 @@ export async function executeOp(
               ? { excludes: CREDENTIAL_OP_EXCLUDES }
               : {}),
     });
-    const result = await applyOp(op, filesystem, deps.fetchImpl);
+    const result = await (deps.runOp ?? applyOp)(
+      op,
+      filesystem,
+      deps.fetchImpl,
+    );
     if (result.agentMissing || result.decline) {
       // Not this worker's agent (legacy layout / stale envelope), or a case
       // the worker cannot serve: decline so the gateway takes its fallback,
@@ -233,6 +238,11 @@ export async function executeOp(
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (error instanceof WorkerOpDeclinedError) {
+      console.warn(`[op] declined kind=${op.op.kind}: ${message}`);
+      if (!res.headersSent) json(res, 200, { ok: true, decline: true });
+      return;
+    }
     // Loud: a 500 here is the gateway's "worker_500" with no other trace.
     console.error(
       `[op] failed kind=${op.op.kind} ${op.op.kind === "route" ? `${op.op.method} ${op.op.rest}` : ""}: ${message}`,

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -9,7 +9,6 @@ import { runWithActingContext } from "../session/acting-context";
 import { releaseConversation, runWithConversationScope } from "../session/bus";
 import { openSSE } from "../transport/sse";
 import { startClaimHeartbeat } from "./claim-heartbeat";
-import { warmClaudeWorker } from "./claude-worker";
 import type { TurnServerDeps } from "./server-types";
 import { finishTurnDurability } from "./turn-durability";
 import { prepareTurnFilesystem } from "./turn-filesystem";
@@ -147,11 +146,6 @@ export async function executeTurn(
           turn.model,
           timings,
         );
-        if (
-          deps.singleUse &&
-          (turn.provider || turn.credential.provider) === "anthropic"
-        )
-          await warmClaudeWorker(root);
         emit({
           type: "shadow",
           data: { ...timings, hydratedObjects: filesystem.manifest.size },

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,13 +9,14 @@ import { runWithActingContext } from "../session/acting-context";
 import { releaseConversation, runWithConversationScope } from "../session/bus";
 import { openSSE } from "../transport/sse";
 import { startClaimHeartbeat } from "./claim-heartbeat";
-import { piTurnRequest } from "./pi-turn-request";
+import { warmClaudeWorker } from "./claude-worker";
 import type { TurnServerDeps } from "./server-types";
 import { finishTurnDurability } from "./turn-durability";
 import { prepareTurnFilesystem } from "./turn-filesystem";
 import { ownConversationOnly } from "./turn-hot-set";
 import { TurnSetupError } from "./turn-layout";
 import { createTurnLog } from "./turn-log";
+import { turnSessionRequest } from "./turn-request";
 import {
   prepareRoutineTurn,
   type RoutinePhase,
@@ -24,7 +25,7 @@ import {
 } from "./turn-routine";
 import { createTurnModelRuntime } from "./turn-runtime";
 import { makeTurnSandboxFetch } from "./turn-sandbox";
-import { runPiTurn, type TurnOutcome } from "./turn-session";
+import { runTurn, type TurnOutcome } from "./turn-session";
 import { poolIdentity, resolveTurnStore } from "./turn-store";
 import { turnSetupErrorFrame, turnTerminalFrame } from "./turn-terminal";
 import { createTurnTranscript } from "./turn-transcript";
@@ -39,6 +40,10 @@ export async function executeTurn(
   timings: Record<string, number>,
 ): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), "houston-turn-"));
+  await Promise.all([
+    mkdir(join(root, "home"), { recursive: true }),
+    mkdir(join(root, "claude-credstore"), { recursive: true }),
+  ]);
   timings.t_tmpdir = performance.now();
   const scope = `${turn.workspaceId}/${turn.agentId}`;
   const abort = new AbortController();
@@ -142,6 +147,11 @@ export async function executeTurn(
           turn.model,
           timings,
         );
+        if (
+          deps.singleUse &&
+          (turn.provider || turn.credential.provider) === "anthropic"
+        )
+          await warmClaudeWorker(root);
         emit({
           type: "shadow",
           data: { ...timings, hydratedObjects: filesystem.manifest.size },
@@ -220,7 +230,7 @@ export async function executeTurn(
           error: "No provider connected. Connect your subscription first.",
         };
       } else {
-        const run = deps.runTurn ?? runPiTurn;
+        const run = deps.runTurn ?? runTurn;
         try {
           outcome = await runWithConversationScope(scope, () =>
             runWithActingContext(
@@ -231,8 +241,8 @@ export async function executeTurn(
               },
               () =>
                 run(
-                  filesystem,
-                  piTurnRequest(
+                  { ...filesystem, turnRoot: root },
+                  turnSessionRequest(
                     effectiveTurn,
                     turnId,
                     emit,

--- a/packages/runtime/src/turn/op-anonymize.ts
+++ b/packages/runtime/src/turn/op-anonymize.ts
@@ -9,6 +9,10 @@ import { PrefixedVfs } from "@houston/host/src/vfs";
 import { applyServedCredential } from "../auth/auth-file";
 import { anonymizeTextsWith } from "../session/anonymize";
 import type { OpAnswer } from "./op-credential";
+import {
+  assertWorkerOpProvider,
+  WorkerOpDeclinedError,
+} from "./op-provider-guard";
 import type { OpRequest } from "./parse-op-request";
 import type { TurnFilesystem } from "./turn-filesystem";
 import { createTurnModelRuntime } from "./turn-runtime";
@@ -50,6 +54,7 @@ export async function applyAnonymizeOp(
           dataDir,
           credential.provider,
         );
+        assertWorkerOpProvider(model.provider);
         return anonymizeTextsWith({ workspaceDir, model, modelRuntime }, items);
       }
     : undefined;
@@ -59,6 +64,7 @@ export async function applyAnonymizeOp(
       vfs,
       root,
       ...(ai ? { ai } : {}),
+      rethrowAiError: (error) => error instanceof WorkerOpDeclinedError,
       aiUnavailableReason:
         "AI anonymization is not available right now; showing pattern-based redactions only",
     },

--- a/packages/runtime/src/turn/op-apply-anthropic.test.ts
+++ b/packages/runtime/src/turn/op-apply-anthropic.test.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, expect, test, vi } from "vitest";
+import { applyOp } from "./op-apply";
+import { WorkerOpDeclinedError } from "./op-provider-guard";
+import { parseOpRequest } from "./parse-op-request";
+import type { TurnFilesystem } from "./turn-filesystem";
+
+const mocks = vi.hoisted(() => ({ generateTitle: vi.fn() }));
+
+vi.mock("./turn-runtime", () => ({
+  createTurnModelRuntime: async () => ({
+    modelRuntime: {},
+    model: {
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      contextWindow: 200_000,
+    },
+  }),
+}));
+
+vi.mock("../session/summarize", () => ({
+  generateTitle: mocks.generateTitle,
+}));
+
+beforeEach(() => {
+  mocks.generateTitle.mockReset();
+});
+
+test("a resolved anthropic title declines before pi is invoked", async () => {
+  const root = mkdtempSync(join(tmpdir(), "op-provider-guard-"));
+  const dataDir = join(root, "data");
+  const workspaceDir = join(root, "workspace");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(workspaceDir, { recursive: true });
+  const op = parseOpRequest({
+    workspaceId: "w1",
+    agentId: "a1",
+    gcsPrefix: "ws/w1/a1",
+    hostToken: "host-token",
+    claim: {
+      id: "claim-1",
+      bootId: "boot-1",
+      token: "claim-token",
+      heartbeatUrl: "https://gateway.test/heartbeat",
+    },
+    credential: {
+      provider: "google",
+      access: "served-key",
+      expires: 0,
+      kind: "api_key",
+    },
+    op: { kind: "title", text: "Conversation excerpt" },
+  });
+  const filesystem = {
+    dataDir,
+    dataRel: "data",
+    workspaceDir,
+    workspaceRel: "workspace",
+  } as TurnFilesystem;
+
+  await expect(applyOp(op, filesystem)).rejects.toThrow(WorkerOpDeclinedError);
+  expect(mocks.generateTitle).not.toHaveBeenCalled();
+});

--- a/packages/runtime/src/turn/op-apply.ts
+++ b/packages/runtime/src/turn/op-apply.ts
@@ -10,6 +10,7 @@ import {
 import { applyAnonymizeOp } from "./op-anonymize";
 import { applyApiKeyConnect, credentialOpFiles } from "./op-credential";
 import { applyEndpointConnect } from "./op-endpoint";
+import { assertWorkerOpProvider } from "./op-provider-guard";
 import { applyRouteOp } from "./op-route";
 import { conversationScope, engineAgentId } from "./op-scope";
 import {
@@ -184,6 +185,7 @@ export async function applyOp(
         dataDir,
         op.credential.provider,
       );
+      assertWorkerOpProvider(model.provider);
       const title = await generateTitle({
         cwd: workspaceDir,
         model,

--- a/packages/runtime/src/turn/op-provider-guard.test.ts
+++ b/packages/runtime/src/turn/op-provider-guard.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+import {
+  assertWorkerOpProvider,
+  WorkerOpDeclinedError,
+} from "./op-provider-guard";
+
+test("worker one-shot ops decline instead of sending anthropic through pi", () => {
+  expect(() => assertWorkerOpProvider("anthropic")).toThrow(
+    WorkerOpDeclinedError,
+  );
+});
+
+test.each([
+  "openai-codex",
+  "google",
+  "groq",
+])("worker one-shot ops admit %s", (provider) => {
+  expect(() => assertWorkerOpProvider(provider)).not.toThrow();
+});

--- a/packages/runtime/src/turn/op-provider-guard.ts
+++ b/packages/runtime/src/turn/op-provider-guard.ts
@@ -1,0 +1,15 @@
+/** A worker op that must be retried by the standing pod without partial state. */
+export class WorkerOpDeclinedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerOpDeclinedError";
+  }
+}
+
+/** Keep Anthropic one-shots off pi even if gateway routing regresses. */
+export function assertWorkerOpProvider(provider: string): void {
+  if (provider === "anthropic")
+    throw new WorkerOpDeclinedError(
+      "anthropic one-shot model calls require the standing pod",
+    );
+}

--- a/packages/runtime/src/turn/pool-leaks.test.ts
+++ b/packages/runtime/src/turn/pool-leaks.test.ts
@@ -12,7 +12,7 @@ import { dirname, join } from "node:path";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterAll, expect, test } from "vitest";
 import { poolBashEnv } from "../session/tools/pool-bash";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 const scratch = mkdtempSync(join(tmpdir(), "houston-pool-leaks-"));
 process.env.HOUSTON_MODE = "turn";
@@ -262,7 +262,7 @@ test("a granted turn keeps every operational secret out of pi, tools, bash, and 
   expect(Object.values(process.env)).not.toContain(secrets.host);
 
   let observed = false;
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     const serialized = JSON.stringify(turn);
     expect(serialized).not.toContain(secrets.grant);
     expect(serialized).not.toContain(secrets.host);

--- a/packages/runtime/src/turn/server-op-lazy.test.ts
+++ b/packages/runtime/src/turn/server-op-lazy.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test } from "vitest";
 import { createTurnServer } from "./server";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 /**
  * Lazy hot-set on pool ops: a sleeping agent's Files tab and one-file reads
@@ -31,7 +31,7 @@ async function listen(server: Server): Promise<string> {
   return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 }
 
-const noopTurn: typeof runPiTurn = async () => ({});
+const noopTurn: TurnRunner = async () => ({});
 const PREFIX = "ws/w1/agent-1";
 
 function countingStore(root: string): ObjectStore & { downloads: string[] } {

--- a/packages/runtime/src/turn/server-op-tranche2.test.ts
+++ b/packages/runtime/src/turn/server-op-tranche2.test.ts
@@ -8,7 +8,7 @@ import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { zipSync } from "fflate";
 import { afterEach, expect, test } from "vitest";
 import { createTurnServer } from "./server";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 /**
  * Tranche-2 pool ops (PRODUCT-1469): portable export/preview/store, the
@@ -28,7 +28,7 @@ async function listen(server: Server): Promise<string> {
   return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 }
 
-const noopTurn: typeof runPiTurn = async () => ({});
+const noopTurn: TurnRunner = async () => ({});
 
 async function seedAgent(): Promise<{
   storeRoot: string;

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -7,7 +7,7 @@ import { LocalWorkspaceStore } from "@houston/host/src/store/local";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test } from "vitest";
 import { createTurnServer } from "./server";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 const servers: Server[] = [];
 afterEach(() => {
@@ -20,7 +20,7 @@ async function listen(server: Server): Promise<string> {
   return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 }
 
-const noopTurn: typeof runPiTurn = async () => ({});
+const noopTurn: TurnRunner = async () => ({});
 
 /** An agent seeded through the host's own store (the pod's real layout). */
 async function seedAgent(): Promise<{

--- a/packages/runtime/src/turn/server-op.test.ts
+++ b/packages/runtime/src/turn/server-op.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { LocalWorkspaceStore } from "@houston/host/src/store/local";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test } from "vitest";
+import { WorkerOpDeclinedError } from "./op-provider-guard";
 import { createTurnServer } from "./server";
 import type { TurnRunner } from "./turn-session";
 
@@ -205,6 +206,32 @@ test("an invalid op is rejected before any hydration", async () => {
   );
   expect(status).toBe(400);
   expect(String(json.error)).toContain("not a read op route");
+});
+
+test("a typed worker-op decline soft-fails to the standing pod", async () => {
+  const { storeRoot, agentId } = await seedAgent();
+  const base = await listen(
+    createTurnServer({
+      store: new LocalDirStore(storeRoot),
+      token: "",
+      runTurn: noopTurn,
+      runOp: async () => {
+        throw new WorkerOpDeclinedError("standing pod required");
+      },
+    }),
+  );
+
+  const { status, json } = await postOp(
+    base,
+    opBody(agentId, await heartbeatOK(), {
+      kind: "settings",
+      action: "put",
+      input: { activeProvider: "anthropic" },
+    }),
+  );
+
+  expect(status).toBe(200);
+  expect(json).toMatchObject({ ok: true, decline: true });
 });
 
 test("a files list runs as a READ op: no sync-back, runtime tree not hydrated", async () => {

--- a/packages/runtime/src/turn/server-pool.test.ts
+++ b/packages/runtime/src/turn/server-pool.test.ts
@@ -15,7 +15,7 @@ import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test } from "vitest";
 import { currentActingContext } from "../session/acting-context";
 import { createTurnServer } from "./server";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 const servers: Server[] = [];
 afterEach(() =>
@@ -81,7 +81,7 @@ test("capacity rejects a concurrent turn and frees the slot after terminal", asy
     markStarted = resolve;
   });
   const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
-  const runTurn: typeof runPiTurn = async () => {
+  const runTurn: TurnRunner = async () => {
     markStarted?.();
     await gate;
     return {};
@@ -104,7 +104,7 @@ test("capacity rejects a concurrent turn and frees the slot after terminal", asy
 test("a thrown turn never wedges admission", async () => {
   let calls = 0;
   const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
-  const runTurn: typeof runPiTurn = async () => {
+  const runTurn: TurnRunner = async () => {
     calls += 1;
     if (calls === 1) throw new Error("boom");
     return {};
@@ -200,7 +200,7 @@ test("a fenced heartbeat skips syncBack and emits claim_fenced", async () => {
   );
   mkdirSync(dirname(settings), { recursive: true });
   writeFileSync(settings, "{}");
-  const runTurn: typeof runPiTurn = async (layout) => {
+  const runTurn: TurnRunner = async (layout) => {
     await writeFile(join(layout.workspaceDir, "must-not-sync.txt"), "nope");
     await new Promise((resolve) => setTimeout(resolve, 20));
     return {};
@@ -229,7 +229,7 @@ test("a fenced heartbeat skips syncBack and emits claim_fenced", async () => {
 test("the supplied turn id and acting identity reach the turn session", async () => {
   let seen: unknown;
   const store = new LocalDirStore(mkdtempSync(join(tmpdir(), "pool-store-")));
-  const runTurn: typeof runPiTurn = async (_root, turn) => {
+  const runTurn: TurnRunner = async (_root, turn) => {
     seen = {
       turnId: turn.turnId,
       author: turn.author,
@@ -299,7 +299,7 @@ test("a claimed turn outlives a dropped client connection and still syncs", asyn
   const done = new Promise<void>((resolve) => {
     finished = resolve;
   });
-  const runTurn: typeof runPiTurn = async (layout, turn) => {
+  const runTurn: TurnRunner = async (layout, turn) => {
     // Give the client time to hang up, then keep working as if nothing
     // happened: the claim, not the socket, owns this turn.
     await new Promise((resolve) => setTimeout(resolve, 150));
@@ -344,7 +344,7 @@ test("a fenced heartbeat aborts the running claimed turn", async () => {
   });
   const heartbeatBase = await listen(heartbeat);
   const store = new LocalDirStore(seedStandingAgent());
-  const runTurn: typeof runPiTurn = async (_layout, turn) => {
+  const runTurn: TurnRunner = async (_layout, turn) => {
     status = 409;
     await new Promise<void>((resolve) => {
       turn.signal?.addEventListener("abort", () => resolve(), { once: true });

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -1,5 +1,6 @@
 import type { ObjectStore } from "@houston/runtime-client/object-sync";
 import type { AdmissionLimiter } from "./admission";
+import type { applyOp } from "./op-apply";
 import type { TurnRunner } from "./turn-session";
 
 /** Injectable dependencies and pool controls for the per-turn HTTP server. */
@@ -8,6 +9,8 @@ export interface TurnServerDeps {
   /** App-layer token; empty means open local development. */
   token: string;
   runTurn?: TurnRunner;
+  /** Test seam for the worker op executor. */
+  runOp?: typeof applyOp;
   concurrency?: number;
   admission?: AdmissionLimiter;
   isDraining?: () => boolean;

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -1,13 +1,13 @@
 import type { ObjectStore } from "@houston/runtime-client/object-sync";
 import type { AdmissionLimiter } from "./admission";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 /** Injectable dependencies and pool controls for the per-turn HTTP server. */
 export interface TurnServerDeps {
   store: ObjectStore;
   /** App-layer token; empty means open local development. */
   token: string;
-  runTurn?: typeof runPiTurn;
+  runTurn?: TurnRunner;
   concurrency?: number;
   admission?: AdmissionLimiter;
   isDraining?: () => boolean;

--- a/packages/runtime/src/turn/server.test.ts
+++ b/packages/runtime/src/turn/server.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../auth/credential-health";
 import { currentActingContext } from "../session/acting-context";
 import { createTurnServer } from "./server";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 /**
  * The per-turn server contract, end to end against a real (local) object
@@ -39,8 +39,8 @@ function seed(rel: string, content: string) {
 
 // A fake pi turn: proves it sees the hydrated workspace + injected credential,
 // mutates the workspace, emits frames (stamped with the server-minted turnId,
-// like the real runPiTurn).
-const fakeTurn: typeof runPiTurn = async (layout, turn) => {
+// like the real runTurn).
+const fakeTurn: TurnRunner = async (layout, turn) => {
   const { text, provider, emit, turnId } = turn;
   const notes = await readFile(join(layout.workspaceDir, "notes.txt"), "utf8");
   const auth = await readFile(join(layout.dataDir, "auth.json"), "utf8");
@@ -131,7 +131,7 @@ test("one agent's auth failure survives another agent's clean turn", async () =>
   resetAuthFailures();
   let agentAFailureSurvived = false;
   let actingIdentityLeaked = false;
-  const probe: typeof runPiTurn = async (_root, turn) => {
+  const probe: TurnRunner = async (_root, turn) => {
     const acting = currentActingContext();
     actingIdentityLeaked ||= !!(acting?.actingAs || acting?.actingUser);
     if (turn.text === "fail") noteAuthFailure(turn.provider, "dead-token");
@@ -216,9 +216,9 @@ test("a sync failure surfaces as the turn's error — never a quiet done", async
 });
 
 test("a routine's model/effort pin reaches the pi turn", async () => {
-  // Capture the pin the server forwards to runPiTurn.
+  // Capture the pin the server forwards to runTurn.
   let seen: { model?: string | null; effort?: string | null } | undefined;
-  const capture: typeof runPiTurn = async (_root, turn) => {
+  const capture: TurnRunner = async (_root, turn) => {
     seen = turn.pin;
     turn.emit({
       type: "user",
@@ -250,7 +250,7 @@ test("a turn's pinned provider outranks the attached credential's (PRODUCT-1515)
   // the PINNED provider's auth error, never silently run the turn on the
   // credential's provider.
   let seen: string | undefined;
-  const capture: typeof runPiTurn = async (_root, turn) => {
+  const capture: TurnRunner = async (_root, turn) => {
     seen = turn.provider;
     turn.emit({
       type: "user",

--- a/packages/runtime/src/turn/single-use.test.ts
+++ b/packages/runtime/src/turn/single-use.test.ts
@@ -10,7 +10,7 @@ import {
   markWorkerSpent,
   workerSpent,
 } from "./single-use";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 const servers: Server[] = [];
 const homes: string[] = [];
@@ -79,7 +79,7 @@ test("the spent marker latches under HOUSTON_HOME and survives re-checks", async
 test("a claimed turn spends the worker: begin before the turn, settled after", async () => {
   await isolatedHome();
   const order: string[] = [];
-  const runTurn: typeof runPiTurn = async () => {
+  const runTurn: TurnRunner = async () => {
     order.push("turn");
     return {};
   };
@@ -113,7 +113,7 @@ test("a single-use worker REJECTS an unclaimed real turn (no reusable bash)", as
   await isolatedHome();
   const begin = vi.fn(async () => undefined);
   const settled = vi.fn();
-  const runTurn: typeof runPiTurn = async () => ({});
+  const runTurn: TurnRunner = async () => ({});
   const base = await listen(
     createTurnServer({
       store: new LocalDirStore(await mkdtemp(join(tmpdir(), "single-use-"))),
@@ -143,7 +143,7 @@ test("a single-use worker binds the turn to its own pod UID (X-Pool-Pod-UID)", a
     await markWorkerSpent();
   });
   const settled = vi.fn();
-  const runTurn: typeof runPiTurn = async () => ({});
+  const runTurn: TurnRunner = async () => ({});
   const base = await listen(
     createTurnServer({
       store: await seededStore(),
@@ -182,7 +182,7 @@ test("a single-use worker binds the turn to its own pod UID (X-Pool-Pod-UID)", a
 test("a spent worker refuses further turns via the draining gate", async () => {
   await isolatedHome();
   await markWorkerSpent();
-  const runTurn: typeof runPiTurn = async () => ({});
+  const runTurn: TurnRunner = async () => ({});
   const base = await listen(
     createTurnServer({
       store: await seededStore(),
@@ -211,7 +211,7 @@ test("concurrency-1: a second claimed turn cannot straddle the first's release",
     firstStarted = r;
   });
   let calls = 0;
-  const runTurn: typeof runPiTurn = async () => {
+  const runTurn: TurnRunner = async () => {
     calls += 1;
     firstStarted();
     await firstRunning;

--- a/packages/runtime/src/turn/turn-anthropic-compliance.test.ts
+++ b/packages/runtime/src/turn/turn-anthropic-compliance.test.ts
@@ -1,0 +1,263 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import type { Server } from "node:http";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import type {
+  createSdkMcpServer,
+  Options,
+  SDKMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import { afterAll, afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { ClaudeQuery } from "../backends/claude/session";
+
+const pi = vi.hoisted(() => ({
+  createBackend: vi.fn(),
+}));
+vi.mock("../backends/pi/backend", async () => {
+  const actual = await vi.importActual<typeof import("../backends/pi/backend")>(
+    "../backends/pi/backend",
+  );
+  return {
+    ...actual,
+    createPiBackend: (
+      ...args: Parameters<typeof actual.createPiBackend>
+    ): ReturnType<typeof actual.createPiBackend> => {
+      pi.createBackend();
+      return actual.createPiBackend(...args);
+    },
+  };
+});
+
+const scratch = mkdtempSync(join(tmpdir(), "anthropic-compliance-"));
+process.env.HOUSTON_MODE = "turn";
+process.env.HOUSTON_DATA_DIR = join(scratch, "process-data");
+process.env.HOUSTON_WORKSPACE_DIR = join(scratch, "process-workspace");
+process.env.HOUSTON_CODE_EXECUTION = "disabled";
+
+const [{ createTurnServer }, { runTurn }] = await Promise.all([
+  import("./server"),
+  import("./turn-session"),
+]);
+
+const storeRoot = join(scratch, "store");
+const store = new LocalDirStore(storeRoot);
+const servers: Server[] = [];
+
+beforeEach(() => {
+  pi.createBackend.mockClear();
+});
+
+function listen(server: Server): Promise<string> {
+  servers.push(server);
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string")
+        return reject(new Error("server did not bind a TCP port"));
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function seed(prefix: string, rel: string, content: string): void {
+  const path = join(storeRoot, ...prefix.split("/"), ...rel.split("/"));
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function fakeMcp() {
+  return ((input: { name: string }) => ({
+    type: "sdk",
+    name: input.name,
+    instance: {},
+  })) as typeof createSdkMcpServer;
+}
+
+const HOST_SECRETS = [
+  "HOUSTON_POOL_WORKER_TOKEN",
+  "HOUSTON_SANDBOX_TOKEN",
+  "HOUSTON_TURN_TOKEN",
+  "HOUSTON_RUNTIME_TOKEN",
+  "HOUSTON_POOL_STORE_URL",
+] as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  pi.createBackend.mockClear();
+  for (const key of HOST_SECRETS) delete process.env[key];
+});
+
+afterAll(async () => {
+  await Promise.all(
+    servers.map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+test.each([
+  {
+    kind: "oauth" as const,
+    access: "sk-ant-oat01-compliance",
+    envKey: "CLAUDE_CODE_OAUTH_TOKEN",
+  },
+  {
+    kind: "api_key" as const,
+    access: "sk-ant-api03-compliance",
+    envKey: "ANTHROPIC_API_KEY",
+  },
+])("$kind Anthropic turn stays inside the Claude SDK boundary", async (input) => {
+  const prefix = `ws/compliance/${input.kind}`;
+  const conversationId = `conversation-${input.kind}`;
+  seed(prefix, "data/settings.json", "{}");
+  for (const key of HOST_SECRETS) process.env[key] = `secret-${key}`;
+
+  const originalFetch = globalThis.fetch;
+  const fetchGuard = vi.fn<typeof fetch>(async (request, init) => {
+    const url = new URL(
+      typeof request === "string" || request instanceof URL
+        ? request
+        : request.url,
+    );
+    if (url.hostname === "api.anthropic.com")
+      throw new Error("Anthropic was dialed outside the Claude SDK seam");
+    return originalFetch(request, init);
+  });
+  vi.stubGlobal("fetch", fetchGuard);
+
+  const originalConnect = net.connect;
+  const dialedHosts: string[] = [];
+  vi.spyOn(net, "connect").mockImplementation(((...args: unknown[]) => {
+    const first = args[0];
+    const host =
+      typeof first === "object" && first !== null && "host" in first
+        ? String(first.host)
+        : typeof args[1] === "string"
+          ? args[1]
+          : "";
+    dialedHosts.push(host);
+    if (host === "api.anthropic.com")
+      throw new Error("Anthropic was dialed through node:net");
+    return Reflect.apply(originalConnect, net, args) as ReturnType<
+      typeof net.connect
+    >;
+  }) as typeof net.connect);
+
+  let queryCalls = 0;
+  let capturedOptions: Options | undefined;
+  const query: ClaudeQuery = async function* ({ options }) {
+    queryCalls += 1;
+    capturedOptions = options;
+    const configDir = options.env?.CLAUDE_CONFIG_DIR;
+    if (!configDir) throw new Error("query received no Claude config dir");
+    const transcript = join(
+      configDir,
+      "projects",
+      "foreign-slug",
+      `${input.kind}-session.jsonl`,
+    );
+    mkdirSync(dirname(transcript), { recursive: true });
+    writeFileSync(transcript, '{"type":"user"}\n');
+    mkdirSync(join(configDir, "statsig"), { recursive: true });
+    writeFileSync(join(configDir, "statsig", "cache.json"), "cache");
+    writeFileSync(join(configDir, ".credentials.json"), "credential-cache");
+    yield {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: `sdk-${input.kind}-reply` },
+      },
+      session_id: `${input.kind}-session`,
+      parent_tool_use_id: null,
+    } as unknown as SDKMessage;
+    yield {
+      type: "result",
+      subtype: "success",
+      usage: { input_tokens: 12, output_tokens: 3 },
+      session_id: `${input.kind}-session`,
+    } as unknown as SDKMessage;
+  };
+  const runtime = createTurnServer({
+    store,
+    token: "",
+    poolStoreUrl: "",
+    runTurn: (directories, turn) =>
+      runTurn(directories, turn, {
+        claudeSdk: { query, createSdkMcpServer: fakeMcp() },
+      }),
+    fetchImpl: async () => new Response(null, { status: 204 }),
+  });
+  const runtimeUrl = await listen(runtime);
+  const response = await fetch(`${runtimeUrl}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      workspaceId: "compliance",
+      agentId: input.kind,
+      conversationId,
+      text: "hello",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      gcsPrefix: prefix,
+      hostToken: "host-token",
+      claim: {
+        id: `claim-${input.kind}`,
+        bootId: "boot-compliance",
+        token: "claim-token",
+        heartbeatUrl: "https://gateway.invalid/heartbeat",
+      },
+      credential: {
+        provider: "anthropic",
+        access: input.access,
+        expires: Date.now() + 60_000,
+        kind: input.kind,
+      },
+    }),
+  });
+  const stream = await response.text();
+  expect(response.status, stream).toBe(200);
+
+  expect(stream).toContain(`sdk-${input.kind}-reply`);
+  expect(queryCalls).toBe(1);
+  expect(pi.createBackend).not.toHaveBeenCalled();
+  expect(dialedHosts).not.toContain("api.anthropic.com");
+  expect(
+    fetchGuard.mock.calls.some(([request]) => {
+      const value =
+        typeof request === "string" || request instanceof URL
+          ? String(request)
+          : request.url;
+      return new URL(value).hostname === "api.anthropic.com";
+    }),
+  ).toBe(false);
+
+  const env = capturedOptions?.env;
+  expect(env?.[input.envKey]).toBe(input.access);
+  expect(env?.CLAUDE_CONFIG_DIR).toContain(
+    `/data/sessions/${conversationId}/claude`,
+  );
+  expect(env?.CLAUDE_SECURESTORAGE_CONFIG_DIR).not.toContain("/store/");
+  expect(env?.HOME).not.toContain("/store/");
+  for (const key of HOST_SECRETS) expect(env?.[key]).toBeUndefined();
+
+  const uploaded = await store.list(prefix);
+  const relativeKeys = uploaded.map((key) => relative(prefix, key));
+  expect(relativeKeys).toContain(
+    `data/sessions/${conversationId}/claude/projects/foreign-slug/${input.kind}-session.jsonl`,
+  );
+  expect(relativeKeys).toContain(
+    `data/sessions/${conversationId}/claude/sessions.json`,
+  );
+  expect(relativeKeys).not.toContain("data/auth.json");
+  expect(relativeKeys).not.toContain(
+    `data/sessions/${conversationId}/claude/statsig/cache.json`,
+  );
+  expect(relativeKeys).not.toContain(
+    `data/sessions/${conversationId}/claude/.credentials.json`,
+  );
+});

--- a/packages/runtime/src/turn/turn-backend.test.ts
+++ b/packages/runtime/src/turn/turn-backend.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { expect, test } from "vitest";
+import { writeAuthFile } from "../auth/auth-file";
+import { createTurnBackend, type TurnBackendDeps } from "./turn-backend";
+import type { TurnSessionRequest } from "./turn-session";
+
+function deps(credential: "oauth" | "api_key"): TurnBackendDeps {
+  const turnRoot = mkdtempSync(join(tmpdir(), "turn-backend-"));
+  const workspaceDir = join(turnRoot, "store", "workspace");
+  const dataDir = join(turnRoot, "store", "data");
+  mkdirSync(workspaceDir, { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
+  writeAuthFile(join(dataDir, "auth.json"), {
+    anthropic:
+      credential === "oauth"
+        ? {
+            type: "oauth",
+            access: "sk-ant-oat01-test",
+            refresh: "",
+            expires: Date.now() + 60_000,
+          }
+        : { type: "api_key", key: "sk-ant-api03-test" },
+  });
+  const turn: TurnSessionRequest = {
+    conversationId: "c1",
+    text: "hello",
+    provider: "anthropic",
+    emit: () => undefined,
+    signal: undefined,
+    turnId: "t1",
+  };
+  return {
+    directories: { workspaceDir, dataDir, turnRoot },
+    turn,
+    modelRuntime: {} as ModelRuntime,
+    toolSelection: { toolNames: [], includeRunCode: false },
+    codeSandbox: null,
+    systemPrompt: "system",
+  };
+}
+
+test.each([
+  "oauth",
+  "api_key",
+] as const)("anthropic uses the Claude backend for a %s credential", (credential) => {
+  expect(createTurnBackend("anthropic", deps(credential)).id).toBe("anthropic");
+});
+
+test.each([
+  "openai-codex",
+  "google",
+  "openrouter",
+])("%s uses the pi backend", (provider) => {
+  expect(createTurnBackend(provider, deps("oauth")).id).toBe("pi");
+});
+
+test("an unavailable Claude SDK becomes a typed provider failure", async () => {
+  const input = deps("oauth");
+  input.claudeSdk = {
+    query: async function* () {},
+    createSdkMcpServer: (() => {
+      throw new Error("SDK binary missing");
+    }) as typeof createSdkMcpServer,
+  };
+  const backend = createTurnBackend("anthropic", input);
+
+  await expect(
+    backend.createSession({
+      conversationId: "c1",
+      model: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        contextWindow: 200_000,
+      },
+    }),
+  ).rejects.toMatchObject({
+    providerError: {
+      kind: "provider_internal",
+      provider: "anthropic",
+      message: "Claude Agent SDK is unavailable in this worker.",
+    },
+  });
+});

--- a/packages/runtime/src/turn/turn-backend.ts
+++ b/packages/runtime/src/turn/turn-backend.ts
@@ -1,0 +1,160 @@
+import { join } from "node:path";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import type { ProviderError } from "@houston/runtime-client";
+import { readAuthFile } from "../auth/auth-file";
+import {
+  type ClaudeBackendDeps,
+  ClaudeBackendUnavailableError,
+  createClaudeBackend,
+} from "../backends/claude/backend";
+import type { BridgedPiTool } from "../backends/claude/custom-tools";
+import type { ClaudeLayout } from "../backends/claude/paths";
+import { readAnthropicToken } from "../backends/claude/read-token";
+import { createSessionsStore } from "../backends/claude/sessions-store";
+import { createPiBackend, type PiBackendDeps } from "../backends/pi/backend";
+import type { HarnessBackend } from "../backends/types";
+import type { ToolSelection } from "../session/tool-selection";
+import { makeAskUserTool } from "../session/tools/ask-user";
+import { makeClampedFileTools } from "../session/tools/clamped-fs";
+import { makePlanReadyTool } from "../session/tools/plan-ready";
+import { makePoolBashTool } from "../session/tools/pool-bash";
+import type { TurnDirectories, TurnSessionRequest } from "./turn-session";
+import { buildTurnHostTools } from "./turn-toolset";
+
+type TurnTool = PiBackendDeps["customTools"][number];
+
+/** Dependencies shared by the pi and Claude pooled-turn backend branches. */
+export interface TurnBackendDeps {
+  directories: TurnDirectories;
+  turn: TurnSessionRequest;
+  modelRuntime: ModelRuntime;
+  toolSelection: ToolSelection;
+  codeSandbox: TurnTool | null;
+  systemPrompt: string;
+  sharedRoots?: string[];
+  claudeSdk?: ClaudeBackendDeps["sdk"];
+}
+
+/** Claude directories split between durable conversation state and turn state. */
+export interface TurnClaudeLayout extends ClaudeLayout {
+  credentialStorageDir: string;
+  homeDir: string;
+  sessionsFile: string;
+}
+
+/** Typed provider failure raised before a backend session can stream events. */
+export class TurnBackendProviderError extends Error {
+  constructor(
+    readonly providerError: ProviderError,
+    options?: ErrorOptions,
+  ) {
+    super(
+      providerError.kind === "unknown"
+        ? providerError.raw_excerpt
+        : providerError.message,
+      options,
+    );
+    this.name = "TurnBackendProviderError";
+  }
+}
+
+/** Build the per-conversation Claude layout for one disposable turn root. */
+export function turnClaudeLayout(
+  turnRoot: string,
+  dataDir: string,
+  conversationId: string,
+): TurnClaudeLayout {
+  const configDir = join(dataDir, "sessions", conversationId, "claude");
+  return {
+    configDir,
+    sessionsFile: join(configDir, "sessions.json"),
+    credentialStorageDir: join(turnRoot, "claude-credstore"),
+    homeDir: join(turnRoot, "home"),
+  };
+}
+
+/** Select and assemble the provider harness for a pooled turn. */
+export function createTurnBackend(
+  provider: string,
+  deps: TurnBackendDeps,
+): HarnessBackend {
+  const { workspaceDir, dataDir, turnRoot } = deps.directories;
+  const hostTools = buildTurnHostTools(deps.turn);
+  const commonTools = [
+    makeAskUserTool(),
+    makePlanReadyTool(),
+    ...(deps.codeSandbox ? [deps.codeSandbox] : []),
+    ...hostTools,
+  ];
+  if (provider === "anthropic") {
+    const backend = createClaudeBackend({
+      workspaceDir,
+      readToken: () =>
+        readAnthropicToken({
+          get: (requestedProvider) =>
+            readAuthFile(join(dataDir, "auth.json"))[requestedProvider],
+        }),
+      toolSelection: deps.toolSelection,
+      systemPrompt: deps.systemPrompt,
+      sharedRoots: deps.sharedRoots,
+      layout: turnClaudeLayout(turnRoot, dataDir, deps.turn.conversationId),
+      // SAFETY: these are the same pi ToolDefinition objects the MCP bridge
+      // accepts; only their heterogeneous schema generics need widening.
+      tools: commonTools as unknown as BridgedPiTool[],
+      sdk: deps.claudeSdk,
+    });
+    return {
+      id: backend.id,
+      async createSession(options) {
+        try {
+          return await backend.createSession(options);
+        } catch (error) {
+          if (error instanceof ClaudeBackendUnavailableError) {
+            throw new TurnBackendProviderError(
+              {
+                kind: "provider_internal",
+                provider: "anthropic",
+                http_status: null,
+                message: "Claude Agent SDK is unavailable in this worker.",
+              },
+              { cause: error },
+            );
+          }
+          throw error;
+        }
+      },
+    };
+  }
+  return createPiBackend({
+    workspaceDir,
+    dataDir,
+    modelRuntime: deps.modelRuntime,
+    tools: deps.toolSelection.toolNames,
+    customTools: [
+      ...makeClampedFileTools(workspaceDir, {
+        sharedRoots: deps.sharedRoots ?? [],
+      }),
+      ...commonTools,
+      ...(deps.toolSelection.toolNames.includes("bash")
+        ? [makePoolBashTool(workspaceDir)]
+        : []),
+    ],
+  });
+}
+
+/** Resolve native Claude continuity, relocating a foreign cwd slug if needed. */
+export function resolveTurnClaudeResume(
+  directories: TurnDirectories,
+  conversationId: string,
+): string | undefined {
+  const layout = turnClaudeLayout(
+    directories.turnRoot,
+    directories.dataDir,
+    conversationId,
+  );
+  return createSessionsStore({
+    configDir: layout.configDir,
+    sessionsFile: layout.sessionsFile,
+    cwd: directories.workspaceDir,
+  }).resolveResume(conversationId);
+}

--- a/packages/runtime/src/turn/turn-claude-layout.test.ts
+++ b/packages/runtime/src/turn/turn-claude-layout.test.ts
@@ -1,0 +1,21 @@
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { turnClaudeLayout } from "./turn-backend";
+
+test("keeps durable Claude state in the claimed conversation session", () => {
+  const layout = turnClaudeLayout("/turn", "/turn/store/data", "c1");
+
+  expect(layout.configDir).toBe(
+    join("/turn/store/data", "sessions", "c1", "claude"),
+  );
+  expect(layout.sessionsFile).toBe(join(layout.configDir, "sessions.json"));
+});
+
+test("keeps credential recovery and HOME outside the synced store", () => {
+  const layout = turnClaudeLayout("/turn", "/turn/store/data", "c1");
+
+  expect(layout.credentialStorageDir).toBe(join("/turn", "claude-credstore"));
+  expect(layout.homeDir).toBe(join("/turn", "home"));
+  expect(layout.credentialStorageDir).not.toContain(join("/turn", "store"));
+  expect(layout.homeDir).not.toContain(join("/turn", "store"));
+});

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { expect, test } from "vitest";
-import { prepareTurnFilesystem } from "./turn-filesystem";
+import { claimedTurnIncludes, prepareTurnFilesystem } from "./turn-filesystem";
 import { ownConversationOnly } from "./turn-hot-set";
 
 test("route-op excludes skip the runtime tree wherever the agent sits", async () => {
@@ -182,4 +182,18 @@ test("the eager path reports the store's generation capability even when the fil
     claimed: true,
   });
   expect(plain.generationAware).toBe(false);
+});
+
+test("a claim syncs only durable Claude conversation state", () => {
+  const include = claimedTurnIncludes("data", "workspace", "c1");
+  const claude = "data/sessions/c1/claude";
+
+  expect(include(`${claude}/projects/slug/session.jsonl`)).toBe(true);
+  expect(include(`${claude}/sessions.json`)).toBe(true);
+  expect(include(`${claude}/statsig/cache.json`)).toBe(false);
+  expect(include(`${claude}/history.jsonl`)).toBe(false);
+  expect(include(`${claude}/.credentials.json`)).toBe(false);
+  expect(include("data/sessions/c2/claude/projects/slug/session.jsonl")).toBe(
+    false,
+  );
 });

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -190,6 +190,7 @@ test("a claim syncs only durable Claude conversation state", () => {
 
   expect(include(`${claude}/projects/slug/session.jsonl`)).toBe(true);
   expect(include(`${claude}/sessions.json`)).toBe(true);
+  expect(include("data/sessions/c1/harness.json")).toBe(true);
   expect(include(`${claude}/statsig/cache.json`)).toBe(false);
   expect(include(`${claude}/history.jsonl`)).toBe(false);
   expect(include(`${claude}/.credentials.json`)).toBe(false);

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -155,10 +155,22 @@ export function claimedTurnIncludes(
   const runs = turnRoutineRunsKey(workspaceRel);
   return (relativePath) =>
     relativePath === conversation ||
-    relativePath.startsWith(`${session}/`) ||
+    turnSessionScopeIncludes(session, relativePath) ||
     relativePath === activity ||
     relativePath === runs ||
     agentScopeIncludes(relativePath, workspaceRel);
+}
+
+/** Keep ordinary session state, but only durable files from the Claude CLI. */
+export function turnSessionScopeIncludes(
+  sessionRel: string,
+  relativePath: string,
+): boolean {
+  if (!relativePath.startsWith(`${sessionRel}/`)) return false;
+  const claudePrefix = `${sessionRel}/claude/`;
+  if (!relativePath.startsWith(claudePrefix)) return true;
+  const claudeRel = relativePath.slice(claudePrefix.length);
+  return claudeRel === "sessions.json" || claudeRel.startsWith("projects/");
 }
 
 /** Store-relative mission-board object granted to a claimed turn. */

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -167,6 +167,7 @@ export function turnSessionScopeIncludes(
   relativePath: string,
 ): boolean {
   if (!relativePath.startsWith(`${sessionRel}/`)) return false;
+  if (relativePath === `${sessionRel}/harness.json`) return true;
   const claudePrefix = `${sessionRel}/claude/`;
   if (!relativePath.startsWith(claudePrefix)) return true;
   const claudeRel = relativePath.slice(claudePrefix.length);

--- a/packages/runtime/src/turn/turn-harness-state.ts
+++ b/packages/runtime/src/turn/turn-harness-state.ts
@@ -1,0 +1,44 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+/** Provider harnesses whose native session histories cannot be interleaved. */
+export type TurnHarness = "claude" | "pi";
+
+export function turnHarnessFile(
+  dataDir: string,
+  conversationId: string,
+): string {
+  return join(dataDir, "sessions", conversationId, "harness.json");
+}
+
+export function readTurnHarness(
+  dataDir: string,
+  conversationId: string,
+): TurnHarness | undefined {
+  const file = turnHarnessFile(dataDir, conversationId);
+  if (!existsSync(file)) return undefined;
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as {
+    backend?: unknown;
+  };
+  if (parsed.backend === "claude" || parsed.backend === "pi")
+    return parsed.backend;
+  throw new Error(`Invalid pooled-turn harness marker: ${file}`);
+}
+
+export function writeTurnHarness(
+  dataDir: string,
+  conversationId: string,
+  backend: TurnHarness,
+): void {
+  const file = turnHarnessFile(dataDir, conversationId);
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ backend }), { mode: 0o600 });
+  renameSync(tmp, file);
+}

--- a/packages/runtime/src/turn/turn-harness-state.ts
+++ b/packages/runtime/src/turn/turn-harness-state.ts
@@ -23,12 +23,22 @@ export function readTurnHarness(
 ): TurnHarness | undefined {
   const file = turnHarnessFile(dataDir, conversationId);
   if (!existsSync(file)) return undefined;
-  const parsed = JSON.parse(readFileSync(file, "utf8")) as {
-    backend?: unknown;
-  };
-  if (parsed.backend === "claude" || parsed.backend === "pi")
-    return parsed.backend;
-  throw new Error(`Invalid pooled-turn harness marker: ${file}`);
+  // A corrupt marker (partial sync, prior crash) must degrade to "unknown" —
+  // the conversation then takes the pre-marker resume path — never fail the
+  // turn. Logged so the corruption is visible to us.
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8")) as {
+      backend?: unknown;
+    };
+    if (parsed.backend === "claude" || parsed.backend === "pi")
+      return parsed.backend;
+    throw new Error(`unrecognized backend ${String(parsed.backend)}`);
+  } catch (error) {
+    console.error(
+      `[turn] harness marker unreadable, treating as unknown (${file}): ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
 }
 
 export function writeTurnHarness(

--- a/packages/runtime/src/turn/turn-hot-set.test.ts
+++ b/packages/runtime/src/turn/turn-hot-set.test.ts
@@ -42,3 +42,14 @@ test("a user project's own conversations folder is never mistaken for the runtim
     ),
   ).toBe(true);
 });
+
+test("hydrates the active conversation's Claude subtree only", () => {
+  const admit = ownConversationOnly("c1");
+  expect(admit(`${standing}/sessions/c1/claude/projects/slug/s.jsonl`)).toBe(
+    true,
+  );
+  expect(admit(`${standing}/sessions/c1/claude/sessions.json`)).toBe(true);
+  expect(admit(`${standing}/sessions/c2/claude/projects/slug/s.jsonl`)).toBe(
+    false,
+  );
+});

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test, vi } from "vitest";
 import { createTurnServer } from "./server";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 const servers: Server[] = [];
 afterEach(() =>
@@ -89,7 +89,7 @@ test.each([
   const prefixRoot = join(storeRoot, "ws", "w1", "agent-1");
   await seed(prefixRoot, `${dataRel}/settings.json`, "{}");
   await seed(prefixRoot, `${dataRel}/conversations/c1.json`, '{"before":1}');
-  const runTurn: typeof runPiTurn = async (layout) => {
+  const runTurn: TurnRunner = async (layout) => {
     await seed(layout.dataDir, "conversations/c1.json", '{"after":1}');
     await seed(layout.dataDir, "sessions/c1/state.json", "session");
     await seed(
@@ -169,7 +169,7 @@ test("an unclaimed turn retains full sync-back", async () => {
   const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
   const prefixRoot = join(storeRoot, "ws", "w1", "agent-1");
   await seed(prefixRoot, "data/settings.json", "{}");
-  const runTurn: typeof runPiTurn = async (layout) => {
+  const runTurn: TurnRunner = async (layout) => {
     await seed(layout.workspaceDir, "result.txt", "workspace");
     await seed(layout.dataDir, "sessions/c1/state.json", "session");
     return {};
@@ -201,7 +201,7 @@ test("shadow resolves a standing layout and reports hydrated objects", async () 
   const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
   const prefixRoot = join(storeRoot, "ws", "w1", "agent-1");
   await seed(prefixRoot, "workspaces/W/A/.houston/runtime/settings.json", "{}");
-  const runTurn = vi.fn<typeof runPiTurn>();
+  const runTurn = vi.fn<TurnRunner>();
   const base = await listen(
     createTurnServer({
       store: new LocalDirStore(storeRoot),
@@ -218,7 +218,7 @@ test("shadow resolves a standing layout and reports hydrated objects", async () 
 
 test("a claimed turn on an EMPTY prefix is layout_unexpected, never a seeded cloudrun tree", async () => {
   const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
-  const runTurn = vi.fn<typeof runPiTurn>();
+  const runTurn = vi.fn<TurnRunner>();
   const base = await listen(
     createTurnServer({
       store: new LocalDirStore(storeRoot),
@@ -240,7 +240,7 @@ test("a claimed turn on an EMPTY prefix is layout_unexpected, never a seeded clo
 
 test("an unclaimed turn on an EMPTY prefix still starts as a fresh cloudrun agent", async () => {
   const storeRoot = await mkdtemp(join(tmpdir(), "turn-store-"));
-  const runTurn = vi.fn<typeof runPiTurn>(async () => ({}));
+  const runTurn = vi.fn<TurnRunner>(async () => ({}));
   const base = await listen(
     createTurnServer({
       store: new LocalDirStore(storeRoot),

--- a/packages/runtime/src/turn/turn-request.test.ts
+++ b/packages/runtime/src/turn/turn-request.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "vitest";
-import { piTurnRequest } from "./pi-turn-request";
+import { turnSessionRequest } from "./turn-request";
 import type { TurnRequest } from "./types";
 
 /**
- * PRODUCT-1515: the provider a pool turn runs on. The turn's PIN (the
+ * The provider a pool turn runs on comes from its pin. The turn's PIN (the
  * conversation's picked provider, forwarded by the dispatcher — or a routine's
  * own pinned provider overlaid by executeTurn) must outrank the attached
  * credential's provider: a dispatcher that serves the wrong credential fails
@@ -30,7 +30,7 @@ const base: TurnRequest = {
 };
 
 test("the pinned provider outranks the attached credential's", () => {
-  const turn = piTurnRequest(
+  const turn = turnSessionRequest(
     { ...base, provider: "openrouter" },
     "t1",
     emit,
@@ -40,18 +40,21 @@ test("the pinned provider outranks the attached credential's", () => {
 });
 
 test("an unpinned legacy dispatch runs on the credential's provider", () => {
-  expect(piTurnRequest(base, "t1", emit, signal).provider).toBe("anthropic");
+  expect(turnSessionRequest(base, "t1", emit, signal).provider).toBe(
+    "anthropic",
+  );
 });
 
 test("no pin and no credential leaves the provider unattributed", () => {
   expect(
-    piTurnRequest({ ...base, credential: null }, "t1", emit, signal).provider,
+    turnSessionRequest({ ...base, credential: null }, "t1", emit, signal)
+      .provider,
   ).toBe("");
 });
 
 test("only grant scopes and the sandbox closure reach the pi request", () => {
   const call = async () => Response.json({});
-  const turn = piTurnRequest(
+  const turn = turnSessionRequest(
     {
       ...base,
       claim: {

--- a/packages/runtime/src/turn/turn-request.ts
+++ b/packages/runtime/src/turn/turn-request.ts
@@ -1,23 +1,23 @@
 import type { WireFrame } from "@houston/runtime-client";
 import type { SandboxFetch } from "../session/tools/sandbox-fetch";
-import type { PiTurnRequest } from "./turn-session";
+import type { TurnSessionRequest } from "./turn-session";
 import type { TurnRequest } from "./types";
 
-/** Project the accepted envelope onto the pi turn the session runs. */
-export function piTurnRequest(
+/** Project the accepted envelope onto the provider-agnostic turn session. */
+export function turnSessionRequest(
   turn: TurnRequest,
   turnId: string,
   emit: (frame: WireFrame) => void,
   signal: AbortSignal,
   sandbox?: { call: SandboxFetch },
-): PiTurnRequest {
+): TurnSessionRequest {
   return {
     conversationId: turn.conversationId,
     text: turn.text,
     // The turn's PIN outranks the attached credential: a dispatcher that
     // serves a different provider's credential must fail as the PINNED
     // provider's auth error, never silently run (and bill) the turn on a
-    // provider the user did not pick (PRODUCT-1515). Legacy dispatches carry
+    // provider the user did not pick. Legacy dispatches carry
     // no pin, so the credential's provider stays the selection there.
     provider: turn.provider || turn.credential?.provider || "",
     emit,

--- a/packages/runtime/src/turn/turn-session-abort.test.ts
+++ b/packages/runtime/src/turn/turn-session-abort.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WireFrame } from "@houston/runtime-client";
 import { expect, test, vi } from "vitest";
-import { runPiTurn } from "./turn-session";
+import { runTurn } from "./turn-session";
 
 vi.mock("./turn-runtime", () => ({
   createTurnModelRuntime: async () => ({
@@ -31,8 +31,8 @@ test("an abort raised out of prompt() ends the turn quietly, not as an error", a
   const dataDir = await mkdtemp(join(tmpdir(), "turn-abort-data-"));
   const frames: WireFrame[] = [];
 
-  const outcome = await runPiTurn(
-    { workspaceDir, dataDir },
+  const outcome = await runTurn(
+    { workspaceDir, dataDir, turnRoot: workspaceDir },
     {
       conversationId: "c1",
       text: "hello",

--- a/packages/runtime/src/turn/turn-session.test.ts
+++ b/packages/runtime/src/turn/turn-session.test.ts
@@ -9,11 +9,20 @@ import type {
 import { beforeEach, expect, test, vi } from "vitest";
 import { writeAuthFile } from "../auth/auth-file";
 import type { ClaudeQuery } from "../backends/claude/session";
+import type {
+  CreateSessionOptions,
+  HarnessBackend,
+  HarnessSession,
+} from "../backends/types";
 import {
   appendAssistantMessageAt,
   appendUserMessageAt,
 } from "../store/conversation-file";
-import { turnClaudeLayout } from "./turn-backend";
+import {
+  createTurnBackend,
+  type TurnBackendDeps,
+  turnClaudeLayout,
+} from "./turn-backend";
 import { runTurn, type TurnDirectories } from "./turn-session";
 
 vi.mock("./turn-runtime", () => ({
@@ -93,6 +102,72 @@ function seedConversation(dataDir: string): void {
   });
 }
 
+interface BackendCall {
+  options: CreateSessionOptions;
+  prompts: string[];
+}
+
+function recordingPiBackend(calls: BackendCall[]): HarnessBackend {
+  return {
+    id: "pi",
+    async createSession(options) {
+      const call: BackendCall = { options, prompts: [] };
+      calls.push(call);
+      return {
+        subscribe: () => () => undefined,
+        prompt: async (prompt) => {
+          call.prompts.push(prompt);
+        },
+        abort: async () => undefined,
+        dispose: () => undefined,
+        setModel: async () => undefined,
+        compact: async () => undefined,
+        setThinkingLevel: () => undefined,
+        getContextUsage: () => undefined,
+      } satisfies HarnessSession;
+    },
+  };
+}
+
+function backendFactory(pi: HarnessBackend) {
+  return (provider: string, input: TurnBackendDeps): HarnessBackend =>
+    provider === "anthropic" ? createTurnBackend(provider, input) : pi;
+}
+
+async function writeClaudeTranscript(
+  dirs: TurnDirectories,
+  sessionId: string,
+): Promise<void> {
+  const layout = turnClaudeLayout(dirs.turnRoot, dirs.dataDir, "c1");
+  const slug = dirs.workspaceDir.replace(/[^A-Za-z0-9]/g, "-");
+  await mkdir(join(layout.configDir, "projects", slug), { recursive: true });
+  await writeFile(
+    join(layout.configDir, "projects", slug, `${sessionId}.jsonl`),
+    "{}\n",
+  );
+}
+
+async function runProviderTurn(
+  dirs: TurnDirectories,
+  provider: string,
+  turnNumber: number,
+  claude: ReturnType<typeof sdk>,
+  pi: HarnessBackend,
+): Promise<void> {
+  await runTurn(
+    dirs,
+    {
+      conversationId: "c1",
+      text: `message ${turnNumber}`,
+      provider,
+      emit: () => undefined,
+      signal: undefined,
+      turnId: `turn-${turnNumber}`,
+    },
+    { claudeSdk: claude, createBackend: backendFactory(pi) },
+  );
+}
+
 test("relocates a hydrated foreign-slug transcript and resumes without replay", async () => {
   const dirs = await directories();
   const layout = turnClaudeLayout(dirs.turnRoot, dirs.dataDir, "c1");
@@ -168,4 +243,112 @@ test("a missing transcript starts fresh with the canonical replay preamble", asy
   expect(captured?.prompt).toContain("User: Remember the blue lantern.");
   expect(captured?.prompt).toContain("Assistant: I will remember it.");
   expect(captured?.prompt).toContain("What did I ask you to remember?");
+});
+
+test("a pooled dangling-resume retry replays the canonical conversation", async () => {
+  const dirs = await directories();
+  const layout = turnClaudeLayout(dirs.turnRoot, dirs.dataDir, "c1");
+  seedConversation(dirs.dataDir);
+  await mkdir(join(layout.configDir, "projects", "foreign-slug"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(layout.configDir, "projects", "foreign-slug", "session-old.jsonl"),
+    "{}\n",
+  );
+  await writeFile(layout.sessionsFile, JSON.stringify({ c1: "session-old" }));
+  const prompts: string[] = [];
+  let attempt = 0;
+  const query: ClaudeQuery = async function* ({ prompt }) {
+    prompts.push(prompt);
+    attempt++;
+    if (attempt === 1)
+      throw new Error("No conversation found with session ID: session-old");
+    yield {
+      type: "result",
+      subtype: "success",
+      usage: { input_tokens: 10, output_tokens: 2 },
+      session_id: "session-next",
+    } as unknown as SDKMessage;
+  };
+
+  await runTurn(
+    dirs,
+    {
+      conversationId: "c1",
+      text: "What did I ask you to remember?",
+      provider: "anthropic",
+      emit: () => undefined,
+      signal: undefined,
+      turnId: "current",
+    },
+    { claudeSdk: sdk(query) },
+  );
+
+  expect(prompts[0]).not.toContain("[Continuing an existing conversation.");
+  expect(prompts[1]).toContain("[Continuing an existing conversation.");
+  expect(prompts[1]).toContain("User: Remember the blue lantern.");
+  expect(prompts[1]).toContain("What did I ask you to remember?");
+});
+
+test("anthropic to pi to anthropic flips fresh with replay while unchanged Claude resumes", async () => {
+  const dirs = await directories();
+  const claudeCalls: Array<{ prompt: string; options: Options }> = [];
+  const claude = sdk(
+    scriptedQuery((prompt, options) => {
+      claudeCalls.push({ prompt, options });
+    }),
+  );
+  const piCalls: BackendCall[] = [];
+  const pi = recordingPiBackend(piCalls);
+
+  await runProviderTurn(dirs, "anthropic", 1, claude, pi);
+  await writeClaudeTranscript(dirs, "session-next");
+  await runProviderTurn(dirs, "anthropic", 2, claude, pi);
+  await runProviderTurn(dirs, "openai-codex", 3, claude, pi);
+  await runProviderTurn(dirs, "anthropic", 4, claude, pi);
+
+  expect(claudeCalls[1]?.options.resume).toBe("session-next");
+  expect(claudeCalls[1]?.prompt).not.toContain(
+    "[Continuing an existing conversation.",
+  );
+  expect(piCalls[0]?.options.fresh).toBe(true);
+  expect(piCalls[0]?.prompts[0]).toContain(
+    "[Continuing an existing conversation.",
+  );
+  expect(claudeCalls[2]?.options.resume).toBeUndefined();
+  expect(claudeCalls[2]?.prompt).toContain(
+    "[Continuing an existing conversation.",
+  );
+});
+
+test("pi to anthropic to pi flips fresh with replay while unchanged pi resumes", async () => {
+  const dirs = await directories();
+  const claudeCalls: Array<{ prompt: string; options: Options }> = [];
+  const claude = sdk(
+    scriptedQuery((prompt, options) => {
+      claudeCalls.push({ prompt, options });
+    }),
+  );
+  const piCalls: BackendCall[] = [];
+  const pi = recordingPiBackend(piCalls);
+
+  await runProviderTurn(dirs, "openai-codex", 1, claude, pi);
+  await runProviderTurn(dirs, "openai-codex", 2, claude, pi);
+  await runProviderTurn(dirs, "anthropic", 3, claude, pi);
+  await runProviderTurn(dirs, "openai-codex", 4, claude, pi);
+
+  expect(piCalls[0]?.options.fresh).toBeUndefined();
+  expect(piCalls[1]?.options.fresh).toBeUndefined();
+  expect(piCalls[1]?.prompts[0]).not.toContain(
+    "[Continuing an existing conversation.",
+  );
+  expect(claudeCalls[0]?.options.resume).toBeUndefined();
+  expect(claudeCalls[0]?.prompt).toContain(
+    "[Continuing an existing conversation.",
+  );
+  expect(piCalls[2]?.options.fresh).toBe(true);
+  expect(piCalls[2]?.prompts[0]).toContain(
+    "[Continuing an existing conversation.",
+  );
 });

--- a/packages/runtime/src/turn/turn-session.test.ts
+++ b/packages/runtime/src/turn/turn-session.test.ts
@@ -1,0 +1,171 @@
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  createSdkMcpServer,
+  Options,
+  SDKMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { beforeEach, expect, test, vi } from "vitest";
+import { writeAuthFile } from "../auth/auth-file";
+import type { ClaudeQuery } from "../backends/claude/session";
+import {
+  appendAssistantMessageAt,
+  appendUserMessageAt,
+} from "../store/conversation-file";
+import { turnClaudeLayout } from "./turn-backend";
+import { runTurn, type TurnDirectories } from "./turn-session";
+
+vi.mock("./turn-runtime", () => ({
+  createTurnModelRuntime: async () => ({
+    modelRuntime: {},
+    model: {
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      contextWindow: 200_000,
+      reasoning: true,
+    },
+  }),
+}));
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+async function directories(): Promise<TurnDirectories> {
+  const turnRoot = await mkdtemp(join(tmpdir(), "claude-turn-session-"));
+  const workspaceDir = join(turnRoot, "store", "workspace");
+  const dataDir = join(turnRoot, "store", "data");
+  await Promise.all([
+    mkdir(workspaceDir, { recursive: true }),
+    mkdir(dataDir, { recursive: true }),
+  ]);
+  writeAuthFile(join(dataDir, "auth.json"), {
+    anthropic: {
+      type: "oauth",
+      access: "sk-ant-oat01-test",
+      refresh: "",
+      expires: Date.now() + 60_000,
+    },
+  });
+  return { turnRoot, workspaceDir, dataDir };
+}
+
+function sdk(query: ClaudeQuery) {
+  const makeMcp = ((input: { name: string }) => ({
+    type: "sdk",
+    name: input.name,
+    instance: {},
+  })) as typeof createSdkMcpServer;
+  return { query, createSdkMcpServer: makeMcp };
+}
+
+function scriptedQuery(capture: (prompt: string, options: Options) => void) {
+  const query: ClaudeQuery = async function* ({ prompt, options }) {
+    capture(prompt, options);
+    yield {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "reply" },
+      },
+      session_id: "session-next",
+      parent_tool_use_id: null,
+    } as unknown as SDKMessage;
+    yield {
+      type: "result",
+      subtype: "success",
+      usage: { input_tokens: 10, output_tokens: 2 },
+      session_id: "session-next",
+    } as unknown as SDKMessage;
+  };
+  return query;
+}
+
+function seedConversation(dataDir: string): void {
+  const conversationsDir = join(dataDir, "conversations");
+  appendUserMessageAt(conversationsDir, "c1", "Remember the blue lantern.", {
+    turnId: "prior-user",
+  });
+  appendAssistantMessageAt(conversationsDir, "c1", "I will remember it.", {
+    turnId: "prior-assistant",
+  });
+}
+
+test("relocates a hydrated foreign-slug transcript and resumes without replay", async () => {
+  const dirs = await directories();
+  const layout = turnClaudeLayout(dirs.turnRoot, dirs.dataDir, "c1");
+  seedConversation(dirs.dataDir);
+  await mkdir(join(layout.configDir, "projects", "foreign-slug"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(layout.configDir, "projects", "foreign-slug", "session-old.jsonl"),
+    "{}\n",
+  );
+  await writeFile(layout.sessionsFile, JSON.stringify({ c1: "session-old" }));
+  let captured: { prompt: string; options: Options } | undefined;
+
+  await runTurn(
+    dirs,
+    {
+      conversationId: "c1",
+      text: "What did I ask you to remember?",
+      provider: "anthropic",
+      emit: () => undefined,
+      signal: undefined,
+      turnId: "current",
+    },
+    {
+      claudeSdk: sdk(
+        scriptedQuery((prompt, options) => {
+          captured = { prompt, options };
+        }),
+      ),
+    },
+  );
+
+  expect(captured?.options.resume).toBe("session-old");
+  expect(captured?.prompt).not.toContain(
+    "[Continuing an existing conversation.",
+  );
+  const slug = dirs.workspaceDir.replace(/[^A-Za-z0-9]/g, "-");
+  await expect(
+    stat(join(layout.configDir, "projects", slug, "session-old.jsonl")),
+  ).resolves.toBeDefined();
+});
+
+test("a missing transcript starts fresh with the canonical replay preamble", async () => {
+  const dirs = await directories();
+  const layout = turnClaudeLayout(dirs.turnRoot, dirs.dataDir, "c1");
+  seedConversation(dirs.dataDir);
+  await mkdir(layout.configDir, { recursive: true });
+  await writeFile(layout.sessionsFile, JSON.stringify({ c1: "missing" }));
+  let captured: { prompt: string; options: Options } | undefined;
+
+  await runTurn(
+    dirs,
+    {
+      conversationId: "c1",
+      text: "What did I ask you to remember?",
+      provider: "anthropic",
+      emit: () => undefined,
+      signal: undefined,
+      turnId: "current",
+    },
+    {
+      claudeSdk: sdk(
+        scriptedQuery((prompt, options) => {
+          captured = { prompt, options };
+        }),
+      ),
+    },
+  );
+
+  expect(captured?.options.resume).toBeUndefined();
+  expect(captured?.prompt).toContain("[Continuing an existing conversation.");
+  expect(captured?.prompt).toContain("User: Remember the blue lantern.");
+  expect(captured?.prompt).toContain("Assistant: I will remember it.");
+  expect(captured?.prompt).toContain("What did I ask you to remember?");
+});

--- a/packages/runtime/src/turn/turn-session.test.ts
+++ b/packages/runtime/src/turn/turn-session.test.ts
@@ -352,3 +352,21 @@ test("pi to anthropic to pi flips fresh with replay while unchanged pi resumes",
     "[Continuing an existing conversation.",
   );
 });
+
+test("a corrupt harness marker degrades to unknown instead of failing the turn", async () => {
+  const { readTurnHarness, turnHarnessFile, writeTurnHarness } = await import(
+    "./turn-harness-state"
+  );
+  const { mkdtempSync, mkdirSync, writeFileSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { dirname, join } = await import("node:path");
+  const dataDir = mkdtempSync(join(tmpdir(), "harness-marker-"));
+  const file = turnHarnessFile(dataDir, "c1");
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, "{not json");
+  expect(readTurnHarness(dataDir, "c1")).toBeUndefined();
+  writeFileSync(file, JSON.stringify({ backend: "spacex" }));
+  expect(readTurnHarness(dataDir, "c1")).toBeUndefined();
+  writeTurnHarness(dataDir, "c1", "claude");
+  expect(readTurnHarness(dataDir, "c1")).toBe("claude");
+});

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -24,6 +24,7 @@ import {
   runWithUsedTokenCapture,
 } from "../auth/used-token";
 import type { ClaudeBackendDeps } from "../backends/claude/backend";
+import type { HarnessBackend } from "../backends/types";
 import { config } from "../config";
 import { framePrompt, type MessageAuthor } from "../session/attribution";
 import {
@@ -54,8 +55,10 @@ import {
 import {
   createTurnBackend,
   resolveTurnClaudeResume,
+  type TurnBackendDeps,
   TurnBackendProviderError,
 } from "./turn-backend";
+import { readTurnHarness, writeTurnHarness } from "./turn-harness-state";
 import { createTurnModelRuntime } from "./turn-runtime";
 import { buildTurnToolSelection } from "./turn-toolset";
 import type { TurnGrantScope } from "./types";
@@ -137,10 +140,15 @@ export interface TurnDirectories {
   turnRoot: string;
 }
 
+export interface RunTurnDeps {
+  claudeSdk?: ClaudeBackendDeps["sdk"];
+  createBackend?: (provider: string, deps: TurnBackendDeps) => HarnessBackend;
+}
+
 export async function runTurn(
   directories: TurnDirectories,
   turn: TurnSessionRequest,
-  deps: { claudeSdk?: ClaudeBackendDeps["sdk"] } = {},
+  deps: RunTurnDeps = {},
 ): Promise<TurnOutcome> {
   const {
     conversationId,
@@ -251,7 +259,7 @@ export async function runTurn(
       pin?.effort ??
       (m.reasoning === true ? DEFAULT_REASONING_EFFORT : undefined);
     const thinkingLevel = toThinkingLevel(effort);
-    const backend = createTurnBackend(provider, {
+    const backend = (deps.createBackend ?? createTurnBackend)(provider, {
       directories,
       turn,
       modelRuntime,
@@ -261,14 +269,32 @@ export async function runTurn(
       sharedRoots: config.sharedSkillsDir ? [config.sharedSkillsDir] : [],
       claudeSdk: deps.claudeSdk,
     });
+    const harness = backend.id === "anthropic" ? "claude" : "pi";
+    const priorHarness = readTurnHarness(dataDir, conversationId);
+    const switchedHarness =
+      priorHarness !== undefined && priorHarness !== harness;
+    writeTurnHarness(dataDir, conversationId, harness);
+    const claudeResume =
+      harness === "claude" && !switchedHarness
+        ? resolveTurnClaudeResume(directories, conversationId)
+        : undefined;
     const replay =
-      provider === "anthropic" &&
-      resolveTurnClaudeResume(directories, conversationId) === undefined
+      canonicalMessages.length > 0 &&
+      (switchedHarness || (harness === "claude" && !claudeResume))
         ? renderReplayPreamble(
             canonicalMessages,
             turnId,
             replayCharBudget(model.contextWindow),
           )
+        : null;
+    const retryReplay =
+      harness === "claude" && canonicalMessages.length > 0
+        ? (replay ??
+          renderReplayPreamble(
+            canonicalMessages,
+            turnId,
+            replayCharBudget(model.contextWindow),
+          ))
         : null;
     const session = await backend.createSession({
       conversationId,
@@ -284,6 +310,10 @@ export async function runTurn(
       // only blocking tool present (integrations are off), so an auto turn here
       // simply drops it.
       ...(mode ? { mode } : {}),
+      ...(switchedHarness ? { fresh: true } : {}),
+      ...(retryReplay?.text
+        ? { freshRetryPromptPrefix: retryReplay.text }
+        : {}),
     });
 
     // Snapshot the hydrated workspace so the turn's created/modified files can

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -23,7 +23,7 @@ import {
   newUsedTokenCapture,
   runWithUsedTokenCapture,
 } from "../auth/used-token";
-import { createPiBackend } from "../backends/pi/backend";
+import type { ClaudeBackendDeps } from "../backends/claude/backend";
 import { config } from "../config";
 import { framePrompt, type MessageAuthor } from "../session/attribution";
 import {
@@ -36,12 +36,13 @@ import {
   planReadyFallback,
   runWithInteractionCapture,
 } from "../session/interaction";
+import {
+  renderReplayPreamble,
+  replayCharBudget,
+} from "../session/replay-transcript";
+import { SYSTEM_PROMPT } from "../session/resource-loader";
 import { turnCodeExecutionMode } from "../session/tool-selection";
-import { makeAskUserTool } from "../session/tools/ask-user";
-import { makeClampedFileTools } from "../session/tools/clamped-fs";
 import { makeIdTokenProvider } from "../session/tools/gcp-id-token";
-import { makePlanReadyTool } from "../session/tools/plan-ready";
-import { makePoolBashTool } from "../session/tools/pool-bash";
 import { makeRunCodeTool } from "../session/tools/run-code";
 import type { SandboxFetch } from "../session/tools/sandbox-fetch";
 import type { ProvidedContext } from "../session/workspace-context";
@@ -50,8 +51,13 @@ import {
   appendUserMessageAt,
   loadConversation,
 } from "../store/conversation-file";
+import {
+  createTurnBackend,
+  resolveTurnClaudeResume,
+  TurnBackendProviderError,
+} from "./turn-backend";
 import { createTurnModelRuntime } from "./turn-runtime";
-import { buildTurnHostTools, buildTurnToolSelection } from "./turn-toolset";
+import { buildTurnToolSelection } from "./turn-toolset";
 import type { TurnGrantScope } from "./types";
 
 /**
@@ -82,7 +88,7 @@ export interface TurnModelPin {
 }
 
 /** Everything one pi turn needs (the per-turn server assembles it per request). */
-export interface PiTurnRequest {
+export interface TurnSessionRequest {
   conversationId: string;
   text: string;
   provider: string;
@@ -125,14 +131,16 @@ export interface PiTurnRequest {
   sandbox?: { call: SandboxFetch };
 }
 
-export interface PiTurnDirectories {
+export interface TurnDirectories {
   workspaceDir: string;
   dataDir: string;
+  turnRoot: string;
 }
 
-export async function runPiTurn(
-  directories: PiTurnDirectories,
-  turn: PiTurnRequest,
+export async function runTurn(
+  directories: TurnDirectories,
+  turn: TurnSessionRequest,
+  deps: { claudeSdk?: ClaudeBackendDeps["sdk"] } = {},
 ): Promise<TurnOutcome> {
   const {
     conversationId,
@@ -151,8 +159,10 @@ export async function runPiTurn(
   const { workspaceDir, dataDir } = directories;
   const conversationsDir = join(dataDir, "conversations");
 
+  const canonicalMessages =
+    loadConversation(conversationsDir, conversationId)?.messages ?? [];
   const priorAuthors = author
-    ? (loadConversation(conversationsDir, conversationId)?.messages ?? [])
+    ? canonicalMessages
         .filter((message) => message.role === "user")
         .map((message) => message.author)
     : [];
@@ -241,39 +251,25 @@ export async function runPiTurn(
       pin?.effort ??
       (m.reasoning === true ? DEFAULT_REASONING_EFFORT : undefined);
     const thinkingLevel = toThinkingLevel(effort);
-    // Per-request pi backend rooted at the throwaway dirs. Same factory the
-    // long-lived server uses (backends/pi) — here nothing survives the request:
-    // auth, registry, tools, and session are all per-turn. Bash reaches a turn
-    // only on a single-use worker (turnCodeExecutionMode); a shared multi-turn
-    // worker never sees it.
-    const backend = createPiBackend({
-      workspaceDir,
-      dataDir,
+    const backend = createTurnBackend(provider, {
+      directories,
+      turn,
       modelRuntime,
-      tools: toolSelection.toolNames,
-      customTools: [
-        ...makeClampedFileTools(workspaceDir, {
-          sharedRoots: config.sharedSkillsDir ? [config.sharedSkillsDir] : [],
-        }),
-        // ask_user is available in every mode (holds no credential); its name is
-        // already in toolSelection.toolNames.
-        makeAskUserTool(),
-        // plan_ready is registered always but name-gated to Plan mode by
-        // toolNamesForMode (harmless in execute/auto — pi exposes it only when
-        // its name is in the mode's allowlist).
-        makePlanReadyTool(),
-        ...(codeSandbox ? [codeSandbox] : []),
-        ...buildTurnHostTools(turn),
-        // When local bash is enabled (single-use pool worker), shadow pi's
-        // built-in bash with one whose child env is scrubbed to a non-secret
-        // allowlist — pi's default copies process.env, which here carries the
-        // pool worker token and store secrets. Same shadow-by-name mechanism
-        // as the clamped file tools.
-        ...(toolSelection.toolNames.includes("bash")
-          ? [makePoolBashTool(workspaceDir)]
-          : []),
-      ],
+      toolSelection,
+      codeSandbox,
+      systemPrompt: config.systemPrompt || SYSTEM_PROMPT,
+      sharedRoots: config.sharedSkillsDir ? [config.sharedSkillsDir] : [],
+      claudeSdk: deps.claudeSdk,
     });
+    const replay =
+      provider === "anthropic" &&
+      resolveTurnClaudeResume(directories, conversationId) === undefined
+        ? renderReplayPreamble(
+            canonicalMessages,
+            turnId,
+            replayCharBudget(model.contextWindow),
+          )
+        : null;
     const session = await backend.createSession({
       conversationId,
       model,
@@ -310,7 +306,9 @@ export async function runPiTurn(
       else if (wire.type === "tool_end") {
         const t = tools[tools.length - 1];
         if (t) t.isError = wire.data.isError;
-      } else if (wire.type === "provider_error") providerError = wire.data;
+      } else if (wire.type === "provider_error") {
+        providerError = wire.data;
+      }
       emit(wire);
     });
     const onAbort = () => void session.abort();
@@ -324,7 +322,9 @@ export async function runPiTurn(
       // (pi/wire.ts) reads THIS turn's seeded token when it reports.
       await runWithInteractionCapture(interaction, () =>
         runWithUsedTokenCapture(usedTokens, () =>
-          session.prompt(framePrompt(text, author, priorAuthors)),
+          session.prompt(
+            (replay?.text ?? "") + framePrompt(text, author, priorAuthors),
+          ),
         ),
       );
     } finally {
@@ -417,11 +417,14 @@ export async function runPiTurn(
     // survives a reload; returning `{}` keeps the per-turn server from
     // stacking a second, generic error frame on top of it.
     if (!providerError) {
-      const thrown = classifyProviderError({
-        provider,
-        model: pin?.model ?? null,
-        message,
-      });
+      const thrown =
+        err instanceof TurnBackendProviderError
+          ? err.providerError
+          : classifyProviderError({
+              provider,
+              model: pin?.model ?? null,
+              message,
+            });
       // The streamed path logged when it classified; a THROWN failure is
       // invisible to Sentry unless this catch logs it too (HOU-1156;
       // mirrors exec-turn).
@@ -472,3 +475,9 @@ export async function runPiTurn(
     return { error: message };
   }
 }
+
+/** Injectable pooled-turn execution contract used by the HTTP server. */
+export type TurnRunner = (
+  directories: TurnDirectories,
+  turn: TurnSessionRequest,
+) => Promise<TurnOutcome>;

--- a/packages/runtime/src/turn/turn-setup-errors.test.ts
+++ b/packages/runtime/src/turn/turn-setup-errors.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { LocalDirStore } from "@houston/runtime-client/object-sync";
 import { afterEach, expect, test, vi } from "vitest";
 import { createTurnServer } from "./server";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 const servers: Server[] = [];
 afterEach(() => {
@@ -19,7 +19,7 @@ async function run(files: Record<string, string>, maxHydrateBytes?: number) {
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, value);
   }
-  const runTurn = vi.fn<typeof runPiTurn>();
+  const runTurn = vi.fn<TurnRunner>();
   const server = createTurnServer({
     store: new LocalDirStore(storeRoot),
     token: "",

--- a/packages/runtime/src/turn/turn-toolset.test.ts
+++ b/packages/runtime/src/turn/turn-toolset.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "vitest";
 import { toolNamesForMode } from "../session/tool-selection";
-import type { PiTurnRequest } from "./turn-session";
+import type { TurnSessionRequest } from "./turn-session";
 import { buildTurnHostTools, buildTurnToolSelection } from "./turn-toolset";
 
-const base = (scopes?: PiTurnRequest["grant"]): PiTurnRequest => ({
+const base = (scopes?: TurnSessionRequest["grant"]): TurnSessionRequest => ({
   conversationId: "c1",
   text: "hello",
   provider: "openai",

--- a/packages/runtime/src/turn/turn-toolset.ts
+++ b/packages/runtime/src/turn/turn-toolset.ts
@@ -9,9 +9,9 @@ import { makeSkillDirectoryTools } from "../session/tools/find-skills";
 import { makeIntegrationTools } from "../session/tools/integrations";
 import { makeSaveLearningTool } from "../session/tools/save-learning";
 import { makeSaveRoutineTool } from "../session/tools/save-routine";
-import type { PiTurnRequest } from "./turn-session";
+import type { TurnSessionRequest } from "./turn-session";
 
-function capabilities(turn: PiTurnRequest) {
+function capabilities(turn: TurnSessionRequest) {
   const scopes = new Set(turn.grant?.scopes ?? []);
   const callable = turn.sandbox !== undefined;
   return {
@@ -22,7 +22,7 @@ function capabilities(turn: PiTurnRequest) {
 
 /** Build the turn's name allowlist from non-secret grant scopes. */
 export function buildTurnToolSelection(
-  turn: PiTurnRequest,
+  turn: TurnSessionRequest,
   codeExecution: CodeExecutionMode,
 ): ToolSelection {
   const enabled = capabilities(turn);
@@ -38,7 +38,7 @@ export function buildTurnToolSelection(
 
 /** Register only the host-proxying tool objects admitted by grant scopes. */
 export function buildTurnHostTools(
-  turn: PiTurnRequest,
+  turn: TurnSessionRequest,
 ): PiBackendDeps["customTools"] {
   if (!turn.sandbox) return [];
   const enabled = capabilities(turn);

--- a/packages/runtime/src/turn/turn-transcript.test.ts
+++ b/packages/runtime/src/turn/turn-transcript.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../store/conversation-file";
 import { createTurnServer } from "./server";
 import type { TurnServerDeps } from "./server-types";
-import type { runPiTurn } from "./turn-session";
+import type { TurnRunner } from "./turn-session";
 
 const servers: Server[] = [];
 
@@ -193,7 +193,7 @@ test("claimed turn publishes its persisted user and assistant before done", asyn
   const requests: TranscriptRequest[] = [];
   let userMessage: ChatMessage | undefined;
   let assistantMessage: ChatMessage | undefined;
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     const conversationsDir = join(filesystem.dataDir, "conversations");
     userMessage = appendUserMessageAt(
       conversationsDir,
@@ -248,7 +248,7 @@ test("claimed turn publishes its persisted user and assistant before done", asyn
 test("a transcript 404 disables publication for the turn without failing it", async () => {
   const objects = seedStandingLayout();
   const requests: TranscriptRequest[] = [];
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     const conversationsDir = join(filesystem.dataDir, "conversations");
     appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
       turnId: turn.turnId,
@@ -279,7 +279,7 @@ test("a transcript 404 disables publication for the turn without failing it", as
 test("a transcript 409 fences the claimed turn", async () => {
   const objects = seedStandingLayout();
   const requests: TranscriptRequest[] = [];
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     const conversationsDir = join(filesystem.dataDir, "conversations");
     appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
       turnId: turn.turnId,
@@ -306,7 +306,7 @@ test("a transcript 409 fences the claimed turn", async () => {
 test("a transcript 503 becomes part of the terminal error", async () => {
   const objects = seedStandingLayout();
   const requests: TranscriptRequest[] = [];
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     const conversationsDir = join(filesystem.dataDir, "conversations");
     appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
       turnId: turn.turnId,
@@ -344,7 +344,7 @@ test("a transcript network failure becomes part of the terminal error", async ()
     }
     return backingFetch(input, init);
   };
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     appendUserMessageAt(
       join(filesystem.dataDir, "conversations"),
       turn.conversationId,
@@ -368,7 +368,7 @@ test("a transcript network failure becomes part of the terminal error", async ()
 test("a turn without an assistant message publishes only its user row", async () => {
   const objects = seedStandingLayout();
   const requests: TranscriptRequest[] = [];
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     appendUserMessageAt(
       join(filesystem.dataDir, "conversations"),
       turn.conversationId,
@@ -428,7 +428,7 @@ test("a shadow turn makes no transcript requests", async () => {
 test("an assistant 404 after a landed user row is a failure, not deploy skew", async () => {
   const objects = seedStandingLayout();
   const requests: TranscriptRequest[] = [];
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     const conversationsDir = join(filesystem.dataDir, "conversations");
     appendUserMessageAt(conversationsDir, turn.conversationId, turn.text, {
       turnId: turn.turnId,
@@ -457,7 +457,7 @@ test("an assistant 404 after a landed user row is a failure, not deploy skew", a
 test("a corrupt conversation file still ends in a terminal error frame", async () => {
   const objects = seedStandingLayout();
   const requests: TranscriptRequest[] = [];
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     // The turn "ran" but left the conversation file unparseable.
     writeFileSync(
       join(filesystem.dataDir, "conversations", `${turn.conversationId}.json`),
@@ -483,7 +483,7 @@ test("the user row lands on the user frame, before the turn finishes", async () 
   const objects = seedStandingLayout();
   const requests: TranscriptRequest[] = [];
   let requestsWhenTurnEnded = -1;
-  const runTurn: typeof runPiTurn = async (filesystem, turn) => {
+  const runTurn: TurnRunner = async (filesystem, turn) => {
     const conversationsDir = join(filesystem.dataDir, "conversations");
     const { message } = appendUserMessageAt(
       conversationsDir,


### PR DESCRIPTION
Pooled single-use turns previously ran every provider through the in-process pi backend. For Anthropic subscription traffic that violates the requirement that Claude traffic go through the Claude Agent SDK — the same rule standing pods already follow. This PR makes pooled turns whose provider resolves to `anthropic` run the Claude SDK (the real `claude` subprocess) inside the single-use worker. Engine-only: no gateway, image, or envelope changes — the engine-pod image already ships the SDK binary for exactly this.

## How

- Per-turn backend selection: `anthropic` → Claude SDK backend, everything else → pi, from one factory; API-key and OAuth anthropic credentials both take the SDK path (same rule as server mode). A compliance test pins that pi is never constructed and `api.anthropic.com` is never dialed directly for an anthropic pooled turn, for both credential kinds.
- Auth: the envelope's access-only token is read from the hydrated `auth.json` per prompt and reaches only the `claude` child env (never worker `process.env`, never sync-back — both test-pinned). The child env is built from an allowlist, so pool secrets can't reach a model-directed subprocess.
- Continuity: the SDK's config dir lives inside the conversation's session directory, so transcripts hydrate and sync with the existing conversation scope and resume works across workers; a foreign-cwd transcript is relocated, and a conversation with no native history (e.g. it last ran on a standing pod) starts fresh with a canonical-transcript replay preamble. A per-conversation harness marker detects backend flips (model switching) and forces fresh + replay in both directions so no turn runs with amnesia; a corrupt marker degrades to unknown, never fails the turn.
- Tools: the same grant-scoped tool surface as the pi branch, bridged over the backend's MCP server (SDK built-ins replace the clamped file tools and pool bash); mode clamping shared.
- Lifecycle: claim-fence/abort kills the subprocess; the ~230MB binary is pre-paged at single-use worker boot (off the request path) so first-turn TTFT doesn't eat the cold page-in; a boot probe reports a missing binary loudly and a CI guard asserts the image ships it for the target arch.
- Worker ops fail closed: an op that resolves provider `anthropic` declines to the standing pod instead of ever building a pi call (defense in depth alongside the gateway's routing).

## Tests

Backend-selection matrix, compliance suite (both credential kinds), continuity + relocation + replay, backend-flip both directions, dangling-resume fresh-retry with replay, newest-transcript selection, boot-warm profiles, op fail-closed, corrupt-marker degradation, secret-leak pins. Full runtime (1503) / host / domain / runtime-client suites green; Biome + boundaries clean.