### PR TITLE
fix(host): community skills search/popular honor injected fetch and time out wedged upstreams

### DIFF
--- a/packages/host/src/routes/skills-directory.ts
+++ b/packages/host/src/routes/skills-directory.ts
@@ -59,6 +59,7 @@ export function failSkill(res: ServerResponse, err: unknown): void {
 export async function communitySearchAction(
   req: IncomingMessage,
   res: ServerResponse,
+  fetchImpl?: typeof fetch,
 ): Promise<void> {
   const body = await readJson(req);
   if (typeof body.query !== "string") {
@@ -66,7 +67,7 @@ export async function communitySearchAction(
     return;
   }
   try {
-    json(res, 200, await directory.search(body.query));
+    json(res, 200, await directory.search(body.query, { fetchImpl }));
   } catch (err) {
     failSkill(res, err);
   }
@@ -74,9 +75,10 @@ export async function communitySearchAction(
 
 export async function communityPopularAction(
   res: ServerResponse,
+  fetchImpl?: typeof fetch,
 ): Promise<void> {
   try {
-    json(res, 200, await directory.popular());
+    json(res, 200, await directory.popular({ fetchImpl }));
   } catch (err) {
     failSkill(res, err);
   }
@@ -139,8 +141,10 @@ export async function handleSkillsDirectory(
     return true;
   }
   const route = m[1];
-  if (route === "community/search") await communitySearchAction(req, res);
-  else if (route === "community/popular") await communityPopularAction(res);
+  if (route === "community/search")
+    await communitySearchAction(req, res, deps.fetchImpl);
+  else if (route === "community/popular")
+    await communityPopularAction(res, deps.fetchImpl);
   else if (route === "community/preview")
     await communityPreviewAction(req, res, deps.fetchImpl ?? fetch);
   else await repoListAction(req, res, deps.fetchImpl ?? fetch);

--- a/packages/host/src/routes/skills-remote.ts
+++ b/packages/host/src/routes/skills-remote.ts
@@ -50,11 +50,11 @@ export async function handleSkillsRemote(
   const fetchImpl = deps.fetchImpl ?? fetch;
 
   if (family === "community" && action === "search") {
-    await communitySearchAction(req, res);
+    await communitySearchAction(req, res, fetchImpl);
     return true;
   }
   if (family === "community" && action === "popular") {
-    await communityPopularAction(res);
+    await communityPopularAction(res, fetchImpl);
     return true;
   }
   if (family === "community" && action === "preview") {

--- a/packages/host/src/skills/community.ts
+++ b/packages/host/src/skills/community.ts
@@ -14,6 +14,9 @@ const SEARCH_RETRY_DELAY_MS = 3_000;
 const SEARCH_FRESH_TTL_MS = 10 * 60_000;
 const SEARCH_STALE_TTL_MS = 24 * 60 * 60_000;
 const SEARCH_MIN_INTERVAL_MS = 750;
+/** Upper bound on one skills.sh round-trip. A wedged upstream must surface as
+ *  the typed offline error, never hang the host route (or a test) open. */
+const SEARCH_REQUEST_TIMEOUT_MS = 10_000;
 
 /**
  * Seed query for the "popular" feed. skills.sh has no dedicated popular
@@ -37,6 +40,7 @@ export interface CommunityDirectoryOptions {
   sleep?: (ms: number) => Promise<void>;
   retryDelayMs?: number;
   minIntervalMs?: number;
+  requestTimeoutMs?: number;
   freshTtlMs?: number;
   staleTtlMs?: number;
   popularFreshTtlMs?: number;
@@ -58,6 +62,7 @@ export class CommunityDirectory {
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly retryDelayMs: number;
   private readonly minIntervalMs: number;
+  private readonly requestTimeoutMs: number;
   private readonly freshTtlMs: number;
   private readonly staleTtlMs: number;
   private readonly popularFreshTtlMs: number;
@@ -74,6 +79,7 @@ export class CommunityDirectory {
     this.sleep = opts.sleep ?? realSleep;
     this.retryDelayMs = opts.retryDelayMs ?? SEARCH_RETRY_DELAY_MS;
     this.minIntervalMs = opts.minIntervalMs ?? SEARCH_MIN_INTERVAL_MS;
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? SEARCH_REQUEST_TIMEOUT_MS;
     this.freshTtlMs = opts.freshTtlMs ?? SEARCH_FRESH_TTL_MS;
     this.staleTtlMs = opts.staleTtlMs ?? SEARCH_STALE_TTL_MS;
     this.popularFreshTtlMs = opts.popularFreshTtlMs ?? POPULAR_FRESH_TTL_MS;
@@ -110,14 +116,15 @@ export class CommunityDirectory {
     }
   }
 
-  async popular(): Promise<CommunitySkill[]> {
+  /** Popular feed with shared cache/spacing and optional request-scoped I/O. */
+  async popular(opts: CommunitySearchOptions = {}): Promise<CommunitySkill[]> {
     const fresh = this.popularEntry;
     if (fresh && this.now() - fresh.fetchedAt <= this.popularFreshTtlMs)
       return fresh.skills.slice(0, POPULAR_LIMIT);
 
     await this.waitForRequestSlot();
     try {
-      const skills = await this.fetchSearch(POPULAR_SEED);
+      const skills = await this.fetchSearch(POPULAR_SEED, opts.fetchImpl);
       this.popularEntry = { skills, fetchedAt: this.now() };
       return skills.slice(0, POPULAR_LIMIT);
     } catch (err) {
@@ -150,7 +157,10 @@ export class CommunityDirectory {
       try {
         res = await (fetchOverride ?? this.fetchImpl)(
           `${this.endpoint}?q=${encodeURIComponent(query)}`,
-          { headers: { "User-Agent": "houston-skills/1.0" } },
+          {
+            headers: { "User-Agent": "houston-skills/1.0" },
+            signal: AbortSignal.timeout(this.requestTimeoutMs),
+          },
         );
       } catch (err) {
         throw new SkillRemoteError(

--- a/packages/host/src/skills/remote.test.ts
+++ b/packages/host/src/skills/remote.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { MemoryVfs } from "../vfs";
 import { CommunityDirectory } from "./community";
 import { fetchSkillMdAtPath, listSkillsFromRepo } from "./github";
@@ -397,4 +397,39 @@ test("installCommunitySkill surfaces skill_not_in_repo when nothing matches", as
     "ghost",
   ).catch((e) => e);
   expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+});
+
+test("a wedged skills.sh surfaces the typed offline error instead of hanging", async () => {
+  const hanging: typeof fetch = (_input, init) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(init.signal?.reason ?? new Error("aborted")),
+      );
+    });
+  const dir = new CommunityDirectory({
+    fetchImpl: hanging,
+    requestTimeoutMs: 20,
+    minIntervalMs: 0,
+  });
+  const err = await dir.search("research").catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("offline");
+});
+
+test("popular threads a request-scoped fetch and never touches global fetch", async () => {
+  const seen: string[] = [];
+  const injected: typeof fetch = async (input) => {
+    seen.push(String(input));
+    return new Response(JSON.stringify({ skills: [] }));
+  };
+  const globalSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockRejectedValue(new Error("global fetch must not be used"));
+  try {
+    const dir = new CommunityDirectory({ minIntervalMs: 0 });
+    await dir.popular({ fetchImpl: injected });
+    expect(seen.length).toBe(1);
+    expect(globalSpy).not.toHaveBeenCalled();
+  } finally {
+    globalSpy.mockRestore();
+  }
 });


### PR DESCRIPTION
Main CI flaked on `skills-remote.test.ts` with a 30s timeout. The test injects a mocked `fetchImpl`, but `communitySearchAction` and `communityPopularAction` never threaded it — the community search and popular routes always used global `fetch`, so the 'unit' test was silently doing live skills.sh calls, and a hung upstream blew the test timeout. The same flaw hangs the real host route indefinitely when skills.sh wedges, since the request had no timeout.

- `communitySearchAction` / `communityPopularAction` now accept and thread `fetchImpl`; both call sites (agent-scoped skills-remote and user-scoped skills-directory) pass theirs through. `CommunityDirectory.popular` takes the same request-scoped options as `search`.
- One skills.sh round-trip is now bounded by a 10s abort signal; a wedged upstream surfaces as the existing typed `offline` error (stale-cache fallback unchanged).
- Regression tests: a hanging upstream errors typed instead of hanging; `popular` with an injected fetch never touches global fetch.

Host suite green (1614).