### PR TITLE
fix(engine): keep pi external to the bundle — its runtime-computed provider imports break inlined

### DIFF
--- a/selfhost/bundle.mjs
+++ b/selfhost/bundle.mjs
@@ -14,9 +14,15 @@ import { build } from "esbuild";
 //    photon_rs_bg.wasm with __dirname — bundled, that resolves nowhere and
 //    every image an agent reads silently degrades to "[Image omitted…]".
 //    Lazily imported; resolves from the image's node_modules.
+//  - @earendil-works/pi-coding-agent: its provider registry lazy-loads
+//    per-provider auth/stream chunks with a RUNTIME-COMPUTED relative
+//    import specifier esbuild cannot rewrite. Inlined, that import resolves
+//    beside the bundle ("/app/dist/runtime/openai-codex.js") and every pi
+//    OAuth derivation for a chunked provider dies at turn time. External,
+//    pi resolves its own chunks from its package directory as designed.
 //  - *.node native addons load via the filesystem by design.
 const externalImport =
-  /^@anthropic-ai\/claude-agent-sdk(?:\/|$)|^@silvia-odwyer\/photon-node(?:\/|$)|\.node$/;
+  /^@anthropic-ai\/claude-agent-sdk(?:\/|$)|^@silvia-odwyer\/photon-node(?:\/|$)|^@earendil-works\/pi-coding-agent(?:\/|$)|\.node$/;
 
 const externalNodeModules = {
   name: "external-unbundleables",
@@ -67,9 +73,13 @@ await Promise.all([
 {
   const { readFileSync } = await import("node:fs");
   const emitted = readFileSync("dist/runtime/main.mjs", "utf8");
+  // photon-node is no longer asserted here: it is imported only from within
+  // pi, which is itself external — its specifier lives in pi's package files,
+  // not this bundle. The resolve filter above still forces it external if any
+  // bundled module ever imports it directly.
   for (const specifier of [
     "@anthropic-ai/claude-agent-sdk",
-    "@silvia-odwyer/photon-node",
+    "@earendil-works/pi-coding-agent",
   ]) {
     if (!emitted.includes(`"${specifier}"`)) {
       throw new Error(


### PR DESCRIPTION
The self-contained engine bundle broke pi's per-provider OAuth path: pi's provider registry lazy-loads per-provider chunks via a runtime-computed relative `import()` that esbuild cannot rewrite. Inlined into the bundle, that import resolves beside `main.mjs` (`/app/dist/runtime/openai-codex.js` — nonexistent), so any pi OAuth derivation for a chunk-loaded provider fails at turn time: `Houston could not classify this OpenAI error … Cannot find module '/app/dist/runtime/openai-codex.js'`. Live on staging for every openai-codex turn since the bundle image rolled; invisible to boot probes and to the original metafile audit because the specifier is computed at runtime.

Fix: `@earendil-works/pi-coding-agent` joins the deliberate externals (same treatment as the Claude SDK) and the build self-check asserts it stays external. photon-node is dropped from the self-check because it is imported only from within pi (now itself external); the resolve filter still forces it external if bundled code ever imports it directly.

Verified: bundle builds clean; with the image-style `node_modules` symlink beside the bundle, pi resolves and `main.mjs` boots past all imports into config validation. Boot-cost impact is a handful of module resolutions for one prebundled package — the self-contained win for the rest of the graph is unchanged.