### PR TITLE
feat(runtime): turn terminal frame reports per-phase timings

### DIFF
--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -242,6 +242,7 @@ export async function executeTurn(
                     emit,
                     abort.signal,
                     turnSandbox ? { call: turnSandbox.call } : undefined,
+                    timings,
                   ),
                 ),
             ),
@@ -277,6 +278,7 @@ export async function executeTurn(
         }
       }
 
+      timings.t_run_done = performance.now();
       const durable = await finishTurnDurability({
         deps,
         turn: { ...turn, turnId },
@@ -288,6 +290,7 @@ export async function executeTurn(
         ...(turnSandbox ? { views: turnSandbox.views() } : {}),
       });
       outcome = durable.outcome;
+      timings.t_durable = performance.now();
       emit(
         turnTerminalFrame(
           outcome,
@@ -296,6 +299,7 @@ export async function executeTurn(
           durable.transcriptSkipped,
           durable.activityDocSkipped,
           durable.changed,
+          timings,
         ),
       );
       await turnLog?.flush();

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -189,12 +189,14 @@ test("an unclaimed turn retains full sync-back", async () => {
   // Unclaimed turns sync the whole prefix and now classify every landed key
   // through the canonical rule: the workspace file fires FilesChanged and the
   // session write fires ConversationsChanged (deduped, sorted).
-  expect(emitted.at(-1)).toEqual(
-    expect.objectContaining({
-      type: "done",
-      data: { changed: ["ConversationsChanged", "FilesChanged"] },
-    }),
-  );
+  const done = emitted.at(-1) as {
+    type: string;
+    data: Record<string, unknown>;
+  };
+  expect(done.type).toBe("done");
+  expect(done.data.changed).toEqual(["ConversationsChanged", "FilesChanged"]);
+  // Every real turn now reports its phase marks as whole-ms deltas.
+  expect(done.data.timingsMs).toMatchObject({ tmpdir: expect.any(Number) });
 });
 
 test("shadow resolves a standing layout and reports hydrated objects", async () => {

--- a/packages/runtime/src/turn/turn-request.ts
+++ b/packages/runtime/src/turn/turn-request.ts
@@ -10,6 +10,7 @@ export function turnSessionRequest(
   emit: (frame: WireFrame) => void,
   signal: AbortSignal,
   sandbox?: { call: SandboxFetch },
+  timings?: Record<string, number>,
 ): TurnSessionRequest {
   return {
     conversationId: turn.conversationId,
@@ -31,6 +32,7 @@ export function turnSessionRequest(
     author: turn.actingAs,
     ...(turn.grant ? { grant: { scopes: turn.grant.scopes } } : {}),
     ...(sandbox ? { sandbox } : {}),
+    ...(timings ? { timings } : {}),
     // Either context field present means "use these" (each defaults to ""),
     // mirroring the long-lived server's message-send contract.
     ...(turn.workspaceContext !== undefined || turn.userContext !== undefined

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -132,6 +132,9 @@ export interface TurnSessionRequest {
   grant?: { scopes: TurnGrantScope[] };
   /** Turn-local routing closure; it owns all grant-bearing calls. */
   sandbox?: { call: SandboxFetch };
+  /** Shared phase-mark sink; the terminal frame reports it (values are
+   *  performance.now() marks, converted to deltas at emission). */
+  timings?: Record<string, number>;
 }
 
 export interface TurnDirectories {
@@ -315,6 +318,7 @@ export async function runTurn(
         ? { freshRetryPromptPrefix: retryReplay.text }
         : {}),
     });
+    if (turn.timings) turn.timings.t_backend_session = performance.now();
 
     // Snapshot the hydrated workspace so the turn's created/modified files can
     // be surfaced as a `file_changes` frame. The per-turn root is exclusive to
@@ -330,6 +334,10 @@ export async function runTurn(
     }
 
     const unsub = session.subscribe((wire: WireEvent) => {
+      // First provider-originated event = the honest first-token bound. Set
+      // once; the terminal frame reports it as a delta.
+      if (turn.timings && turn.timings.t_first_model_event === undefined)
+        turn.timings.t_first_model_event = performance.now();
       if (wire.type === "text") assistantText += wire.data;
       else if (wire.type === "usage") usage = wire.data;
       else if (wire.type === "tool_start") tools.push({ name: wire.data.name });

--- a/packages/runtime/src/turn/turn-terminal.test.ts
+++ b/packages/runtime/src/turn/turn-terminal.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import { turnTerminalFrame } from "./turn-terminal";
 
 describe("turnTerminalFrame", () => {
@@ -40,4 +40,24 @@ describe("turnTerminalFrame", () => {
       turnId: "t1",
     });
   });
+});
+
+test("the done frame reports phase marks as whole-ms deltas from the earliest", () => {
+  const frame = turnTerminalFrame({}, "t1", 0, undefined, undefined, [], {
+    t_accept: 1000,
+    t_tmpdir: 1010.4,
+    t_first_model_event: 2500.9,
+  }) as unknown as { data: { timingsMs: Record<string, number> } };
+  expect(frame.data.timingsMs).toEqual({
+    accept: 0,
+    tmpdir: 10,
+    first_model_event: 1501,
+  });
+});
+
+test("no marks means no timings field on the done frame", () => {
+  const frame = turnTerminalFrame({}, "t1", 0) as unknown as {
+    data: unknown;
+  };
+  expect(frame.data).toBeNull();
 });

--- a/packages/runtime/src/turn/turn-terminal.ts
+++ b/packages/runtime/src/turn/turn-terminal.ts
@@ -9,6 +9,18 @@ import type { TurnOutcome } from "./turn-session";
  * rides the error frame too: a provider failure after a durable tool write
  * still changed what other tabs show.
  */
+/** performance.now() marks → whole-ms deltas from the earliest mark. */
+function timingDeltas(
+  marks: Record<string, number> | undefined,
+): Record<string, number> | undefined {
+  const entries = Object.entries(marks ?? {});
+  if (entries.length === 0) return undefined;
+  const base = Math.min(...entries.map(([, v]) => v));
+  return Object.fromEntries(
+    entries.map(([k, v]) => [k.replace(/^t_/, ""), Math.round(v - base)]),
+  );
+}
+
 export function turnTerminalFrame(
   outcome: TurnOutcome,
   turnId: string,
@@ -16,8 +28,11 @@ export function turnTerminalFrame(
   transcriptSkipped?: "route_absent",
   activityDocSkipped?: "route_absent",
   changed: readonly string[] = [],
+  timings?: Record<string, number>,
 ): WireFrame {
+  const timingsMs = timingDeltas(timings);
   const fields = {
+    ...(timingsMs ? { timingsMs } : {}),
     ...(changed.length > 0 ? { changed } : {}),
     ...(poolWritesOutOfScope > 0 ? { poolWritesOutOfScope } : {}),
     ...(transcriptSkipped ? { transcriptSkipped } : {}),


### PR DESCRIPTION
Every pooled turn already records phase marks (tmpdir, hydration, credential write, SSE open, model-runtime build/resolve) but only shadow turns emitted them — real-turn latency questions (how much is hydration vs backend spawn vs provider first token?) had to be answered by correlating gateway request timestamps, with second-level resolution and guesswork.

Now every turn's terminal `done`/`error` frame carries `timingsMs`: the existing marks plus three new ones — `backend_session` (harness session ready: pi construction or Claude SDK spawn+handshake), `first_model_event` (first provider-originated event, the honest first-token bound), `run_done` and `durable` (generation end, sync-back end) — as whole-ms deltas from the earliest mark. Same additive internal-diagnostic channel the frame already uses for `changed`/`poolWritesOutOfScope`; ordinary frames with no marks are byte-identical (`data: null`).

The frame rides the turnlog, so per-phase latency for any past turn is queryable after the single-use worker is gone — which is also the only place it CAN live: spent workers are deleted seconds after their turn, taking stdout with them.

Tests: delta conversion (rounding, prefix strip, empty → absent), done-frame shape regression updated, full runtime/host/domain/runtime-client suites green.