### PR TITLE
fix(host): accept agent-emitted absolute paths on chat file downloads (PRODUCT-1575)

### DIFF
--- a/packages/host/src/turn/files-ops.ts
+++ b/packages/host/src/turn/files-ops.ts
@@ -1,5 +1,11 @@
-import { posix } from "node:path";
 import type { Vfs } from "../vfs";
+import {
+  extOf,
+  FilePathError,
+  fileKey,
+  safeRel,
+  workspaceRel,
+} from "./files-path";
 
 /**
  * Pure workspace file operations behind the Files tab — shared by the HTTP
@@ -7,6 +13,9 @@ import type { Vfs } from "../vfs";
  * (`files-archive.ts`). Layout-blind: `root` is the agent's workspace root in
  * the vfs (cloud `<prefix>/workspace`, local `<Workspace>/<Agent>`).
  */
+
+// Path validation is part of this module's public surface (handler, tests).
+export * from "./files-path";
 
 export const FOLDER_KEEP = ".keep"; // marker that lets an empty folder show up in a listing
 
@@ -20,51 +29,6 @@ export interface ProjectFile {
   date_modified?: number;
   date_created?: number;
 }
-
-export class FilePathError extends Error {
-  constructor(rel: string) {
-    super(`invalid workspace path: ${rel}`);
-    this.name = "FilePathError";
-  }
-}
-
-/** A file operation that failed with a specific HTTP status (409 conflict, 413 too large, …). */
-export class FileOpError extends Error {
-  constructor(
-    readonly status: number,
-    message: string,
-  ) {
-    super(message);
-    this.name = "FileOpError";
-  }
-}
-
-/** Normalize a UI-supplied relative path; require it to stay inside the workspace and clear of internal dot-dirs. */
-export function safeRel(rel: string): string {
-  const cleaned = rel.replace(/\\/g, "/");
-  // Absolute (POSIX or Windows-drive) paths are anomalous — reject, don't silently clamp.
-  if (cleaned.startsWith("/") || /^[A-Za-z]:/.test(cleaned))
-    throw new FilePathError(rel);
-  const norm = posix.normalize(cleaned);
-  if (
-    norm === "" ||
-    norm === "." ||
-    norm.startsWith("..") ||
-    norm.split("/").includes("..")
-  ) {
-    throw new FilePathError(rel);
-  }
-  // Internal Houston state lives in top-level dot-dirs (.houston, .agents). The
-  // Files tab must never read or write there.
-  if (norm.split("/")[0]?.startsWith(".")) throw new FilePathError(rel);
-  return norm;
-}
-
-export const fileKey = (root: string, rel: string) => `${root}/${rel}`;
-export const extOf = (name: string) => {
-  const dot = name.lastIndexOf(".");
-  return dot > 0 ? name.slice(dot + 1) : "";
-};
 
 /**
  * List every file under the agent's workspace, plus a synthesized entry for
@@ -131,13 +95,14 @@ export async function listWorkspace(
   });
 }
 
-/** Read one workspace file. Text comes back as `content`; binary as base64. */
+/** Read one workspace file. Text comes back as `content`; binary as base64.
+ * Chat-driven, so `workspaceRel`: agents link files by absolute path. */
 export async function readWorkspaceFile(
   vfs: Vfs,
   root: string,
   rel: string,
 ): Promise<{ content: string; base64: boolean } | null> {
-  const buf = await vfs.readBytes(fileKey(root, safeRel(rel)));
+  const buf = await vfs.readBytes(fileKey(root, workspaceRel(root, rel)));
   if (buf === null) return null;
   // Treat a buffer as text only if it round-trips through UTF-8 without
   // replacement chars (so a .pptx comes back as base64 for download, not garbage).

--- a/packages/host/src/turn/files-path.test.ts
+++ b/packages/host/src/turn/files-path.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "vitest";
+import type { Agent, Workspace } from "../domain/types";
+import type { WorkspacePaths } from "../paths";
+import { MemoryVfs } from "../vfs";
+import { handleFiles } from "./files";
+import { FilePathError, safeRel, workspaceRel } from "./files-path";
+
+/**
+ * `workspaceRel`: the host-side strip of engine-emitted ABSOLUTE paths down to
+ * workspace-relative. Agents drop their own working directory's absolute path
+ * into chat links (`/data/workspaces/W/A/x.md` on pods); cloud clients can't
+ * strip it (their agent key is an opaque id), so the host must (PRODUCT-1575).
+ */
+
+// The pod/local layout root the strip keys on (`<Workspace>/<Agent>`).
+const ROOT = "Personal/Marketing Manager";
+
+test("strips a pod absolute path down to workspace-relative", () => {
+  expect(
+    workspaceRel(
+      ROOT,
+      "/data/workspaces/Personal/Marketing Manager/uploads/report.html",
+    ),
+  ).toBe("uploads/report.html");
+  // Desktop macOS shape.
+  expect(
+    workspaceRel(
+      ROOT,
+      "/Users/jo/.houston/workspaces/Personal/Marketing Manager/deck.pptx",
+    ),
+  ).toBe("deck.pptx");
+});
+
+test("strips Windows absolute paths, with or without a mangled leading slash", () => {
+  expect(
+    workspaceRel(
+      ROOT,
+      "C:\\Users\\jo\\.houston\\workspaces\\Personal\\Marketing Manager\\plan.md",
+    ),
+  ).toBe("plan.md");
+  // Markdown href normalization can prefix the drive with a slash.
+  expect(
+    workspaceRel(
+      ROOT,
+      "/C:/Users/jo/.houston/workspaces/Personal/Marketing Manager/plan.md",
+    ),
+  ).toBe("plan.md");
+});
+
+test("relative paths pass through workspaceRel unchanged (same wall as safeRel)", () => {
+  expect(workspaceRel(ROOT, "uploads/report.html")).toBe(
+    safeRel("uploads/report.html"),
+  );
+});
+
+test("absolute path outside the workspace is still rejected", () => {
+  expect(() => workspaceRel(ROOT, "/etc/passwd")).toThrow(FilePathError);
+  expect(() =>
+    workspaceRel(ROOT, "/data/workspaces/Personal/Other Agent/x.md"),
+  ).toThrow(FilePathError);
+});
+
+test("stripped remainder still hits the traversal + dot-dir wall", () => {
+  expect(() =>
+    workspaceRel(
+      ROOT,
+      "/data/workspaces/Personal/Marketing Manager/../Other Agent/x.md",
+    ),
+  ).toThrow(FilePathError);
+  expect(() =>
+    workspaceRel(
+      ROOT,
+      "/data/workspaces/Personal/Marketing Manager/.houston/runtime/auth.json",
+    ),
+  ).toThrow(FilePathError);
+});
+
+test("download route accepts the absolute path an agent linked in chat", async () => {
+  const objects = new MemoryVfs();
+  await objects.writeText(`${ROOT}/uploads/report.html`, "<html>ok</html>");
+  const paths = { agentRoot: () => ROOT } as unknown as WorkspacePaths;
+  const ctx = { workspace: {} as Workspace, agent: {} as Agent };
+
+  const state = {
+    status: 0,
+    headers: {} as Record<string, unknown>,
+    body: null as Buffer | null,
+  };
+  const res = {
+    writeHead(code: number, h?: Record<string, unknown>) {
+      state.status = code;
+      if (h) Object.assign(state.headers, h);
+      return this;
+    },
+    end(buf?: Buffer | string) {
+      if (buf !== undefined)
+        state.body = Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
+    },
+  };
+
+  await handleFiles(
+    objects,
+    paths,
+    ctx,
+    "GET",
+    "files/download",
+    { url: "/x" } as never,
+    res as never,
+    new URLSearchParams({
+      path: "/data/workspaces/Personal/Marketing Manager/uploads/report.html",
+    }),
+  );
+  expect(state.status).toBe(200);
+  expect(state.body?.toString("utf8")).toBe("<html>ok</html>");
+  expect(String(state.headers["Content-Disposition"])).toContain("report.html");
+});

--- a/packages/host/src/turn/files-path.ts
+++ b/packages/host/src/turn/files-path.ts
@@ -1,0 +1,76 @@
+import { posix } from "node:path";
+
+/**
+ * Path validation for the workspace files routes — the wall every UI- or
+ * chat-supplied path passes before it touches storage. Split out of
+ * `files-ops.ts` (which re-exports everything here) so the ops module stays
+ * focused on storage operations.
+ */
+
+export class FilePathError extends Error {
+  constructor(rel: string) {
+    super(`invalid workspace path: ${rel}`);
+    this.name = "FilePathError";
+  }
+}
+
+/** A file operation that failed with a specific HTTP status (409 conflict, 413 too large, …). */
+export class FileOpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "FileOpError";
+  }
+}
+
+/** Normalize a UI-supplied relative path; require it to stay inside the workspace and clear of internal dot-dirs. */
+export function safeRel(rel: string): string {
+  const cleaned = rel.replace(/\\/g, "/");
+  // Absolute (POSIX or Windows-drive) paths are anomalous — reject, don't silently clamp.
+  if (cleaned.startsWith("/") || /^[A-Za-z]:/.test(cleaned))
+    throw new FilePathError(rel);
+  const norm = posix.normalize(cleaned);
+  if (
+    norm === "" ||
+    norm === "." ||
+    norm.startsWith("..") ||
+    norm.split("/").includes("..")
+  ) {
+    throw new FilePathError(rel);
+  }
+  // Internal Houston state lives in top-level dot-dirs (.houston, .agents). The
+  // Files tab must never read or write there.
+  if (norm.split("/")[0]?.startsWith(".")) throw new FilePathError(rel);
+  return norm;
+}
+
+/**
+ * Resolve a chat-supplied path to workspace-relative, accepting the ABSOLUTE
+ * paths agents drop in prose and tool summaries (`/data/workspaces/W/A/x.md`
+ * on cloud pods, `C:\Users\...\workspaces\W\A\x.md` on Windows desktops).
+ *
+ * Cloud clients cannot strip these themselves — their agent key is an opaque
+ * id, not the `<Workspace>/<Agent>` the path embeds — so every click on such a
+ * link 400'd. The host DOES know its root: on the local/pod
+ * layout the runtime's working directory is `<fsRoot>/<root>`, so the root
+ * appears verbatim in every engine-emitted absolute path. Strip up to the
+ * first `/<root>/` and validate the remainder; anything else falls through to
+ * the strict relative validation.
+ */
+export function workspaceRel(root: string, raw: string): string {
+  const cleaned = raw.replace(/\\/g, "/");
+  if (cleaned.startsWith("/") || /^[A-Za-z]:/.test(cleaned)) {
+    const marker = `/${root}/`;
+    const at = cleaned.indexOf(marker);
+    if (at !== -1) return safeRel(cleaned.slice(at + marker.length));
+  }
+  return safeRel(raw);
+}
+
+export const fileKey = (root: string, rel: string) => `${root}/${rel}`;
+export const extOf = (name: string) => {
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(dot + 1) : "";
+};

--- a/packages/host/src/turn/files.ts
+++ b/packages/host/src/turn/files.ts
@@ -22,6 +22,7 @@ import {
   readWorkspaceFile,
   renameWorkspaceFile,
   safeRel,
+  workspaceRel,
 } from "./files-ops";
 
 /**
@@ -116,7 +117,9 @@ export async function handleFiles(
       return true;
     }
     if (method === "GET" && rest === "files/download") {
-      const rel = safeRel(query.get("path") ?? "");
+      // Chat-driven (file cards, prose links), so `workspaceRel`: agents link
+      // files by the absolute path of their own working directory.
+      const rel = workspaceRel(root, query.get("path") ?? "");
       const buf = await vfs.readBytes(fileKey(root, rel));
       if (buf === null) {
         json(res, 404, { error: "file not found" });

--- a/packages/web/e2e/sidebar-dnd.spec.ts
+++ b/packages/web/e2e/sidebar-dnd.spec.ts
@@ -23,19 +23,20 @@ async function center(loc: Locator) {
   return { x: b.x + b.width / 2, y: b.y + b.height / 2 };
 }
 
-/** Drag `source` onto `target`, re-reading the target's live position as the
- *  list reflows during the drag (a fixed pre-drag coordinate would miss). */
+/** Drag `source` onto `target`. The target's position is read ONCE, after the
+ *  drag has activated (so any lift-time reflow is in) and never again: the
+ *  sortable list live-reorders on every hover, so re-reading the target
+ *  mid-drag chases it into its swapped slot and swaps it right back —
+ *  dnd-kit then reports the item dropped over ITSELF (flaky order). */
 async function dragOnto(page: Page, source: Locator, target: Locator) {
   const s = await center(source);
   await page.mouse.move(s.x, s.y);
   await page.mouse.down();
   await page.waitForTimeout(60);
   await page.mouse.move(s.x, s.y + 10, { steps: 5 }); // cross activation
-  for (let i = 0; i < 3; i++) {
-    const t = await center(target);
-    await page.mouse.move(t.x, t.y, { steps: 8 });
-    await page.waitForTimeout(60);
-  }
+  const t = await center(target);
+  await page.mouse.move(t.x, t.y, { steps: 8 });
+  await page.waitForTimeout(120); // let the hover's live-reorder commit
   await page.mouse.up();
   await page.waitForTimeout(300); // drop-animation + overlay unmount
 }
@@ -97,9 +98,14 @@ test("team create + type name + reorder agents inside the default team", async (
     sidebar.getByText("Beta", { exact: true }),
     sidebar.getByText("Houston", { exact: true }),
   );
-  expect(await rowY(sidebar, "Beta")).toBeLessThan(
-    await rowY(sidebar, "Houston"),
-  );
+  // Poll: the committed order re-renders from the layout write-back, a beat
+  // after the drop animation ends.
+  await expect
+    .poll(
+      async () =>
+        (await rowY(sidebar, "Beta")) < (await rowY(sidebar, "Houston")),
+    )
+    .toBe(true);
 
   // Every gesture above is written back with
   // `PUT /v1/workspaces/:id/sidebar-layout`. A reload throws away all the


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1575 (Sentry HOUSTON-APP-4ZN, 65 users / 190 events): clicking a file link the agent dropped in chat failed with `download_project_file: invalid workspace path: /data/workspaces/<W>/<A>/... (engine error 400)`.

**Root cause:** agents link files by the absolute path of their own working directory (`/data/workspaces/W/A/x.md` on cloud pods, `C:\...\workspaces\W\A\x.md` on Windows desktops). The client normally converts those to workspace-relative (`toWorkspaceRelative`), but on the cloud adapter the agent's `folderPath` is an opaque id — not the `W/A` the path embeds — so the strip never matches and the raw absolute path reaches the host's files routes, where `safeRel` rejects it.

**Fix:** the host is the layer that authoritatively knows the root. New `workspaceRel(root, raw)` (`packages/host/src/turn/files-path.ts`) strips an absolute path up to the first `/<root>/` — on the local/pod layout the runtime's working directory is `<fsRoot>/<root>`, so the root appears verbatim in every engine-emitted absolute path — then validates the remainder through the same `safeRel` wall (traversal and internal dot-dirs still refused). Applied to the two chat-driven read routes (`files/download`, `files/read`); mutations keep strict relative validation. Path validation moved out of `files-ops.ts` into `files-path.ts` (re-exported) to stay under the line limit.

Of 100 sampled Sentry events, 85 are absolute paths this fix resolves; ~10 point into a top-level dot-dir (`.pdfgen_tmp/…`) and stay deliberately refused (internal-state wall — workspace roots also hold `.houston/runtime/auth.json`, `.env`, `.git`).

## Reproduce (before)

1. On a cloud agent, ask it to create a file and it links it in chat as an absolute path (or hit the route directly): `GET /agents/<id>/files/download?path=%2Fdata%2Fworkspaces%2FPersonal%2F<Agent>%2Freport.html`
2. → 400 `invalid workspace path`, red inline error in the preview dialog, Sentry `app_error_shown`.

## Verify (after)

1. Same request → 200 with the file bytes; clicking the chat link opens the preview.
2. `pnpm --filter @houston/host test src/turn/files-path.test.ts` — covers pod/macOS/Windows absolute shapes, pass-through of relative paths, and that traversal, other agents' paths, and dot-dirs are still rejected.
3. Host suite green (one unrelated pre-existing 1 ms-race flake in `vfs/contract.test.ts` passes on re-run).