### PR TITLE
fix(web): terminal sign-out answers the quiet signed-out 401, not a Sentry burst (PRODUCT-1574)

### DIFF
--- a/packages/web/src/engine-adapter/cp/fetch.ts
+++ b/packages/web/src/engine-adapter/cp/fetch.ts
@@ -1,6 +1,6 @@
 import { appVersionHeader } from "../app-version";
 import { HoustonEngineError, SIGNED_OUT_ERROR } from "../client/errors";
-import { refreshLiveToken } from "../session-refresh";
+import { hasSessionRefresher, refreshLiveToken } from "../session-refresh";
 import { transientRetryFetch } from "./transient-retry";
 
 /**
@@ -68,8 +68,11 @@ const signedOutResponse = () =>
  * A `fetch` for gateway calls that keeps auth invisible across cloud restarts
  * (HOU-687): the bearer is read LIVE per attempt (never a pinned copy), and a
  * 401 triggers one single-flight session refresh and one replay with the fresh
- * token. A 401 that survives the refresh is returned as-is — a real sign-out
- * must surface, not spin. A refresh beaten TRANSIENTLY by the network (a
+ * token. A 401 that survives the refresh is returned as-is — a fresh bearer
+ * the gateway rejects is a real bug that must surface, not spin. A refresh
+ * that answers NULL in hosted mode means the session is terminally gone, and
+ * resolves to the same quiet synthetic signed-out 401 as the no-bearer case:
+ * signed-out is an expected state and the sign-in screen is its surface. A refresh beaten TRANSIENTLY by the network (a
  * sleep-wake reconnect still settling — HOU-1106) throws the transport-shaped
  * TypeError `refreshLiveToken` mints, exactly as if the request itself had
  * dropped: `transientRetryFetch` re-attempts reads (re-running the refresh
@@ -116,7 +119,21 @@ export function gatewayAuthFetch(
     const res = await send(bearer);
     if (res.status !== 401) return res;
     const fresh = await refreshLiveToken();
-    if (!fresh) return res;
+    // An installed refresher answering null in hosted mode is its terminal
+    // verdict: the session is gone (HOU-1106's three-valued contract) — the
+    // same expected lifecycle state as the no-bearer branch above. Answer with
+    // the quiet synthetic instead of the gateway's raw 401 so the burst of
+    // live queries caught holding the stale bearer doesn't file a Sentry
+    // report per query while the sign-in screen mounts (HOUSTON-APP-4WR).
+    // With NO refresher installed null only means "nobody to ask" (static
+    // tokens, tests, the pre-mount boot window), so the original 401 stands.
+    // A 401 that survives a SUCCESSFUL refresh also returns as-is below — a
+    // fresh bearer the gateway rejects is a real bug and must stay loud.
+    if (!fresh) {
+      return inControlPlaneMode() && hasSessionRefresher()
+        ? signedOutResponse()
+        : res;
+    }
     return send(fresh);
   };
 }

--- a/packages/web/src/engine-adapter/session-refresh.ts
+++ b/packages/web/src/engine-adapter/session-refresh.ts
@@ -12,7 +12,8 @@
  *
  * The refresher's answer is three-valued, and the distinction is load-bearing
  * (HOU-1106): a token means refreshed, null means the session is terminally
- * gone (a real sign-out — the caller lets its 401 surface), and a TRANSIENT
+ * gone (a real sign-out — the transport answers with the quiet signed-out 401,
+ * since the sign-in screen is that state's surface), and a TRANSIENT
  * failure — the identity service unreachable while a sleep-wake reconnect
  * settles — THROWS. Both installers already speak this contract: the desktop's
  * `refreshNow()` rethrows `IdentityError("network")` precisely so callers
@@ -48,15 +49,27 @@ const isTransientRefreshFailure = (err: unknown): boolean => {
 };
 
 /**
+ * Whether a session refresher is installed at all. Callers use this to read a
+ * null refresh correctly: WITH a refresher, null is its terminal verdict (the
+ * session is gone — signed-out is the state); WITHOUT one, null only means
+ * "nobody to ask" (static-token hosts, tests, the pre-mount boot window) and
+ * says nothing about the session.
+ */
+export function hasSessionRefresher(): boolean {
+  return typeof window !== "undefined" && !!window.__HOUSTON_SESSION_REFRESH__;
+}
+
+/**
  * Force-refresh the hosted session. Resolves the new access token; resolves
  * null when there is no refresher or the session is terminally gone (a real
- * sign-out — the caller lets its 401 surface); THROWS a transport-shaped
- * `TypeError` when the refresher failed transiently. The message starts with
- * "Load failed" on purpose: that is the prefix the app's connectivity
- * classifier (`isNetworkTransportError`, HOU-1085) keys on, so a refresh
- * beaten by a settling reconnect surfaces as the one deduped connectivity
- * notice — never as an auth error or a Sentry report. Concurrent callers
- * share one refresh; a caller arriving after it settles starts a new one.
+ * sign-out — the caller answers with the quiet signed-out 401); THROWS a
+ * transport-shaped `TypeError` when the refresher failed transiently. The
+ * message starts with "Load failed" on purpose: that is the prefix the app's
+ * connectivity classifier (`isNetworkTransportError`, HOU-1085) keys on, so a
+ * refresh beaten by a settling reconnect surfaces as the one deduped
+ * connectivity notice — never as an auth error or a Sentry report. Concurrent
+ * callers share one refresh; a caller arriving after it settles starts a new
+ * one.
  */
 export function refreshLiveToken(): Promise<string | null> {
   const refresh =
@@ -70,6 +83,11 @@ export function refreshLiveToken(): Promise<string | null> {
         if (isTransientRefreshFailure(err)) {
           throw new TypeError("Load failed (session refresh)", { cause: err });
         }
+        // Terminal verdict (a revoked/expired refresh token, or a refresher
+        // bug). The caller answers with the quiet signed-out 401, so this
+        // warn is the failure's only trace — a breadcrumb on whatever fires
+        // next, naming WHY the session was declared gone.
+        console.warn("[session-refresh] terminal refresh failure:", err);
         return null;
       })
       .finally(() => {

--- a/packages/web/tests/session-refresh-transient.test.ts
+++ b/packages/web/tests/session-refresh-transient.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import { isHoustonEngineError } from "../src/engine-adapter/client/errors";
+import {
+  isHoustonEngineError,
+  isSignedOutEngineError,
+} from "../src/engine-adapter/client/errors";
 import { cpFetch } from "../src/engine-adapter/cp/fetch";
 
 // HOU-1106 (Sentry HOUSTON-APP-515): a sleep-wake reconnect leaves every live
@@ -37,8 +40,14 @@ function stubGateway(): { bearers: (string | null)[] } {
   return { bearers };
 }
 
-function installRefresher(impl: () => Promise<string | null>): void {
-  vi.stubGlobal("window", { __HOUSTON_SESSION_REFRESH__: vi.fn(impl) });
+function installRefresher(
+  impl: () => Promise<string | null>,
+  opts?: { controlPlane?: boolean },
+): void {
+  vi.stubGlobal("window", {
+    __HOUSTON_SESSION_REFRESH__: vi.fn(impl),
+    ...(opts?.controlPlane ? { __HOUSTON_CP__: true } : {}),
+  });
 }
 
 beforeEach(() => {
@@ -108,7 +117,7 @@ test("firebase network-request-failed is transient too", async () => {
   expect(await pending).toBeInstanceOf(TypeError);
 });
 
-test("terminal refresh (null) still surfaces the real 401 — a sign-out must not hide", async () => {
+test("terminal refresh (null) outside hosted mode surfaces the real 401", async () => {
   stubGateway();
   installRefresher(() => Promise.resolve(null));
   const pending = cpFetch(CFG, "/agents/a/skills").then(
@@ -121,6 +130,27 @@ test("terminal refresh (null) still surfaces the real 401 — a sign-out must no
   const err = await pending;
   expect(isHoustonEngineError(err)).toBe(true);
   expect((err as { status: number }).status).toBe(401);
+  expect(isSignedOutEngineError(err)).toBe(false);
+});
+
+test("terminal refresh (null) in hosted mode is the quiet signed-out 401 (HOUSTON-APP-4WR)", async () => {
+  // A real sign-out catches every live query holding the stale bearer: each
+  // gets a gateway 401, refreshes (single-flight), and learns the session is
+  // gone. That must fail the queries as signed-out — the state the error-toast
+  // layer recognizes and never reports — not as one Sentry event per query.
+  const gw = stubGateway();
+  installRefresher(() => Promise.resolve(null), { controlPlane: true });
+  const pending = cpFetch(CFG, "/agents/a/skills").then(
+    () => {
+      throw new Error("expected rejection");
+    },
+    (err: unknown) => err,
+  );
+  await vi.advanceTimersByTimeAsync(5_000);
+  const err = await pending;
+  expect(isSignedOutEngineError(err)).toBe(true);
+  // No replay was attempted with a dead session: one gateway round trip only.
+  expect(gw.bearers).toEqual(["Bearer stale"]);
 });
 
 test("an unexpected refresher bug is treated as terminal, not connectivity", async () => {

--- a/packages/web/tests/shim-report-bug.test.ts
+++ b/packages/web/tests/shim-report-bug.test.ts
@@ -151,8 +151,20 @@ test("report_bug with no token yet still reaches the gateway after a refresh", a
   expect(calls.map((c) => bearer(c.init))).toEqual(["Bearer minted"]);
 });
 
-test("report_bug surfaces the gateway's reason when the refresh cannot save it", async () => {
+test("report_bug fails as quiet signed-out when the refresher declares the session gone", async () => {
+  // Refresher installed and answering null = terminal sign-out: the sign-in
+  // screen is the surface, so the failure carries the recognized signed_out
+  // marker instead of the gateway's raw reason (HOUSTON-APP-4WR).
   setCloudWindow({ token: "stale", refresh: async () => null });
+  stubFetch(json(401, { error: "session expired" }));
+
+  await expect(invoke("report_bug", { payload: {} })).rejects.toThrow(
+    "signed_out",
+  );
+});
+
+test("report_bug surfaces the gateway's reason when there is no refresher to consult", async () => {
+  setCloudWindow({ token: "stale" });
   stubFetch(json(401, { error: "session expired" }));
 
   await expect(invoke("report_bug", { payload: {} })).rejects.toThrow(


### PR DESCRIPTION
Fixes PRODUCT-1574 (Sentry HOUSTON-APP-4WR).

## Root cause

The Sentry group is a grab-bag of `list_conversations`/`list_all_conversations` failures; almost all of its 227 events came from desktop releases ≤0.6.9 already fixed elsewhere (the PRODUCT-1531 refresher flatten fix shipped in 0.6.11, and the sweep-recovery toast split). The one remaining live path — confirmed by the group's latest event (web, 0.6.6-web) — is the **terminal sign-out burst**:

- A wake-from-sleep leaves every live query holding an expired bearer; the gateway answers 401.
- `gatewayAuthFetch` runs the single-flight session refresh; the refresher answers **null** — its terminal verdict that the session is gone (HOU-1106 three-valued contract).
- The transport then returned the gateway's **raw** 401 (`invalid or expired token`), so every live query filed an `error_kind: auth` Sentry report while the sign-in screen was about to mount — even though the adapter already has a quiet `signed_out` synthetic (HOU-1014) for exactly this lifecycle state.

## Fix

- `cp/fetch.ts`: when the post-401 refresh answers null **and** a refresher is installed **and** we're in control-plane mode, answer with the quiet synthetic signed-out 401 (`{error: "signed_out"}`), which the error-toast layer recognizes and never reports. With no refresher installed (static tokens, tests, pre-mount boot window) null only means "nobody to ask", so the raw 401 still stands. A 401 that survives a *successful* refresh also still surfaces — a fresh bearer the gateway rejects is a real bug and must stay loud.
- `session-refresh.ts`: new `hasSessionRefresher()` seam; a non-transient refresher failure now leaves a `console.warn` breadcrumb naming why the session was declared gone (it was silently flattened to null before).
- Tests: new hosted-mode terminal-null case (asserts the `signed_out` marker and that no replay is attempted with a dead session); the pre-existing raw-401 expectations are split into with-refresher vs no-refresher variants.

## Verification

Before the fix (reproduces the bug):
1. On `main`, in `packages/web`, run `pnpm vitest run tests/session-refresh-transient.test.ts` after adding the hosted-mode case — a CP-mode `cpFetch` whose refresher resolves null rejects with the gateway's raw `invalid or expired token` body, and `isSignedOutEngineError(err)` is `false` (so `showErrorToast` reports it to Sentry).
2. In production this is the HOUSTON-APP-4WR shape: wake a signed-out-underneath web session from sleep and every live query files one Sentry event.

After the fix:
1. `pnpm --filter houston-web test` — 425 tests pass, including `terminal refresh (null) in hosted mode is the quiet signed-out 401`, which pins: `isSignedOutEngineError(err) === true` and exactly one gateway round trip (no replay with a dead session).
2. `pnpm check`, `pnpm --filter houston-web typecheck` clean.
3. In Sentry: HOUSTON-APP-4WR (and 401 siblings 546/4YD/4YE/…) should show no new events from releases carrying this change; the sign-in screen remains the only surface of a real sign-out.