### PR TITLE
perf(runtime): overlap pooled-turn hydration with backend and credential setup

### DIFF
--- a/packages/runtime-client/src/object-sync/http-store-download.ts
+++ b/packages/runtime-client/src/object-sync/http-store-download.ts
@@ -12,6 +12,7 @@ export async function downloadFile(
   response: Response,
   key: string,
   destFile: string,
+  signal?: AbortSignal,
 ): Promise<ReadResult> {
   if (!response.body) {
     throw new Error(`object store GET ${key} returned no response body`);
@@ -22,6 +23,7 @@ export async function downloadFile(
     await pipeline(
       Readable.fromWeb(response.body as NodeReadableStream),
       createWriteStream(tempFile),
+      ...(signal ? [{ signal }] : []),
     );
     await rename(tempFile, destFile);
   } catch (error) {

--- a/packages/runtime-client/src/object-sync/http-store-read.ts
+++ b/packages/runtime-client/src/object-sync/http-store-read.ts
@@ -1,0 +1,37 @@
+import { downloadFile } from "./http-store-download";
+import { objectStoreResponseError } from "./http-store-errors";
+import { type ObjectMetadata, parseObjectManifest } from "./object-manifest";
+import type { ReadResult } from "./object-store";
+
+type CaptureResponse = (response: Response) => void;
+
+export async function readHttpManifest(
+  request: () => Promise<Response>,
+  capture: CaptureResponse,
+  prefix: string,
+): Promise<ObjectMetadata[]> {
+  const response = await request();
+  capture(response);
+  if (!response.ok) {
+    throw await objectStoreResponseError(response, "GET", "manifest");
+  }
+  return parseObjectManifest(
+    await response.json(),
+    "object store GET manifest",
+  ).filter((object) => !prefix || object.key.startsWith(prefix));
+}
+
+export async function downloadHttpObject(
+  request: () => Promise<Response>,
+  capture: CaptureResponse,
+  key: string,
+  destFile: string,
+  signal?: AbortSignal,
+): Promise<ReadResult> {
+  const response = await request();
+  capture(response);
+  if (!response.ok) {
+    throw await objectStoreResponseError(response, "GET", key);
+  }
+  return downloadFile(response, key, destFile, signal);
+}

--- a/packages/runtime-client/src/object-sync/http-store-write.ts
+++ b/packages/runtime-client/src/object-sync/http-store-write.ts
@@ -1,0 +1,39 @@
+import { objectStoreResponseError } from "./http-store-errors";
+import { uploadFile } from "./http-store-upload";
+import { parseObjectManifest } from "./object-manifest";
+import type { WriteResult } from "./object-store";
+
+/** Upload one object and normalize its generation response. */
+export async function uploadHttpObject(input: {
+  fetchRequest: Parameters<typeof uploadFile>[0];
+  url: string;
+  srcFile: string;
+  key: string;
+  headers: Record<string, string>;
+  retryable: boolean;
+  capture: (response: Response) => void;
+}): Promise<WriteResult | undefined> {
+  const response = await uploadFile(
+    input.fetchRequest,
+    input.url,
+    input.srcFile,
+    input.headers,
+    input.retryable,
+  );
+  input.capture(response);
+  if (!response.ok) {
+    throw await objectStoreResponseError(response, "PUT", input.key);
+  }
+  const body: unknown = await response.json();
+  const metadata = parseObjectManifest(
+    { objects: [body] },
+    `object store PUT ${input.key}`,
+  )[0];
+  if (!metadata) {
+    throw new Error(`object store PUT ${input.key} returned a malformed body`);
+  }
+  const header = response.headers.get("X-Houston-Generation");
+  const generation =
+    metadata.generation ?? (header && header !== "0" ? header : undefined);
+  return generation === undefined ? undefined : { generation };
+}

--- a/packages/runtime-client/src/object-sync/http-store.test.ts
+++ b/packages/runtime-client/src/object-sync/http-store.test.ts
@@ -71,6 +71,39 @@ test("round-trips objects through the agent-scoped HTTP API", async () => {
   expect(await store.list("")).toEqual([]);
 });
 
+test("download forwards cancellation to the HTTP request", async () => {
+  let requestSignal: AbortSignal | null | undefined;
+  const store = new HttpObjectStore({
+    baseUrl: "https://store.test",
+    token: "pod-token",
+    retryDelaysMs: [],
+    fetchImpl: async (_input, init) => {
+      requestSignal = init?.signal;
+      await new Promise<void>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(init.signal?.reason),
+          { once: true },
+        );
+      });
+      throw new Error("unreachable");
+    },
+  });
+  const controller = new AbortController();
+  const destination = join(
+    mkdtempSync(join(tmpdir(), "http-abort-")),
+    "download.txt",
+  );
+
+  const downloading = store.download("file.txt", destination, {
+    signal: controller.signal,
+  });
+  controller.abort(new Error("stop hydration"));
+
+  await expect(downloading).rejects.toThrow("stop hydration");
+  expect(requestSignal).toBe(controller.signal);
+});
+
 test("PUTs shared objects with the pod agent binding", async () => {
   const dir = mkdtempSync(join(tmpdir(), "http-shared-object-store-"));
   const source = join(dir, "SKILL.md");

--- a/packages/runtime-client/src/object-sync/http-store.ts
+++ b/packages/runtime-client/src/object-sync/http-store.ts
@@ -1,10 +1,11 @@
-import { downloadFile } from "./http-store-download";
 import { objectStoreResponseError } from "./http-store-errors";
 import type { HttpObjectStoreOptions } from "./http-store-options";
-import { uploadFile } from "./http-store-upload";
-import { type ObjectMetadata, parseObjectManifest } from "./object-manifest";
+import { downloadHttpObject, readHttpManifest } from "./http-store-read";
+import { uploadHttpObject } from "./http-store-write";
+import type { ObjectMetadata } from "./object-manifest";
 import type {
   ObjectStore,
+  ReadOptions,
   ReadResult,
   WriteOptions,
   WriteResult,
@@ -53,29 +54,41 @@ export class HttpObjectStore implements ObjectStore {
 
   async manifest(prefix = ""): Promise<ObjectMetadata[]> {
     const query = prefix ? `?prefix=${encodeURIComponent(prefix)}` : "";
-    const res = await this.fetch(`${this.baseUrl}/manifest${query}`, {
-      headers: this.authHeaders(),
-    });
-    this.captureFence(res);
-    if (!res.ok) throw await objectStoreResponseError(res, "GET", "manifest");
-    return parseObjectManifest(
-      await res.json(),
-      "object store GET manifest",
-    ).filter((object) => !prefix || object.key.startsWith(prefix));
+    return readHttpManifest(
+      () =>
+        this.fetch(`${this.baseUrl}/manifest${query}`, {
+          headers: this.authHeaders(),
+        }),
+      (response) => this.captureFence(response),
+      prefix,
+    );
   }
 
-  async download(key: string, destFile: string): Promise<void> {
-    await this.downloadVersioned(key, destFile);
+  async download(
+    key: string,
+    destFile: string,
+    opts?: ReadOptions,
+  ): Promise<void> {
+    await this.downloadVersioned(key, destFile, opts);
   }
 
   /** Download one object and preserve the generation from its GET response. */
-  async downloadVersioned(key: string, destFile: string): Promise<ReadResult> {
-    const res = await this.fetch(this.objectUrl(key), {
-      headers: this.authHeaders(),
-    });
-    this.captureFence(res);
-    if (!res.ok) throw await objectStoreResponseError(res, "GET", key);
-    return downloadFile(res, key, destFile);
+  async downloadVersioned(
+    key: string,
+    destFile: string,
+    opts?: ReadOptions,
+  ): Promise<ReadResult> {
+    return downloadHttpObject(
+      () =>
+        this.fetch(this.objectUrl(key), {
+          headers: this.authHeaders(),
+          signal: opts?.signal,
+        }),
+      (response) => this.captureFence(response),
+      key,
+      destFile,
+      opts?.signal,
+    );
   }
 
   async upload(
@@ -90,32 +103,15 @@ export class HttpObjectStore implements ObjectStore {
     // writer is rejected by its token. Generation-guarded writes cannot retry
     // because a lost success is indistinguishable from a failed attempt.
     const retryable = !this.guardedWrite(opts);
-    const res = await uploadFile(
-      this.fetch.bind(this),
+    return uploadHttpObject({
+      fetchRequest: this.fetch.bind(this),
       url,
       srcFile,
+      key,
       headers,
       retryable,
-    );
-    this.captureFence(res);
-    if (!res.ok) throw await objectStoreResponseError(res, "PUT", key);
-    const body: unknown = await res.json();
-    const metadata = parseObjectManifest(
-      { objects: [body] },
-      `object store PUT ${key}`,
-    )[0];
-    if (!metadata) {
-      throw new Error(`object store PUT ${key} returned a malformed body`);
-    }
-    // "0" from the header means the backend has no generations (dir) — the
-    // same normalization parseObjectManifest applies to the manifest body.
-    const headerGeneration = res.headers.get("X-Houston-Generation");
-    const generation =
-      metadata.generation ??
-      (headerGeneration && headerGeneration !== "0"
-        ? headerGeneration
-        : undefined);
-    return generation === undefined ? undefined : { generation };
+      capture: (response) => this.captureFence(response),
+    });
   }
 
   async delete(key: string, opts?: WriteOptions): Promise<void> {

--- a/packages/runtime-client/src/object-sync/hydrate-download.ts
+++ b/packages/runtime-client/src/object-sync/hydrate-download.ts
@@ -14,6 +14,7 @@ export interface HydrateDownloadState {
   total: number;
   failed: boolean;
   firstError?: unknown;
+  fail: (error: unknown) => void;
 }
 
 /** Download one hydration batch while sharing the cap and failure latch. */
@@ -25,6 +26,7 @@ export async function downloadHydrationEntries(opts: {
   maxBytes: number;
   concurrency: number;
   state: HydrateDownloadState;
+  signal: AbortSignal;
   limitError: (observedBytes: number) => Error;
 }): Promise<void> {
   let next = 0;
@@ -35,7 +37,8 @@ export async function downloadHydrationEntries(opts: {
       const { generation, key, rel } = entry;
       try {
         const dest = join(opts.destDir, ...rel.split("/"));
-        await opts.store.download(key, dest);
+        await opts.store.download(key, dest, { signal: opts.signal });
+        if (opts.signal.aborted) return;
         const { size } = await stat(dest);
         opts.state.total += size;
         if (opts.state.total > opts.maxBytes) {
@@ -46,14 +49,11 @@ export async function downloadHydrationEntries(opts: {
           generation,
         });
       } catch (error) {
-        if (error instanceof ObjectNotFoundError) {
+        if (!opts.signal.aborted && error instanceof ObjectNotFoundError) {
           await rm(join(opts.destDir, ...rel.split("/")), { force: true });
           continue;
         }
-        if (!opts.state.failed) {
-          opts.state.failed = true;
-          opts.state.firstError = error;
-        }
+        opts.state.fail(error);
         return;
       }
     }

--- a/packages/runtime-client/src/object-sync/hydrate-download.ts
+++ b/packages/runtime-client/src/object-sync/hydrate-download.ts
@@ -1,0 +1,68 @@
+import { rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { fileSha256 } from "./file-hash";
+import type { HydrateManifest } from "./hydrate";
+import { ObjectNotFoundError, type ObjectStore } from "./object-store";
+
+export interface HydrateEntry {
+  generation?: string;
+  key: string;
+  rel: string;
+}
+
+export interface HydrateDownloadState {
+  total: number;
+  failed: boolean;
+  firstError?: unknown;
+}
+
+/** Download one hydration batch while sharing the cap and failure latch. */
+export async function downloadHydrationEntries(opts: {
+  store: ObjectStore;
+  destDir: string;
+  entries: HydrateEntry[];
+  manifest: HydrateManifest;
+  maxBytes: number;
+  concurrency: number;
+  state: HydrateDownloadState;
+  limitError: (observedBytes: number) => Error;
+}): Promise<void> {
+  let next = 0;
+  const worker = async () => {
+    while (!opts.state.failed && opts.state.total <= opts.maxBytes) {
+      const entry = opts.entries[next++];
+      if (!entry) return;
+      const { generation, key, rel } = entry;
+      try {
+        const dest = join(opts.destDir, ...rel.split("/"));
+        await opts.store.download(key, dest);
+        const { size } = await stat(dest);
+        opts.state.total += size;
+        if (opts.state.total > opts.maxBytes) {
+          throw opts.limitError(opts.state.total);
+        }
+        opts.manifest.set(rel, {
+          hash: await fileSha256(dest, size),
+          generation,
+        });
+      } catch (error) {
+        if (error instanceof ObjectNotFoundError) {
+          await rm(join(opts.destDir, ...rel.split("/")), { force: true });
+          continue;
+        }
+        if (!opts.state.failed) {
+          opts.state.failed = true;
+          opts.state.firstError = error;
+        }
+        return;
+      }
+    }
+  };
+  await Promise.all(
+    Array.from(
+      { length: Math.min(opts.concurrency, opts.entries.length) },
+      worker,
+    ),
+  );
+  if (opts.state.failed) throw opts.state.firstError;
+}

--- a/packages/runtime-client/src/object-sync/hydrate-excludes.ts
+++ b/packages/runtime-client/src/object-sync/hydrate-excludes.ts
@@ -1,0 +1,36 @@
+import { basename, sep } from "node:path";
+
+export const DEFAULT_EXCLUDES = ["data/auth.json"];
+
+const norm = (rel: string) => rel.split(sep).join("/");
+
+function segmentGlobMatches(pattern: string, path: string): boolean {
+  const subtree = pattern.endsWith("/");
+  const want = (subtree ? pattern.slice(0, -1) : pattern).split("/");
+  const have = path.split("/");
+  if (subtree ? have.length < want.length : have.length !== want.length) {
+    return false;
+  }
+  return want.every((seg, i) => seg === "*" || seg === have[i]);
+}
+
+export function excluded(rel: string, excludes: string[]): boolean {
+  const normalized = norm(rel);
+  if (normalized.endsWith(".tmp")) return true;
+  if (normalized.endsWith(".houston/runtime/auth.json")) return true;
+  // Credential paths differ by deployment depth, so segment matching must
+  // exclude auth-users unconditionally instead of relying on caller patterns.
+  if (normalized.split("/").includes("auth-users")) return true;
+  return excludes.some((exclude) => {
+    const pattern = norm(exclude);
+    if (pattern.includes("*")) {
+      return segmentGlobMatches(pattern, normalized);
+    }
+    if (pattern.endsWith("/")) {
+      const subtree = pattern.slice(0, -1);
+      return normalized === subtree || normalized.startsWith(pattern);
+    }
+    if (!pattern.includes("/")) return basename(normalized) === pattern;
+    return normalized === pattern;
+  });
+}

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -700,6 +700,35 @@ test("startHydrate lands priority files before background hydration resolves", a
   ]);
 });
 
+test("startHydrate aborts in-flight downloads before settlement", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, { "workspace/late.txt": "late" });
+  let downloadSignal: AbortSignal | undefined;
+  const gated: ObjectStore = {
+    list: (prefix) => store.list(prefix),
+    manifest: (prefix) => store.manifest(prefix),
+    download: async (_key, _destination, options) => {
+      downloadSignal = options?.signal;
+      await new Promise<void>((_resolve, reject) => {
+        options?.signal?.addEventListener(
+          "abort",
+          () => reject(options.signal?.reason),
+          { once: true },
+        );
+      });
+    },
+    upload: (source, key, options) => store.upload(source, key, options),
+    delete: (key, options) => store.delete(key, options),
+  };
+
+  const started = await startHydrate(gated, PREFIX, work);
+  started.abort();
+
+  await expect(started.done).rejects.toThrow("hydration aborted");
+  expect(downloadSignal?.aborted).toBe(true);
+  expect(existsSync(join(work, "workspace", "late.txt"))).toBe(false);
+});
+
 test("a non-finite concurrency override still hydrates everything", async () => {
   const { storeRoot, store, work } = setup();
   seed(storeRoot, PREFIX, { "workspace/a.txt": "a", "workspace/b.txt": "b" });

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -12,7 +12,13 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
-import { excluded, type HydrateLimitError, hydrate, syncBack } from "./hydrate";
+import {
+  excluded,
+  type HydrateLimitError,
+  hydrate,
+  startHydrate,
+  syncBack,
+} from "./hydrate";
 import type { ObjectMetadata } from "./object-manifest";
 import {
   LocalDirStore,
@@ -652,6 +658,46 @@ test("hydrate materializes many files faithfully under concurrency", async () =>
       `content-${i}`,
     );
   }
+});
+
+test("startHydrate lands priority files before background hydration resolves", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, {
+    "data/settings.json": "settings",
+    "workspace/late.txt": "late",
+  });
+  let release: () => void = () => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const gated: ObjectStore = {
+    list: (prefix) => store.list(prefix),
+    manifest: (prefix) => store.manifest(prefix),
+    download: async (key, destination) => {
+      if (key.endsWith("workspace/late.txt")) await gate;
+      await store.download(key, destination);
+    },
+    upload: (source, key, options) => store.upload(source, key, options),
+    delete: (key, options) => store.delete(key, options),
+  };
+
+  const started = await startHydrate(gated, PREFIX, work, {
+    priority: (rel) => rel === "data/settings.json",
+  });
+
+  expect(readFileSync(join(work, "data", "settings.json"), "utf8")).toBe(
+    "settings",
+  );
+  expect(existsSync(join(work, "workspace", "late.txt"))).toBe(false);
+  release();
+  await started.done;
+  expect(readFileSync(join(work, "workspace", "late.txt"), "utf8")).toBe(
+    "late",
+  );
+  expect([...started.manifest.keys()].sort()).toEqual([
+    "data/settings.json",
+    "workspace/late.txt",
+  ]);
 });
 
 test("a non-finite concurrency override still hydrates everything", async () => {

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -1,7 +1,10 @@
-import { rm, stat } from "node:fs/promises";
-import { basename, join, sep } from "node:path";
-import { fileSha256 } from "./file-hash";
-import { ObjectNotFoundError, type ObjectStore } from "./object-store";
+import { basename, sep } from "node:path";
+import {
+  downloadHydrationEntries,
+  type HydrateDownloadState,
+  type HydrateEntry,
+} from "./hydrate-download";
+import type { ObjectStore } from "./object-store";
 
 /**
  * Durable engine state is materialized into a local cache, then synchronized
@@ -80,7 +83,12 @@ export interface HydrateOptions {
   /** Every admitted path BEFORE `filter` (the store's view of the tree) and
    *  whether the listing carried generations (the CAS capability, which a
    *  filtered manifest can no longer answer on its own). */
-  onListed?: (listing: { rels: string[]; generationAware: boolean }) => void;
+  onListed?: (listing: {
+    rels: string[];
+    generationAware: boolean;
+  }) => void | Promise<void>;
+  /** Download these admitted objects before the remaining hydration starts. */
+  priority?: (rel: string) => boolean;
 }
 
 /** The hydrated prefix exceeded the caller's aggregate byte cap. */
@@ -98,13 +106,20 @@ export class HydrateLimitError extends Error {
 
 const DEFAULT_HYDRATE_CONCURRENCY = 16;
 
-/** Download everything under `prefix` into `destDir`. Returns the manifest. */
-export async function hydrate(
+export interface StartedHydration {
+  manifest: HydrateManifest;
+  listed: { rels: string[]; generationAware: boolean };
+  /** Resolves only after every non-priority object has landed. */
+  done: Promise<void>;
+}
+
+/** List once, hydrate priority inputs, then start the remaining downloads. */
+export async function startHydrate(
   store: ObjectStore,
   prefix: string,
   destDir: string,
   opts: HydrateOptions = {},
-): Promise<HydrateManifest> {
+): Promise<StartedHydration> {
   const excludes = opts.excludes ?? DEFAULT_EXCLUDES;
   const maxBytes = opts.maxBytes ?? 512 * 1024 * 1024;
   // Guard against a non-finite override (NaN sizes the worker array to ZERO,
@@ -117,13 +132,13 @@ export async function hydrate(
       : DEFAULT_HYDRATE_CONCURRENCY;
   const manifest: HydrateManifest = new Map();
   const objects = store.manifest ? await store.manifest(prefix) : undefined;
-  const listed =
+  const storeObjects =
     objects ??
     (await store.list(prefix)).map((key) => ({ key, generation: undefined }));
-  const entries: { generation?: string; key: string; rel: string }[] = [];
+  const entries: HydrateEntry[] = [];
   const admitted: string[] = [];
   let generationAware = false;
-  for (const object of listed) {
+  for (const object of storeObjects) {
     const { key } = object;
     const rel = prefix ? key.slice(prefix.length + 1) : key;
     if (!rel || excluded(rel, excludes)) continue;
@@ -132,57 +147,41 @@ export async function hydrate(
     if (opts.filter && !opts.filter(rel)) continue;
     entries.push({ key, rel, generation: object.generation });
   }
-  opts.onListed?.({ rels: admitted, generationAware });
-  // Workers pull from a shared cursor. The first failure (download error or
-  // the size cap) parks every worker before it takes new work, and only that
-  // first error is thrown — workers themselves never reject, so a second
-  // failure can never become an unhandled rejection behind Promise.all.
-  let total = 0;
-  let next = 0;
-  let failed = false;
-  let firstError: unknown;
-  const worker = async () => {
-    // The cap check also gates NEW downloads (not only completed ones), so an
-    // over-cap workspace overshoots by at most the in-flight batch — the
-    // pooled analogue of the sequential loop's one-object overshoot.
-    while (!failed && total <= maxBytes) {
-      const entry = entries[next++];
-      if (!entry) return;
-      const { generation, key, rel } = entry;
-      try {
-        const dest = join(destDir, ...rel.split("/"));
-        await store.download(key, dest);
-        // Size from stat, hash streamed for large files: wake-hydrating a
-        // multi-GiB object must not buffer it in heap just to digest it.
-        const { size } = await stat(dest);
-        total += size;
-        if (total > maxBytes) {
-          throw new HydrateLimitError(maxBytes, total);
-        }
-        manifest.set(rel, { hash: await fileSha256(dest, size), generation });
-      } catch (err) {
-        // Vanished between the listing and its download: another writer
-        // deleted it. The object is simply not part of this hydration —
-        // failing the whole (boot-gating) pass over it would wedge the pod.
-        // A half-opened destination must not survive outside the manifest:
-        // sync-back would read it as a fresh local write of an empty file.
-        if (err instanceof ObjectNotFoundError) {
-          await rm(join(destDir, ...rel.split("/")), { force: true });
-          continue;
-        }
-        if (!failed) {
-          failed = true;
-          firstError = err;
-        }
-        return;
-      }
-    }
-  };
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, entries.length) }, worker),
-  );
-  if (failed) throw firstError;
-  return manifest;
+  const listed = { rels: admitted, generationAware };
+  await opts.onListed?.(listed);
+  const priority = opts.priority
+    ? entries.filter((entry) => opts.priority?.(entry.rel))
+    : [];
+  const remaining = opts.priority
+    ? entries.filter((entry) => !opts.priority?.(entry.rel))
+    : entries;
+  const state: HydrateDownloadState = { total: 0, failed: false };
+  const download = (batch: HydrateEntry[]) =>
+    downloadHydrationEntries({
+      store,
+      destDir,
+      entries: batch,
+      manifest,
+      maxBytes,
+      concurrency,
+      state,
+      limitError: (observedBytes) =>
+        new HydrateLimitError(maxBytes, observedBytes),
+    });
+  await download(priority);
+  return { manifest, listed, done: download(remaining) };
+}
+
+/** Download everything under `prefix` into `destDir`. Returns the manifest. */
+export async function hydrate(
+  store: ObjectStore,
+  prefix: string,
+  destDir: string,
+  opts: HydrateOptions = {},
+): Promise<HydrateManifest> {
+  const started = await startHydrate(store, prefix, destDir, opts);
+  await started.done;
+  return started.manifest;
 }
 
 export type { SyncBackOptions, SyncResult } from "./sync-back";

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -1,10 +1,12 @@
-import { basename, sep } from "node:path";
 import {
   downloadHydrationEntries,
   type HydrateDownloadState,
   type HydrateEntry,
 } from "./hydrate-download";
+import { DEFAULT_EXCLUDES, excluded } from "./hydrate-excludes";
 import type { ObjectStore } from "./object-store";
+
+export { DEFAULT_EXCLUDES, excluded } from "./hydrate-excludes";
 
 /**
  * Durable engine state is materialized into a local cache, then synchronized
@@ -20,48 +22,6 @@ export interface HydrateManifestEntry {
 
 /** Relative path to the hydrated bytes and their optional remote generation. */
 export type HydrateManifest = Map<string, HydrateManifestEntry>;
-
-export const DEFAULT_EXCLUDES = ["data/auth.json"];
-
-const norm = (rel: string) => rel.split(sep).join("/");
-
-function segmentGlobMatches(pattern: string, path: string): boolean {
-  const subtree = pattern.endsWith("/");
-  const want = (subtree ? pattern.slice(0, -1) : pattern).split("/");
-  const have = path.split("/");
-  if (subtree ? have.length < want.length : have.length !== want.length) {
-    return false;
-  }
-  return want.every((seg, i) => seg === "*" || seg === have[i]);
-}
-
-export function excluded(rel: string, excludes: string[]): boolean {
-  const normalized = norm(rel);
-  if (normalized.endsWith(".tmp")) return true;
-  if (normalized.endsWith(".houston/runtime/auth.json")) return true;
-  // Per-member credential files. Their directory's depth differs per deployment
-  // (`<agent>/.houston/runtime/auth-users/` on a standing pod, `data/auth-users/`
-  // in the per-turn layout), so it must be matched by SEGMENT the same way
-  // auth.json is matched by suffix — a root-relative pattern misses the real
-  // key. Unconditional, not caller-configurable: this is credential material,
-  // and one member's tokens reaching the shared store leaks them to the space.
-  if (normalized.split("/").includes("auth-users")) return true;
-  return excludes.some((exclude) => {
-    const pattern = norm(exclude);
-    if (pattern.includes("*")) {
-      // Segment glob: `*` matches exactly one path segment; a trailing `/`
-      // names a subtree. `workspaces/*/*/.houston/runtime/` is the agent's
-      // own runtime dir at its fixed depth — never a user project's.
-      return segmentGlobMatches(pattern, normalized);
-    }
-    if (pattern.endsWith("/")) {
-      const subtree = pattern.slice(0, -1);
-      return normalized === subtree || normalized.startsWith(pattern);
-    }
-    if (!pattern.includes("/")) return basename(normalized) === pattern;
-    return normalized === pattern;
-  });
-}
 
 export interface HydrateOptions {
   /** Reject prefixes whose total size exceeds this (default 512 MiB). */
@@ -111,6 +71,8 @@ export interface StartedHydration {
   listed: { rels: string[]; generationAware: boolean };
   /** Resolves only after every non-priority object has landed. */
   done: Promise<void>;
+  /** Stop admitting downloads and cancel adapters that support AbortSignal. */
+  abort: () => void;
 }
 
 /** List once, hydrate priority inputs, then start the remaining downloads. */
@@ -155,7 +117,17 @@ export async function startHydrate(
   const remaining = opts.priority
     ? entries.filter((entry) => !opts.priority?.(entry.rel))
     : entries;
-  const state: HydrateDownloadState = { total: 0, failed: false };
+  const controller = new AbortController();
+  const state: HydrateDownloadState = {
+    total: 0,
+    failed: false,
+    fail(error) {
+      if (this.failed) return;
+      this.failed = true;
+      this.firstError = error;
+      controller.abort(error);
+    },
+  };
   const download = (batch: HydrateEntry[]) =>
     downloadHydrationEntries({
       store,
@@ -165,11 +137,17 @@ export async function startHydrate(
       maxBytes,
       concurrency,
       state,
+      signal: controller.signal,
       limitError: (observedBytes) =>
         new HydrateLimitError(maxBytes, observedBytes),
     });
   await download(priority);
-  return { manifest, listed, done: download(remaining) };
+  return {
+    manifest,
+    listed,
+    done: download(remaining),
+    abort: () => state.fail(new Error("hydration aborted before cleanup")),
+  };
 }
 
 /** Download everything under `prefix` into `destDir`. Returns the manifest. */

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -4,6 +4,7 @@ export { HttpObjectStore } from "./http-store";
 export type {
   HydrateManifest,
   HydrateOptions,
+  StartedHydration,
   SyncBackOptions,
   SyncResult,
 } from "./hydrate";
@@ -12,6 +13,7 @@ export {
   excluded,
   HydrateLimitError,
   hydrate,
+  startHydrate,
   syncBack,
 } from "./hydrate";
 export type {

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -22,6 +22,7 @@ export type {
 } from "./object-manifest";
 export type {
   ObjectStore,
+  ReadOptions,
   ReadResult,
   WriteOptions,
   WriteResult,

--- a/packages/runtime-client/src/object-sync/object-store.ts
+++ b/packages/runtime-client/src/object-sync/object-store.ts
@@ -16,9 +16,13 @@ export interface ObjectStore {
   manifest?(
     prefix?: string,
   ): Promise<import("./object-manifest").ObjectMetadata[]>;
-  download(key: string, destFile: string): Promise<void>;
+  download(key: string, destFile: string, opts?: ReadOptions): Promise<void>;
   /** Download one object and return metadata from the same read response. */
-  downloadVersioned?(key: string, destFile: string): Promise<ReadResult>;
+  downloadVersioned?(
+    key: string,
+    destFile: string,
+    opts?: ReadOptions,
+  ): Promise<ReadResult>;
   upload(
     srcFile: string,
     key: string,
@@ -26,6 +30,10 @@ export interface ObjectStore {
     // biome-ignore lint/suspicious/noConfusingVoidType: additive port widening must accept existing void-returning stores.
   ): Promise<WriteResult | void>;
   delete(key: string, opts?: WriteOptions): Promise<void>;
+}
+
+export interface ReadOptions {
+  signal?: AbortSignal;
 }
 
 export interface WriteOptions {
@@ -148,12 +156,17 @@ export class LocalDirStore implements ObjectStore {
     return out;
   }
 
-  async download(key: string, destFile: string): Promise<void> {
+  async download(
+    key: string,
+    destFile: string,
+    opts?: ReadOptions,
+  ): Promise<void> {
     await mkdir(dirname(destFile), { recursive: true });
     try {
       await pipeline(
         createReadStream(this.fileFor(key)),
         createWriteStream(destFile),
+        ...(opts?.signal ? [{ signal: opts.signal }] : []),
       );
     } catch (error) {
       // Same taxonomy as the HTTP store's 404: a listed file deleted before

--- a/packages/runtime-client/src/object-sync/retry.ts
+++ b/packages/runtime-client/src/object-sync/retry.ts
@@ -65,8 +65,10 @@ export async function fetchWithRetry(
       const res = await fetchImpl(url, attemptInit);
       if (lastAttempt || !(await isTransientResponse(res))) return res;
     } catch (err) {
+      if (init?.signal?.aborted) throw err;
       if (lastAttempt) throw err;
     }
+    if (init?.signal?.aborted) throw init.signal.reason;
     await sleep(delays[attempt] ?? 0);
   }
 }

--- a/packages/runtime/src/backends/claude/backend-types.ts
+++ b/packages/runtime/src/backends/claude/backend-types.ts
@@ -1,0 +1,26 @@
+import type { ToolSelection } from "../../session/tool-selection";
+import type { IntegrationToolOptions } from "../../session/tools/integrations";
+import type { BridgedPiTool } from "./custom-tools";
+import type { ClaudeLayout } from "./paths";
+import type { ClaudeSdk, ClaudeSdkLoadResult } from "./sdk-loader";
+
+/** A resolved Anthropic credential for one SDK subprocess environment. */
+export type ClaudeToken =
+  | { kind: "oauth-token"; value: string; accessDigest?: string }
+  | { kind: "api-key"; value: string; accessDigest?: string };
+
+/** Everything the Claude backend needs to open a session. */
+export interface ClaudeBackendDeps {
+  workspaceDir: string;
+  layout: ClaudeLayout;
+  readToken: () => ClaudeToken | undefined;
+  toolSelection: ToolSelection;
+  systemPrompt: string;
+  sharedRoots?: string[];
+  integrations?: IntegrationToolOptions;
+  tools?: BridgedPiTool[];
+  /** External SDK adapter for tests that must not spawn a process. */
+  sdk?: ClaudeSdk;
+  /** Optional import already running during pooled-turn hydration. */
+  sdkLoad?: Promise<ClaudeSdkLoadResult>;
+}

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -1,79 +1,27 @@
-import type {
-  createSdkMcpServer,
-  Options,
-} from "@anthropic-ai/claude-agent-sdk";
-import type { ToolSelection } from "../../session/tool-selection";
-import type { IntegrationToolOptions } from "../../session/tools/integrations";
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
 import type {
   CreateSessionOptions,
   HarnessBackend,
   HarnessSession,
 } from "../types";
+import type { ClaudeBackendDeps } from "./backend-types";
 import { resolveClaudeExecutable } from "./binary-path";
 import { buildClaudeEnv } from "./claude-env";
-import {
-  type BridgedPiTool,
-  buildHoustonMcpServer,
-  HOUSTON_MCP_SERVER_NAME,
-} from "./custom-tools";
+import { buildHoustonMcpServer, HOUSTON_MCP_SERVER_NAME } from "./custom-tools";
 import { toSdkModel } from "./model";
-import type { ClaudeLayout } from "./paths";
 import { assertAnthropicScopeCredential } from "./scope-guard";
+import {
+  ClaudeBackendUnavailableError,
+  loadedClaudeSdk,
+  preloadClaudeSdk,
+} from "./sdk-loader";
 import { type ClaudeQuery, ClaudeSession } from "./session";
 import { createSessionsStore } from "./sessions-store";
 import { buildSystemPrompt } from "./system-prompt";
 import { buildToolPolicy, makeCanUseTool } from "./tool-policy";
 
-/**
- * A resolved Anthropic credential: an OAuth token or a pasted API key.
- * `accessDigest` is set ONLY when the value came from an OAUTH-typed store
- * entry's access token (read-token.ts): it is what a revoked-token report
- * names, captured at spawn preparation — the env is rebuilt from a fresh read
- * at every prompt (PRODUCT-1355), so the digest travels WITH that read; still
- * never re-digested at failure time, which would name whatever a re-serve
- * stored since, not the token the failed turn ran on (PRODUCT-1319).
- */
-export type ClaudeToken =
-  | { kind: "oauth-token"; value: string; accessDigest?: string }
-  | { kind: "api-key"; value: string; accessDigest?: string };
-
-/** Everything the Claude backend needs to open a session. */
-export interface ClaudeBackendDeps {
-  workspaceDir: string;
-  layout: ClaudeLayout;
-  /** The current Anthropic credential, or undefined when none is connected. */
-  readToken: () => ClaudeToken | undefined;
-  /** Houston's active tool selection (its code-execution mode gates Bash). */
-  toolSelection: ToolSelection;
-  /** Houston's product system prompt (full-replace, not the claude_code preset). */
-  systemPrompt: string;
-  /** Extra roots available to read-only file tools, never Edit/Write/Bash. */
-  sharedRoots?: string[];
-  /**
-   * Integration proxy config when this runtime can reach its host with a sandbox
-   * token — the SAME gate the pi path applies (`config.controlPlaneUrl &&
-   * config.sandboxToken`). Present → the in-process MCP server also exposes
-   * `request_connection` + `integration_search` + `integration_execute`; absent
-   * → only `ask_user` (which holds no credential and makes no network call).
-   */
-  integrations?: IntegrationToolOptions;
-  /** Prebuilt turn tools replace the long-lived server's default set. */
-  tools?: BridgedPiTool[];
-  /** External SDK adapter for tests that must not spawn a process. */
-  sdk?: {
-    query: ClaudeQuery;
-    createSdkMcpServer: typeof createSdkMcpServer;
-  };
-}
-
-/** Thrown when the optional Claude Agent SDK is not present in this build. */
-export class ClaudeBackendUnavailableError extends Error {
-  constructor(cause?: unknown) {
-    super("Claude backend unavailable in this build");
-    this.name = "ClaudeBackendUnavailableError";
-    if (cause !== undefined) this.cause = cause;
-  }
-}
+export type { ClaudeBackendDeps, ClaudeToken } from "./backend-types";
+export { ClaudeBackendUnavailableError } from "./sdk-loader";
 
 /**
  * Build the Claude Agent SDK `HarnessBackend` for the `anthropic` provider.
@@ -120,7 +68,8 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
       let houstonMcp: ReturnType<typeof buildHoustonMcpServer>;
       try {
         const sdk =
-          deps.sdk ?? (await import("@anthropic-ai/claude-agent-sdk"));
+          deps.sdk ??
+          (await loadedClaudeSdk(deps.sdkLoad ?? preloadClaudeSdk()));
         query = sdk.query as ClaudeQuery;
         // Build the in-process MCP server that exposes Houston's custom tools to
         // the subprocess. Built here (not at module load) so the optional SDK's

--- a/packages/runtime/src/backends/claude/sdk-loader.ts
+++ b/packages/runtime/src/backends/claude/sdk-loader.ts
@@ -1,0 +1,47 @@
+import type { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import type { ClaudeQuery } from "./session";
+
+/** Thrown when the optional Claude Agent SDK is not present in this build. */
+export class ClaudeBackendUnavailableError extends Error {
+  constructor(cause?: unknown) {
+    super("Claude backend unavailable in this build");
+    this.name = "ClaudeBackendUnavailableError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+/** Optional Claude SDK slice used by the backend and its tests. */
+export interface ClaudeSdk {
+  query: ClaudeQuery;
+  createSdkMcpServer: typeof createSdkMcpServer;
+}
+
+export type ClaudeSdkLoadResult =
+  | { ok: true; sdk: ClaudeSdk }
+  | { ok: false; error: unknown };
+
+/** Start the optional SDK import without leaving an early rejection unhandled. */
+export function preloadClaudeSdk(
+  sdk?: ClaudeSdk,
+): Promise<ClaudeSdkLoadResult> {
+  if (sdk) return Promise.resolve({ ok: true, sdk });
+  return import("@anthropic-ai/claude-agent-sdk").then(
+    (loaded) => ({
+      ok: true,
+      sdk: {
+        query: loaded.query as ClaudeQuery,
+        createSdkMcpServer: loaded.createSdkMcpServer,
+      },
+    }),
+    (error: unknown) => ({ ok: false, error }),
+  );
+}
+
+/** Recover the loaded SDK or raise its original import failure. */
+export async function loadedClaudeSdk(
+  load: Promise<ClaudeSdkLoadResult>,
+): Promise<ClaudeSdk> {
+  const result = await load;
+  if (!result.ok) throw result.error;
+  return result.sdk;
+}

--- a/packages/runtime/src/turn/execute-ready-turn.ts
+++ b/packages/runtime/src/turn/execute-ready-turn.ts
@@ -1,0 +1,170 @@
+import type { WireFrame } from "@houston/runtime-client";
+import { runWithActingContext } from "../session/acting-context";
+import { runWithConversationScope } from "../session/bus";
+import type { startClaimHeartbeat } from "./claim-heartbeat";
+import type { TurnServerDeps } from "./server-types";
+import { finishTurnDurability } from "./turn-durability";
+import type { TurnFilesystem } from "./turn-filesystem";
+import type { createTurnLog } from "./turn-log";
+import { turnSessionRequest } from "./turn-request";
+import {
+  prepareRoutineTurn,
+  RoutineTurnError,
+  settleRoutineTurn,
+} from "./turn-routine";
+import type { makeTurnSandboxFetch } from "./turn-sandbox";
+import { runTurn, type TurnOutcome } from "./turn-session";
+import type { TurnSessionStartupTask } from "./turn-session-startup";
+import type { resolveTurnStore } from "./turn-store";
+import { turnTerminalFrame } from "./turn-terminal";
+import type { createTurnTranscript } from "./turn-transcript";
+import type { TurnRequest } from "./types";
+
+/** Run a fully hydrated non-shadow turn, then make its writes durable. */
+export async function executeReadyTurn(input: {
+  deps: TurnServerDeps;
+  turn: TurnRequest;
+  turnId: string;
+  root: string;
+  scope: string;
+  authPath: string;
+  signal: AbortSignal;
+  filesystem: TurnFilesystem;
+  resolved: ReturnType<typeof resolveTurnStore>;
+  heartbeat: ReturnType<typeof startClaimHeartbeat> | null;
+  sandbox: ReturnType<typeof makeTurnSandboxFetch> | null;
+  startup?: TurnSessionStartupTask;
+  timings: Record<string, number>;
+  emit: (frame: WireFrame) => void;
+  turnLog: ReturnType<typeof createTurnLog>;
+  transcript: ReturnType<typeof createTurnTranscript>;
+}): Promise<void> {
+  let routinePhase = null;
+  let effectiveTurn = input.turn;
+  if (input.turn.routine) {
+    try {
+      routinePhase = await prepareRoutineTurn(
+        input.filesystem.workspaceDir,
+        input.turn,
+        input.turnId,
+        new Date().toISOString(),
+      );
+      effectiveTurn = {
+        ...input.turn,
+        text: routinePhase.text,
+        ...(routinePhase.provider ? { provider: routinePhase.provider } : {}),
+        ...(routinePhase.model ? { model: routinePhase.model } : {}),
+        ...(routinePhase.effort ? { effort: routinePhase.effort } : {}),
+        mode: "auto",
+      };
+    } catch (error) {
+      const code =
+        error instanceof RoutineTurnError ? error.code : "routine_error";
+      input.emit({
+        type: "error",
+        data: {
+          message: error instanceof Error ? error.message : String(error),
+          code,
+        },
+        turnId: input.turnId,
+      } as WireFrame);
+      await input.turnLog?.flush();
+      return;
+    }
+  }
+
+  let outcome: TurnOutcome;
+  if (!input.turn.credential) {
+    input.emit({
+      type: "user",
+      data: {
+        content: input.turn.text,
+        ts: Date.now(),
+        nonce: input.turn.nonce,
+        mentions: input.turn.mentions,
+      },
+      turnId: input.turnId,
+    });
+    outcome = {
+      error: "No provider connected. Connect your subscription first.",
+    };
+  } else {
+    const run = input.deps.runTurn ?? runTurn;
+    try {
+      outcome = await runWithConversationScope(input.scope, () =>
+        runWithActingContext(
+          {
+            credentialScopeKey: `u:turn:${input.turn.workspaceId}:${input.turn.agentId}`,
+            authPath: input.authPath,
+            ...(input.turn.actingAs
+              ? { actingUser: input.turn.actingAs.userId }
+              : {}),
+          },
+          () =>
+            run(
+              { ...input.filesystem, turnRoot: input.root },
+              turnSessionRequest(
+                effectiveTurn,
+                input.turnId,
+                input.emit,
+                input.signal,
+                input.sandbox ? { call: input.sandbox.call } : undefined,
+                input.timings,
+                input.startup,
+              ),
+            ),
+        ),
+      );
+    } catch (error) {
+      outcome = {
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  if (routinePhase) {
+    try {
+      await settleRoutineTurn({
+        workspaceDir: input.filesystem.workspaceDir,
+        phase: routinePhase,
+        conversationId: input.turn.conversationId,
+        ...(outcome.error ? { turnError: outcome.error } : {}),
+        nowIso: new Date().toISOString(),
+        newId: () => crypto.randomUUID(),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      outcome = {
+        ...outcome,
+        error: outcome.error
+          ? `${outcome.error}; routine settle failed: ${message}`
+          : `routine settle failed: ${message}`,
+      };
+    }
+  }
+
+  input.timings.t_run_done = performance.now();
+  const durable = await finishTurnDurability({
+    deps: input.deps,
+    turn: { ...input.turn, turnId: input.turnId },
+    filesystem: input.filesystem,
+    resolved: input.resolved,
+    heartbeat: input.heartbeat,
+    outcome,
+    transcript: input.transcript,
+    ...(input.sandbox ? { views: input.sandbox.views() } : {}),
+  });
+  input.timings.t_durable = performance.now();
+  input.emit(
+    turnTerminalFrame(
+      durable.outcome,
+      input.turnId,
+      durable.poolWritesOutOfScope,
+      durable.transcriptSkipped,
+      durable.activityDocSkipped,
+      durable.changed,
+      input.timings,
+    ),
+  );
+  await input.turnLog?.flush();
+}

--- a/packages/runtime/src/turn/execute-ready-turn.ts
+++ b/packages/runtime/src/turn/execute-ready-turn.ts
@@ -89,7 +89,6 @@ export async function executeReadyTurn(input: {
       error: "No provider connected. Connect your subscription first.",
     };
   } else {
-    const run = input.deps.runTurn ?? runTurn;
     try {
       outcome = await runWithConversationScope(input.scope, () =>
         runWithActingContext(
@@ -100,19 +99,24 @@ export async function executeReadyTurn(input: {
               ? { actingUser: input.turn.actingAs.userId }
               : {}),
           },
-          () =>
-            run(
-              { ...input.filesystem, turnRoot: input.root },
-              turnSessionRequest(
-                effectiveTurn,
-                input.turnId,
-                input.emit,
-                input.signal,
-                input.sandbox ? { call: input.sandbox.call } : undefined,
-                input.timings,
-                input.startup,
-              ),
-            ),
+          () => {
+            const directories = {
+              ...input.filesystem,
+              turnRoot: input.root,
+            };
+            const request = turnSessionRequest(
+              effectiveTurn,
+              input.turnId,
+              input.emit,
+              input.signal,
+              input.sandbox ? { call: input.sandbox.call } : undefined,
+              input.timings,
+              input.startup,
+            );
+            return input.deps.runTurn
+              ? input.deps.runTurn(directories, request)
+              : runTurn(directories, request, input.deps.turnSessionDeps);
+          },
         ),
       );
     } catch (error) {

--- a/packages/runtime/src/turn/execute-shadow-turn.ts
+++ b/packages/runtime/src/turn/execute-shadow-turn.ts
@@ -1,0 +1,39 @@
+import type { WireFrame } from "@houston/runtime-client";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { createTurnModelRuntime } from "./turn-runtime";
+import type { TurnRequest } from "./types";
+
+/** Resolve a shadow turn's model without creating a provider session. */
+export async function executeShadowTurn(input: {
+  turn: TurnRequest;
+  turnId: string;
+  filesystem: TurnFilesystem;
+  timings: Record<string, number>;
+  emit: (frame: WireFrame) => void;
+}): Promise<void> {
+  try {
+    if (!input.turn.credential)
+      throw new Error("shadow turn needs a credential");
+    await createTurnModelRuntime(
+      input.filesystem.dataDir,
+      input.turn.provider || input.turn.credential.provider,
+      input.turn.model,
+      input.timings,
+    );
+    input.emit({
+      type: "shadow",
+      data: {
+        ...input.timings,
+        hydratedObjects: input.filesystem.manifest.size,
+      },
+      turnId: input.turnId,
+    } as unknown as WireFrame);
+    input.emit({ type: "done", data: null, turnId: input.turnId });
+  } catch (error) {
+    input.emit({
+      type: "error",
+      data: { message: error instanceof Error ? error.message : String(error) },
+      turnId: input.turnId,
+    });
+  }
+}

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -1,32 +1,28 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WireFrame } from "@houston/runtime-client";
 import { applyServedAzureEndpoint } from "../ai/azure-openai";
 import { applyServedCredential } from "../auth/auth-file";
-import { runWithActingContext } from "../session/acting-context";
-import { releaseConversation, runWithConversationScope } from "../session/bus";
 import { openSSE } from "../transport/sse";
 import { startClaimHeartbeat } from "./claim-heartbeat";
+import { executeReadyTurn } from "./execute-ready-turn";
+import { executeShadowTurn } from "./execute-shadow-turn";
 import type { TurnServerDeps } from "./server-types";
-import { finishTurnDurability } from "./turn-durability";
-import { prepareTurnFilesystem } from "./turn-filesystem";
+import { cleanupTurn } from "./turn-cleanup";
+import { startTurnFilesystem } from "./turn-filesystem";
 import { ownConversationOnly } from "./turn-hot-set";
 import { TurnSetupError } from "./turn-layout";
 import { createTurnLog } from "./turn-log";
 import { turnSessionRequest } from "./turn-request";
-import {
-  prepareRoutineTurn,
-  type RoutinePhase,
-  RoutineTurnError,
-  settleRoutineTurn,
-} from "./turn-routine";
-import { createTurnModelRuntime } from "./turn-runtime";
 import { makeTurnSandboxFetch } from "./turn-sandbox";
-import { runTurn, type TurnOutcome } from "./turn-session";
+import {
+  startTurnSession,
+  type TurnSessionStartupTask,
+} from "./turn-session-startup";
 import { poolIdentity, resolveTurnStore } from "./turn-store";
-import { turnSetupErrorFrame, turnTerminalFrame } from "./turn-terminal";
+import { turnSetupErrorFrame } from "./turn-terminal";
 import { createTurnTranscript } from "./turn-transcript";
 import type { TurnRequest } from "./types";
 
@@ -72,7 +68,7 @@ export async function executeTurn(
               : {}),
           })
         : null;
-    const filesystem = await prepareTurnFilesystem({
+    const preparation = await startTurnFilesystem({
       store: resolved.store,
       prefix: resolved.prefix,
       root,
@@ -87,8 +83,13 @@ export async function executeTurn(
       ...(turn.claim
         ? { filter: ownConversationOnly(turn.conversationId) }
         : {}),
+      timings,
     });
-    timings.t_hydrated = performance.now();
+    const filesystem = preparation.filesystem;
+    const hydrated = preparation.hydrated.then((result) => {
+      timings.t_hydrated = performance.now();
+      return result;
+    });
     const { dataDir } = filesystem;
     if (turn.grant && turn.hostToken) {
       const identity = poolIdentity(turn.gcsPrefix);
@@ -120,6 +121,26 @@ export async function executeTurn(
     }
     timings.t_cred_written = performance.now();
 
+    let sendFrame: ((frame: WireFrame) => void) | undefined;
+    const earlyEmit = (frame: WireFrame) => sendFrame?.(frame);
+    let startup: TurnSessionStartupTask | undefined;
+    if (turn.credential && !turn.routine && !turn.shadow && !deps.runTurn) {
+      startup = startTurnSession(
+        { ...filesystem, turnRoot: root },
+        turnSessionRequest(
+          turn,
+          turnId,
+          earlyEmit,
+          abort.signal,
+          turnSandbox ? { call: turnSandbox.call } : undefined,
+          timings,
+        ),
+        deps.turnSessionDeps,
+      );
+    }
+
+    await hydrated;
+
     const sse = openSSE(res);
     closeSse = sse.close;
     timings.t_sse_open = performance.now();
@@ -136,199 +157,42 @@ export async function executeTurn(
       // the turn. Errors are remembered and surfaced at durability time.
       if (frame.type === "user") void transcript?.publishUser();
     };
+    sendFrame = emit;
 
-    if (turn.shadow) {
-      try {
-        if (!turn.credential) throw new Error("shadow turn needs a credential");
-        await createTurnModelRuntime(
-          dataDir,
-          turn.provider || turn.credential.provider,
-          turn.model,
-          timings,
-        );
-        emit({
-          type: "shadow",
-          data: { ...timings, hydratedObjects: filesystem.manifest.size },
-          turnId,
-          // SAFETY: shadow is an internal turn-server control frame. It uses
-          // the WireFrame transport without entering the public protocol.
-        } as unknown as WireFrame);
-        emit({ type: "done", data: null, turnId });
-      } catch (error) {
-        emit({
-          type: "error",
-          data: {
-            message: error instanceof Error ? error.message : String(error),
-          },
-          turnId,
-        });
-      }
-    } else {
-      let outcome: TurnOutcome;
-      // A routine fire derives its prompt and pins from the agent's own
-      // routine file (the prompt authority), records the running row, and
-      // gates double-fires — the worker-side twin of the host's
-      // fireRoutineRun. Typed failures terminate the turn with a machine
-      // code the dispatcher settles the fire from.
-      let routinePhase: RoutinePhase | null = null;
-      let effectiveTurn = turn;
-      if (turn.routine) {
-        try {
-          routinePhase = await prepareRoutineTurn(
-            filesystem.workspaceDir,
-            turn,
-            turnId,
-            new Date().toISOString(),
-          );
-          effectiveTurn = {
-            ...turn,
-            text: routinePhase.text,
-            // The routine's pinned provider is the routine's own statement of
-            // what it runs on — it must outrank the dispatcher-attached
-            // credential's provider, or a mismatched serve silently moves the
-            // fire onto a provider the routine never picked (PRODUCT-1515).
-            ...(routinePhase.provider
-              ? { provider: routinePhase.provider }
-              : {}),
-            ...(routinePhase.model ? { model: routinePhase.model } : {}),
-            ...(routinePhase.effort ? { effort: routinePhase.effort } : {}),
-            mode: "auto",
-          };
-        } catch (error) {
-          const code =
-            error instanceof RoutineTurnError ? error.code : "routine_error";
-          emit({
-            type: "error",
-            data: {
-              message: error instanceof Error ? error.message : String(error),
-              code,
-            },
-            turnId,
-          } as WireFrame);
-          await turnLog?.flush();
-          return;
-        }
-      }
-      if (!turn.credential) {
-        emit({
-          type: "user",
-          data: {
-            content: turn.text,
-            ts: Date.now(),
-            nonce: turn.nonce,
-            mentions: turn.mentions,
-          },
-          turnId,
-        });
-        outcome = {
-          error: "No provider connected. Connect your subscription first.",
-        };
-      } else {
-        const run = deps.runTurn ?? runTurn;
-        try {
-          outcome = await runWithConversationScope(scope, () =>
-            runWithActingContext(
-              {
-                credentialScopeKey: `u:turn:${turn.workspaceId}:${turn.agentId}`,
-                authPath,
-                ...(turn.actingAs ? { actingUser: turn.actingAs.userId } : {}),
-              },
-              () =>
-                run(
-                  { ...filesystem, turnRoot: root },
-                  turnSessionRequest(
-                    effectiveTurn,
-                    turnId,
-                    emit,
-                    abort.signal,
-                    turnSandbox ? { call: turnSandbox.call } : undefined,
-                    timings,
-                  ),
-                ),
-            ),
-          );
-        } catch (error) {
-          outcome = {
-            error: error instanceof Error ? error.message : String(error),
-          };
-        }
-      }
-
-      if (routinePhase) {
-        // The run row must leave "running" and land in the tree BEFORE the
-        // claimed sync-back uploads it — never a stuck row, never silent.
-        try {
-          await settleRoutineTurn({
-            workspaceDir: filesystem.workspaceDir,
-            phase: routinePhase,
-            conversationId: turn.conversationId,
-            ...(outcome.error ? { turnError: outcome.error } : {}),
-            nowIso: new Date().toISOString(),
-            newId: () => crypto.randomUUID(),
-          });
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          outcome = {
-            ...outcome,
-            error: outcome.error
-              ? `${outcome.error}; routine settle failed: ${message}`
-              : `routine settle failed: ${message}`,
-          };
-        }
-      }
-
-      timings.t_run_done = performance.now();
-      const durable = await finishTurnDurability({
+    if (turn.shadow)
+      await executeShadowTurn({ turn, turnId, filesystem, timings, emit });
+    else
+      await executeReadyTurn({
         deps,
-        turn: { ...turn, turnId },
+        turn,
+        turnId,
+        root,
+        scope,
+        authPath,
+        signal: abort.signal,
         filesystem,
         resolved,
         heartbeat,
-        outcome,
+        sandbox: turnSandbox,
+        startup,
+        timings,
+        emit,
+        turnLog,
         transcript,
-        ...(turnSandbox ? { views: turnSandbox.views() } : {}),
       });
-      outcome = durable.outcome;
-      timings.t_durable = performance.now();
-      emit(
-        turnTerminalFrame(
-          outcome,
-          turnId,
-          durable.poolWritesOutOfScope,
-          durable.transcriptSkipped,
-          durable.activityDocSkipped,
-          durable.changed,
-          timings,
-        ),
-      );
-      await turnLog?.flush();
-    }
   } catch (error) {
     if (!(error instanceof TurnSetupError)) throw error;
     const sse = openSSE(res);
     closeSse = sse.close;
     sse.send(turnSetupErrorFrame(error, turnId));
   } finally {
-    try {
-      await turnSandbox?.dispose().catch((error: unknown) => {
-        const detail =
-          error instanceof Error
-            ? `${error.name}: ${error.message}`
-            : typeof error;
-        console.error(`[turn] sandbox dispose failed (${detail})`);
-      });
-    } finally {
-      try {
-        await heartbeat?.stop();
-      } finally {
-        releaseConversation(scope, turn.conversationId);
-        try {
-          await rm(root, { recursive: true, force: true });
-        } finally {
-          closeSse?.();
-        }
-      }
-    }
+    await cleanupTurn({
+      root,
+      scope,
+      conversationId: turn.conversationId,
+      heartbeat,
+      sandbox: turnSandbox,
+      closeSse,
+    });
   }
 }

--- a/packages/runtime/src/turn/execute-turn.ts
+++ b/packages/runtime/src/turn/execute-turn.ts
@@ -3,21 +3,25 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WireFrame } from "@houston/runtime-client";
-import { applyServedAzureEndpoint } from "../ai/azure-openai";
-import { applyServedCredential } from "../auth/auth-file";
 import { openSSE } from "../transport/sse";
 import { startClaimHeartbeat } from "./claim-heartbeat";
 import { executeReadyTurn } from "./execute-ready-turn";
 import { executeShadowTurn } from "./execute-shadow-turn";
 import type { TurnServerDeps } from "./server-types";
 import { cleanupTurn } from "./turn-cleanup";
-import { startTurnFilesystem } from "./turn-filesystem";
+import { writeTurnCredential } from "./turn-credential";
+import {
+  startTurnFilesystem,
+  type TurnFilesystemPreparation,
+} from "./turn-filesystem";
 import { ownConversationOnly } from "./turn-hot-set";
 import { TurnSetupError } from "./turn-layout";
 import { createTurnLog } from "./turn-log";
 import { turnSessionRequest } from "./turn-request";
-import { makeTurnSandboxFetch } from "./turn-sandbox";
+import type { makeTurnSandboxFetch } from "./turn-sandbox";
+import { createTurnSandbox } from "./turn-sandbox-startup";
 import {
+  reportAbandonedTurnStartup,
   startTurnSession,
   type TurnSessionStartupTask,
 } from "./turn-session-startup";
@@ -50,8 +54,12 @@ export async function executeTurn(
   const turnId = turn.turnId ?? crypto.randomUUID();
   let heartbeat: ReturnType<typeof startClaimHeartbeat> | null = null;
   let turnSandbox: ReturnType<typeof makeTurnSandboxFetch> | null = null;
+  let preparation: TurnFilesystemPreparation | undefined;
+  let startup: TurnSessionStartupTask | undefined;
   let closeSse: (() => void) | undefined;
   try {
+    const sandboxIdentity =
+      turn.grant && turn.hostToken ? poolIdentity(turn.gcsPrefix) : undefined;
     const resolved = resolveTurnStore(turn, deps.store, {
       poolStoreUrl: deps.poolStoreUrl,
       fetchImpl: deps.fetchImpl,
@@ -68,7 +76,7 @@ export async function executeTurn(
               : {}),
           })
         : null;
-    const preparation = await startTurnFilesystem({
+    preparation = await startTurnFilesystem({
       store: resolved.store,
       prefix: resolved.prefix,
       root,
@@ -86,44 +94,27 @@ export async function executeTurn(
       timings,
     });
     const filesystem = preparation.filesystem;
-    const hydrated = preparation.hydrated.then((result) => {
-      timings.t_hydrated = performance.now();
-      return result;
-    });
     const { dataDir } = filesystem;
-    if (turn.grant && turn.hostToken) {
-      const identity = poolIdentity(turn.gcsPrefix);
-      turnSandbox = makeTurnSandboxFetch({
-        grant: turn.grant,
-        hostToken: turn.hostToken,
-        store: resolved.store,
-        prefix: resolved.prefix,
-        filesystem,
-        workspaceId: turn.workspaceId,
-        conversationId: turn.conversationId,
-        ...(turn.actingAs ? { actingAs: turn.actingAs } : {}),
-        orgSlug: identity.org,
-        agentSlug: identity.agent,
-        ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
-      });
-    }
+    turnSandbox = createTurnSandbox({
+      deps,
+      turn,
+      identity: sandboxIdentity,
+      resolved,
+      filesystem,
+    });
     const authPath = join(dataDir, "auth.json");
     if (turn.credential) {
-      applyServedCredential(authPath, turn.credential);
-      // Azure's per-resource endpoint rides the served credential; land it in
-      // THIS turn's hydrated root so model resolution finds a base URL even
-      // when this agent never ran the connect itself (PRODUCT-1532).
-      applyServedAzureEndpoint(
-        turn.credential.provider,
-        turn.credential.enterpriseUrl,
+      writeTurnCredential(
+        authPath,
+        turn.credential,
         dataDir,
+        deps.writeTurnCredential,
       );
     }
     timings.t_cred_written = performance.now();
 
     let sendFrame: ((frame: WireFrame) => void) | undefined;
     const earlyEmit = (frame: WireFrame) => sendFrame?.(frame);
-    let startup: TurnSessionStartupTask | undefined;
     if (turn.credential && !turn.routine && !turn.shadow && !deps.runTurn) {
       startup = startTurnSession(
         { ...filesystem, turnRoot: root },
@@ -139,7 +130,13 @@ export async function executeTurn(
       );
     }
 
-    await hydrated;
+    try {
+      await preparation.hydrated;
+      timings.t_hydrated = performance.now();
+    } catch (error) {
+      await reportAbandonedTurnStartup(startup);
+      throw error;
+    }
 
     const sse = openSSE(res);
     closeSse = sse.close;
@@ -192,6 +189,9 @@ export async function executeTurn(
       conversationId: turn.conversationId,
       heartbeat,
       sandbox: turnSandbox,
+      hydration: preparation,
+      hydrationSettleTimeoutMs: deps.hydrationSettleTimeoutMs,
+      removeRoot: deps.removeTurnRoot,
       closeSse,
     });
   }

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -1,6 +1,7 @@
 import type { ObjectStore } from "@houston/runtime-client/object-sync";
 import type { AdmissionLimiter } from "./admission";
 import type { applyOp } from "./op-apply";
+import type { TurnCredentialWriter } from "./turn-credential";
 import type { TurnRunner } from "./turn-session";
 import type { RunTurnDeps } from "./turn-session-startup";
 
@@ -12,6 +13,11 @@ export interface TurnServerDeps {
   runTurn?: TurnRunner;
   /** Test seams and optional preloaded SDK input for pooled-turn setup. */
   turnSessionDeps?: RunTurnDeps;
+  /** Test seam for a synchronous credential filesystem failure. */
+  writeTurnCredential?: TurnCredentialWriter;
+  /** Test seam for ordering root removal after hydration settlement. */
+  removeTurnRoot?: (root: string) => Promise<void>;
+  hydrationSettleTimeoutMs?: number;
   /** Test seam for the worker op executor. */
   runOp?: typeof applyOp;
   concurrency?: number;

--- a/packages/runtime/src/turn/server-types.ts
+++ b/packages/runtime/src/turn/server-types.ts
@@ -2,6 +2,7 @@ import type { ObjectStore } from "@houston/runtime-client/object-sync";
 import type { AdmissionLimiter } from "./admission";
 import type { applyOp } from "./op-apply";
 import type { TurnRunner } from "./turn-session";
+import type { RunTurnDeps } from "./turn-session-startup";
 
 /** Injectable dependencies and pool controls for the per-turn HTTP server. */
 export interface TurnServerDeps {
@@ -9,6 +10,8 @@ export interface TurnServerDeps {
   /** App-layer token; empty means open local development. */
   token: string;
   runTurn?: TurnRunner;
+  /** Test seams and optional preloaded SDK input for pooled-turn setup. */
+  turnSessionDeps?: RunTurnDeps;
   /** Test seam for the worker op executor. */
   runOp?: typeof applyOp;
   concurrency?: number;

--- a/packages/runtime/src/turn/turn-backend.ts
+++ b/packages/runtime/src/turn/turn-backend.ts
@@ -33,6 +33,7 @@ export interface TurnBackendDeps {
   systemPrompt: string;
   sharedRoots?: string[];
   claudeSdk?: ClaudeBackendDeps["sdk"];
+  claudeSdkLoad?: ClaudeBackendDeps["sdkLoad"];
 }
 
 /** Claude directories split between durable conversation state and turn state. */
@@ -102,6 +103,7 @@ export function createTurnBackend(
       // accepts; only their heterogeneous schema generics need widening.
       tools: commonTools as unknown as BridgedPiTool[],
       sdk: deps.claudeSdk,
+      sdkLoad: deps.claudeSdkLoad,
     });
     return {
       id: backend.id,

--- a/packages/runtime/src/turn/turn-cleanup.ts
+++ b/packages/runtime/src/turn/turn-cleanup.ts
@@ -1,7 +1,28 @@
 import { rm } from "node:fs/promises";
 import { releaseConversation } from "../session/bus";
 import type { startClaimHeartbeat } from "./claim-heartbeat";
+import type { TurnFilesystemPreparation } from "./turn-filesystem";
 import type { makeTurnSandboxFetch } from "./turn-sandbox";
+
+const HYDRATION_SETTLE_TIMEOUT_MS = 5_000;
+
+async function hydrationIsQuiet(
+  hydration: Pick<TurnFilesystemPreparation, "abortHydration" | "settled">,
+  timeoutMs: number,
+): Promise<boolean> {
+  hydration.abortHydration();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<false>((resolve) => {
+    timeout = setTimeout(() => resolve(false), timeoutMs);
+    timeout.unref?.();
+  });
+  const quiet = await Promise.race([
+    hydration.settled.then(() => true as const),
+    expired,
+  ]);
+  if (timeout) clearTimeout(timeout);
+  return quiet;
+}
 
 /** Release every per-turn resource even when an earlier cleanup step fails. */
 export async function cleanupTurn(input: {
@@ -10,6 +31,9 @@ export async function cleanupTurn(input: {
   conversationId: string;
   heartbeat: ReturnType<typeof startClaimHeartbeat> | null;
   sandbox: ReturnType<typeof makeTurnSandboxFetch> | null;
+  hydration?: Pick<TurnFilesystemPreparation, "abortHydration" | "settled">;
+  hydrationSettleTimeoutMs?: number;
+  removeRoot?: (root: string) => Promise<void>;
   closeSse?: () => void;
 }): Promise<void> {
   try {
@@ -26,7 +50,22 @@ export async function cleanupTurn(input: {
     } finally {
       releaseConversation(input.scope, input.conversationId);
       try {
-        await rm(input.root, { recursive: true, force: true });
+        const quiet = input.hydration
+          ? await hydrationIsQuiet(
+              input.hydration,
+              input.hydrationSettleTimeoutMs ?? HYDRATION_SETTLE_TIMEOUT_MS,
+            )
+          : true;
+        if (quiet) {
+          const removeRoot =
+            input.removeRoot ??
+            ((root: string) => rm(root, { recursive: true, force: true }));
+          await removeRoot(input.root);
+        } else {
+          console.error(
+            `[turn] hydration cleanup timed out after ${input.hydrationSettleTimeoutMs ?? HYDRATION_SETTLE_TIMEOUT_MS}ms; leaving the turn root in place`,
+          );
+        }
       } finally {
         input.closeSse?.();
       }

--- a/packages/runtime/src/turn/turn-cleanup.ts
+++ b/packages/runtime/src/turn/turn-cleanup.ts
@@ -1,0 +1,35 @@
+import { rm } from "node:fs/promises";
+import { releaseConversation } from "../session/bus";
+import type { startClaimHeartbeat } from "./claim-heartbeat";
+import type { makeTurnSandboxFetch } from "./turn-sandbox";
+
+/** Release every per-turn resource even when an earlier cleanup step fails. */
+export async function cleanupTurn(input: {
+  root: string;
+  scope: string;
+  conversationId: string;
+  heartbeat: ReturnType<typeof startClaimHeartbeat> | null;
+  sandbox: ReturnType<typeof makeTurnSandboxFetch> | null;
+  closeSse?: () => void;
+}): Promise<void> {
+  try {
+    await input.sandbox?.dispose().catch((error: unknown) => {
+      const detail =
+        error instanceof Error
+          ? `${error.name}: ${error.message}`
+          : typeof error;
+      console.error(`[turn] sandbox dispose failed (${detail})`);
+    });
+  } finally {
+    try {
+      await input.heartbeat?.stop();
+    } finally {
+      releaseConversation(input.scope, input.conversationId);
+      try {
+        await rm(input.root, { recursive: true, force: true });
+      } finally {
+        input.closeSse?.();
+      }
+    }
+  }
+}

--- a/packages/runtime/src/turn/turn-credential.ts
+++ b/packages/runtime/src/turn/turn-credential.ts
@@ -1,0 +1,41 @@
+import { applyServedAzureEndpoint } from "../ai/azure-openai";
+import {
+  applyServedCredential,
+  type ServedCredential,
+} from "../auth/auth-file";
+import { TurnSetupError } from "./turn-layout";
+
+export type TurnCredentialWriter = (
+  authPath: string,
+  credential: ServedCredential,
+  dataDir: string,
+) => void;
+
+const defaultWriter: TurnCredentialWriter = (authPath, credential, dataDir) => {
+  applyServedCredential(authPath, credential);
+  applyServedAzureEndpoint(
+    credential.provider,
+    credential.enterpriseUrl,
+    dataDir,
+  );
+};
+
+/** Write turn-local provider inputs and map filesystem failures to setup. */
+export function writeTurnCredential(
+  authPath: string,
+  credential: ServedCredential,
+  dataDir: string,
+  writer: TurnCredentialWriter = defaultWriter,
+): void {
+  try {
+    writer(authPath, credential, dataDir);
+  } catch (error) {
+    if (error instanceof TurnSetupError) throw error;
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new TurnSetupError(
+      "credential_write_failed",
+      `credential setup failed: ${detail}`,
+      { cause: error },
+    );
+  }
+}

--- a/packages/runtime/src/turn/turn-filesystem-scope.ts
+++ b/packages/runtime/src/turn/turn-filesystem-scope.ts
@@ -1,0 +1,46 @@
+import { posix } from "node:path";
+import { docKey } from "@houston/domain";
+import { agentScopeIncludes } from "./turn-agent-scope";
+
+/** Build the object scope owned by one claimed conversation turn. */
+export function claimedTurnIncludes(
+  dataRel: string,
+  workspaceRel: string,
+  conversationId: string,
+): (relativePath: string) => boolean {
+  const conversation = posix.join(
+    dataRel,
+    "conversations",
+    `${encodeURIComponent(conversationId)}.json`,
+  );
+  const session = posix.join(dataRel, "sessions", conversationId);
+  const activity = turnActivityKey(workspaceRel);
+  const runs = turnRoutineRunsKey(workspaceRel);
+  return (relativePath) =>
+    relativePath === conversation ||
+    turnSessionScopeIncludes(session, relativePath) ||
+    relativePath === activity ||
+    relativePath === runs ||
+    agentScopeIncludes(relativePath, workspaceRel);
+}
+
+/** Keep ordinary session state, but only durable files from the Claude CLI. */
+export function turnSessionScopeIncludes(
+  sessionRel: string,
+  relativePath: string,
+): boolean {
+  if (!relativePath.startsWith(`${sessionRel}/`)) return false;
+  if (relativePath === `${sessionRel}/harness.json`) return true;
+  const claudePrefix = `${sessionRel}/claude/`;
+  if (!relativePath.startsWith(claudePrefix)) return true;
+  const claudeRel = relativePath.slice(claudePrefix.length);
+  return claudeRel === "sessions.json" || claudeRel.startsWith("projects/");
+}
+
+/** Store-relative mission-board object granted to a claimed turn. */
+export const turnActivityKey = (workspaceRel: string): string =>
+  docKey(workspaceRel, "activity");
+
+/** Store-relative routine-runs object granted to a claimed turn. */
+export const turnRoutineRunsKey = (workspaceRel: string): string =>
+  docKey(workspaceRel, "routine_runs");

--- a/packages/runtime/src/turn/turn-filesystem-sync.ts
+++ b/packages/runtime/src/turn/turn-filesystem-sync.ts
@@ -1,0 +1,60 @@
+import {
+  type ObjectStore,
+  syncBack,
+} from "@houston/runtime-client/object-sync";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { claimedTurnIncludes } from "./turn-filesystem-scope";
+
+/** Sync a turn, limiting a claimed writer to its granted turn-owned files. */
+export async function syncTurnFilesystem(opts: {
+  store: ObjectStore;
+  prefix: string;
+  filesystem: TurnFilesystem;
+  conversationId: string;
+  claimed: boolean;
+}): Promise<{
+  uploaded: string[];
+  deleted: string[];
+  outOfScope: number;
+  skipped: { key: string; reason: string }[];
+  conflicts: { key: string; reason: string }[];
+}> {
+  const result = await syncBack(
+    opts.store,
+    opts.prefix,
+    opts.filesystem.storeRoot,
+    opts.filesystem.manifest,
+    {
+      generations: opts.filesystem.generationAware,
+      // The temp tree disappears after one pool turn. If a replacement write
+      // fails, keep the durable source object instead of completing its delete.
+      holdDeletesOnFailure: opts.claimed,
+      ...(opts.claimed
+        ? {
+            include: claimedTurnIncludes(
+              opts.filesystem.dataRel,
+              opts.filesystem.workspaceRel,
+              opts.conversationId,
+            ),
+          }
+        : {}),
+    },
+  );
+  if (result.outOfScope > 0) {
+    console.info(
+      `[turn] pool_writes_out_of_scope=${result.outOfScope} prefix=${opts.prefix || opts.filesystem.dataRel} conversation=${opts.conversationId}`,
+    );
+  }
+  if (result.skipped.length > 0 || result.conflicts.length > 0) {
+    console.warn(
+      `[turn] pool_sync_incomplete skipped=${result.skipped.length} conflicts=${result.conflicts.length} conversation=${opts.conversationId}`,
+    );
+  }
+  return {
+    uploaded: result.uploaded,
+    deleted: result.deleted,
+    outOfScope: result.outOfScope,
+    skipped: result.skipped,
+    conflicts: result.conflicts,
+  };
+}

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -4,11 +4,11 @@ import { MAX_UPLOAD_BYTES } from "@houston/host/src/turn/files-import";
 import { FsVfs, LazyStoreVfs, type Vfs } from "@houston/host/src/vfs";
 import {
   DEFAULT_EXCLUDES,
-  HydrateLimitError,
   type HydrateManifest,
   type ObjectStore,
   startHydrate,
 } from "@houston/runtime-client/object-sync";
+import { turnHydrationError } from "./turn-hydration-error";
 import {
   layoutSkeleton,
   resolveTurnLayout,
@@ -50,12 +50,12 @@ export interface TurnFilesystem extends TurnLayout {
 export interface TurnFilesystemPreparation {
   filesystem: TurnFilesystem;
   hydrated: Promise<TurnFilesystem>;
-}
-
-function hydrationError(error: unknown): unknown {
-  return error instanceof HydrateLimitError
-    ? new TurnSetupError("hydrate_over_cap", error.message)
-    : error;
+  /** Attached immediately so a later synchronous setup failure cannot leave
+   *  the rejecting hydration promise unobserved. */
+  settled: Promise<
+    { ok: true; filesystem: TurnFilesystem } | { ok: false; error: unknown }
+  >;
+  abortHydration: () => void;
 }
 
 /**
@@ -134,7 +134,12 @@ export async function startTurnFilesystem(opts: {
       generationAware: vfs.generationAware,
       immediateWrites: new Set<string>(),
     };
-    return { filesystem, hydrated: Promise.resolve(filesystem) };
+    return {
+      filesystem,
+      hydrated: Promise.resolve(filesystem),
+      settled: Promise.resolve({ ok: true, filesystem }),
+      abortHydration: () => undefined,
+    };
   }
   let layout: TurnLayout | undefined;
   try {
@@ -153,7 +158,12 @@ export async function startTurnFilesystem(opts: {
         if (opts.timings) opts.timings.t_layout = performance.now();
       },
     });
-    if (!layout) throw new Error("turn layout did not resolve from listing");
+    if (!layout) {
+      throw new TurnSetupError(
+        "layout_unexpected",
+        "turn layout did not resolve from the store listing",
+      );
+    }
     if (opts.timings) opts.timings.t_startup_files = performance.now();
     const filesystem: TurnFilesystem = {
       ...layout,
@@ -167,11 +177,20 @@ export async function startTurnFilesystem(opts: {
     const hydrated = started.done.then(
       () => filesystem,
       (error: unknown) => {
-        throw hydrationError(error);
+        throw turnHydrationError(error);
       },
     );
-    return { filesystem, hydrated };
+    const settled = hydrated.then(
+      (result) => ({ ok: true as const, filesystem: result }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    return {
+      filesystem,
+      hydrated,
+      settled,
+      abortHydration: started.abort,
+    };
   } catch (error) {
-    throw hydrationError(error);
+    throw turnHydrationError(error);
   }
 }

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -1,23 +1,29 @@
 import { mkdir } from "node:fs/promises";
-import { join, posix } from "node:path";
-import { docKey } from "@houston/domain";
+import { join } from "node:path";
 import { MAX_UPLOAD_BYTES } from "@houston/host/src/turn/files-import";
 import { FsVfs, LazyStoreVfs, type Vfs } from "@houston/host/src/vfs";
 import {
   DEFAULT_EXCLUDES,
   HydrateLimitError,
   type HydrateManifest,
-  hydrate,
   type ObjectStore,
-  syncBack,
+  startHydrate,
 } from "@houston/runtime-client/object-sync";
-import { agentScopeIncludes } from "./turn-agent-scope";
 import {
   layoutSkeleton,
   resolveTurnLayout,
   type TurnLayout,
   TurnSetupError,
 } from "./turn-layout";
+import { turnRuntimeInputIncludes } from "./turn-runtime";
+
+export {
+  claimedTurnIncludes,
+  turnActivityKey,
+  turnRoutineRunsKey,
+  turnSessionScopeIncludes,
+} from "./turn-filesystem-scope";
+export { syncTurnFilesystem } from "./turn-filesystem-sync";
 
 /** Maximum hydrated bytes accepted by a pooled turn. */
 export const TURN_HYDRATE_MAX_BYTES = 2 * 1024 * 1024 * 1024;
@@ -39,6 +45,17 @@ export interface TurnFilesystem extends TurnLayout {
   generationAware: boolean;
   /** Tool-call-time CAS writes already durable before the final sync pass. */
   immediateWrites: Set<string>;
+}
+
+export interface TurnFilesystemPreparation {
+  filesystem: TurnFilesystem;
+  hydrated: Promise<TurnFilesystem>;
+}
+
+function hydrationError(error: unknown): unknown {
+  return error instanceof HydrateLimitError
+    ? new TurnSetupError("hydrate_over_cap", error.message)
+    : error;
 }
 
 /**
@@ -67,6 +84,21 @@ export async function prepareTurnFilesystem(opts: {
    */
   lazy?: boolean;
 }): Promise<TurnFilesystem> {
+  return (await startTurnFilesystem(opts)).hydrated;
+}
+
+/** Resolve the listed layout, then hydrate runtime inputs before the bulk tree. */
+export async function startTurnFilesystem(opts: {
+  store: ObjectStore;
+  prefix: string;
+  root: string;
+  claimed: boolean;
+  maxBytes?: number;
+  excludes?: string[];
+  filter?: (rel: string) => boolean;
+  lazy?: boolean;
+  timings?: Record<string, number>;
+}): Promise<TurnFilesystemPreparation> {
   const storeRoot = join(opts.root, "store");
   await mkdir(storeRoot, { recursive: true });
   const excludes = opts.excludes
@@ -76,6 +108,7 @@ export async function prepareTurnFilesystem(opts: {
     opts.maxBytes ?? (opts.claimed ? TURN_HYDRATE_MAX_BYTES : undefined);
   if (opts.lazy && opts.store.manifest) {
     const objects = await opts.store.manifest(opts.prefix);
+    if (opts.timings) opts.timings.t_listing = performance.now();
     const manifest: HydrateManifest = new Map();
     const vfs = new LazyStoreVfs({
       store: opts.store,
@@ -88,153 +121,57 @@ export async function prepareTurnFilesystem(opts: {
       maxBytes: maxBytes ?? TURN_HYDRATE_MAX_BYTES,
     });
     await layoutSkeleton(storeRoot, vfs.remoteKeys);
-    return {
-      ...(await resolveTurnLayout(storeRoot, { allowEmpty: !opts.claimed })),
+    const layout = await resolveTurnLayout(storeRoot, {
+      allowEmpty: !opts.claimed,
+    });
+    if (opts.timings) opts.timings.t_layout = performance.now();
+    const filesystem: TurnFilesystem = {
+      ...layout,
       storeRoot,
       manifest,
       vfs,
       listedObjects: objects.length,
       generationAware: vfs.generationAware,
-      immediateWrites: new Set(),
+      immediateWrites: new Set<string>(),
     };
+    return { filesystem, hydrated: Promise.resolve(filesystem) };
   }
-  let manifest: HydrateManifest;
-  let listed = { rels: [] as string[], generationAware: false };
+  let layout: TurnLayout | undefined;
   try {
-    manifest = await hydrate(opts.store, opts.prefix, storeRoot, {
+    const started = await startHydrate(opts.store, opts.prefix, storeRoot, {
       ...(maxBytes !== undefined ? { maxBytes } : {}),
       excludes,
       ...(opts.filter ? { filter: opts.filter } : {}),
-      onListed: (listing) => {
-        listed = listing;
+      priority: (rel) =>
+        layout !== undefined && turnRuntimeInputIncludes(layout.dataRel, rel),
+      onListed: async (listing) => {
+        if (opts.timings) opts.timings.t_listing = performance.now();
+        await layoutSkeleton(storeRoot, listing.rels);
+        layout = await resolveTurnLayout(storeRoot, {
+          allowEmpty: !opts.claimed,
+        });
+        if (opts.timings) opts.timings.t_layout = performance.now();
       },
     });
-    // The layout must resolve from what the STORE holds, not from what the
-    // filter admitted: a turn whose agent has nothing but other
-    // conversations' history still targets an existing agent.
-    await layoutSkeleton(storeRoot, listed.rels);
+    if (!layout) throw new Error("turn layout did not resolve from listing");
+    if (opts.timings) opts.timings.t_startup_files = performance.now();
+    const filesystem: TurnFilesystem = {
+      ...layout,
+      storeRoot,
+      manifest: started.manifest,
+      vfs: new FsVfs(storeRoot),
+      listedObjects: started.listed.rels.length,
+      generationAware: started.listed.generationAware,
+      immediateWrites: new Set(),
+    };
+    const hydrated = started.done.then(
+      () => filesystem,
+      (error: unknown) => {
+        throw hydrationError(error);
+      },
+    );
+    return { filesystem, hydrated };
   } catch (error) {
-    if (!(error instanceof HydrateLimitError)) throw error;
-    throw new TurnSetupError("hydrate_over_cap", error.message);
+    throw hydrationError(error);
   }
-  return {
-    ...(await resolveTurnLayout(storeRoot, { allowEmpty: !opts.claimed })),
-    storeRoot,
-    manifest,
-    vfs: new FsVfs(storeRoot),
-    listedObjects: listed.rels.length,
-    generationAware: listed.generationAware,
-    immediateWrites: new Set(),
-  };
-}
-
-/**
- * Build a claimed turn's write scope: its own conversation, session, the two
- * granted docs, and the agent's workspace FILES. Workspace files are the
- * turn's deliverable — a spreadsheet the agent built, a document it edited
- * (via the clamped file tools or, on a single-use worker, bash) must survive
- * sync-back or the work silently vanishes. Everything else under `.houston/`
- * stays out of scope: runtime data, docs, and credentials belong to their own
- * writers, and two concurrent conversations of one agent must not clobber
- * them from here. Concurrent workspace-file writes from two conversations of
- * the same agent are last-writer-wins per object, same as the standing host's
- * store-sync daemon.
- */
-export function claimedTurnIncludes(
-  dataRel: string,
-  workspaceRel: string,
-  conversationId: string,
-): (relativePath: string) => boolean {
-  const conversation = posix.join(
-    dataRel,
-    "conversations",
-    `${encodeURIComponent(conversationId)}.json`,
-  );
-  const session = posix.join(dataRel, "sessions", conversationId);
-  const activity = turnActivityKey(workspaceRel);
-  const runs = turnRoutineRunsKey(workspaceRel);
-  return (relativePath) =>
-    relativePath === conversation ||
-    turnSessionScopeIncludes(session, relativePath) ||
-    relativePath === activity ||
-    relativePath === runs ||
-    agentScopeIncludes(relativePath, workspaceRel);
-}
-
-/** Keep ordinary session state, but only durable files from the Claude CLI. */
-export function turnSessionScopeIncludes(
-  sessionRel: string,
-  relativePath: string,
-): boolean {
-  if (!relativePath.startsWith(`${sessionRel}/`)) return false;
-  if (relativePath === `${sessionRel}/harness.json`) return true;
-  const claudePrefix = `${sessionRel}/claude/`;
-  if (!relativePath.startsWith(claudePrefix)) return true;
-  const claudeRel = relativePath.slice(claudePrefix.length);
-  return claudeRel === "sessions.json" || claudeRel.startsWith("projects/");
-}
-
-/** Store-relative mission-board object granted to a claimed turn. */
-export const turnActivityKey = (workspaceRel: string): string =>
-  docKey(workspaceRel, "activity");
-
-/** Store-relative routine-runs object granted to a claimed turn. */
-export const turnRoutineRunsKey = (workspaceRel: string): string =>
-  docKey(workspaceRel, "routine_runs");
-
-/** Sync a turn, limiting a claimed writer to its granted turn-owned files. */
-export async function syncTurnFilesystem(opts: {
-  store: ObjectStore;
-  prefix: string;
-  filesystem: TurnFilesystem;
-  conversationId: string;
-  claimed: boolean;
-}): Promise<{
-  uploaded: string[];
-  deleted: string[];
-  outOfScope: number;
-  skipped: { key: string; reason: string }[];
-  conflicts: { key: string; reason: string }[];
-}> {
-  const result = await syncBack(
-    opts.store,
-    opts.prefix,
-    opts.filesystem.storeRoot,
-    opts.filesystem.manifest,
-    {
-      generations: opts.filesystem.generationAware,
-      // A single-use worker has no later retry — its temp tree is wiped after
-      // the turn. A failed/oversized workspace-file upload must NOT then delete
-      // the durable object it was replacing, so hold the delete pass whenever
-      // any write was skipped or conflicted (turn durability surfaces it).
-      holdDeletesOnFailure: opts.claimed,
-      ...(opts.claimed
-        ? {
-            include: claimedTurnIncludes(
-              opts.filesystem.dataRel,
-              opts.filesystem.workspaceRel,
-              opts.conversationId,
-            ),
-          }
-        : {}),
-    },
-  );
-  if (result.outOfScope > 0) {
-    // Attributed: on a shared worker an unattributed count is unactionable.
-    console.info(
-      `[turn] pool_writes_out_of_scope=${result.outOfScope} prefix=${opts.prefix || opts.filesystem.dataRel} conversation=${opts.conversationId}`,
-    );
-  }
-  if (result.skipped.length > 0 || result.conflicts.length > 0) {
-    console.warn(
-      `[turn] pool_sync_incomplete skipped=${result.skipped.length} conflicts=${result.conflicts.length} conversation=${opts.conversationId}`,
-    );
-  }
-  return {
-    uploaded: result.uploaded,
-    deleted: result.deleted,
-    outOfScope: result.outOfScope,
-    skipped: result.skipped,
-    conflicts: result.conflicts,
-  };
 }

--- a/packages/runtime/src/turn/turn-hydration-error.ts
+++ b/packages/runtime/src/turn/turn-hydration-error.ts
@@ -1,0 +1,9 @@
+import { HydrateLimitError } from "@houston/runtime-client/object-sync";
+import { TurnSetupError } from "./turn-layout";
+
+/** Map runtime-client hydration limits onto the turn setup taxonomy. */
+export function turnHydrationError(error: unknown): unknown {
+  return error instanceof HydrateLimitError
+    ? new TurnSetupError("hydrate_over_cap", error.message)
+    : error;
+}

--- a/packages/runtime/src/turn/turn-layout-sync.test.ts
+++ b/packages/runtime/src/turn/turn-layout-sync.test.ts
@@ -196,7 +196,14 @@ test("an unclaimed turn retains full sync-back", async () => {
   expect(done.type).toBe("done");
   expect(done.data.changed).toEqual(["ConversationsChanged", "FilesChanged"]);
   // Every real turn now reports its phase marks as whole-ms deltas.
-  expect(done.data.timingsMs).toMatchObject({ tmpdir: expect.any(Number) });
+  expect(done.data.timingsMs).toMatchObject({
+    tmpdir: expect.any(Number),
+    listing: expect.any(Number),
+    layout: expect.any(Number),
+    startup_files: expect.any(Number),
+    cred_written: expect.any(Number),
+    hydrated: expect.any(Number),
+  });
 });
 
 test("shadow resolves a standing layout and reports hydrated objects", async () => {

--- a/packages/runtime/src/turn/turn-layout.ts
+++ b/packages/runtime/src/turn/turn-layout.ts
@@ -3,15 +3,19 @@ import { mkdir, readdir } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 /** Stable internal codes for failures before provider execution. */
-export type TurnSetupCode = "hydrate_over_cap" | "layout_unexpected";
+export type TurnSetupCode =
+  | "credential_write_failed"
+  | "hydrate_over_cap"
+  | "layout_unexpected";
 
 /** A setup failure the internal turn stream exposes as a stable code. */
 export class TurnSetupError extends Error {
   constructor(
     readonly code: TurnSetupCode,
     message: string,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = "TurnSetupError";
   }
 }

--- a/packages/runtime/src/turn/turn-overlap.test.ts
+++ b/packages/runtime/src/turn/turn-overlap.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -8,9 +9,10 @@ import {
   LocalDirStore,
   type ObjectStore,
 } from "@houston/runtime-client/object-sync";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import type { HarnessSession } from "../backends/types";
 import { createTurnServer } from "./server";
+import type { TurnServerDeps } from "./server-types";
 import type { RunTurnDeps } from "./turn-session";
 
 const servers: Server[] = [];
@@ -114,7 +116,11 @@ test("turn setup overlaps hydration but prompt waits for the complete tree", asy
     createTurnServer({
       store,
       token: "",
-      turnSessionDeps: { createModelRuntime, createBackend },
+      turnSessionDeps: {
+        createModelRuntime,
+        createBackend,
+        claudeSdk: {} as NonNullable<RunTurnDeps["claudeSdk"]>,
+      },
     }),
   );
 
@@ -128,7 +134,7 @@ test("turn setup overlaps hydration but prompt waits for the complete tree", asy
       text: "hello",
       gcsPrefix: prefix,
       credential: {
-        provider: "openai-codex",
+        provider: "anthropic",
         access: "access-token",
         expires: Date.now() + 60_000,
       },
@@ -151,4 +157,244 @@ test("turn setup overlaps hydration but prompt waits for the complete tree", asy
   expect(body).toContain('"startup_files"');
   expect(body).toContain('"backend_created"');
   expect(body).toContain('"hydrated"');
+  const done = body
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map(
+      (line) =>
+        JSON.parse(line.slice(6)) as {
+          type: string;
+          data?: { timingsMs?: Record<string, number> };
+        },
+    )
+    .find((frame) => frame.type === "done");
+  const phase = done?.data?.timingsMs;
+  expect(phase?.backend_loaded).toBeLessThanOrEqual(
+    phase?.backend_created ?? -1,
+  );
+  expect(phase?.backend_created).toBeLessThanOrEqual(phase?.run_done ?? -1);
+});
+
+test("credential failure waits for hydration before removing the turn root", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-overlap-failure-"));
+  const prefix = "ws/w1/agent-1";
+  await seed(storeRoot, `${prefix}/data/settings.json`, "{}");
+  await seed(storeRoot, `${prefix}/workspace/late.txt`, "late bytes");
+  const inner = new LocalDirStore(storeRoot);
+  const downloadStarted = deferred();
+  const releaseDownload = deferred();
+  let downloadInFlight = false;
+  let downloadSettled = false;
+  let turnRoot = "";
+  const store: ObjectStore = {
+    list: (listedPrefix) => inner.list(listedPrefix),
+    manifest: (listedPrefix) => inner.manifest(listedPrefix),
+    download: async (key, destination) => {
+      if (!key.endsWith("workspace/late.txt")) {
+        return inner.download(key, destination);
+      }
+      turnRoot = dirname(dirname(dirname(destination)));
+      downloadInFlight = true;
+      downloadStarted.resolve();
+      await releaseDownload.promise;
+      await mkdir(dirname(destination), { recursive: true });
+      await writeFile(destination, "late bytes");
+      downloadInFlight = false;
+      downloadSettled = true;
+      throw new Error("late hydration failed");
+    },
+    upload: (source, key, options) => inner.upload(source, key, options),
+    delete: (key, options) => inner.delete(key, options),
+  };
+  let removeCalls = 0;
+  const deps = {
+    store,
+    token: "",
+    runTurn: async () => ({}),
+    writeTurnCredential: () => {
+      expect(downloadInFlight).toBe(true);
+      throw new Error("ENOSPC credential write");
+    },
+    removeTurnRoot: async (root: string) => {
+      removeCalls += 1;
+      expect(downloadSettled).toBe(true);
+      await rm(root, { recursive: true, force: true });
+    },
+  } as TurnServerDeps & {
+    writeTurnCredential: () => never;
+    removeTurnRoot: (root: string) => Promise<void>;
+  };
+  const base = await listen(createTurnServer(deps));
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    const response = fetch(`${base}/turn`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        workspaceId: "w1",
+        agentId: "agent-1",
+        conversationId: "c1",
+        text: "hello",
+        gcsPrefix: prefix,
+        credential: {
+          provider: "openai-codex",
+          access: "access-token",
+          expires: Date.now() + 60_000,
+        },
+      }),
+    });
+    await downloadStarted.promise;
+    expect(removeCalls).toBe(0);
+    releaseDownload.resolve();
+    const body = await (await response).text();
+    expect(body.match(/"type":"error"/g)).toHaveLength(1);
+    expect(body).toContain("credential_write_failed");
+    expect(removeCalls).toBe(1);
+    expect(existsSync(turnRoot)).toBe(false);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(existsSync(turnRoot)).toBe(false);
+    expect(unhandled).toEqual([]);
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+});
+
+test("hydration failure reports an abandoned startup failure", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-startup-failure-"));
+  const prefix = "ws/w1/agent-1";
+  await seed(storeRoot, `${prefix}/data/settings.json`, "{}");
+  await seed(storeRoot, `${prefix}/workspace/late.txt`, "late");
+  const inner = new LocalDirStore(storeRoot);
+  const store: ObjectStore = {
+    list: (listedPrefix) => inner.list(listedPrefix),
+    manifest: (listedPrefix) => inner.manifest(listedPrefix),
+    download: async (key, destination) => {
+      if (key.endsWith("workspace/late.txt")) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        throw new Error("hydration failed");
+      }
+      await inner.download(key, destination);
+    },
+    upload: (source, key, options) => inner.upload(source, key, options),
+    delete: (key, options) => inner.delete(key, options),
+  };
+  const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+  const base = await listen(
+    createTurnServer({
+      store,
+      token: "",
+      turnSessionDeps: {
+        createModelRuntime: async () => {
+          throw new Error("startup failed");
+        },
+      },
+    }),
+  );
+  try {
+    await fetch(`${base}/turn`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        workspaceId: "w1",
+        agentId: "agent-1",
+        conversationId: "c1",
+        text: "hello",
+        gcsPrefix: prefix,
+        credential: {
+          provider: "openai-codex",
+          access: "access-token",
+          expires: Date.now() + 60_000,
+        },
+      }),
+    });
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining("[turn] overlapped startup failed"),
+    );
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining("startup failed"),
+    );
+  } finally {
+    errorLog.mockRestore();
+  }
+});
+
+test("routine fallback uses injected turn session dependencies", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-routine-deps-"));
+  const prefix = "ws/w1/agent-1";
+  await seed(storeRoot, `${prefix}/data/settings.json`, "{}");
+  await seed(
+    storeRoot,
+    `${prefix}/workspace/.houston/routines/routines.json`,
+    JSON.stringify([
+      {
+        id: "daily-check",
+        name: "Daily check",
+        prompt: "Check the queue.",
+        schedule: "0 9 * * *",
+        enabled: true,
+        provider: "openai-codex",
+      },
+    ]),
+  );
+  const inner = new LocalDirStore(storeRoot);
+  let backendCalls = 0;
+  const session: HarnessSession = {
+    subscribe: () => () => undefined,
+    prompt: async () => undefined,
+    abort: async () => undefined,
+    dispose: () => undefined,
+    setModel: async () => undefined,
+    compact: async () => undefined,
+    setThinkingLevel: () => undefined,
+    getContextUsage: () => undefined,
+  };
+  const base = await listen(
+    createTurnServer({
+      store: inner,
+      token: "",
+      fetchImpl: async () => new Response(null, { status: 200 }),
+      turnSessionDeps: {
+        createModelRuntime: async () => ({
+          modelRuntime: {} as ModelRuntime,
+          model: {
+            provider: "openai-codex",
+            id: "gpt-test",
+            contextWindow: 128_000,
+          } as unknown as Model<Api>,
+        }),
+        createBackend: () => {
+          backendCalls += 1;
+          return { id: "pi", createSession: async () => session };
+        },
+      },
+    }),
+  );
+  const response = await fetch(`${base}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      workspaceId: "w1",
+      agentId: "agent-1",
+      conversationId: "routine-daily-check",
+      text: "",
+      gcsPrefix: prefix,
+      hostToken: "host-token",
+      claim: {
+        id: "claim-1",
+        bootId: "boot-1",
+        token: "claim-token",
+        heartbeatUrl: "https://gateway.test/heartbeat",
+      },
+      routine: { id: "daily-check" },
+      credential: {
+        provider: "openai-codex",
+        access: "access-token",
+        expires: Date.now() + 60_000,
+      },
+    }),
+  });
+  expect(await response.text()).toContain('"type":"done"');
+  expect(backendCalls).toBe(1);
 });

--- a/packages/runtime/src/turn/turn-overlap.test.ts
+++ b/packages/runtime/src/turn/turn-overlap.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import {
+  LocalDirStore,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
+import { afterEach, expect, test } from "vitest";
+import type { HarnessSession } from "../backends/types";
+import { createTurnServer } from "./server";
+import type { RunTurnDeps } from "./turn-session";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function seed(root: string, rel: string, content: string): Promise<void> {
+  const path = join(root, ...rel.split("/"));
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+test("turn setup overlaps hydration but prompt waits for the complete tree", async () => {
+  const storeRoot = await mkdtemp(join(tmpdir(), "turn-overlap-store-"));
+  const prefix = "ws/w1/agent-1";
+  await seed(storeRoot, `${prefix}/data/settings.json`, "{}");
+  await seed(storeRoot, `${prefix}/workspace/late.txt`, "fully hydrated");
+  const inner = new LocalDirStore(storeRoot);
+  const downloadStarted = deferred();
+  const releaseDownload = deferred();
+  const store: ObjectStore = {
+    list: (listedPrefix) => inner.list(listedPrefix),
+    manifest: (listedPrefix) => inner.manifest(listedPrefix),
+    download: async (key, destination) => {
+      if (key.endsWith("workspace/late.txt")) {
+        downloadStarted.resolve();
+        await releaseDownload.promise;
+      }
+      await inner.download(key, destination);
+    },
+    upload: (source, key, options) => inner.upload(source, key, options),
+    delete: (key, options) => inner.delete(key, options),
+  };
+  const startupBegan = deferred();
+  const backendBuilt = deferred();
+  let prompted = false;
+  let promptSaw = "";
+  let startupSaw = "";
+  let hydratedWorkspace = "";
+  const session: HarnessSession = {
+    subscribe: () => () => undefined,
+    prompt: async () => {
+      prompted = true;
+      promptSaw = await readFile(join(hydratedWorkspace, "late.txt"), "utf8");
+    },
+    abort: async () => undefined,
+    dispose: () => undefined,
+    setModel: async () => undefined,
+    compact: async () => undefined,
+    setThinkingLevel: () => undefined,
+    getContextUsage: () => undefined,
+  };
+  const createModelRuntime: NonNullable<
+    RunTurnDeps["createModelRuntime"]
+  > = async (dataDir) => {
+    startupSaw = await readFile(join(dataDir, "settings.json"), "utf8");
+    startupBegan.resolve();
+    return {
+      modelRuntime: {} as ModelRuntime,
+      model: {
+        provider: "openai-codex",
+        id: "gpt-test",
+        contextWindow: 128_000,
+      } as unknown as Model<Api>,
+    };
+  };
+  const createBackend: NonNullable<RunTurnDeps["createBackend"]> = (
+    _provider,
+    input,
+  ) => {
+    hydratedWorkspace = input.directories.workspaceDir;
+    backendBuilt.resolve();
+    return { id: "pi", createSession: async () => session };
+  };
+  const base = await listen(
+    createTurnServer({
+      store,
+      token: "",
+      turnSessionDeps: { createModelRuntime, createBackend },
+    }),
+  );
+
+  const response = fetch(`${base}/turn`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      workspaceId: "w1",
+      agentId: "agent-1",
+      conversationId: "c1",
+      text: "hello",
+      gcsPrefix: prefix,
+      credential: {
+        provider: "openai-codex",
+        access: "access-token",
+        expires: Date.now() + 60_000,
+      },
+    }),
+  });
+
+  await downloadStarted.promise;
+  await startupBegan.promise;
+  await backendBuilt.promise;
+  expect(prompted).toBe(false);
+  expect(startupSaw).toBe("{}");
+  releaseDownload.resolve();
+  const body = await (await response).text();
+
+  expect(body).toContain('"type":"done"');
+  expect(prompted).toBe(true);
+  expect(promptSaw).toBe("fully hydrated");
+  expect(body).toContain('"listing"');
+  expect(body).toContain('"layout"');
+  expect(body).toContain('"startup_files"');
+  expect(body).toContain('"backend_created"');
+  expect(body).toContain('"hydrated"');
+});

--- a/packages/runtime/src/turn/turn-request.ts
+++ b/packages/runtime/src/turn/turn-request.ts
@@ -1,6 +1,7 @@
 import type { WireFrame } from "@houston/runtime-client";
 import type { SandboxFetch } from "../session/tools/sandbox-fetch";
 import type { TurnSessionRequest } from "./turn-session";
+import type { TurnSessionStartupTask } from "./turn-session-startup";
 import type { TurnRequest } from "./types";
 
 /** Project the accepted envelope onto the provider-agnostic turn session. */
@@ -11,6 +12,7 @@ export function turnSessionRequest(
   signal: AbortSignal,
   sandbox?: { call: SandboxFetch },
   timings?: Record<string, number>,
+  startup?: TurnSessionStartupTask,
 ): TurnSessionRequest {
   return {
     conversationId: turn.conversationId,
@@ -33,6 +35,7 @@ export function turnSessionRequest(
     ...(turn.grant ? { grant: { scopes: turn.grant.scopes } } : {}),
     ...(sandbox ? { sandbox } : {}),
     ...(timings ? { timings } : {}),
+    ...(startup ? { startup } : {}),
     // Either context field present means "use these" (each defaults to ""),
     // mirroring the long-lived server's message-send contract.
     ...(turn.workspaceContext !== undefined || turn.userContext !== undefined

--- a/packages/runtime/src/turn/turn-runtime.ts
+++ b/packages/runtime/src/turn/turn-runtime.ts
@@ -13,7 +13,6 @@ import { resolveTurnModel } from "./turn-model";
 const TURN_RUNTIME_INPUTS = new Set([
   "azure-endpoint.json",
   "custom-endpoint.json",
-  "models-store.json",
   "models.json",
   "qwen-region.json",
   "settings.json",

--- a/packages/runtime/src/turn/turn-runtime.ts
+++ b/packages/runtime/src/turn/turn-runtime.ts
@@ -10,6 +10,28 @@ import {
 } from "../ai/qwen-dashscope";
 import { resolveTurnModel } from "./turn-model";
 
+const TURN_RUNTIME_INPUTS = new Set([
+  "azure-endpoint.json",
+  "custom-endpoint.json",
+  "models-store.json",
+  "models.json",
+  "qwen-region.json",
+  "settings.json",
+  "xiaomi-endpoint.json",
+]);
+
+/** Files that model construction reads before the full tree is hydrated. */
+export function turnRuntimeInputIncludes(
+  dataRel: string,
+  relativePath: string,
+): boolean {
+  const prefix = `${dataRel}/`;
+  return (
+    relativePath.startsWith(prefix) &&
+    TURN_RUNTIME_INPUTS.has(relativePath.slice(prefix.length))
+  );
+}
+
 /** Build and resolve the isolated model runtime for one hydrated turn root. */
 export async function createTurnModelRuntime(
   dataDir: string,

--- a/packages/runtime/src/turn/turn-sandbox-startup.ts
+++ b/packages/runtime/src/turn/turn-sandbox-startup.ts
@@ -1,0 +1,30 @@
+import type { TurnServerDeps } from "./server-types";
+import type { TurnFilesystem } from "./turn-filesystem";
+import { makeTurnSandboxFetch } from "./turn-sandbox";
+import type { poolIdentity, resolveTurnStore } from "./turn-store";
+import type { TurnRequest } from "./types";
+
+/** Build the grant-bound sandbox after identity validation. */
+export function createTurnSandbox(input: {
+  deps: TurnServerDeps;
+  turn: TurnRequest;
+  identity: ReturnType<typeof poolIdentity> | undefined;
+  resolved: ReturnType<typeof resolveTurnStore>;
+  filesystem: TurnFilesystem;
+}): ReturnType<typeof makeTurnSandboxFetch> | null {
+  const { turn, identity } = input;
+  if (!turn.grant || !turn.hostToken || !identity) return null;
+  return makeTurnSandboxFetch({
+    grant: turn.grant,
+    hostToken: turn.hostToken,
+    store: input.resolved.store,
+    prefix: input.resolved.prefix,
+    filesystem: input.filesystem,
+    workspaceId: turn.workspaceId,
+    conversationId: turn.conversationId,
+    ...(turn.actingAs ? { actingAs: turn.actingAs } : {}),
+    orgSlug: identity.org,
+    agentSlug: identity.agent,
+    ...(input.deps.fetchImpl ? { fetchImpl: input.deps.fetchImpl } : {}),
+  });
+}

--- a/packages/runtime/src/turn/turn-session-backend.ts
+++ b/packages/runtime/src/turn/turn-session-backend.ts
@@ -1,0 +1,87 @@
+import { join } from "node:path";
+import type { ChatMessage } from "@houston/runtime-client";
+import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
+import { readAuthFile } from "../auth/auth-file";
+import type { newUsedTokenCapture } from "../auth/used-token";
+import {
+  renderReplayPreamble,
+  replayCharBudget,
+} from "../session/replay-transcript";
+import { resolveTurnClaudeResume } from "./turn-backend";
+import { readTurnHarness, writeTurnHarness } from "./turn-harness-state";
+import {
+  finishTurnSessionStartup,
+  type RunTurnDeps,
+  startTurnSession,
+} from "./turn-session-startup";
+import type { TurnDirectories, TurnSessionRequest } from "./turn-session-types";
+
+/** Finish overlapped setup and open a backend session from hydrated state. */
+export async function openTurnBackendSession(input: {
+  directories: TurnDirectories;
+  turn: TurnSessionRequest;
+  deps: RunTurnDeps;
+  canonicalMessages: ChatMessage[];
+  usedTokens: ReturnType<typeof newUsedTokenCapture>;
+}) {
+  const { turn, directories } = input;
+  const { provider, pin, conversationId, turnId } = turn;
+  const { backend, model } = await finishTurnSessionStartup(
+    turn.startup ?? startTurnSession(directories, turn, input.deps),
+  );
+  const turnCred = readAuthFile(join(directories.dataDir, "auth.json"))[
+    provider
+  ];
+  if (turnCred?.type === "oauth" && turnCred.access)
+    input.usedTokens.record(provider, turnCred.access);
+  const diagnostic = model as unknown as {
+    id?: string;
+    baseUrl?: string;
+    reasoning?: boolean;
+  };
+  console.log(
+    `[turn] provider=${provider} model=${diagnostic.id} baseUrl=${diagnostic.baseUrl}`,
+  );
+  const effort =
+    pin?.effort ??
+    (diagnostic.reasoning === true ? DEFAULT_REASONING_EFFORT : undefined);
+  const thinkingLevel = toThinkingLevel(effort);
+  const harness = backend.id === "anthropic" ? "claude" : "pi";
+  const priorHarness = readTurnHarness(directories.dataDir, conversationId);
+  const switchedHarness =
+    priorHarness !== undefined && priorHarness !== harness;
+  writeTurnHarness(directories.dataDir, conversationId, harness);
+  const claudeResume =
+    harness === "claude" && !switchedHarness
+      ? resolveTurnClaudeResume(directories, conversationId)
+      : undefined;
+  const replay =
+    input.canonicalMessages.length > 0 &&
+    (switchedHarness || (harness === "claude" && !claudeResume))
+      ? renderReplayPreamble(
+          input.canonicalMessages,
+          turnId,
+          replayCharBudget(model.contextWindow),
+        )
+      : null;
+  const retryReplay =
+    harness === "claude" && input.canonicalMessages.length > 0
+      ? (replay ??
+        renderReplayPreamble(
+          input.canonicalMessages,
+          turnId,
+          replayCharBudget(model.contextWindow),
+        ))
+      : null;
+  const session = await backend.createSession({
+    conversationId,
+    model,
+    ...(thinkingLevel ? { thinkingLevel } : {}),
+    ...(turn.context ? { context: turn.context } : {}),
+    ...(turn.mode ? { mode: turn.mode } : {}),
+    ...(switchedHarness ? { fresh: true } : {}),
+    ...(retryReplay?.text ? { freshRetryPromptPrefix: retryReplay.text } : {}),
+  });
+  if (turn.timings) turn.timings.t_backend_session = performance.now();
+  return { replay, session };
+}

--- a/packages/runtime/src/turn/turn-session-failure.ts
+++ b/packages/runtime/src/turn/turn-session-failure.ts
@@ -1,0 +1,103 @@
+import type {
+  ProviderError,
+  TokenUsage,
+  ToolCallRecord,
+  WireFrame,
+} from "@houston/runtime-client";
+import { classifyProviderError } from "../ai/provider-error";
+import { logProviderError } from "../ai/provider-error-log";
+import { noteAuthFailure, noteQuotaExhausted } from "../auth/credential-health";
+import { reportRevokedServedToken } from "../auth/report-revoked";
+import type { newUsedTokenCapture } from "../auth/used-token";
+import { appendAssistantMessageAt } from "../store/conversation-file";
+import { TurnBackendProviderError } from "./turn-backend";
+import type { TurnOutcome } from "./turn-session-types";
+
+/** Classify and persist a thrown session failure. */
+export function handleTurnSessionFailure(input: {
+  error: unknown;
+  signal?: AbortSignal;
+  providerError?: ProviderError;
+  assistantText: string;
+  tools: ToolCallRecord[];
+  usage: TokenUsage | null;
+  conversationsDir: string;
+  conversationId: string;
+  turnId: string;
+  provider: string;
+  model?: string | null;
+  text: string;
+  usedTokens: ReturnType<typeof newUsedTokenCapture>;
+  emit: (frame: WireFrame) => void;
+}): TurnOutcome {
+  const message =
+    input.error instanceof Error ? input.error.message : String(input.error);
+  if (
+    !input.providerError &&
+    (input.signal?.aborted ||
+      (input.error instanceof Error && input.error.name === "AbortError"))
+  ) {
+    if (input.assistantText)
+      appendAssistantMessageAt(
+        input.conversationsDir,
+        input.conversationId,
+        input.assistantText,
+        { tools: input.tools, usage: input.usage, turnId: input.turnId },
+      );
+    return {};
+  }
+  if (!input.providerError) {
+    const thrown =
+      input.error instanceof TurnBackendProviderError
+        ? input.error.providerError
+        : classifyProviderError({
+            provider: input.provider,
+            model: input.model ?? null,
+            message,
+          });
+    logProviderError(thrown, { model: input.model ?? null });
+    if (
+      thrown.kind === "unauthenticated" &&
+      !input.assistantText &&
+      input.tools.length === 0
+    )
+      thrown.undelivered_prompt = input.text;
+    if (thrown.kind === "unauthenticated") {
+      noteAuthFailure(thrown.provider);
+      reportRevokedServedToken(
+        thrown,
+        input.usedTokens.digestFor(thrown.provider),
+      );
+    }
+    if (thrown.kind === "quota_exhausted")
+      noteQuotaExhausted(thrown.provider, thrown.resets_at);
+    if (thrown.kind !== "unknown") {
+      appendAssistantMessageAt(
+        input.conversationsDir,
+        input.conversationId,
+        input.assistantText,
+        {
+          tools: input.tools,
+          usage: input.usage,
+          providerError: thrown,
+          turnId: input.turnId,
+        },
+      );
+      input.emit({ type: "provider_error", data: thrown });
+      return {};
+    }
+  }
+  if (input.assistantText || input.providerError)
+    appendAssistantMessageAt(
+      input.conversationsDir,
+      input.conversationId,
+      input.assistantText,
+      {
+        tools: input.tools,
+        usage: input.usage,
+        providerError: input.providerError,
+        turnId: input.turnId,
+      },
+    );
+  return { error: message };
+}

--- a/packages/runtime/src/turn/turn-session-startup.ts
+++ b/packages/runtime/src/turn/turn-session-startup.ts
@@ -1,0 +1,97 @@
+import type { ClaudeBackendDeps } from "../backends/claude/backend";
+import { preloadClaudeSdk } from "../backends/claude/sdk-loader";
+import type { HarnessBackend } from "../backends/types";
+import { config } from "../config";
+import { SYSTEM_PROMPT } from "../session/resource-loader";
+import { turnCodeExecutionMode } from "../session/tool-selection";
+import { makeIdTokenProvider } from "../session/tools/gcp-id-token";
+import { makeRunCodeTool } from "../session/tools/run-code";
+import { createTurnBackend, type TurnBackendDeps } from "./turn-backend";
+import { createTurnModelRuntime } from "./turn-runtime";
+import type { TurnDirectories, TurnSessionRequest } from "./turn-session";
+import { buildTurnToolSelection } from "./turn-toolset";
+
+export interface RunTurnDeps {
+  claudeSdk?: ClaudeBackendDeps["sdk"];
+  createBackend?: (provider: string, deps: TurnBackendDeps) => HarnessBackend;
+  createModelRuntime?: typeof createTurnModelRuntime;
+}
+
+export interface TurnSessionStartup {
+  backend: HarnessBackend;
+  model: Awaited<ReturnType<typeof createTurnModelRuntime>>["model"];
+}
+
+export type TurnSessionStartupTask = Promise<
+  { ok: true; startup: TurnSessionStartup } | { ok: false; error: unknown }
+>;
+
+/** Start model setup, the Claude SDK import, and backend construction. */
+export function startTurnSession(
+  directories: TurnDirectories,
+  turn: TurnSessionRequest,
+  deps: RunTurnDeps = {},
+): TurnSessionStartupTask {
+  return prepareTurnSession(directories, turn, deps).then(
+    (startup) => ({ ok: true, startup }),
+    (error: unknown) => ({ ok: false, error }),
+  );
+}
+
+async function prepareTurnSession(
+  directories: TurnDirectories,
+  turn: TurnSessionRequest,
+  deps: RunTurnDeps,
+): Promise<TurnSessionStartup> {
+  const sdkLoad =
+    turn.provider === "anthropic"
+      ? preloadClaudeSdk(deps.claudeSdk).then((result) => {
+          if (turn.timings) turn.timings.t_backend_loaded = performance.now();
+          return result;
+        })
+      : undefined;
+  const createRuntime = deps.createModelRuntime ?? createTurnModelRuntime;
+  const { modelRuntime, model } = await createRuntime(
+    directories.dataDir,
+    turn.provider,
+    turn.pin?.model,
+    turn.timings,
+  );
+  const toolSelection = buildTurnToolSelection(
+    turn,
+    turnCodeExecutionMode(config.codeExecution, config.poolSingleUse),
+  );
+  const codeSandbox = toolSelection.includeRunCode
+    ? makeRunCodeTool({
+        baseUrl: config.codeSandboxUrl,
+        token: config.codeSandboxToken,
+        workspaceDir: directories.workspaceDir,
+        limits: {
+          maxConcurrent: config.runCodeMaxConcurrent,
+          maxPerMinute: config.runCodePerMinute,
+        },
+        idToken: makeIdTokenProvider(config.codeSandboxUrl),
+      })
+    : null;
+  const backend = (deps.createBackend ?? createTurnBackend)(turn.provider, {
+    directories,
+    turn,
+    modelRuntime,
+    toolSelection,
+    codeSandbox,
+    systemPrompt: config.systemPrompt || SYSTEM_PROMPT,
+    sharedRoots: config.sharedSkillsDir ? [config.sharedSkillsDir] : [],
+    claudeSdk: deps.claudeSdk,
+    claudeSdkLoad: sdkLoad,
+  });
+  if (turn.timings) turn.timings.t_backend_created = performance.now();
+  return { backend, model };
+}
+
+export async function finishTurnSessionStartup(
+  task: TurnSessionStartupTask,
+): Promise<TurnSessionStartup> {
+  const result = await task;
+  if (!result.ok) throw result.error;
+  return result.startup;
+}

--- a/packages/runtime/src/turn/turn-session-startup.ts
+++ b/packages/runtime/src/turn/turn-session-startup.ts
@@ -57,6 +57,7 @@ async function prepareTurnSession(
     turn.pin?.model,
     turn.timings,
   );
+  if (sdkLoad) await sdkLoad;
   const toolSelection = buildTurnToolSelection(
     turn,
     turnCodeExecutionMode(config.codeExecution, config.poolSingleUse),
@@ -94,4 +95,18 @@ export async function finishTurnSessionStartup(
   const result = await task;
   if (!result.ok) throw result.error;
   return result.startup;
+}
+
+/** Report setup work that failed after hydration had already doomed the turn. */
+export async function reportAbandonedTurnStartup(
+  task: TurnSessionStartupTask | undefined,
+): Promise<void> {
+  if (!task) return;
+  const result = await task;
+  if (result.ok) return;
+  const detail =
+    result.error instanceof Error
+      ? `${result.error.name}: ${result.error.message}`
+      : String(result.error);
+  console.error(`[turn] overlapped startup failed after hydration (${detail})`);
 }

--- a/packages/runtime/src/turn/turn-session-success.ts
+++ b/packages/runtime/src/turn/turn-session-success.ts
@@ -1,0 +1,90 @@
+import type {
+  ProviderError,
+  TokenUsage,
+  ToolCallRecord,
+  WireFrame,
+} from "@houston/runtime-client";
+import { clearProviderMarks } from "../auth/credential-health";
+import {
+  diffSnapshots,
+  type FileSnapshot,
+  snapshotWorkspace,
+} from "../session/file-changes";
+import {
+  type newInteractionHolder,
+  planReadyFallback,
+} from "../session/interaction";
+import { appendAssistantMessageAt } from "../store/conversation-file";
+import type { TurnOutcome, TurnSessionRequest } from "./turn-session-types";
+
+/** Capture the hydrated workspace before the provider can mutate it. */
+export function captureWorkspaceSnapshot(
+  workspaceDir: string,
+): FileSnapshot | null {
+  try {
+    return snapshotWorkspace(workspaceDir);
+  } catch (error) {
+    console.warn(
+      "[turn] file snapshot failed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  }
+}
+
+/** Persist the successful prompt result and emit its workspace diff. */
+export function finishSuccessfulTurn(input: {
+  beforeFiles: FileSnapshot | null;
+  providerError?: ProviderError;
+  workspaceDir: string;
+  mode: TurnSessionRequest["mode"];
+  assistantText: string;
+  interaction: ReturnType<typeof newInteractionHolder>;
+  conversationsDir: string;
+  conversationId: string;
+  tools: ToolCallRecord[];
+  usage: TokenUsage | null;
+  provider: string;
+  turnId: string;
+  emit: (frame: WireFrame) => void;
+}): TurnOutcome {
+  let fileChanges: { created: string[]; modified: string[] } | undefined;
+  if (input.beforeFiles && !input.providerError) {
+    try {
+      const changes = diffSnapshots(
+        input.beforeFiles,
+        snapshotWorkspace(input.workspaceDir),
+      );
+      if (changes.created.length || changes.modified.length)
+        fileChanges = changes;
+    } catch (error) {
+      console.warn(
+        "[turn] file diff failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+  const pendingInteraction =
+    !input.providerError &&
+    input.mode === "plan" &&
+    input.assistantText.trim() &&
+    !input.interaction.pending
+      ? planReadyFallback()
+      : input.interaction.pending;
+  appendAssistantMessageAt(
+    input.conversationsDir,
+    input.conversationId,
+    input.assistantText,
+    {
+      tools: input.tools,
+      usage: input.usage,
+      providerError: input.providerError,
+      fileChanges,
+      pendingInteraction: input.providerError ? undefined : pendingInteraction,
+      turnId: input.turnId,
+    },
+  );
+  if (fileChanges) input.emit({ type: "file_changes", data: fileChanges });
+  if (!input.providerError) clearProviderMarks(input.provider);
+  return input.providerError ? {} : { pendingInteraction };
+}

--- a/packages/runtime/src/turn/turn-session-types.ts
+++ b/packages/runtime/src/turn/turn-session-types.ts
@@ -1,0 +1,58 @@
+import type { TurnMode } from "@houston/protocol";
+import type {
+  ChatMessage,
+  PendingInteraction,
+  WireFrame,
+} from "@houston/runtime-client";
+import type { MessageAuthor } from "../session/attribution";
+import type { SandboxFetch } from "../session/tools/sandbox-fetch";
+import type { ProvidedContext } from "../session/workspace-context";
+import type { TurnSessionStartupTask } from "./turn-session-startup";
+import type { TurnGrantScope } from "./types";
+
+export interface TurnOutcome {
+  error?: string;
+  /** Interaction the model ended the turn waiting on, if any. */
+  pendingInteraction?: PendingInteraction;
+}
+
+/** Per-turn model/effort pin. Absent means inherit the agent setting. */
+export interface TurnModelPin {
+  model?: string | null;
+  effort?: string | null;
+}
+
+/** Everything one pooled model session needs. */
+export interface TurnSessionRequest {
+  conversationId: string;
+  text: string;
+  provider: string;
+  emit: (e: WireFrame) => void;
+  signal: AbortSignal | undefined;
+  nonce?: string;
+  pin?: TurnModelPin;
+  mode?: TurnMode;
+  turnId: string;
+  displayText?: string;
+  mentions?: ChatMessage["mentions"];
+  author?: MessageAuthor;
+  context?: ProvidedContext;
+  /** Non-secret capability scopes copied from the parsed turn grant. */
+  grant?: { scopes: TurnGrantScope[] };
+  /** Turn-local routing closure; it owns all grant-bearing calls. */
+  sandbox?: { call: SandboxFetch };
+  timings?: Record<string, number>;
+  /** Setup begun after layout resolution and before bulk hydration completes. */
+  startup?: TurnSessionStartupTask;
+}
+
+export interface TurnDirectories {
+  workspaceDir: string;
+  dataDir: string;
+  turnRoot: string;
+}
+
+export type TurnRunner = (
+  directories: TurnDirectories,
+  turn: TurnSessionRequest,
+) => Promise<TurnOutcome>;

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -1,67 +1,36 @@
 import { join } from "node:path";
-import type { TurnMode } from "@houston/protocol";
 import type {
-  ChatMessage,
-  PendingInteraction,
   ProviderError,
   TokenUsage,
   ToolCallRecord,
   WireEvent,
   WireFrame,
 } from "@houston/runtime-client";
-import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
-import { classifyProviderError } from "../ai/provider-error";
-import { logProviderError } from "../ai/provider-error-log";
-import { readAuthFile } from "../auth/auth-file";
-import {
-  clearProviderMarks,
-  noteAuthFailure,
-  noteQuotaExhausted,
-} from "../auth/credential-health";
-import { reportRevokedServedToken } from "../auth/report-revoked";
 import {
   newUsedTokenCapture,
   runWithUsedTokenCapture,
 } from "../auth/used-token";
-import type { ClaudeBackendDeps } from "../backends/claude/backend";
-import type { HarnessBackend } from "../backends/types";
-import { config } from "../config";
-import { framePrompt, type MessageAuthor } from "../session/attribution";
-import {
-  diffSnapshots,
-  type FileSnapshot,
-  snapshotWorkspace,
-} from "../session/file-changes";
+import { framePrompt } from "../session/attribution";
 import {
   newInteractionHolder,
-  planReadyFallback,
   runWithInteractionCapture,
 } from "../session/interaction";
 import {
-  renderReplayPreamble,
-  replayCharBudget,
-} from "../session/replay-transcript";
-import { SYSTEM_PROMPT } from "../session/resource-loader";
-import { turnCodeExecutionMode } from "../session/tool-selection";
-import { makeIdTokenProvider } from "../session/tools/gcp-id-token";
-import { makeRunCodeTool } from "../session/tools/run-code";
-import type { SandboxFetch } from "../session/tools/sandbox-fetch";
-import type { ProvidedContext } from "../session/workspace-context";
-import {
-  appendAssistantMessageAt,
   appendUserMessageAt,
   loadConversation,
 } from "../store/conversation-file";
+import { openTurnBackendSession } from "./turn-session-backend";
+import { handleTurnSessionFailure } from "./turn-session-failure";
+import type { RunTurnDeps } from "./turn-session-startup";
 import {
-  createTurnBackend,
-  resolveTurnClaudeResume,
-  type TurnBackendDeps,
-  TurnBackendProviderError,
-} from "./turn-backend";
-import { readTurnHarness, writeTurnHarness } from "./turn-harness-state";
-import { createTurnModelRuntime } from "./turn-runtime";
-import { buildTurnToolSelection } from "./turn-toolset";
-import type { TurnGrantScope } from "./types";
+  captureWorkspaceSnapshot,
+  finishSuccessfulTurn,
+} from "./turn-session-success";
+import type {
+  TurnDirectories,
+  TurnOutcome,
+  TurnSessionRequest,
+} from "./turn-session-types";
 
 /**
  * One pi turn against resolved hydrated directories. Unlike chat.ts (one
@@ -74,79 +43,14 @@ import type { TurnGrantScope } from "./types";
  * client could see `done` before its files are durable).
  */
 
-export interface TurnOutcome {
-  error?: string;
-  /**
-   * What the model ended the turn waiting on the user for (ask_user), if
-   * anything. The per-turn SERVER carries it on the clean terminal `done` frame
-   * it sends after sync-back, never on an error.
-   */
-  pendingInteraction?: PendingInteraction;
-}
-
-/** Per-turn model/effort pin (a routine's, when it pinned them). Absent = inherit. */
-export interface TurnModelPin {
-  model?: string | null;
-  effort?: string | null;
-}
-
-/** Everything one pi turn needs (the per-turn server assembles it per request). */
-export interface TurnSessionRequest {
-  conversationId: string;
-  text: string;
-  provider: string;
-  /** Receives every non-terminal wire frame, already stamped with `turnId`. */
-  emit: (e: WireFrame) => void;
-  signal: AbortSignal | undefined;
-  nonce?: string;
-  pin?: TurnModelPin;
-  /**
-   * The turn's execution mode ("plan" = read-only + planning overlay). Absent =
-   * execute. Threaded into the pi session's tool allowlist + system prompt via
-   * `createSession`, identical to the long-lived server path.
-   */
-  mode?: TurnMode;
-  /**
-   * The turn's wire identity, minted by the per-turn SERVER (which also stamps
-   * it on the terminal frame it sends after sync-back) — stamped here on every
-   * emitted frame and persisted on both stored messages.
-   */
-  turnId: string;
-  /**
-   * Presentation-only bubble text, when it must differ from `text` (the real
-   * prompt the model runs on). Persisted alongside the user message so a
-   * history reload renders `displayText ?? content`. Absent when they match.
-   */
-  displayText?: string;
-  /**
-   * The teammates the message @mentions (HOU-944). Structure only — the names
-   * are already plain text inside `text`. Persisted beside the user message and
-   * echoed on the `user` frame. Absent when the message mentions nobody.
-   */
-  mentions?: ChatMessage["mentions"];
-  /** Human author supplied by the trusted pool dispatcher. */
-  author?: MessageAuthor;
-  /** Gateway-provided workspace/user context for the session prompt. */
-  context?: ProvidedContext;
-  /** Non-secret capability scopes copied from the parsed turn grant. */
-  grant?: { scopes: TurnGrantScope[] };
-  /** Turn-local routing closure; it owns all grant-bearing calls. */
-  sandbox?: { call: SandboxFetch };
-  /** Shared phase-mark sink; the terminal frame reports it (values are
-   *  performance.now() marks, converted to deltas at emission). */
-  timings?: Record<string, number>;
-}
-
-export interface TurnDirectories {
-  workspaceDir: string;
-  dataDir: string;
-  turnRoot: string;
-}
-
-export interface RunTurnDeps {
-  claudeSdk?: ClaudeBackendDeps["sdk"];
-  createBackend?: (provider: string, deps: TurnBackendDeps) => HarnessBackend;
-}
+export type { RunTurnDeps } from "./turn-session-startup";
+export type {
+  TurnDirectories,
+  TurnModelPin,
+  TurnOutcome,
+  TurnRunner,
+  TurnSessionRequest,
+} from "./turn-session-types";
 
 export async function runTurn(
   directories: TurnDirectories,
@@ -209,129 +113,18 @@ export async function runTurn(
    */
   const usedTokens = newUsedTokenCapture();
   try {
-    // Per-turn model/auth runtime over the hydrated throwaway data dir. The
-    // default file-backed credential store reads the hydrated auth.json; the
-    // local (openai-compatible) provider registers from the dir's own
-    // custom-endpoint config so its model can dispatch (pi 0.82 streams
-    // strictly by registered provider id).
-    const { modelRuntime, model } = await createTurnModelRuntime(
-      dataDir,
-      provider,
-      pin?.model,
-    );
-
-    const toolSelection = buildTurnToolSelection(
-      turn,
-      turnCodeExecutionMode(config.codeExecution, config.poolSingleUse),
-    );
-    const codeSandbox = toolSelection.includeRunCode
-      ? makeRunCodeTool({
-          baseUrl: config.codeSandboxUrl,
-          token: config.codeSandboxToken,
-          workspaceDir,
-          limits: {
-            maxConcurrent: config.runCodeMaxConcurrent,
-            maxPerMinute: config.runCodePerMinute,
-          },
-          idToken: makeIdTokenProvider(config.codeSandboxUrl),
-        })
-      : null;
-
-    // Seed the used-token capture with the credential this turn will run on
-    // (see the declaration above). OAuth access only — an api_key has no
-    // revocation semantics the report may act on.
-    const turnCred = readAuthFile(join(dataDir, "auth.json"))[provider];
-    if (turnCred?.type === "oauth" && turnCred.access)
-      usedTokens.record(provider, turnCred.access);
-    // Ground-truth diagnostic: provider + model + the model's actual API base URL
-    // (opencode.ai/zen/go/v1 = OpenCode Go, openai/chatgpt = Codex). Unambiguous,
-    // unlike asking the model itself.
-    const m = model as unknown as {
-      id?: string;
-      baseUrl?: string;
-      reasoning?: boolean;
-    };
-    console.log(
-      `[turn] provider=${provider} model=${m.id} baseUrl=${m.baseUrl}`,
-    );
-    // Effort → pi's thinking level. The turn's pin (the host bakes the agent's
-    // saved effort into it) wins; if none and the model can reason, default to
-    // medium so a "thinking" model actually reasons (pi enables reasoning only
-    // when a level is set). pi clamps to what the model supports.
-    const effort =
-      pin?.effort ??
-      (m.reasoning === true ? DEFAULT_REASONING_EFFORT : undefined);
-    const thinkingLevel = toThinkingLevel(effort);
-    const backend = (deps.createBackend ?? createTurnBackend)(provider, {
+    const { replay, session } = await openTurnBackendSession({
       directories,
       turn,
-      modelRuntime,
-      toolSelection,
-      codeSandbox,
-      systemPrompt: config.systemPrompt || SYSTEM_PROMPT,
-      sharedRoots: config.sharedSkillsDir ? [config.sharedSkillsDir] : [],
-      claudeSdk: deps.claudeSdk,
+      deps,
+      canonicalMessages,
+      usedTokens,
     });
-    const harness = backend.id === "anthropic" ? "claude" : "pi";
-    const priorHarness = readTurnHarness(dataDir, conversationId);
-    const switchedHarness =
-      priorHarness !== undefined && priorHarness !== harness;
-    writeTurnHarness(dataDir, conversationId, harness);
-    const claudeResume =
-      harness === "claude" && !switchedHarness
-        ? resolveTurnClaudeResume(directories, conversationId)
-        : undefined;
-    const replay =
-      canonicalMessages.length > 0 &&
-      (switchedHarness || (harness === "claude" && !claudeResume))
-        ? renderReplayPreamble(
-            canonicalMessages,
-            turnId,
-            replayCharBudget(model.contextWindow),
-          )
-        : null;
-    const retryReplay =
-      harness === "claude" && canonicalMessages.length > 0
-        ? (replay ??
-          renderReplayPreamble(
-            canonicalMessages,
-            turnId,
-            replayCharBudget(model.contextWindow),
-          ))
-        : null;
-    const session = await backend.createSession({
-      conversationId,
-      model,
-      ...(thinkingLevel ? { thinkingLevel } : {}),
-      // Hosted turn context rides the envelope; the loader overlays it exactly
-      // as the long-lived server path does for a message-send body.
-      ...(turn.context ? { context: turn.context } : {}),
-      // The turn's mode clamps this pi session's tools + overlays its prompt,
-      // exactly as the long-lived server path does (createPiBackend applies
-      // `toolNamesForMode` + the loader overlay from `opts.mode`): plan →
-      // read-only, auto → no blocking tools. In cloud turn mode ask_user is the
-      // only blocking tool present (integrations are off), so an auto turn here
-      // simply drops it.
-      ...(mode ? { mode } : {}),
-      ...(switchedHarness ? { fresh: true } : {}),
-      ...(retryReplay?.text
-        ? { freshRetryPromptPrefix: retryReplay.text }
-        : {}),
-    });
-    if (turn.timings) turn.timings.t_backend_session = performance.now();
 
     // Snapshot the hydrated workspace so the turn's created/modified files can
     // be surfaced as a `file_changes` frame. The per-turn root is exclusive to
     // this request, so the diff is attributable by construction. Best-effort.
-    let beforeFiles: FileSnapshot | null = null;
-    try {
-      beforeFiles = snapshotWorkspace(workspaceDir);
-    } catch (err) {
-      console.warn(
-        "[turn] file snapshot failed:",
-        err instanceof Error ? err.message : String(err),
-      );
-    }
+    const beforeFiles = captureWorkspaceSnapshot(workspaceDir);
 
     const unsub = session.subscribe((wire: WireEvent) => {
       // First provider-originated event = the honest first-token bound. Set
@@ -369,153 +162,37 @@ export async function runTurn(
       signal?.removeEventListener("abort", onAbort);
       unsub();
     }
-    // Diff what this turn created/modified; skipped on a failed turn (a
-    // provider error means the model never finished). Emitted BEFORE the
-    // caller's terminal frame, mirroring the long-lived runtime's order.
-    let fileChanges: { created: string[]; modified: string[] } | undefined;
-    if (beforeFiles && !providerError) {
-      try {
-        const changes = diffSnapshots(
-          beforeFiles,
-          snapshotWorkspace(workspaceDir),
-        );
-        if (changes.created.length || changes.modified.length)
-          fileChanges = changes;
-      } catch (err) {
-        console.warn(
-          "[turn] file diff failed:",
-          err instanceof Error ? err.message : String(err),
-        );
-      }
-    }
-    // Persist the turn's assistant message with any typed provider error so the
-    // inline card survives a reload of this cloud conversation. The provider_error
-    // frame was already streamed to the client (which settles on it), so this
-    // returns no `outcome.error` — the per-turn server's trailing terminal is a
-    // no-op for the already-settled client, and reporting an error here would make
-    // it send a SECOND, generic error frame on top of the typed card.
-    // Mirrors exec-turn's plan-mode backstop: a clean plan turn with visible
-    // assistant output but no recorded interaction still owes the user an
-    // approval card (models occasionally write the plan and skip plan_ready).
-    const pendingInteraction =
-      !providerError &&
-      mode === "plan" &&
-      assistantText.trim() &&
-      !interaction.pending
-        ? planReadyFallback()
-        : interaction.pending;
-    appendAssistantMessageAt(conversationsDir, conversationId, assistantText, {
+    return finishSuccessfulTurn({
+      beforeFiles,
+      providerError,
+      workspaceDir,
+      mode,
+      assistantText,
+      interaction,
+      conversationsDir,
+      conversationId,
       tools,
       usage,
-      providerError,
-      fileChanges,
-      // Same clean-only condition as the returned outcome (below): persist the
-      // pending question only when the turn ended without a provider error, so
-      // a reload of this cloud conversation settles to `needs_you`, not a false
-      // `done`. Mirrors exec-turn — only the clean turn carries it.
-      pendingInteraction: providerError ? undefined : pendingInteraction,
+      provider,
       turnId,
+      emit,
     });
-    if (fileChanges) emit({ type: "file_changes", data: fileChanges });
-    // A completed turn proves this provider's credential works — heal any
-    // stale turn-failure mark (auth/credential-health.ts; mirrors exec-turn).
-    if (!providerError) clearProviderMarks(provider);
-    // Carry the pending question only on a clean turn — never alongside a
-    // provider error (mirrors exec-turn: only the clean `done` carries it).
-    return providerError ? {} : { pendingInteraction };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    // The caller's cancel usually resolves prompt() clean (pi routes an abort
-    // down the usage path), but one landing mid-request RAISES the AbortError
-    // instead. Same user action either way — not a provider failure and not
-    // an outcome error: persist what streamed and end the turn quietly.
-    if (
-      !providerError &&
-      (signal?.aborted || (err instanceof Error && err.name === "AbortError"))
-    ) {
-      if (assistantText)
-        appendAssistantMessageAt(
-          conversationsDir,
-          conversationId,
-          assistantText,
-          {
-            tools,
-            usage,
-            turnId,
-          },
-        );
-      return {};
-    }
-    // Classify the throw before reporting a generic outcome error: pi RAISES
-    // a missing/expired credential at prompt time ("No API key found for
-    // <provider>. Use /login …"), before any stream exists, so this catch is
-    // the only place it can become the typed reconnect card (HOU-718 —
-    // mirrors exec-turn). The typed error is emitted as a provider_error
-    // frame (the terminal the client settles on) and persisted so the card
-    // survives a reload; returning `{}` keeps the per-turn server from
-    // stacking a second, generic error frame on top of it.
-    if (!providerError) {
-      const thrown =
-        err instanceof TurnBackendProviderError
-          ? err.providerError
-          : classifyProviderError({
-              provider,
-              model: pin?.model ?? null,
-              message,
-            });
-      // The streamed path logged when it classified; a THROWN failure is
-      // invisible to Sentry unless this catch logs it too (HOU-1156;
-      // mirrors exec-turn).
-      logProviderError(thrown, { model: pin?.model ?? null });
-      // Prompt-time credential guard: pi raised BEFORE recording the user
-      // message in its session store, so the reconnect retry must re-deliver
-      // the text (mirrors exec-turn).
-      if (
-        thrown.kind === "unauthenticated" &&
-        !assistantText &&
-        tools.length === 0
-      )
-        thrown.undelivered_prompt = text;
-      // A thrown auth failure never crossed the backends' streamed-error
-      // seams — feed it into the status surface (auth/credential-health.ts;
-      // mirrors exec-turn).
-      if (thrown.kind === "unauthenticated") {
-        noteAuthFailure(thrown.provider);
-        // A REVOKED served token is invisible to the control plane (HOU-952).
-        // Named by the seeded at-failure token; a throw before the seed (a
-        // bad model resolution) recorded nothing and the reporter skips
-        // (PRODUCT-1319).
-        reportRevokedServedToken(thrown, usedTokens.digestFor(thrown.provider));
-      }
-      // The account ran out of credits: a valid credential with nothing left,
-      // so the status surface must say so instead of "Connected" (mirrors
-      // exec-turn).
-      if (thrown.kind === "quota_exhausted")
-        noteQuotaExhausted(thrown.provider, thrown.resets_at);
-      if (thrown.kind !== "unknown") {
-        appendAssistantMessageAt(
-          conversationsDir,
-          conversationId,
-          assistantText,
-          { tools, usage, providerError: thrown, turnId },
-        );
-        emit({ type: "provider_error", data: thrown });
-        return {};
-      }
-    }
-    if (assistantText || providerError)
-      appendAssistantMessageAt(
-        conversationsDir,
-        conversationId,
-        assistantText,
-        { tools, usage, providerError, turnId },
-      );
-    return { error: message };
+  } catch (error) {
+    return handleTurnSessionFailure({
+      error,
+      signal,
+      providerError,
+      assistantText,
+      tools,
+      usage,
+      conversationsDir,
+      conversationId,
+      turnId,
+      provider,
+      model: pin?.model,
+      text,
+      usedTokens,
+      emit,
+    });
   }
 }
-
-/** Injectable pooled-turn execution contract used by the HTTP server. */
-export type TurnRunner = (
-  directories: TurnDirectories,
-  turn: TurnSessionRequest,
-) => Promise<TurnOutcome>;


### PR DESCRIPTION
Pooled turns ran their startup phases serially: hydrate (1.2–1.6s measured) → credential write → model runtime → backend construction (Claude SDK module load ~1.3s) → prompt. Nothing forces that order, and the per-turn timings added recently showed the SDK load fits entirely inside hydration.

## What changed

- `prepareTurnFilesystem` splits into list → resolve layout → priority-hydrate the runtime input files → then bulk downloads run CONCURRENTLY with credential writing, model-runtime setup, Claude SDK loading, tool selection, and backend construction. `session.prompt()`, conversation loading, and everything reading the workspace tree still gate on full hydration.
- Expected effect (from live timings): Claude pooled pipeline ~2.9s → ~1.7s before the provider is asked; pi saves ~50ms. The new marks (listing, layout, startup_files, model_runtime, backend_loaded/created, hydrated) make the overlap measurable on every live turn.
- Concurrency safety, adversarially reviewed: the derived hydration promise can never become an unhandled rejection (worker fatalCrash guard); cleanup aborts in-flight downloads and settles all writers before removing the turn root (no rm-under-writer, no resurrected /tmp trees); credential-write failures emit one typed setup frame; abandoned startup tasks are consumed and logged, never silently dropped; routine turns thread injected session deps.
- `turn-session.ts` split into focused modules (backend/startup/success/failure/types) to stay under the line cap — verified a verbatim move, no behavior change; server-mode/standing-pod hydration callers byte-identical.

## Tests

New coverage: overlap gating (backend starts during hydration, prompt waits), credential-write race with in-flight downloads (single error frame, no unhandled rejection, no root resurrection), download cancellation, startup-failure logging, routine deps injection, timing mark ordering. Full suites green: runtime 1509 · runtime-client 194 · host · domain; Biome + boundaries clean.