### PR TITLE
test(web): sidebar-dnd reorder waits for the layout write and polls after reload

### DIFF
--- a/packages/web/e2e/sidebar-dnd.spec.ts
+++ b/packages/web/e2e/sidebar-dnd.spec.ts
@@ -93,6 +93,14 @@ test("team create + type name + reorder agents inside the default team", async (
   expect(await rowY(sidebar, "Beta")).toBeGreaterThan(
     await rowY(sidebar, "Houston"),
   );
+  // Arm the write listener BEFORE the drop: the reload below must not race
+  // the layout PUT, or it re-reads the pre-drag order from the server.
+  const layoutWrite = page.waitForResponse(
+    (r) =>
+      r.url().includes("/sidebar-layout") &&
+      r.request().method() === "PUT" &&
+      r.ok(),
+  );
   await dragOnto(
     page,
     sidebar.getByText("Beta", { exact: true }),
@@ -106,6 +114,7 @@ test("team create + type name + reorder agents inside the default team", async (
         (await rowY(sidebar, "Beta")) < (await rowY(sidebar, "Houston")),
     )
     .toBe(true);
+  await layoutWrite;
 
   // Every gesture above is written back with
   // `PUT /v1/workspaces/:id/sidebar-layout`. A reload throws away all the
@@ -115,9 +124,13 @@ test("team create + type name + reorder agents inside the default team", async (
   await expect(page.getByText("Your teams")).toBeVisible();
   await expect(header).toHaveCount(1);
   await expect(sidebar.getByText("Work")).toBeVisible();
-  expect(await rowY(sidebar, "Beta")).toBeLessThan(
-    await rowY(sidebar, "Houston"),
-  );
+  // Same poll after reload: the server layout applies a beat after first paint.
+  await expect
+    .poll(
+      async () =>
+        (await rowY(sidebar, "Beta")) < (await rowY(sidebar, "Houston")),
+    )
+    .toBe(true);
 });
 
 test("an agent dragged onto ANOTHER team is refused and stays put", async ({


### PR DESCRIPTION
The reorder spec has flaked three times in CI today (`--fail-on-flaky-tests` turns one flake into a red run). Two remaining races after the earlier post-drag poll fix:

1. The post-reload assertion sampled row positions ONCE at first paint, before the server layout applies — now polls like the post-drag check.
2. `page.reload()` could race the drag's `PUT /sidebar-layout` — the server then legitimately returns the pre-drag order and no amount of polling fixes it. The write listener is armed before the drop and awaited before reload.

Note for the record: this suite also fails locally under `--repeat-each` on unmodified main (repeat workers share one fake-host; pre-existing, unrelated), so CI is the validation surface for this change.