### PR TITLE
fix(runtime): models-store.json is a startup hydration input — pi reads it during offline refresh

### DIFF
--- a/packages/runtime/src/turn/turn-runtime.ts
+++ b/packages/runtime/src/turn/turn-runtime.ts
@@ -14,6 +14,11 @@ const TURN_RUNTIME_INPUTS = new Set([
   "azure-endpoint.json",
   "custom-endpoint.json",
   "models.json",
+  // Read by pi, not by this repo: ModelRuntime.create's offline refresh loads
+  // stored dynamic models through its FileModelsStore at
+  // dirname(modelsPath)/models-store.json. Left to the bulk pass, that read
+  // races an in-flight download and can parse a partial file.
+  "models-store.json",
   "qwen-region.json",
   "settings.json",
   "xiaomi-endpoint.json",


### PR DESCRIPTION
The phase-overlap PR removed `models-store.json` from the priority hydration set on the grounds that nothing in this repo reads it during startup. True but incomplete: pi's `ModelRuntime.create` runs an offline refresh whose `FileModelsStore` reads `dirname(modelsPath)/models-store.json` — so under the new concurrency, that read races the file's own in-flight bulk download and can parse a partial JSON. Restored to the priority set with a comment naming the real (external) reader so it doesn't get 'cleaned up' again. Runtime suite green (1509).