### PR TITLE
perf(runtime): hydrate only the live session tail for pooled turns

### DIFF
--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -682,10 +682,11 @@ test("hydrate materializes many files faithfully under concurrency", async () =>
   }
 });
 
-test("startHydrate lands priority files before background hydration resolves", async () => {
+test("startHydrate lands priority files before filtering the bulk", async () => {
   const { storeRoot, store, work } = setup();
   seed(storeRoot, PREFIX, {
-    "data/settings.json": "settings",
+    "data/settings.json": "workspace/late.txt",
+    "workspace/drop.txt": "drop",
     "workspace/late.txt": "late",
   });
   let release: () => void = () => undefined;
@@ -705,11 +706,16 @@ test("startHydrate lands priority files before background hydration resolves", a
 
   const started = await startHydrate(gated, PREFIX, work, {
     priority: (rel) => rel === "data/settings.json",
+    filter: (rel, _listing, hydratedRoot) =>
+      rel === "data/settings.json" ||
+      rel === readFileSync(join(hydratedRoot, "data", "settings.json"), "utf8"),
   });
 
   expect(readFileSync(join(work, "data", "settings.json"), "utf8")).toBe(
-    "settings",
+    "workspace/late.txt",
   );
+  expect(started.skippedObjects).toBe(1);
+  expect(existsSync(join(work, "workspace", "drop.txt"))).toBe(false);
   expect(existsSync(join(work, "workspace", "late.txt"))).toBe(false);
   release();
   await started.done;

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -645,6 +645,28 @@ test("missing prefix hydrates to an empty manifest", async () => {
   expect((await hydrate(store, "ws/none/agent-x", work)).size).toBe(0);
 });
 
+test("startHydrate exposes the complete listing and counts filtered objects", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, PREFIX, {
+    "workspace/keep.txt": "keep",
+    "workspace/skip.txt": "skip",
+  });
+  let listed: string[] = [];
+
+  const started = await startHydrate(store, PREFIX, work, {
+    filter: (rel, listing) => {
+      listed = listing.map((object) => object.rel);
+      return rel.endsWith("keep.txt");
+    },
+  });
+  await started.done;
+
+  expect(listed.sort()).toEqual(["workspace/keep.txt", "workspace/skip.txt"]);
+  expect(started.skippedObjects).toBe(1);
+  expect([...started.manifest.keys()]).toEqual(["workspace/keep.txt"]);
+  expect(existsSync(join(work, "workspace", "skip.txt"))).toBe(false);
+});
+
 test("hydrate materializes many files faithfully under concurrency", async () => {
   const { storeRoot, store, work } = setup();
   const files: Record<string, string> = {};

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -39,7 +39,7 @@ export interface HydrateOptions {
    * accepts are downloaded. Lets a caller hydrate a hot-set (one
    * conversation's files, not every conversation's) without a glob per id.
    */
-  filter?: (rel: string) => boolean;
+  filter?: (rel: string, listing: readonly HydrateListedObject[]) => boolean;
   /** Every admitted path BEFORE `filter` (the store's view of the tree) and
    *  whether the listing carried generations (the CAS capability, which a
    *  filtered manifest can no longer answer on its own). */
@@ -49,6 +49,12 @@ export interface HydrateOptions {
   }) => void | Promise<void>;
   /** Download these admitted objects before the remaining hydration starts. */
   priority?: (rel: string) => boolean;
+}
+
+/** Store-listing fields available to a caller's hot-set selector. */
+export interface HydrateListedObject {
+  rel: string;
+  updated?: string;
 }
 
 /** The hydrated prefix exceeded the caller's aggregate byte cap. */
@@ -69,6 +75,8 @@ const DEFAULT_HYDRATE_CONCURRENCY = 16;
 export interface StartedHydration {
   manifest: HydrateManifest;
   listed: { rels: string[]; generationAware: boolean };
+  /** Listed objects rejected by the caller's filter. */
+  skippedObjects: number;
   /** Resolves only after every non-priority object has landed. */
   done: Promise<void>;
   /** Stop admitting downloads and cancel adapters that support AbortSignal. */
@@ -97,19 +105,33 @@ export async function startHydrate(
   const storeObjects =
     objects ??
     (await store.list(prefix)).map((key) => ({ key, generation: undefined }));
-  const entries: HydrateEntry[] = [];
-  const admitted: string[] = [];
+  const candidates: (HydrateEntry & { updated?: string })[] = [];
   let generationAware = false;
   for (const object of storeObjects) {
     const { key } = object;
     const rel = prefix ? key.slice(prefix.length + 1) : key;
     if (!rel || excluded(rel, excludes)) continue;
-    admitted.push(rel);
     if (object.generation !== undefined) generationAware = true;
-    if (opts.filter && !opts.filter(rel)) continue;
-    entries.push({ key, rel, generation: object.generation });
+    candidates.push({
+      key,
+      rel,
+      generation: object.generation,
+      ...("updated" in object && object.updated
+        ? { updated: object.updated }
+        : {}),
+    });
   }
-  const listed = { rels: admitted, generationAware };
+  const filterListing = candidates.map(({ rel, updated }) => ({
+    rel,
+    ...(updated ? { updated } : {}),
+  }));
+  const entries = opts.filter
+    ? candidates.filter((entry) => opts.filter?.(entry.rel, filterListing))
+    : candidates;
+  const listed = {
+    rels: candidates.map(({ rel }) => rel),
+    generationAware,
+  };
   await opts.onListed?.(listed);
   const priority = opts.priority
     ? entries.filter((entry) => opts.priority?.(entry.rel))
@@ -145,6 +167,7 @@ export async function startHydrate(
   return {
     manifest,
     listed,
+    skippedObjects: candidates.length - entries.length,
     done: download(remaining),
     abort: () => state.fail(new Error("hydration aborted before cleanup")),
   };

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -34,20 +34,20 @@ export interface HydrateOptions {
    * 133-object workspace measured 10.5 s sequential vs 0.4 s at 16.
    */
   concurrency?: number;
-  /**
-   * Per-object admission on top of `excludes`: only objects the predicate
-   * accepts are downloaded. Lets a caller hydrate a hot-set (one
-   * conversation's files, not every conversation's) without a glob per id.
-   */
-  filter?: (rel: string, listing: readonly HydrateListedObject[]) => boolean;
-  /** Every admitted path BEFORE `filter` (the store's view of the tree) and
+  /** Admit objects after priorities land using the listing and hydrated root. */
+  filter?: (
+    rel: string,
+    listing: readonly HydrateListedObject[],
+    hydratedRoot: string,
+  ) => boolean;
+  /** Every non-excluded path before `filter` (the store's view of the tree) and
    *  whether the listing carried generations (the CAS capability, which a
    *  filtered manifest can no longer answer on its own). */
   onListed?: (listing: {
     rels: string[];
     generationAware: boolean;
   }) => void | Promise<void>;
-  /** Download these admitted objects before the remaining hydration starts. */
+  /** Download these candidates before filtering the non-priority objects. */
   priority?: (rel: string) => boolean;
 }
 
@@ -125,20 +125,15 @@ export async function startHydrate(
     rel,
     ...(updated ? { updated } : {}),
   }));
-  const entries = opts.filter
-    ? candidates.filter((entry) => opts.filter?.(entry.rel, filterListing))
-    : candidates;
   const listed = {
     rels: candidates.map(({ rel }) => rel),
     generationAware,
   };
   await opts.onListed?.(listed);
-  const priority = opts.priority
-    ? entries.filter((entry) => opts.priority?.(entry.rel))
+  const priorityCandidates = opts.priority
+    ? candidates.filter((entry) => opts.priority?.(entry.rel))
     : [];
-  const remaining = opts.priority
-    ? entries.filter((entry) => !opts.priority?.(entry.rel))
-    : entries;
+  const priorityRels = new Set(priorityCandidates.map(({ rel }) => rel));
   const controller = new AbortController();
   const state: HydrateDownloadState = {
     total: 0,
@@ -163,11 +158,25 @@ export async function startHydrate(
       limitError: (observedBytes) =>
         new HydrateLimitError(maxBytes, observedBytes),
     });
+  const filter = opts.filter;
+  const priority = filter
+    ? priorityCandidates.filter((entry) =>
+        filter(entry.rel, filterListing, destDir),
+      )
+    : priorityCandidates;
   await download(priority);
+  const remainingCandidates = candidates.filter(
+    ({ rel }) => !priorityRels.has(rel),
+  );
+  const remaining = filter
+    ? remainingCandidates.filter((entry) =>
+        filter(entry.rel, filterListing, destDir),
+      )
+    : remainingCandidates;
   return {
     manifest,
     listed,
-    skippedObjects: candidates.length - entries.length,
+    skippedObjects: candidates.length - priority.length - remaining.length,
     done: download(remaining),
     abort: () => state.fail(new Error("hydration aborted before cleanup")),
   };

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -2,6 +2,7 @@ export { fileSha256 } from "./file-hash";
 export type { HttpObjectStoreOptions } from "./http-store";
 export { HttpObjectStore } from "./http-store";
 export type {
+  HydrateListedObject,
   HydrateManifest,
   HydrateOptions,
   StartedHydration,

--- a/packages/runtime/src/backends/pi/backend.ts
+++ b/packages/runtime/src/backends/pi/backend.ts
@@ -93,6 +93,19 @@ function newestSessionFile(sessionDir: string): string | null {
   return null;
 }
 
+/** Whether a present hydrated Pi tail is corrupt and cannot be resumed. */
+export function hasUnreadablePiSessionTail(sessionDir: string): boolean {
+  let hasSessionFile = false;
+  try {
+    hasSessionFile = readdirSync(sessionDir).some((file) =>
+      file.endsWith(".jsonl"),
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return hasSessionFile && newestSessionFile(sessionDir) === null;
+}
+
 function isReadableSession(file: string): boolean {
   // Bounded: only the header line matters, and session files grow to MBs.
   const buffer = Buffer.alloc(64 * 1024);

--- a/packages/runtime/src/turn/execute-ready-turn.ts
+++ b/packages/runtime/src/turn/execute-ready-turn.ts
@@ -168,6 +168,10 @@ export async function executeReadyTurn(input: {
       durable.activityDocSkipped,
       durable.changed,
       input.timings,
+      {
+        hydratedObjects: input.filesystem.manifest.size,
+        skippedObjects: input.filesystem.skippedObjects,
+      },
     ),
   );
   await input.turnLog?.flush();

--- a/packages/runtime/src/turn/execute-shadow-turn.ts
+++ b/packages/runtime/src/turn/execute-shadow-turn.ts
@@ -25,6 +25,7 @@ export async function executeShadowTurn(input: {
       data: {
         ...input.timings,
         hydratedObjects: input.filesystem.manifest.size,
+        skippedObjects: input.filesystem.skippedObjects,
       },
       turnId: input.turnId,
     } as unknown as WireFrame);

--- a/packages/runtime/src/turn/gcs-store.test.ts
+++ b/packages/runtime/src/turn/gcs-store.test.ts
@@ -1,0 +1,52 @@
+import type { Storage } from "@google-cloud/storage";
+import { expect, test, vi } from "vitest";
+import { GcsStore } from "./gcs-store";
+import { ownConversationOnly } from "./turn-hot-set";
+
+test("GCS update timestamps select exactly one Claude transcript", async () => {
+  const prefix = "ws/w1/agent-1";
+  const session =
+    "workspaces/Personal/Bob/.houston/runtime/sessions/c1/claude/projects";
+  const older = `${session}/old/ffffffff.jsonl`;
+  const newer = `${session}/current/00000000.jsonl`;
+  const getFiles = vi.fn(async (_query: { prefix: string; fields: string }) => [
+    [
+      {
+        name: `${prefix}/${older}`,
+        metadata: {
+          size: "10",
+          md5Hash: "older-hash",
+          updated: "2026-08-20T12:00:00.000Z",
+        },
+      },
+      {
+        name: `${prefix}/${newer}`,
+        metadata: {
+          size: "20",
+          md5Hash: "newer-hash",
+          updated: "2026-08-21T12:00:00.000Z",
+        },
+      },
+    ],
+  ]);
+  // SAFETY: this manifest test exercises only Storage.bucket().getFiles(),
+  // and the fixture supplies that exact external-client seam.
+  const storage = {
+    bucket: () => ({ getFiles }),
+  } as unknown as Storage;
+  const manifest = await new GcsStore("turns", storage).manifest(prefix);
+  const listing = manifest.map(({ key, updated }) => ({
+    rel: key.slice(prefix.length + 1),
+    ...(updated ? { updated } : {}),
+  }));
+  const admit = ownConversationOnly("c1");
+
+  expect(
+    listing.filter(({ rel }) => admit(rel, listing)).map(({ rel }) => rel),
+  ).toEqual([newer]);
+  expect(getFiles).toHaveBeenCalledWith({
+    prefix: `${prefix}/`,
+    fields: expect.stringContaining("updated"),
+  });
+  expect(getFiles.mock.calls[0]?.[0].fields).toContain("nextPageToken");
+});

--- a/packages/runtime/src/turn/gcs-store.test.ts
+++ b/packages/runtime/src/turn/gcs-store.test.ts
@@ -1,9 +1,8 @@
 import type { Storage } from "@google-cloud/storage";
 import { expect, test, vi } from "vitest";
 import { GcsStore } from "./gcs-store";
-import { ownConversationOnly } from "./turn-hot-set";
 
-test("GCS update timestamps select exactly one Claude transcript", async () => {
+test("GCS manifests propagate update timestamps without breaking pagination", async () => {
   const prefix = "ws/w1/agent-1";
   const session =
     "workspaces/Personal/Bob/.houston/runtime/sessions/c1/claude/projects";
@@ -35,15 +34,17 @@ test("GCS update timestamps select exactly one Claude transcript", async () => {
     bucket: () => ({ getFiles }),
   } as unknown as Storage;
   const manifest = await new GcsStore("turns", storage).manifest(prefix);
-  const listing = manifest.map(({ key, updated }) => ({
-    rel: key.slice(prefix.length + 1),
-    ...(updated ? { updated } : {}),
-  }));
-  const admit = ownConversationOnly("c1");
 
-  expect(
-    listing.filter(({ rel }) => admit(rel, listing)).map(({ rel }) => rel),
-  ).toEqual([newer]);
+  expect(manifest.map(({ key, updated }) => ({ key, updated }))).toEqual([
+    {
+      key: `${prefix}/${newer}`,
+      updated: "2026-08-21T12:00:00.000Z",
+    },
+    {
+      key: `${prefix}/${older}`,
+      updated: "2026-08-20T12:00:00.000Z",
+    },
+  ]);
   expect(getFiles).toHaveBeenCalledWith({
     prefix: `${prefix}/`,
     fields: expect.stringContaining("updated"),

--- a/packages/runtime/src/turn/gcs-store.ts
+++ b/packages/runtime/src/turn/gcs-store.ts
@@ -1,14 +1,18 @@
 import { Storage } from "@google-cloud/storage";
 import {
+  type ObjectMetadata,
   ObjectNotFoundError,
   type ObjectStore,
 } from "@houston/runtime-client/object-sync";
 
+// Partial responses must retain nextPageToken or the client cannot auto-page.
+const LIST_FIELDS = "items(name,size,md5Hash,updated),nextPageToken";
+
 /**
  * GCS-backed ObjectStore. Auth is Application Default Credentials (the Cloud
  * Run service account); the runtime SA holds objectAdmin on THIS bucket only.
- * Thin by design — all hydration/diff logic lives in hydrate.ts and is tested
- * against LocalDirStore; this adapter is exercised by the deploy smoke test.
+ * Thin by design — hydration/diff logic lives in hydrate.ts; this adapter only
+ * maps GCS object operations and listing metadata onto the shared port.
  */
 export class GcsStore implements ObjectStore {
   private readonly bucket;
@@ -19,8 +23,24 @@ export class GcsStore implements ObjectStore {
   }
 
   async list(prefix: string): Promise<string[]> {
-    const [files] = await this.bucket.getFiles({ prefix: `${prefix}/` });
+    const files = await this.listFiles(prefix);
     return files.map((f) => f.name).sort();
+  }
+
+  /** GCS listing metadata for hydration; generations stay disabled here. */
+  async manifest(prefix = ""): Promise<ObjectMetadata[]> {
+    const files = await this.listFiles(prefix);
+    return files
+      .map((file) => {
+        const size = Number(file.metadata.size ?? 0);
+        return {
+          key: file.name,
+          size: Number.isFinite(size) && size >= 0 ? size : 0,
+          md5: file.metadata.md5Hash ?? "",
+          updated: file.metadata.updated ?? "",
+        };
+      })
+      .sort((left, right) => left.key.localeCompare(right.key));
   }
 
   async download(key: string, destFile: string): Promise<void> {
@@ -43,5 +63,13 @@ export class GcsStore implements ObjectStore {
 
   async delete(key: string): Promise<void> {
     await this.bucket.file(key).delete({ ignoreNotFound: true });
+  }
+
+  private async listFiles(prefix: string) {
+    const [files] = await this.bucket.getFiles({
+      prefix: prefix ? `${prefix}/` : "",
+      fields: LIST_FIELDS,
+    });
+    return files;
   }
 }

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -115,9 +115,14 @@ test("a claimed turn's filter leaves other conversations' history out of the hyd
   );
   for (const id of ["c1", "c2"]) {
     mkdirSync(join(runtime, "sessions", id), { recursive: true });
+    mkdirSync(join(runtime, "sessions", id, "claude"), { recursive: true });
     mkdirSync(join(runtime, "conversations"), { recursive: true });
     writeFileSync(join(runtime, "conversations", `${id}.json`), "{}");
     writeFileSync(join(runtime, "sessions", id, "s.jsonl"), "");
+    writeFileSync(
+      join(runtime, "sessions", id, "claude", "sessions.json"),
+      "{}",
+    );
   }
   writeFileSync(join(runtime, "settings.json"), "{}");
   const fs = await prepareTurnFilesystem({
@@ -130,12 +135,13 @@ test("a claimed turn's filter leaves other conversations' history out of the hyd
   const keys = [...fs.manifest.keys()].sort();
   expect(keys).toEqual([
     "workspaces/Personal/Bob/.houston/runtime/conversations/c1.json",
+    "workspaces/Personal/Bob/.houston/runtime/sessions/c1/claude/sessions.json",
     "workspaces/Personal/Bob/.houston/runtime/sessions/c1/s.jsonl",
     "workspaces/Personal/Bob/.houston/runtime/settings.json",
   ]);
 });
 
-test("a claimed turn hydrates one session tail and leaves skipped objects untouched", async () => {
+test("a claimed turn hydrates live session tails and leaves skips untouched", async () => {
   const storeRoot = mkdtempSync(join(tmpdir(), "session-diet-store-"));
   const prefix = "ws/w1/agent-1";
   const agentRel = "workspaces/Personal/Bob";
@@ -152,7 +158,8 @@ test("a claimed turn hydrates one session tail and leaves skipped objects untouc
   seed(`${runtimeRel}/settings.json`, "{}");
   seed(`${runtimeRel}/conversations/c1.json`, "{}");
   const piOld = `${sessionRel}/2026-08-20T19-00-01-250Z_old.jsonl`;
-  const piNew = `${sessionRel}/2026-08-21T19-00-01-250Z_new.jsonl`;
+  const piReadable = `${sessionRel}/2026-08-21T19-00-01-250Z_readable.jsonl`;
+  const piCorrupt = `${sessionRel}/2026-08-22T19-00-01-250Z_torn.jsonl`;
   const piSession = (id: string) =>
     `${JSON.stringify({
       type: "session",
@@ -162,7 +169,8 @@ test("a claimed turn hydrates one session tail and leaves skipped objects untouc
       cwd: "/previous/turn/workspace",
     })}\n`;
   seed(piOld, piSession("old"));
-  const piNewFile = seed(piNew, piSession("new"));
+  const piReadableFile = seed(piReadable, piSession("readable"));
+  seed(piCorrupt, "not json\n");
   const unexpectedSibling = `${sessionRel}/session.lock`;
   seed(unexpectedSibling, "stale lock");
   seed(`${sessionRel}/harness.json`, '{"backend":"claude"}');
@@ -172,9 +180,11 @@ test("a claimed turn hydrates one session tail and leaves skipped objects untouc
   const claudeOldFile = seed(claudeOld, "old claude");
   const claudeNewFile = seed(claudeNew, "new claude");
   seed(`${sessionRel}/claude/statsig/cache.json`, "cache");
-  utimesSync(piNewFile, new Date(1_000), new Date(1_000));
-  utimesSync(claudeOldFile, new Date(1_000), new Date(1_000));
-  utimesSync(claudeNewFile, new Date(2_000), new Date(2_000));
+  utimesSync(piReadableFile, new Date(1_000), new Date(1_000));
+  // The relocated stale session uploaded after the fresh retry. Its newer
+  // store timestamp must not outrank the sessions.json pointer.
+  utimesSync(claudeOldFile, new Date(2_000), new Date(2_000));
+  utimesSync(claudeNewFile, new Date(1_000), new Date(1_000));
 
   const inner = new LocalDirStore(storeRoot);
   const uploads: string[] = [];
@@ -200,7 +210,8 @@ test("a claimed turn hydrates one session tail and leaves skipped objects untouc
     filter: ownConversationOnly("c1"),
   });
 
-  expect([...fs.manifest.keys()]).toContain(piNew);
+  expect([...fs.manifest.keys()]).toContain(piReadable);
+  expect([...fs.manifest.keys()]).toContain(piCorrupt);
   expect([...fs.manifest.keys()]).toContain(claudeNew);
   expect([...fs.manifest.keys()]).not.toContain(piOld);
   expect([...fs.manifest.keys()]).not.toContain(claudeOld);
@@ -216,7 +227,7 @@ test("a claimed turn hydrates one session tail and leaves skipped objects untouc
       join(fs.dataDir, "sessions", "c1"),
       false,
     ).getSessionFile(),
-  ).toBe(join(fs.storeRoot, ...piNew.split("/")));
+  ).toBe(join(fs.storeRoot, ...piReadable.split("/")));
 
   const configDir = join(fs.dataDir, "sessions", "c1", "claude");
   const sessions = createSessionsStore({

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -1,9 +1,24 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { LocalDirStore } from "@houston/runtime-client/object-sync";
+import {
+  LocalDirStore,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
 import { expect, test } from "vitest";
-import { claimedTurnIncludes, prepareTurnFilesystem } from "./turn-filesystem";
+import { createSessionsStore } from "../backends/claude/sessions-store";
+import { resumeSessionManager } from "../backends/pi/backend";
+import {
+  claimedTurnIncludes,
+  prepareTurnFilesystem,
+  syncTurnFilesystem,
+} from "./turn-filesystem";
 import { ownConversationOnly } from "./turn-hot-set";
 
 test("route-op excludes skip the runtime tree wherever the agent sits", async () => {
@@ -118,6 +133,113 @@ test("a claimed turn's filter leaves other conversations' history out of the hyd
     "workspaces/Personal/Bob/.houston/runtime/sessions/c1/s.jsonl",
     "workspaces/Personal/Bob/.houston/runtime/settings.json",
   ]);
+});
+
+test("a claimed turn hydrates one session tail and leaves skipped objects untouched", async () => {
+  const storeRoot = mkdtempSync(join(tmpdir(), "session-diet-store-"));
+  const prefix = "ws/w1/agent-1";
+  const agentRel = "workspaces/Personal/Bob";
+  const runtimeRel = `${agentRel}/.houston/runtime`;
+  const sessionRel = `${runtimeRel}/sessions/c1`;
+  const root = join(storeRoot, prefix);
+  const seed = (rel: string, content: string) => {
+    const file = join(root, ...rel.split("/"));
+    mkdirSync(join(file, ".."), { recursive: true });
+    writeFileSync(file, content);
+    return file;
+  };
+  seed(`${agentRel}/note.txt`, "workspace stays eager");
+  seed(`${runtimeRel}/settings.json`, "{}");
+  seed(`${runtimeRel}/conversations/c1.json`, "{}");
+  const piOld = `${sessionRel}/2026-08-20T19-00-01-250Z_old.jsonl`;
+  const piNew = `${sessionRel}/2026-08-21T19-00-01-250Z_new.jsonl`;
+  const piSession = (id: string) =>
+    `${JSON.stringify({
+      type: "session",
+      version: 3,
+      id,
+      timestamp: "2026-08-20T19:00:01.250Z",
+      cwd: "/previous/turn/workspace",
+    })}\n`;
+  seed(piOld, piSession("old"));
+  const piNewFile = seed(piNew, piSession("new"));
+  const unexpectedSibling = `${sessionRel}/session.lock`;
+  seed(unexpectedSibling, "stale lock");
+  seed(`${sessionRel}/harness.json`, '{"backend":"claude"}');
+  seed(`${sessionRel}/claude/sessions.json`, '{"c1":"session-new"}');
+  const claudeOld = `${sessionRel}/claude/projects/old/session-old.jsonl`;
+  const claudeNew = `${sessionRel}/claude/projects/foreign/session-new.jsonl`;
+  const claudeOldFile = seed(claudeOld, "old claude");
+  const claudeNewFile = seed(claudeNew, "new claude");
+  seed(`${sessionRel}/claude/statsig/cache.json`, "cache");
+  utimesSync(piNewFile, new Date(1_000), new Date(1_000));
+  utimesSync(claudeOldFile, new Date(1_000), new Date(1_000));
+  utimesSync(claudeNewFile, new Date(2_000), new Date(2_000));
+
+  const inner = new LocalDirStore(storeRoot);
+  const uploads: string[] = [];
+  const deletes: string[] = [];
+  const store: ObjectStore = {
+    list: (scope) => inner.list(scope),
+    manifest: (scope) => inner.manifest(scope),
+    download: (key, dest, options) => inner.download(key, dest, options),
+    upload: async (source, key, options) => {
+      uploads.push(key);
+      return inner.upload(source, key, options);
+    },
+    delete: async (key, options) => {
+      deletes.push(key);
+      return inner.delete(key, options);
+    },
+  };
+  const fs = await prepareTurnFilesystem({
+    store,
+    prefix,
+    root: mkdtempSync(join(tmpdir(), "session-diet-root-")),
+    claimed: true,
+    filter: ownConversationOnly("c1"),
+  });
+
+  expect([...fs.manifest.keys()]).toContain(piNew);
+  expect([...fs.manifest.keys()]).toContain(claudeNew);
+  expect([...fs.manifest.keys()]).not.toContain(piOld);
+  expect([...fs.manifest.keys()]).not.toContain(claudeOld);
+  expect(fs.skippedObjects).toBe(4);
+  expect(existsSync(join(fs.storeRoot, ...piOld.split("/")))).toBe(false);
+  expect(existsSync(join(fs.storeRoot, ...claudeOld.split("/")))).toBe(false);
+  expect(existsSync(join(fs.storeRoot, ...unexpectedSibling.split("/")))).toBe(
+    false,
+  );
+  expect(
+    resumeSessionManager(
+      fs.workspaceDir,
+      join(fs.dataDir, "sessions", "c1"),
+      false,
+    ).getSessionFile(),
+  ).toBe(join(fs.storeRoot, ...piNew.split("/")));
+
+  const configDir = join(fs.dataDir, "sessions", "c1", "claude");
+  const sessions = createSessionsStore({
+    configDir,
+    sessionsFile: join(configDir, "sessions.json"),
+    cwd: fs.workspaceDir,
+  });
+  expect(sessions.resolveResume("c1")).toBe("session-new");
+
+  await syncTurnFilesystem({
+    store,
+    prefix,
+    filesystem: fs,
+    conversationId: "c1",
+    claimed: true,
+  });
+  expect(uploads.some((key) => key.endsWith(`/${piOld}`))).toBe(false);
+  expect(uploads.some((key) => key.endsWith(`/${claudeOld}`))).toBe(false);
+  expect(deletes.some((key) => key.endsWith(`/${piOld}`))).toBe(false);
+  expect(deletes.some((key) => key.endsWith(`/${claudeOld}`))).toBe(false);
+  expect(await inner.list(prefix)).toContain(`${prefix}/${piOld}`);
+  expect(await inner.list(prefix)).toContain(`${prefix}/${claudeOld}`);
+  expect(await inner.list(prefix)).toContain(`${prefix}/${unexpectedSibling}`);
 });
 
 test("a claimed turn whose agent holds only other conversations still resolves its layout", async () => {

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -16,7 +16,7 @@ import {
   type TurnLayout,
   TurnSetupError,
 } from "./turn-layout";
-import { turnRuntimeInputIncludes } from "./turn-runtime";
+import { turnHydrationPriorityIncludes } from "./turn-runtime";
 
 export {
   claimedTurnIncludes,
@@ -60,12 +60,8 @@ export interface TurnFilesystemPreparation {
   abortHydration: () => void;
 }
 
-/**
- * Hydrate an isolated store tree and resolve the layout it contains. Only a
- * CLAIMED (pool) turn gets the pool's 2 GiB cap; an unclaimed turn keeps
- * hydrate's own default so a deployment without the pool env behaves exactly
- * as before.
- */
+/** Hydrate an isolated store tree and resolve its layout. Claimed turns use
+ *  the pool's 2 GiB cap; unclaimed turns keep hydrate's default. */
 export async function prepareTurnFilesystem(opts: {
   store: ObjectStore;
   prefix: string;
@@ -75,7 +71,6 @@ export async function prepareTurnFilesystem(opts: {
   /** Extra hydrate excludes (on top of the defaults), e.g. the runtime tree
    *  for an op that never reads conversations. */
   excludes?: string[];
-  /** Per-object hot-set admission on top of the excludes. */
   filter?: HydrateOptions["filter"];
   /**
    * Download nothing up front: list the store, lay out the agent's
@@ -151,7 +146,11 @@ export async function startTurnFilesystem(opts: {
       excludes,
       ...(opts.filter ? { filter: opts.filter } : {}),
       priority: (rel) =>
-        layout !== undefined && turnRuntimeInputIncludes(layout.dataRel, rel),
+        turnHydrationPriorityIncludes(
+          layout?.dataRel,
+          rel,
+          opts.filter !== undefined,
+        ),
       onListed: async (listing) => {
         if (opts.timings) opts.timings.t_listing = performance.now();
         await layoutSkeleton(storeRoot, listing.rels);

--- a/packages/runtime/src/turn/turn-filesystem.ts
+++ b/packages/runtime/src/turn/turn-filesystem.ts
@@ -5,6 +5,7 @@ import { FsVfs, LazyStoreVfs, type Vfs } from "@houston/host/src/vfs";
 import {
   DEFAULT_EXCLUDES,
   type HydrateManifest,
+  type HydrateOptions,
   type ObjectStore,
   startHydrate,
 } from "@houston/runtime-client/object-sync";
@@ -40,6 +41,7 @@ export interface TurnFilesystem extends TurnLayout {
   vfs: Vfs;
   /** Remote objects the lazy listing knows about (diagnostics). */
   listedObjects: number;
+  skippedObjects: number;
   /** The store's generation capability as the LISTING showed it. A filtered
    *  or lazy manifest may be empty and cannot answer this on its own. */
   generationAware: boolean;
@@ -74,7 +76,7 @@ export async function prepareTurnFilesystem(opts: {
    *  for an op that never reads conversations. */
   excludes?: string[];
   /** Per-object hot-set admission on top of the excludes. */
-  filter?: (rel: string) => boolean;
+  filter?: HydrateOptions["filter"];
   /**
    * Download nothing up front: list the store, lay out the agent's
    * directory skeleton, and serve reads through a store-backed vfs that
@@ -95,7 +97,7 @@ export async function startTurnFilesystem(opts: {
   claimed: boolean;
   maxBytes?: number;
   excludes?: string[];
-  filter?: (rel: string) => boolean;
+  filter?: HydrateOptions["filter"];
   lazy?: boolean;
   timings?: Record<string, number>;
 }): Promise<TurnFilesystemPreparation> {
@@ -131,6 +133,7 @@ export async function startTurnFilesystem(opts: {
       manifest,
       vfs,
       listedObjects: objects.length,
+      skippedObjects: 0,
       generationAware: vfs.generationAware,
       immediateWrites: new Set<string>(),
     };
@@ -171,6 +174,7 @@ export async function startTurnFilesystem(opts: {
       manifest: started.manifest,
       vfs: new FsVfs(storeRoot),
       listedObjects: started.listed.rels.length,
+      skippedObjects: started.skippedObjects,
       generationAware: started.listed.generationAware,
       immediateWrites: new Set(),
     };

--- a/packages/runtime/src/turn/turn-hot-set.test.ts
+++ b/packages/runtime/src/turn/turn-hot-set.test.ts
@@ -3,11 +3,11 @@ import { ownConversationOnly } from "./turn-hot-set";
 
 const standing = "workspaces/Personal/Bob/.houston/runtime";
 
-test("admits the turn's own conversation file and session dir, nothing of the others", () => {
+test("admits the turn's own conversation state, nothing of the others", () => {
   const admit = ownConversationOnly("c1");
   expect(admit(`${standing}/conversations/c1.json`)).toBe(true);
   expect(admit(`${standing}/sessions/c1/session.jsonl`)).toBe(true);
-  expect(admit(`${standing}/sessions/c1/deep/x`)).toBe(true);
+  expect(admit(`${standing}/sessions/c1/deep/x`)).toBe(false);
   expect(admit(`${standing}/conversations/c2.json`)).toBe(false);
   expect(admit(`${standing}/sessions/c2/session.jsonl`)).toBe(false);
   // A conversation id that needs encoding matches its encoded file name.
@@ -52,4 +52,46 @@ test("hydrates the active conversation's Claude subtree only", () => {
   expect(admit(`${standing}/sessions/c2/claude/projects/slug/s.jsonl`)).toBe(
     false,
   );
+});
+
+test("keeps only the live session tail from the complete listing", () => {
+  const session = `${standing}/sessions/c1`;
+  const piOld = `${session}/2026-08-20T19-00-01-250Z_old.jsonl`;
+  const piNew = `${session}/2026-08-21T19-00-01-250Z_new.jsonl`;
+  const claudeOld = `${session}/claude/projects/old/old-session.jsonl`;
+  const claudeNew = `${session}/claude/projects/foreign/new-session.jsonl`;
+  const listing = [
+    { rel: piOld, updated: "2026-08-28T12:00:00.000Z" },
+    { rel: piNew, updated: "2026-08-20T12:00:00.000Z" },
+    { rel: `${session}/harness.json`, updated: "2026-08-20T12:00:00.000Z" },
+    {
+      rel: `${session}/claude/sessions.json`,
+      updated: "2026-08-20T12:00:00.000Z",
+    },
+    { rel: claudeOld, updated: "2026-08-20T12:00:00.000Z" },
+    { rel: claudeNew, updated: "2026-08-21T12:00:00.000Z" },
+  ];
+  const admit = ownConversationOnly("c1");
+
+  expect(admit(piOld, listing)).toBe(false);
+  expect(admit(piNew, listing)).toBe(true);
+  expect(admit(`${session}/harness.json`, listing)).toBe(true);
+  expect(admit(`${session}/claude/sessions.json`, listing)).toBe(true);
+  expect(admit(claudeOld, listing)).toBe(false);
+  expect(admit(claudeNew, listing)).toBe(true);
+});
+
+test("admits every Claude transcript when listing timestamps are incomplete", () => {
+  const session = `${standing}/sessions/c1/claude/projects`;
+  const first = `${session}/old/0f28a2aa.jsonl`;
+  const second = `${session}/current/fd190c42.jsonl`;
+  const admit = ownConversationOnly("c1");
+
+  for (const listing of [
+    [{ rel: first }, { rel: second }],
+    [{ rel: first, updated: "2026-08-20T12:00:00.000Z" }, { rel: second }],
+  ]) {
+    expect(admit(first, listing)).toBe(true);
+    expect(admit(second, listing)).toBe(true);
+  }
 });

--- a/packages/runtime/src/turn/turn-hot-set.test.ts
+++ b/packages/runtime/src/turn/turn-hot-set.test.ts
@@ -1,97 +1,118 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HydrateListedObject } from "@houston/runtime-client/object-sync";
 import { expect, test } from "vitest";
 import { ownConversationOnly } from "./turn-hot-set";
 
 const standing = "workspaces/Personal/Bob/.houston/runtime";
+const session = `${standing}/sessions/c1`;
+const sessionsRel = `${session}/claude/sessions.json`;
+
+function rootWithSessions(contents?: string): string {
+  const root = mkdtempSync(join(tmpdir(), "hot-set-"));
+  if (contents !== undefined) {
+    const file = join(root, ...sessionsRel.split("/"));
+    mkdirSync(join(file, ".."), { recursive: true });
+    writeFileSync(file, contents);
+  }
+  return root;
+}
+
+function listed(...rels: string[]): HydrateListedObject[] {
+  return rels.map((rel) => ({ rel }));
+}
 
 test("admits the turn's own conversation state, nothing of the others", () => {
+  const root = rootWithSessions();
+  const ownConversation = `${standing}/conversations/c1.json`;
+  const ownSession = `${session}/session.jsonl`;
+  const listing = listed(ownConversation, ownSession);
   const admit = ownConversationOnly("c1");
-  expect(admit(`${standing}/conversations/c1.json`)).toBe(true);
-  expect(admit(`${standing}/sessions/c1/session.jsonl`)).toBe(true);
-  expect(admit(`${standing}/sessions/c1/deep/x`)).toBe(false);
-  expect(admit(`${standing}/conversations/c2.json`)).toBe(false);
-  expect(admit(`${standing}/sessions/c2/session.jsonl`)).toBe(false);
-  // A conversation id that needs encoding matches its encoded file name.
-  expect(
-    ownConversationOnly("a b")(`${standing}/conversations/a%20b.json`),
-  ).toBe(true);
+  expect(admit(ownConversation, listing, root)).toBe(true);
+  expect(admit(ownSession, listing, root)).toBe(true);
+  expect(admit(`${session}/deep/x`, listing, root)).toBe(false);
+  expect(admit(`${standing}/conversations/c2.json`, listing, root)).toBe(false);
+  expect(admit(`${standing}/sessions/c2/session.jsonl`, listing, root)).toBe(
+    false,
+  );
+  const encoded = `${standing}/conversations/a%20b.json`;
+  expect(ownConversationOnly("a b")(encoded, listed(encoded), root)).toBe(true);
 });
 
 test("everything outside conversations/sessions is admitted, in both layouts", () => {
+  const root = rootWithSessions();
+  const paths = [
+    "workspaces/Personal/Bob/CLAUDE.md",
+    `${standing}/settings.json`,
+    "workspaces/Personal/Bob/.houston/routines/routines.json",
+    "workspaces/Personal/Bob/files/report.csv",
+    "data/settings.json",
+    "data/conversations/c1.json",
+    "workspace/notes.md",
+  ];
+  const listing = listed(...paths);
   const admit = ownConversationOnly("c1");
-  expect(admit("workspaces/Personal/Bob/CLAUDE.md")).toBe(true);
-  expect(admit(`${standing}/settings.json`)).toBe(true);
-  expect(admit("workspaces/Personal/Bob/.houston/routines/routines.json")).toBe(
-    true,
-  );
-  expect(admit("workspaces/Personal/Bob/files/report.csv")).toBe(true);
-  expect(admit("data/settings.json")).toBe(true);
-  expect(admit("data/conversations/c1.json")).toBe(true);
-  expect(admit("data/conversations/c2.json")).toBe(false);
-  expect(admit("data/sessions/c2/s.jsonl")).toBe(false);
-  expect(admit("workspace/notes.md")).toBe(true);
+  for (const path of paths) expect(admit(path, listing, root)).toBe(true);
+  expect(admit("data/conversations/c2.json", listing, root)).toBe(false);
+  expect(admit("data/sessions/c2/s.jsonl", listing, root)).toBe(false);
 });
 
-test("a user project's own conversations folder is never mistaken for the runtime", () => {
+test("a user project's conversations folder is never mistaken for runtime", () => {
+  const root = rootWithSessions();
+  const paths = [
+    "workspaces/Personal/Bob/files/conversations/c2.json",
+    "workspaces/Personal/Bob/proj/.houston/runtime/conversations/c2.json",
+  ];
+  const listing = listed(...paths);
   const admit = ownConversationOnly("c1");
-  expect(admit("workspaces/Personal/Bob/files/conversations/c2.json")).toBe(
-    true,
-  );
-  expect(
-    admit(
-      "workspaces/Personal/Bob/proj/.houston/runtime/conversations/c2.json",
-    ),
-  ).toBe(true);
+  for (const path of paths) expect(admit(path, listing, root)).toBe(true);
 });
 
-test("hydrates the active conversation's Claude subtree only", () => {
-  const admit = ownConversationOnly("c1");
-  expect(admit(`${standing}/sessions/c1/claude/projects/slug/s.jsonl`)).toBe(
-    true,
-  );
-  expect(admit(`${standing}/sessions/c1/claude/sessions.json`)).toBe(true);
-  expect(admit(`${standing}/sessions/c2/claude/projects/slug/s.jsonl`)).toBe(
-    false,
-  );
-});
-
-test("keeps only the live session tail from the complete listing", () => {
-  const session = `${standing}/sessions/c1`;
+test("keeps two Pi tails and the Claude transcript named by sessions.json", () => {
+  const root = rootWithSessions('{"c1":"session-new"}');
   const piOld = `${session}/2026-08-20T19-00-01-250Z_old.jsonl`;
-  const piNew = `${session}/2026-08-21T19-00-01-250Z_new.jsonl`;
-  const claudeOld = `${session}/claude/projects/old/old-session.jsonl`;
-  const claudeNew = `${session}/claude/projects/foreign/new-session.jsonl`;
+  const piReadable = `${session}/2026-08-21T19-00-01-250Z_readable.jsonl`;
+  const piNewest = `${session}/2026-08-22T19-00-01-250Z_torn.jsonl`;
+  const stale = `${session}/claude/projects/old/session-old.jsonl`;
+  const mapped = `${session}/claude/projects/current/session-new.jsonl`;
   const listing = [
-    { rel: piOld, updated: "2026-08-28T12:00:00.000Z" },
-    { rel: piNew, updated: "2026-08-20T12:00:00.000Z" },
-    { rel: `${session}/harness.json`, updated: "2026-08-20T12:00:00.000Z" },
-    {
-      rel: `${session}/claude/sessions.json`,
-      updated: "2026-08-20T12:00:00.000Z",
-    },
-    { rel: claudeOld, updated: "2026-08-20T12:00:00.000Z" },
-    { rel: claudeNew, updated: "2026-08-21T12:00:00.000Z" },
+    { rel: piOld },
+    { rel: piReadable },
+    { rel: piNewest },
+    { rel: sessionsRel },
+    { rel: stale, updated: "2026-08-28T12:00:00.000Z" },
+    { rel: mapped, updated: "2026-08-20T12:00:00.000Z" },
   ];
   const admit = ownConversationOnly("c1");
 
-  expect(admit(piOld, listing)).toBe(false);
-  expect(admit(piNew, listing)).toBe(true);
-  expect(admit(`${session}/harness.json`, listing)).toBe(true);
-  expect(admit(`${session}/claude/sessions.json`, listing)).toBe(true);
-  expect(admit(claudeOld, listing)).toBe(false);
-  expect(admit(claudeNew, listing)).toBe(true);
+  expect(admit(piOld, listing, root)).toBe(false);
+  expect(admit(piReadable, listing, root)).toBe(true);
+  expect(admit(piNewest, listing, root)).toBe(true);
+  expect(admit(sessionsRel, listing, root)).toBe(true);
+  expect(admit(stale, listing, root)).toBe(false);
+  expect(admit(mapped, listing, root)).toBe(true);
 });
 
-test("admits every Claude transcript when listing timestamps are incomplete", () => {
-  const session = `${standing}/sessions/c1/claude/projects`;
-  const first = `${session}/old/0f28a2aa.jsonl`;
-  const second = `${session}/current/fd190c42.jsonl`;
-  const admit = ownConversationOnly("c1");
+test("Claude selection fails open without a usable present pointer", () => {
+  const first = `${session}/claude/projects/old/session-one.jsonl`;
+  const second = `${session}/claude/projects/current/session-two.jsonl`;
+  const cache = `${session}/claude/projects/current/cache.bin`;
 
-  for (const listing of [
-    [{ rel: first }, { rel: second }],
-    [{ rel: first, updated: "2026-08-20T12:00:00.000Z" }, { rel: second }],
+  for (const { root, listing } of [
+    { root: rootWithSessions(), listing: listed(first, second, cache) },
+    {
+      root: rootWithSessions("not json"),
+      listing: listed(sessionsRel, first, second, cache),
+    },
+    {
+      root: rootWithSessions('{"c1":"missing-session"}'),
+      listing: listed(sessionsRel, first, second, cache),
+    },
   ]) {
-    expect(admit(first, listing)).toBe(true);
-    expect(admit(second, listing)).toBe(true);
+    const admit = ownConversationOnly("c1");
+    expect(admit(first, listing, root)).toBe(true);
+    expect(admit(second, listing, root)).toBe(true);
+    expect(admit(cache, listing, root)).toBe(false);
   }
 });

--- a/packages/runtime/src/turn/turn-hot-set.ts
+++ b/packages/runtime/src/turn/turn-hot-set.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { HydrateListedObject } from "@houston/runtime-client/object-sync";
 
 function runtimeIndex(segments: string[]): number {
@@ -11,41 +13,57 @@ function runtimeIndex(segments: string[]): number {
   return -1;
 }
 
-function newestByName(paths: string[]): string | undefined {
-  return paths.toSorted().at(-1);
-}
-
-function newestClaudeTranscript(
+function mappedClaudeTranscript(
+  hydratedRoot: string,
+  sessionsRel: string,
+  conversationId: string,
   listing: readonly HydrateListedObject[],
-  prefix: string,
-): string | undefined {
-  const candidates = listing.filter(
-    ({ rel }) => rel.startsWith(`${prefix}/`) && rel.endsWith(".jsonl"),
-  );
-  // UUID filenames carry no chronology. Legacy/list-only stores may provide no
-  // `updated`, so incomplete metadata must fail open to continuity.
-  if (candidates.some(({ updated }) => !updated)) return undefined;
-  return candidates
-    .toSorted(
-      (left, right) =>
-        (left.updated as string).localeCompare(right.updated as string) ||
-        left.rel.localeCompare(right.rel),
-    )
-    .at(-1)?.rel;
+): string | null {
+  const pointerRel = `${sessionsRel}/claude/sessions.json`;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(
+      readFileSync(join(hydratedRoot, ...pointerRel.split("/")), "utf8"),
+    );
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  // SAFETY: JSON.parse returned a non-null, non-array object; values remain
+  // unknown until the conversation's entry is refined below.
+  const sessionId = (parsed as Record<string, unknown>)[conversationId];
+  if (typeof sessionId !== "string" || !sessionId) return null;
+  const file = `${sessionId}.jsonl`;
+  const prefix = `${sessionsRel}/claude/projects/`;
+  return listing.some(
+    ({ rel }) => rel.startsWith(prefix) && rel.endsWith(`/${file}`),
+  )
+    ? file
+    : null;
 }
 
 /**
  * Hot-set admission for one conversation: its canonical conversation,
- * harness markers, and newest backend session tails. Other conversations and
- * older session files never need to hydrate for a claimed turn.
+ * harness markers, the two newest Pi tails, and the Claude transcript named by
+ * sessions.json. Other conversations and older session files stay remote.
  * Matches both layouts: `workspaces/<ws>/<agent>/.houston/runtime/…` and
  * the per-turn `data/…`.
+ *
+ * Claimed stores provide manifests. The only list-only claimed fallback is
+ * poolOnlyFallbackStore, whose list call fails before this filter can run.
  */
 export function ownConversationOnly(
   conversationId: string,
-): (rel: string, listing?: readonly HydrateListedObject[]) => boolean {
+): (
+  rel: string,
+  listing: readonly HydrateListedObject[],
+  hydratedRoot: string,
+) => boolean {
   const file = `${encodeURIComponent(conversationId)}.json`;
-  return (rel, listing = []) => {
+  let claudeSelection: { file: string | null } | undefined;
+  return (rel, listing, hydratedRoot) => {
     const segments = rel.split("/");
     const runtimeAt = runtimeIndex(segments);
     if (runtimeAt === -1) return true;
@@ -71,16 +89,24 @@ export function ownConversationOnly(
               candidate.endsWith(".jsonl")
             );
           });
-        return listing.length === 0 || rel === newestByName(sessions);
+        return sessions.toSorted().slice(-2).includes(rel);
       }
       const claudeRel = tail.join("/");
       if (claudeRel === "claude/sessions.json") return true;
       if (claudeRel.startsWith("claude/projects/")) {
-        const newest = newestClaudeTranscript(
-          listing,
-          `${sessionRel}/claude/projects`,
+        if (!rel.endsWith(".jsonl")) return false;
+        claudeSelection ??= {
+          file: mappedClaudeTranscript(
+            hydratedRoot,
+            sessionRel,
+            conversationId,
+            listing,
+          ),
+        };
+        return (
+          claudeSelection.file === null ||
+          rel.endsWith(`/${claudeSelection.file}`)
         );
-        return listing.length === 0 || newest === undefined || rel === newest;
       }
       // Pi's SessionManager writes and discovers only direct `*.jsonl` files;
       // backend.ts enforces the same resume filter, and turn-harness-state.ts

--- a/packages/runtime/src/turn/turn-hot-set.ts
+++ b/packages/runtime/src/turn/turn-hot-set.ts
@@ -1,25 +1,53 @@
+import type { HydrateListedObject } from "@houston/runtime-client/object-sync";
+
+function runtimeIndex(segments: string[]): number {
+  if (segments[0] === "data") return 1;
+  if (
+    segments[0] === "workspaces" &&
+    segments[3] === ".houston" &&
+    segments[4] === "runtime"
+  )
+    return 5;
+  return -1;
+}
+
+function newestByName(paths: string[]): string | undefined {
+  return paths.toSorted().at(-1);
+}
+
+function newestClaudeTranscript(
+  listing: readonly HydrateListedObject[],
+  prefix: string,
+): string | undefined {
+  const candidates = listing.filter(
+    ({ rel }) => rel.startsWith(`${prefix}/`) && rel.endsWith(".jsonl"),
+  );
+  // UUID filenames carry no chronology. Legacy/list-only stores may provide no
+  // `updated`, so incomplete metadata must fail open to continuity.
+  if (candidates.some(({ updated }) => !updated)) return undefined;
+  return candidates
+    .toSorted(
+      (left, right) =>
+        (left.updated as string).localeCompare(right.updated as string) ||
+        left.rel.localeCompare(right.rel),
+    )
+    .at(-1)?.rel;
+}
+
 /**
- * Hot-set admission for one conversation: every runtime conversation file
- * and session dir that is NOT this conversation's is left out. A turn reads
- * only its own history (`conversations/<id>.json`, `sessions/<id>/`), so
- * other conversations (the bulk of a busy agent) never need to hydrate.
+ * Hot-set admission for one conversation: its canonical conversation,
+ * harness markers, and newest backend session tails. Other conversations and
+ * older session files never need to hydrate for a claimed turn.
  * Matches both layouts: `workspaces/<ws>/<agent>/.houston/runtime/…` and
  * the per-turn `data/…`.
  */
 export function ownConversationOnly(
   conversationId: string,
-): (rel: string) => boolean {
+): (rel: string, listing?: readonly HydrateListedObject[]) => boolean {
   const file = `${encodeURIComponent(conversationId)}.json`;
-  return (rel) => {
+  return (rel, listing = []) => {
     const segments = rel.split("/");
-    const runtimeAt =
-      segments[0] === "data"
-        ? 1
-        : segments[0] === "workspaces" &&
-            segments[3] === ".houston" &&
-            segments[4] === "runtime"
-          ? 5
-          : -1;
+    const runtimeAt = runtimeIndex(segments);
     if (runtimeAt === -1) return true;
     const kind = segments[runtimeAt];
     const own = segments[runtimeAt + 1];
@@ -27,7 +55,37 @@ export function ownConversationOnly(
       return own === file;
     }
     if (kind === "sessions" && segments.length > runtimeAt + 1) {
-      return own === conversationId;
+      if (own !== conversationId) return false;
+      const sessionAt = runtimeAt + 2;
+      const sessionRel = segments.slice(0, sessionAt).join("/");
+      const tail = segments.slice(sessionAt);
+      if (tail.length === 1 && tail[0] === "harness.json") return true;
+      if (tail.length === 1 && tail[0]?.endsWith(".jsonl")) {
+        const sessions = listing
+          .map(({ rel: candidate }) => candidate)
+          .filter((candidate) => {
+            const candidateSegments = candidate.split("/");
+            return (
+              candidateSegments.length === sessionAt + 1 &&
+              candidate.startsWith(`${sessionRel}/`) &&
+              candidate.endsWith(".jsonl")
+            );
+          });
+        return listing.length === 0 || rel === newestByName(sessions);
+      }
+      const claudeRel = tail.join("/");
+      if (claudeRel === "claude/sessions.json") return true;
+      if (claudeRel.startsWith("claude/projects/")) {
+        const newest = newestClaudeTranscript(
+          listing,
+          `${sessionRel}/claude/projects`,
+        );
+        return listing.length === 0 || newest === undefined || rel === newest;
+      }
+      // Pi's SessionManager writes and discovers only direct `*.jsonl` files;
+      // backend.ts enforces the same resume filter, and turn-harness-state.ts
+      // is Houston's only other direct-file writer (`harness.json`).
+      return false;
     }
     return true;
   };

--- a/packages/runtime/src/turn/turn-runtime.ts
+++ b/packages/runtime/src/turn/turn-runtime.ts
@@ -31,6 +31,20 @@ export function turnRuntimeInputIncludes(
   );
 }
 
+/** Inputs that must land before hot-set admission and model startup. */
+export function turnHydrationPriorityIncludes(
+  dataRel: string | undefined,
+  relativePath: string,
+  needsClaudePointer: boolean,
+): boolean {
+  if (needsClaudePointer && relativePath.endsWith("/claude/sessions.json")) {
+    return true;
+  }
+  return (
+    dataRel !== undefined && turnRuntimeInputIncludes(dataRel, relativePath)
+  );
+}
+
 /** Build and resolve the isolated model runtime for one hydrated turn root. */
 export async function createTurnModelRuntime(
   dataDir: string,

--- a/packages/runtime/src/turn/turn-sandbox.test.ts
+++ b/packages/runtime/src/turn/turn-sandbox.test.ts
@@ -26,6 +26,7 @@ async function fixture(fetchImpl: typeof fetch = fetch) {
     manifest: new Map(),
     vfs: new FsVfs(root),
     listedObjects: 0,
+    skippedObjects: 0,
     generationAware: true,
     immediateWrites: new Set(),
   } satisfies TurnFilesystem;

--- a/packages/runtime/src/turn/turn-session-backend.ts
+++ b/packages/runtime/src/turn/turn-session-backend.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from "@houston/runtime-client";
 import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
 import { readAuthFile } from "../auth/auth-file";
 import type { newUsedTokenCapture } from "../auth/used-token";
+import { hasUnreadablePiSessionTail } from "../backends/pi/backend";
 import {
   renderReplayPreamble,
   replayCharBudget,
@@ -50,6 +51,13 @@ export async function openTurnBackendSession(input: {
   const priorHarness = readTurnHarness(directories.dataDir, conversationId);
   const switchedHarness =
     priorHarness !== undefined && priorHarness !== harness;
+  const unreadablePiResume =
+    harness === "pi" &&
+    input.canonicalMessages.length > 0 &&
+    hasUnreadablePiSessionTail(
+      join(directories.dataDir, "sessions", conversationId),
+    );
+  const freshSession = switchedHarness || unreadablePiResume;
   writeTurnHarness(directories.dataDir, conversationId, harness);
   const claudeResume =
     harness === "claude" && !switchedHarness
@@ -57,7 +65,7 @@ export async function openTurnBackendSession(input: {
       : undefined;
   const replay =
     input.canonicalMessages.length > 0 &&
-    (switchedHarness || (harness === "claude" && !claudeResume))
+    (freshSession || (harness === "claude" && !claudeResume))
       ? renderReplayPreamble(
           input.canonicalMessages,
           turnId,
@@ -79,7 +87,7 @@ export async function openTurnBackendSession(input: {
     ...(thinkingLevel ? { thinkingLevel } : {}),
     ...(turn.context ? { context: turn.context } : {}),
     ...(turn.mode ? { mode: turn.mode } : {}),
-    ...(switchedHarness ? { fresh: true } : {}),
+    ...(freshSession ? { fresh: true } : {}),
     ...(retryReplay?.text ? { freshRetryPromptPrefix: retryReplay.text } : {}),
   });
   if (turn.timings) turn.timings.t_backend_session = performance.now();

--- a/packages/runtime/src/turn/turn-session.test.ts
+++ b/packages/runtime/src/turn/turn-session.test.ts
@@ -353,6 +353,32 @@ test("pi to anthropic to pi flips fresh with replay while unchanged pi resumes",
   );
 });
 
+test("an unreadable newest pi session starts fresh with canonical replay", async () => {
+  const dirs = await directories();
+  seedConversation(dirs.dataDir);
+  const sessionDir = join(dirs.dataDir, "sessions", "c1");
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(
+    join(sessionDir, "2026-08-28T12-00-00-000Z_broken.jsonl"),
+    "not json\n",
+  );
+  const piCalls: BackendCall[] = [];
+
+  await runProviderTurn(
+    dirs,
+    "openai-codex",
+    3,
+    sdk(scriptedQuery(() => undefined)),
+    recordingPiBackend(piCalls),
+  );
+
+  expect(piCalls[0]?.options.fresh).toBe(true);
+  expect(piCalls[0]?.prompts[0]).toContain(
+    "[Continuing an existing conversation.",
+  );
+  expect(piCalls[0]?.prompts[0]).toContain("User: Remember the blue lantern.");
+});
+
 test("a corrupt harness marker degrades to unknown instead of failing the turn", async () => {
   const { readTurnHarness, turnHarnessFile, writeTurnHarness } = await import(
     "./turn-harness-state"

--- a/packages/runtime/src/turn/turn-terminal.test.ts
+++ b/packages/runtime/src/turn/turn-terminal.test.ts
@@ -61,3 +61,17 @@ test("no marks means no timings field on the done frame", () => {
   };
   expect(frame.data).toBeNull();
 });
+
+test("the done frame reports hydrated and skipped object counts", () => {
+  const frame = turnTerminalFrame(
+    {},
+    "t1",
+    0,
+    undefined,
+    undefined,
+    [],
+    undefined,
+    { hydratedObjects: 7, skippedObjects: 88 },
+  ) as unknown as { data: Record<string, number> };
+  expect(frame.data).toMatchObject({ hydratedObjects: 7, skippedObjects: 88 });
+});

--- a/packages/runtime/src/turn/turn-terminal.ts
+++ b/packages/runtime/src/turn/turn-terminal.ts
@@ -29,6 +29,7 @@ export function turnTerminalFrame(
   activityDocSkipped?: "route_absent",
   changed: readonly string[] = [],
   timings?: Record<string, number>,
+  hydration?: { hydratedObjects: number; skippedObjects: number },
 ): WireFrame {
   const timingsMs = timingDeltas(timings);
   const fields = {
@@ -37,6 +38,7 @@ export function turnTerminalFrame(
     ...(poolWritesOutOfScope > 0 ? { poolWritesOutOfScope } : {}),
     ...(transcriptSkipped ? { transcriptSkipped } : {}),
     ...(activityDocSkipped ? { activityDocSkipped } : {}),
+    ...hydration,
   };
   const diagnostic = Object.keys(fields).length > 0 ? fields : undefined;
   if (outcome.error) {


### PR DESCRIPTION
Pooled-turn hydration grows with conversation age: a routine conversation firing every 2 minutes accumulated 95 session objects (411KB) in days, and every historical session file re-downloaded on every turn — measured hydration crept from 1.2s to 3.9s. A claimed turn only needs the live tail.

## What hydrates now (for the turn's own conversation)

The conversation JSON, the harness marker, Claude's `sessions.json`, the newest TWO pi session files (timestamp-named; the second is insurance so a crash-corrupted newest tail still resumes the older readable one), and exactly the Claude transcript that `sessions.json` — the authoritative pointer, priority-downloaded before the bulk filter runs — names for this conversation. Older session files, older transcripts, and Claude cache dirs stay remote and never enter the hydration manifest, so sync-back structurally cannot delete or re-upload them (test-pinned end-to-end).

Adversarial review drove the selector design: any timestamp heuristic (store `updated` is upload wall-clock, not chronology) mis-picks after a relocate+fresh double-upload — selection now follows the pointer and fails open (all transcripts) when the pointer is absent or unreadable. GCS listings now populate per-object `updated` metadata as well (fields projection keeps pagination). Ops, shadow, and unclaimed turns are unaffected; the filter attaches only under a claim, and its listing argument is compile-time required so no future caller can silently revert to full hydration.

Observability: `done`/`shadow` frames now carry `hydratedObjects` + `skippedObjects`, so the diet's effect is visible on every live turn.

Effect on the measured 95-object case: 95.8% of session objects skipped. Workspace files stay eager deliberately — lazy materialization for real-filesystem bash/file-tool reads would be novel machinery, evaluated and declined for this increment.

## Tests

Newest-by-name selection matrix, pointer-based transcript selection incl. the relocate/fresh double-upload regression, corrupt-newest-tail resume via the second file, all fail-open cases, skipped-siblings survive sync-back, skipped-count accounting. Suites green: runtime 1514 · runtime-client 195 · host · domain; Biome + boundaries clean.