### PR TITLE
fix(runtime): repair garbled unicode escapes in Claude tool input (PRODUCT-1589)

### DIFF
--- a/packages/runtime/src/backends/claude/translate-support.ts
+++ b/packages/runtime/src/backends/claude/translate-support.ts
@@ -42,12 +42,39 @@ export interface ToolBlock {
   input: unknown;
 }
 
+/**
+ * The model occasionally garbles a `\uXXXX` escape in streamed tool input
+ * (e.g. `\u22co` — `o` is not hex), which fails JSON.parse for the WHOLE
+ * payload and loses every argument. Rewrite any escape with fewer than 4 hex
+ * digits to U+FFFD so the rest of the input survives. Only true escapes
+ * match: the leading group asserts an even backslash run before `\u`, so a
+ * literal `\\u` in the text is left alone.
+ */
+export function repairInvalidUnicodeEscapes(json: string): string {
+  return json.replace(
+    /((?:^|[^\\])(?:\\\\)*)\\u([0-9a-fA-F]{0,3})(?![0-9a-fA-F])/g,
+    "$1\\ufffd",
+  );
+}
+
 /** Parse a completed tool call's accumulated input; never drops silently. */
 export function parseArgs(tb: ToolBlock): unknown {
   if (!tb.json) return tb.input ?? {};
   try {
     return JSON.parse(tb.json);
   } catch (err) {
+    const repaired = repairInvalidUnicodeEscapes(tb.json);
+    if (repaired !== tb.json) {
+      try {
+        const parsed = JSON.parse(repaired);
+        console.warn(
+          `[claude] repaired invalid \\u escape(s) in tool "${tb.name}" input JSON`,
+        );
+        return parsed;
+      } catch {
+        // Still unparseable — fall through to the loud report below.
+      }
+    }
     console.error(
       `[claude] failed to parse tool "${tb.name}" input JSON: ${
         err instanceof Error ? err.message : String(err)

--- a/packages/runtime/src/backends/claude/translate.test.ts
+++ b/packages/runtime/src/backends/claude/translate.test.ts
@@ -2,6 +2,7 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { WireEvent } from "@houston/runtime-client";
 import { beforeEach, expect, test, vi } from "vitest";
 import { createStreamTranslator, normalizeUsage } from "./translate";
+import { repairInvalidUnicodeEscapes } from "./translate-support";
 
 beforeEach(() => {
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -194,6 +195,45 @@ test("tool_use: accumulated input_json_delta parses into tool_start args at stop
       data: { name: "Read", args: { file_path: "a.txt" } },
     },
   ]);
+});
+
+test("a model-garbled \\u escape is repaired instead of dropping the whole tool input", () => {
+  // Real payload shape from prod: Claude streamed `\u22co` — `o` is not hex —
+  // and the parse failure dropped every suggested action for the user.
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const err = vi.spyOn(console, "error").mockImplementation(() => {});
+  const { events } = collect([
+    toolStart(0, "t1", "mcp__houston__suggest_actions"),
+    jsonDelta(0, '{"actions": [{"label": "Quitar tambi\\u00e9n \\u22co'),
+    jsonDelta(0, 'ALIANZA\\u22cb"}]}'),
+    blockStop(0),
+  ]);
+  expect(events).toEqual([
+    {
+      type: "tool_start",
+      data: {
+        name: "mcp__houston__suggest_actions",
+        // é and ⋋ are valid and kept; the bad \u22c→ becomes U+FFFD.
+        args: { actions: [{ label: "Quitar también �oALIANZA⋋" }] },
+      },
+    },
+  ]);
+  expect(warn).toHaveBeenCalled();
+  expect(err).not.toHaveBeenCalled();
+});
+
+test("repairInvalidUnicodeEscapes touches only true, malformed escapes", () => {
+  // Valid escapes and literal backslash-u text pass through untouched.
+  expect(repairInvalidUnicodeEscapes('{"a":"\\u00e9 \\\\u22co"}')).toBe(
+    '{"a":"\\u00e9 \\\\u22co"}',
+  );
+  // Truncated escape at end of string, and adjacent malformed escapes.
+  expect(repairInvalidUnicodeEscapes('"\\u12')).toBe('"\\ufffd');
+  expect(repairInvalidUnicodeEscapes('"\\uZZ\\uZZ"')).toBe(
+    '"\\ufffdZZ\\ufffdZZ"',
+  );
+  // Malformed escape at position 0 (the ^ alternative).
+  expect(repairInvalidUnicodeEscapes("\\uxy")).toBe("\\ufffdxy");
 });
 
 test("tool_start with unparseable JSON emits args:{} and logs (never a silent drop)", () => {


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1589 (Sentry HOUSTON-APP-4ZA, 30 users / 57 events).

**Root cause:** Claude occasionally streams a malformed `\uXXXX` escape in tool-input JSON — the captured prod payload contained `\u22co` (`o` is not a hex digit). `JSON.parse` in `parseArgs` (`packages/runtime/src/backends/claude/translate-support.ts`) then failed the WHOLE payload, returned `{}`, and every suggested action was silently dropped for the user while the parse failure hit Sentry.

**Fix:** on parse failure, `repairInvalidUnicodeEscapes` rewrites any `\u` escape with fewer than 4 hex digits to `\ufffd` (U+FFFD) and re-parses, so the rest of the arguments survive. Valid escapes and literal `\\u` text are untouched (the regex asserts an even backslash run before `\u`). A successful repair logs a `console.warn`; only a payload that still fails after repair reaches the loud `console.error` path.

## Before / after

**Before:** feed the translator a tool_use block whose `input_json_delta` accumulates `{"actions": [{"label": "Quitar tambi\u00e9n \u22co..."}]}` — `tool_start` emits `args: {}` (suggestions lost) and Sentry records `failed to parse tool "mcp__houston__suggest_actions" input JSON: Bad Unicode escape`.

**After:** the same payload parses with the bad escape as U+FFFD; all actions reach the UI and no Sentry error is emitted.

## Verification

- New tests in `packages/runtime/src/backends/claude/translate.test.ts`: the prod payload shape round-trips through the stream translator, plus direct edge-case coverage of the repair regex (valid escapes untouched, literal `\\u`, truncated escape at EOF, adjacent malformed escapes).
- `pnpm --filter @houston/runtime test`: 1516 tests pass. Biome + workspace typecheck clean (pre-commit).
- Post-deploy: Sentry issue HOUSTON-APP-4ZA should stop accruing events on the new engine release.