### PR TITLE
fix(chat): show the out-of-usage card at the bottom and stop thinking phrases (PRODUCT-1578)

### DIFF
--- a/packages/sdk/src/modules/turns/history.test.ts
+++ b/packages/sdk/src/modules/turns/history.test.ts
@@ -100,6 +100,38 @@ describe("historyToFeed", () => {
     });
   });
 
+  it("replays the provider-error card AFTER the turn's work, mirroring the live settle (PRODUCT-1578)", () => {
+    const feed = historyToFeed([
+      { role: "user", content: "go", ts: 1, turnId: "t-1" },
+      {
+        role: "assistant",
+        content: "got halfway",
+        thinking: "planning",
+        tools: [{ name: "shell" }],
+        ts: 2,
+        turnId: "t-1",
+        providerError: {
+          kind: "rate_limited",
+          provider: "anthropic",
+          model: null,
+          retry_after_seconds: null,
+          message: "slow down",
+        },
+      },
+    ]);
+    const types = feed.map((f) => f.feed_type);
+    // The card is the turn's LAST frame — a reload must show the failure at
+    // the bottom of the turn, never above its mission log and streamed text.
+    expect(types).toEqual([
+      "user_message",
+      "thinking",
+      "tool_call",
+      "tool_result",
+      "assistant_text",
+      "provider_error",
+    ]);
+  });
+
   it("replays tool calls and preserves a multiplayer author on user messages", () => {
     const feed = historyToFeed([
       {

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -123,19 +123,6 @@ export function historyToFeed(
         ...turn,
       });
     }
-    // A persisted provider failure: replay the typed card so the inline
-    // reconnect / rate-limit surface survives a reload.
-    if (m.providerError) {
-      out.push({
-        feed_type: "provider_error",
-        data: {
-          ...m.providerError,
-          provider: mapProvider(m.providerError.provider),
-        },
-        ts,
-        ...turn,
-      });
-    }
     // Replay the turn's reasoning BEFORE its tool calls — the live VM keeps a
     // single thinking entry positioned where the first thinking block streamed
     // (ahead of the tools), so a reload renders the mission log in the same
@@ -168,6 +155,22 @@ export function historyToFeed(
     // the chat attaches it to this turn's assistant message on reload.
     if (m.fileChanges) {
       out.push({ feed_type: "file_changes", data: m.fileChanges, ts, ...turn });
+    }
+    // A persisted provider failure: replay the typed card so the inline
+    // reconnect / rate-limit surface survives a reload. AFTER the turn's
+    // thinking/tools/content — the live settle pushes the card last, and a
+    // reseed that reordered it above the streamed work read as "the agent is
+    // still going" with the failure buried mid-transcript.
+    if (m.providerError) {
+      out.push({
+        feed_type: "provider_error",
+        data: {
+          ...m.providerError,
+          provider: mapProvider(m.providerError.provider),
+        },
+        ts,
+        ...turn,
+      });
     }
     // A turn the user interrupted persisted `stopped`: replay the standard
     // "Stopped by user" system line so the transcript reads identically after a

--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -84,6 +84,11 @@ function adoptReply(
     onAdoptTurnId?.(reply.turnId);
   }
   if (reply.providerError) {
+    // Adopt the persisted partial reply (same guards as the clean path below)
+    // so the settle finalizes what streamed before the failure and the card
+    // lands below it — never above a bubble still marked streaming.
+    if (reply.content) s.text = reply.content;
+    if (reply.thinking && !s.thinking) s.thinking = reply.thinking;
     settleProviderErrorCard(s, reply.providerError);
     return;
   }

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -6,6 +6,7 @@ import {
   finishErr,
   finishOk,
   newTurnState,
+  settleProviderErrorCard,
   type TurnState,
 } from "./turn-settle";
 
@@ -213,6 +214,59 @@ test("a persisted providerError for our turn settles as the typed card", () => {
   );
   expect(s.settled).toBe(true);
   expect(items.some((i) => i.feed_type === "provider_error")).toBe(true);
+});
+
+// ── The card is the transcript's LAST word (PRODUCT-1578) ─────────────────────
+// A turn that streamed work before failing must finalize that work and put the
+// typed card BELOW it — a card above a bubble still marked streaming read as
+// "the agent is still going" with the failure buried mid-transcript.
+
+test("a live provider-error settle finalizes the streamed reply BEFORE the card", () => {
+  const { items, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity", output);
+  s.delivered = true;
+  s.text = "partial reply";
+  s.thinking = "some reasoning";
+  settleProviderErrorCard(s, {
+    kind: "rate_limited",
+    provider: "anthropic",
+    model: null,
+    retry_after_seconds: null,
+    message: "slow down",
+  });
+  expect(items.map((i) => i.feed_type)).toEqual([
+    "thinking",
+    "assistant_text",
+    "provider_error",
+    "final_result",
+  ]);
+  expect(items[1].data).toBe("partial reply");
+});
+
+test("a history settle of a failed turn adopts the persisted partial reply below-the-card too", () => {
+  const providerError = {
+    kind: "rate_limited",
+    provider: "anthropic",
+    message: "slow down",
+  } as ChatMessage["providerError"];
+  const { items } = run(
+    [
+      { role: "user", content: "hi", ts: 1, turnId: "t-1" },
+      {
+        role: "assistant",
+        content: "got halfway",
+        ts: 2,
+        turnId: "t-1",
+        providerError,
+      },
+    ],
+    "t-1",
+  );
+  const textAt = items.findIndex((i) => i.feed_type === "assistant_text");
+  const cardAt = items.findIndex((i) => i.feed_type === "provider_error");
+  expect(textAt).toBeGreaterThanOrEqual(0);
+  expect(items[textAt].data).toBe("got halfway");
+  expect(cardAt).toBeGreaterThan(textAt);
 });
 
 test("a persisted stopped reply settles needs_you with the standard stop line, not a plain finish", () => {

--- a/packages/sdk/src/modules/turns/turn-settle.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.ts
@@ -202,6 +202,15 @@ export function settleProviderErrorCard(
   s: TurnState,
   err: ProviderError & { failed_prompt?: string },
 ): void {
+  // Finalize whatever streamed before the failure (mirrors finishOk): the
+  // partial reply must stop rendering as "still streaming", and the card must
+  // land BELOW it — the terminal card is the last thing in the transcript, so
+  // the user sees the turn is over (PRODUCT-1578). Skipped once settled: an
+  // extra late provider_error frame only refreshes the card.
+  if (!s.settled) {
+    if (s.thinking) push(s, { feed_type: "thinking", data: s.thinking });
+    if (s.text) push(s, { feed_type: "assistant_text", data: s.text });
+  }
   // A card for a refused SEND (the not-connected path, `!delivered` — the prompt
   // never left) fails the optimistic bubble; a mid-turn typed provider error is
   // `delivered` (frames arrived first), so the flag is omitted and the bubble

--- a/ui/chat/src/chat-status.ts
+++ b/ui/chat/src/chat-status.ts
@@ -32,6 +32,14 @@ export function deriveStatus(
   if (last?.feed_type === "assistant_text_streaming") {
     return "streaming";
   }
+  // A typed provider error is a TERMINAL settle — the agent cannot continue
+  // (out of usage, rate-limited, logged out). Whatever a stale `isLoading`
+  // flag says (a lost terminal frame can leave the VM's running flag up until
+  // the idle reconcile), the honest state is "the turn is over": no rotating
+  // thinking phrases under a card that says the work stopped (PRODUCT-1578).
+  // The card's trailing invisible final_result (and any session-error echo)
+  // is skipped when locating the transcript's last visible event.
+  if (endsOnProviderError(items)) return "ready";
   // Active turn → indicator visible. Covers:
   //   - brand-new chat with no items yet
   //   - user just sent (last == user_message)
@@ -49,4 +57,20 @@ export function deriveStatus(
     return "submitted";
   }
   return "ready";
+}
+
+/**
+ * Whether the feed's last VISIBLE event is a terminal `provider_error` card.
+ * `final_result` (the settle's invisible frame) and `system_message` (the
+ * session-status echo a failed turn can trail) are skipped; anything else —
+ * a user message, streaming content, a tool row — means the conversation
+ * moved past the failure.
+ */
+function endsOnProviderError(items: FeedItem[]): boolean {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const type = items[i].feed_type;
+    if (type === "final_result" || type === "system_message") continue;
+    return type === "provider_error";
+  }
+  return false;
 }

--- a/ui/chat/tests/chat-status.test.ts
+++ b/ui/chat/tests/chat-status.test.ts
@@ -42,6 +42,33 @@ describe("deriveStatus", () => {
     );
   });
 
+  it("is ready when the feed ends on a terminal provider-error card, even mid-load", () => {
+    // The agent cannot continue (out of usage / rate-limited / logged out) —
+    // the thinking phrases must stop, whatever a stale running flag says.
+    const card: FeedItem = {
+      feed_type: "provider_error",
+      data: {
+        kind: "rate_limited",
+        provider: "anthropic",
+        message: "slow down",
+      },
+    };
+    const invisibleFinal: FeedItem = {
+      feed_type: "final_result",
+      data: { result: "", cost_usd: null, duration_ms: null, usage: null },
+    };
+    equal(deriveStatus([user(), card], true), "ready");
+    // The settle's trailing invisible final_result doesn't hide the card.
+    equal(deriveStatus([user(), card, invisibleFinal], true), "ready");
+    // A NEW user message after the card is a fresh turn — loader returns.
+    equal(
+      deriveStatus([user(), card, invisibleFinal, user()], true),
+      "submitted",
+    );
+    // A card buried under later streamed work does not silence a live turn.
+    equal(deriveStatus([user(), card, toolCall()], true), "submitted");
+  });
+
   it("stays submitted mid-tool-cycle (HOU-655: loader must not vanish)", () => {
     equal(deriveStatus([user(), toolCall()], true), "submitted");
     equal(deriveStatus([user(), toolCall(), toolResult()], true), "submitted");


### PR DESCRIPTION
## Summary

PRODUCT-1578: when a turn dies on a provider limit (out of usage / rate limit), the error card could render **above** the turn's task log and streamed text, while the rotating thinking phrases kept animating below — the chat read as "the agent is still working" when it could not continue.

Two root causes:

1. **History fold order** — `historyToFeed` replayed a persisted `provider_error` **before** the turn's thinking/tools/content, while the live settle pushes it last. Any reseed (reload, `ConversationsChanged` re-read, observer attach) reordered the card above the streamed work, and the VM's turn-id dedup then kept the live card pinned at that early position.
2. **Stale running flag** — when the terminal frame is lost (the failure is persisted pod-side but the stream drops before delivering it), the VM's `running` flag stays up until the idle reconcile, so `deriveStatus` kept returning `submitted` and the thinking phrases kept rotating under a card that says the work stopped.

## Fix

- `packages/sdk` `historyToFeed`: replay the card **after** the turn's thinking/tools/content/file-changes, mirroring the live order.
- `packages/sdk` `settleProviderErrorCard`: finalize the streamed reply (thinking + text) before pushing the card, so the partial bubble stops rendering as still-streaming and the card is the transcript's last item. The lost-terminal history settle (`adoptReply`) adopts the persisted partial reply the same way.
- `ui/chat` `deriveStatus`: when the feed's last visible event is a terminal `provider_error` card (skipping the settle's invisible `final_result` and a trailing session-status echo), the status is `ready` — no thinking phrases regardless of a stale loading flag. A later user message or streamed frame restores the normal in-flight indicator.

## Before (repro)

1. Open a chat and start a long agentic task on an account whose usage window is nearly exhausted.
2. Let the turn hit the limit mid-run (or reload the conversation after such a failure).
3. The limit card renders above the task log / streamed text, and the thinking phrases keep rotating at the bottom.

## After (verify)

1. Same scenario: the turn's streamed work renders finalized, the limit card is the **last** item in the transcript.
2. No thinking phrase / loading shimmer shows under the card; it returns as soon as a new message is sent.
3. Reloading the conversation keeps the card at the bottom of its turn.

## Tests

- `packages/sdk`: history fold order, live settle order, lost-terminal settle adoption (vitest, 415 pass).
- `ui/chat`: `deriveStatus` terminal-card cases (node:test, 400 pass).
- `pnpm check`, ui + web typechecks, app tests (3825), `check:parity` all green.