### PR TITLE
fix(runtime): copilot no-access login refusal logs WARN, not a Sentry error (PRODUCT-1594)

### DIFF
--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -367,6 +367,11 @@ test("github-copilot: a no-Copilot-subscription 403 surfaces the sentinel in aut
   // The user authorized the device flow, then GitHub's token exchange answered
   // 403 no_copilot_access. The raw JSON (with the user's GitHub handle) used to
   // land verbatim in the failure toast; status must now carry the sentinel.
+  // The refusal is also an EXPECTED business state: it must log as a WARN
+  // breadcrumb without the handle, never a console.error that mints a Sentry
+  // error event per subscription-less user (Sentry issue 7623743057).
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   const piLogin = stubPiLogin((interaction) => {
     interaction.notify({
       type: "device_code",
@@ -384,8 +389,17 @@ test("github-copilot: a no-Copilot-subscription 403 surfaces the sentinel in aut
     );
     expect(row?.login?.status).toBe("error");
     expect(row?.login?.error).toBe(COPILOT_NO_ACCESS_ERROR);
+
+    const logged = (calls: unknown[][]) =>
+      calls.map((args) => args.join(" ")).join("\n");
+    expect(logged(warnSpy.mock.calls)).toContain("no_copilot_access");
+    expect(logged(errorSpy.mock.calls)).not.toContain("no_copilot_access");
+    // The GitHub handle from the raw body never reaches any log line.
+    expect(logged(warnSpy.mock.calls)).not.toContain("octocat");
   } finally {
     piLogin.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
     cancelLogin("github-copilot");
   }
 });

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -116,8 +116,10 @@ export const COPILOT_NO_ACCESS_ERROR =
 /**
  * Collapse a provider login failure to a stable sentinel where the raw
  * message is unfit for the failure toast; every other message passes through
- * verbatim (beta policy: the real reason, never a generic swallow). The raw
- * text is still logged by the caller for the bug-report log tail.
+ * verbatim (beta policy: the real reason, never a generic swallow). A
+ * pass-through message is still logged raw by the caller for the bug-report
+ * log tail; a collapsed one is an expected business state whose raw body
+ * carries the user's GitHub handle, so the caller logs a fixed line instead.
  */
 export function loginFailureMessage(provider: ProviderId, raw: string): string {
   if (
@@ -463,6 +465,17 @@ export async function startLogin(
       state.status = "error";
       const raw = e instanceof Error ? e.message : String(e);
       state.error = loginFailureMessage(provider, raw);
+      // WARN, not error, for the no-Copilot-subscription refusal: a GitHub
+      // account without Copilot is expected user behavior (the toast tells
+      // them how to enable it), not a Houston failure — and the raw 403 body
+      // carries the user's GitHub handle, which must never reach the crash
+      // feed. Same policy as the abandoned-login expiry above.
+      if (state.error === COPILOT_NO_ACCESS_ERROR) {
+        console.warn(
+          `[oauth:${provider}] login refused: 403 no_copilot_access — account has no Copilot subscription`,
+        );
+        return;
+      }
       console.error(`[oauth:${provider}] failed:`, raw);
     });
 


### PR DESCRIPTION
## Summary

Sentry issue 7623743057 (HOUSTON-APP-4YT): every GitHub Copilot connect attempt by an account **without a Copilot subscription** minted a Sentry error event — 159 events across 81 users. The device flow succeeds, then GitHub's token exchange answers `403 Forbidden` with `no_copilot_access`.

**Root cause:** the user-facing side was already fixed (#1017 collapses the raw body to the friendly "enable Copilot Free" toast), but the login failure handler in `packages/runtime/src/auth/login.ts` still logged the raw message via `console.error`, which mints a Sentry error. Two problems with that:

- It's an **expected business state** (the user simply has no Copilot subscription; the toast tells them how to get one), not a Houston failure — it doesn't belong in the crash feed.
- The raw 403 body **contains the user's GitHub handle**, which was being shipped to Sentry verbatim.

**Fix:** when `loginFailureMessage` collapses the failure to the Copilot no-access sentinel, log a fixed, PII-free `console.warn` breadcrumb instead of the raw `console.error` — the same policy the abandoned-login expiry already uses. Every other login failure keeps its raw `console.error` unchanged.

## Reproduction (before)

1. Connect the GitHub Copilot provider from a GitHub account with no Copilot subscription and complete the device flow.
2. The toast correctly shows the friendly no-access message, but the runtime logs `[oauth:github-copilot] failed: 403 Forbidden: {..."no_copilot_access"...logged in as <handle>...}` at ERROR level → a new Sentry error event carrying the user's GitHub handle.

## Verification (after)

1. Repeat the same flow (or run the updated test): the auth status row still carries the friendly sentinel.
2. The runtime now logs `[oauth:github-copilot] login refused: 403 no_copilot_access — account has no Copilot subscription` at WARN — a breadcrumb, no Sentry error event, no GitHub handle in any log line.
3. `pnpm --filter @houston/runtime test` — the extended test asserts WARN-not-ERROR and that the handle never reaches a log line (1516 tests pass).
4. Once released, Sentry HOUSTON-APP-4YT stops receiving events (resolve-in-next-release).

## Tests

- Extended `github-copilot: a no-Copilot-subscription 403 surfaces the sentinel…` in `login.test.ts` with warn/error spies: refusal logs WARN containing `no_copilot_access`, nothing at ERROR, and the GitHub handle appears in no log line.