### PR TITLE
fix(chat): Azure DeploymentNotFound card says deploy the model, not pick another (PRODUCT-1600)

### DIFF
--- a/app/src/components/shell/provider-error-cards/quota.tsx
+++ b/app/src/components/shell/provider-error-cards/quota.tsx
@@ -115,17 +115,22 @@ export function ModelUnavailableCard({
   // admin to fix a plan that is theirs. No credential context (desktop,
   // self-host, personal space, routine) keeps the body byte-identical.
   const personal = credentialScopeOf(error.credential) === "personal";
+  // `not_deployed` (Azure) outranks the personal-plan wording: the model is
+  // missing from the RESOURCE, not from a plan, and picking another model
+  // fails the same way until the user deploys one under the model's exact
+  // name (PRODUCT-1600).
+  const bodyKey =
+    error.reason === "not_deployed"
+      ? "providerError.modelUnavailable.bodyNotDeployed"
+      : personal
+        ? "providerError.credential.modelUnavailableBody"
+        : "providerError.modelUnavailable.body";
   return (
     <div className="w-full px-1 py-2">
       <RowCard
         media={<AlertTriangleIcon className="size-5" />}
         title={t("providerError.modelUnavailable.title")}
-        description={t(
-          personal
-            ? "providerError.credential.modelUnavailableBody"
-            : "providerError.modelUnavailable.body",
-          { provider, model: error.model },
-        )}
+        description={t(bodyKey, { provider, model: error.model })}
         // Same `undefined`-not-a-fragment rule as the card above.
         action={
           (fallback && onApplyModel) || onSwitchModel ? (

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -552,6 +552,7 @@
     "modelUnavailable": {
       "title": "Model not available",
       "body": "{{model}} is not available on your {{provider}} account.",
+      "bodyNotDeployed": "{{model}} is not deployed on your {{provider}} resource. Deploy it there with the exact name \"{{model}}\", or pick a model you already deployed.",
       "switchToFallback": "Switch to {{model}}",
       "pickAnother": "Pick another model"
     },

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -552,6 +552,7 @@
     "modelUnavailable": {
       "title": "Modelo no disponible",
       "body": "{{model}} no está disponible en tu cuenta de {{provider}}.",
+      "bodyNotDeployed": "{{model}} no está desplegado en tu recurso de {{provider}}. Despliégalo ahí con el nombre exacto \"{{model}}\" o elige un modelo que ya hayas desplegado.",
       "switchToFallback": "Cambiar a {{model}}",
       "pickAnother": "Elegir otro modelo"
     },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -547,6 +547,7 @@
     "modelUnavailable": {
       "title": "Modelo não disponível",
       "body": "O modelo {{model}} não está disponível na sua conta {{provider}}.",
+      "bodyNotDeployed": "O modelo {{model}} não está implantado no seu recurso do {{provider}}. Implante-o lá com o nome exato \"{{model}}\" ou escolha um modelo que você já implantou.",
       "switchToFallback": "Trocar para {{model}}",
       "pickAnother": "Escolher outro modelo"
     },

--- a/packages/protocol/src/provider-error.ts
+++ b/packages/protocol/src/provider-error.ts
@@ -41,6 +41,11 @@ export type ModelUnavailableReason =
   | "preview_gated"
   | "deprecated"
   | "region_restricted"
+  // Azure OpenAI's DeploymentNotFound: the RESOURCE has no deployment named
+  // after the model. Switching models cannot help until the user deploys one
+  // (deployment name must equal the model id), so the card must say "deploy
+  // it", not "pick another".
+  | "not_deployed"
   | "unknown";
 
 /**

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -435,6 +435,13 @@ test("Azure missing-deployment 404 → model_unavailable, never unknown (PRODUCT
       "Azure OpenAI API error (404 DeploymentNotFound): The API deployment for this resource does not exist. If you created the deployment within the last 5 minutes, please wait a moment and try again.",
   });
   expect(err.kind).toBe("model_unavailable");
+  // The reason drives the card body (PRODUCT-1600): "pick another model" is a
+  // dead end on Azure — every not-deployed pick fails identically — so the
+  // card must say "deploy it under the model's exact name" instead. No
+  // fallback either: we cannot know which deployments the resource has.
+  if (err.kind !== "model_unavailable") throw new Error("unreachable");
+  expect(err.reason).toBe("not_deployed");
+  expect(err.suggested_fallback).toBeNull();
 });
 
 test("Bedrock bare-foundation-id on-demand rejection → model_unavailable, never unknown (PRODUCT-1477)", () => {

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -735,13 +735,23 @@ function isModelUnavailable(lower: string): boolean {
 }
 
 /**
- * The card copy keys off the message either way; the tag exists for the
- * frontend union. Only region gating is identifiable from real payloads today
- * (opencode.ai's RegionError / "hosted in China" opt-in body).
+ * Two reasons are identifiable from real payloads and change what the card
+ * says. Azure's DeploymentNotFound (patterns above) means the RESOURCE has no
+ * deployment named after the model — pi calls the deployment named exactly
+ * like the model id, so "pick another model" is a dead end (every not-deployed
+ * pick fails identically, PRODUCT-1600) and the card must say "deploy it"
+ * instead. Region gating is opencode.ai's RegionError / "hosted in China"
+ * opt-in body. Everything else stays `unknown`; there the actionable detail is
+ * the `suggested_fallback`, not this tag.
  */
 function modelUnavailableReason(
   lower: string,
-): "region_restricted" | "unknown" {
+): "not_deployed" | "region_restricted" | "unknown" {
+  if (
+    lower.includes("deploymentnotfound") ||
+    lower.includes("deployment for this resource does not exist")
+  )
+    return "not_deployed";
   return lower.includes("regionerror") || lower.includes("hosted in china")
     ? "region_restricted"
     : "unknown";

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -289,6 +289,10 @@ export type ModelUnavailableReason =
   | "preview_gated"
   | "deprecated"
   | "region_restricted"
+  // Azure OpenAI's DeploymentNotFound: the resource has no deployment named
+  // after the model, so only deploying it (or picking an already-deployed
+  // model) helps.
+  | "not_deployed"
   | "unknown";
 
 export type AuthFailureCause =


### PR DESCRIPTION
## Summary

PRODUCT-1600 — a user with Azure OpenAI connected (valid key + endpoint, credits available) got "Model not available … Pick another model" on every model they tried.

**Root cause:** pi-ai calls the Azure deployment named exactly like the model id (`resolveDeploymentName`), so a resource with no deployment under that name answers `404 DeploymentNotFound` for every pick. The classifier already mapped that to `model_unavailable` (correct — the key is fine), but the card's only advice was "pick another model", which fails identically for every model the user has not deployed. Dead-end loop; the user cannot discover that the fix lives in the Azure portal.

**Fix:** classify Azure's `DeploymentNotFound` bodies with a new `model_unavailable` reason `not_deployed` (runtime classifier + protocol + `@houston-ai/chat` unions), and give the card a dedicated body for it: the model is not deployed on the resource, deploy it under the exact model name or pick one you already deployed. en/es/pt. The `not_deployed` body outranks the personal-credential wording since the gap is resource-level, not plan-level. No suggested fallback is offered: we cannot know which deployments the resource has.

Verified against pi 0.84.4: the Azure catalog serves the models the picker offers, the endpoint is normalized to the resource host root, and deployment resolution is strictly model-id-named — so a connected user whose chats all fail this way is missing deployments, which is exactly what the card now says.

## Before (repro)

1. Connect Azure OpenAI with a valid key + endpoint but no deployment named after the models you pick (or none at all — connect-time verify passes either way, since `DeploymentNotFound` proves auth).
2. Send a message on any Azure model.
3. Card: "{model} is not available on your personal Azure OpenAI account." with only "Pick another model" — and every other pick fails the same way.

## After

1. Same setup, same send.
2. Card body now reads: "{model} is not deployed on your Azure OpenAI resource. Deploy it there with the exact name \"{model}\", or pick a model you already deployed."
3. Creating a deployment named exactly like the model (e.g. `gpt-5.6-sol`) in the Azure portal makes that model work with no reconnect.

## Tests

- `packages/runtime` provider-error test extended: Azure `DeploymentNotFound` → `model_unavailable` with `reason: "not_deployed"`, no fallback.
- `pnpm check`, runtime/host/domain vitest suites, `app` tsgo + unit tests + `check-locales`, ui + web typecheck all green.