### PR TITLE
fix(runtime): mission settle report retries network drops and logs WARN, not a Sentry error (PRODUCT-1599)

### DIFF
--- a/packages/runtime/src/session/mission-settle.test.ts
+++ b/packages/runtime/src/session/mission-settle.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { config } from "../config";
+import { reportMissionSettle } from "./mission-settle";
+
+/**
+ * The settle report crosses the pod↔control-plane network, whose drops are
+ * connectivity, not Houston faults (Sentry HOUSTON-APP-595: 225 undici
+ * `TypeError: fetch failed` events, every one a socket reset mid-settle).
+ * The contract under test: transient failures RETRY (the host applies at most
+ * one settle per mission, so replays are safe), and a settle that still fails
+ * logs a WARN breadcrumb — never a console.error, which the capture feed
+ * would mint into a Sentry error event.
+ */
+
+const prev = { url: "", token: "" };
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  prev.url = config.controlPlaneUrl;
+  prev.token = config.sandboxToken;
+  config.controlPlaneUrl = "http://control-plane.test";
+  config.sandboxToken = "sbx-token";
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  config.controlPlaneUrl = prev.url;
+  config.sandboxToken = prev.token;
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+/** Fire-and-forget returns void; drain its internal promise chain. */
+async function settled(check: () => boolean): Promise<void> {
+  await vi.waitFor(() => {
+    expect(check()).toBe(true);
+  });
+}
+
+test("posts the settle payload with the sandbox bearer", async () => {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fetchImpl: typeof fetch = async (url, init) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return new Response(null, { status: 200 });
+  };
+
+  reportMissionSettle("conv-1", "needs_you", null, { fetchImpl });
+  await settled(() => calls.length === 1);
+
+  expect(calls[0]?.url).toBe(
+    "http://control-plane.test/sandbox/missions/settle",
+  );
+  const headers = calls[0]?.init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer sbx-token");
+  expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+    conversation_id: "conv-1",
+    status: "needs_you",
+    pending_interaction: null,
+  });
+  expect(warnSpy).not.toHaveBeenCalled();
+  expect(errorSpy).not.toHaveBeenCalled();
+});
+
+test("a transient network drop retries and succeeds silently", async () => {
+  let attempts = 0;
+  const fetchImpl: typeof fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) throw new TypeError("fetch failed");
+    return new Response(null, { status: 200 });
+  };
+
+  reportMissionSettle("conv-2", "error", null, {
+    fetchImpl,
+    retryDelaysMs: [0, 0],
+  });
+  await settled(() => attempts === 2);
+
+  expect(warnSpy).not.toHaveBeenCalled();
+  expect(errorSpy).not.toHaveBeenCalled();
+});
+
+test("a settle that fails every attempt logs WARN, never console.error", async () => {
+  let attempts = 0;
+  const fetchImpl: typeof fetch = async () => {
+    attempts += 1;
+    throw new TypeError("fetch failed");
+  };
+
+  reportMissionSettle("conv-3", "error", null, {
+    fetchImpl,
+    retryDelaysMs: [0, 0],
+  });
+  await settled(() => warnSpy.mock.calls.length === 1);
+
+  expect(attempts).toBe(3);
+  expect(String(warnSpy.mock.calls[0]?.[0])).toContain("conv-3");
+  expect(errorSpy).not.toHaveBeenCalled();
+});
+
+test("no control plane configured means no request at all", async () => {
+  config.controlPlaneUrl = "";
+  let attempts = 0;
+  const fetchImpl: typeof fetch = async () => {
+    attempts += 1;
+    return new Response(null, { status: 200 });
+  };
+
+  reportMissionSettle("conv-4", "needs_you", null, { fetchImpl });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  expect(attempts).toBe(0);
+});

--- a/packages/runtime/src/session/mission-settle.ts
+++ b/packages/runtime/src/session/mission-settle.ts
@@ -1,5 +1,14 @@
 import type { PendingInteraction } from "@houston/protocol";
+import { fetchWithRetry } from "@houston/runtime-client/object-sync";
 import { config } from "../config";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+/** Injectable seams for tests: fake fetch, no real timer waits. */
+export interface MissionSettleOptions {
+  fetchImpl?: typeof fetch;
+  retryDelaysMs?: number[];
+}
 
 /**
  * Report a turn's terminal board state to the host (PRODUCT-1244). Board settle
@@ -11,32 +20,48 @@ import { config } from "../config";
  * missions keep the client settle path byte-identical.
  *
  * Fire-and-forget, never turn-fatal: this runs after the turn's terminal frame
- * is already published, with no UI thread to toast on — the one sanctioned
- * log-only context. A missed settle self-heals when the user opens the mission
- * (settle-from-history).
+ * is already published, with no UI thread to toast on. Network drops retry
+ * (the host applies at most one settle per mission, so replays are safe) with
+ * a fresh timeout per attempt; a settle that still fails logs a WARN
+ * breadcrumb, never a console.error — the pod↔control-plane socket dropping
+ * is connectivity, not a Houston fault, and it self-heals when the user opens
+ * the mission (settle-from-history).
  */
 export function reportMissionSettle(
   conversationId: string,
   status: "needs_you" | "error",
   pendingInteraction: PendingInteraction | null,
+  opts: MissionSettleOptions = {},
 ): void {
   if (!config.controlPlaneUrl || !config.sandboxToken) return;
   const base = config.controlPlaneUrl.replace(/\/$/, "");
-  void fetch(`${base}/sandbox/missions/settle`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${config.sandboxToken}`,
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  void fetchWithRetry(
+    (url, init) =>
+      fetchImpl(url, {
+        ...init,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      }),
+    `${base}/sandbox/missions/settle`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${config.sandboxToken}`,
+      },
+      body: JSON.stringify({
+        conversation_id: conversationId,
+        status,
+        pending_interaction: pendingInteraction,
+      }),
     },
-    body: JSON.stringify({
-      conversation_id: conversationId,
-      status,
-      pending_interaction: pendingInteraction,
-    }),
-  }).catch((err) => {
-    console.error(
-      `[missions] settle report failed for ${conversationId}:`,
-      err,
-    );
-  });
+    opts.retryDelaysMs ? { delaysMs: opts.retryDelaysMs } : {},
+  )
+    .then((response) => response.body?.cancel())
+    .catch((err) => {
+      console.warn(
+        `[missions] settle report failed for ${conversationId}; settle-from-history will heal:`,
+        err,
+      );
+    });
 }

--- a/packages/web/e2e/mobile/mission-chat.spec.ts
+++ b/packages/web/e2e/mobile/mission-chat.spec.ts
@@ -47,7 +47,11 @@ test("a follow-up sent from the pushed chat round-trips", async ({ page }) => {
   await composer.press("Enter");
 
   // The user's bubble and the fake host's echoed reply both land in the log.
-  await expect(chat.getByText("Also check the trains")).toBeVisible();
+  // Exact match: the reply quotes the sent text, so a substring locator races
+  // the echo into a strict-mode violation when the reply lands first.
+  await expect(
+    chat.getByText("Also check the trains", { exact: true }),
+  ).toBeVisible();
   await expect(chat.getByText(/Roger that\. You said:/)).toBeVisible({
     timeout: 15_000,
   });


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-595 (`TypeError: fetch failed`, undici, system-only frames — 225 events / 7 users, still firing) is the runtime's fire-and-forget mission settle report (`packages/runtime/src/session/mission-settle.ts`, PRODUCT-1244) hitting a pod↔control-plane connectivity blip. Every sampled event's `log_message` is `[missions] settle report failed for <routine-…>` with cause `SocketError: other side closed` or `read ECONNRESET`.

Root cause: the settle POST had no retry and logged any fetch rejection via `console.error`, which the runtime's Sentry capture feed mints into an error event — but a dropped socket to the control plane is connectivity, not a Houston fault, and a missed settle already self-heals when the user opens the mission (settle-from-history).

## Fix

- The settle POST now goes through `fetchWithRetry` (bounded retries on network drops and 502/503/504) with a fresh 5s timeout per attempt. The host applies at most one settle per agent-started mission still on `running`, so replays are safe.
- A settle that still fails after retries logs a WARN breadcrumb, never a `console.error`.
- The success path now cancels the response body (it was previously left unconsumed).

## Before (reproduce)

1. On a managed pod, let an agent-started mission finish a turn while the control-plane connection drops (or point `HOUSTON_CONTROL_PLANE_URL` at a server that resets the socket mid-request).
2. The single failed POST logs `[missions] settle report failed …` at ERROR → one `TypeError: fetch failed` Sentry error event per turn end (HOUSTON-APP-595).

## After (verify)

1. `pnpm --filter @houston/runtime test -- mission-settle` — covers: payload/bearer shape, transient drop → retry → silent success, all-attempts-fail → single WARN with the conversation id and no `console.error`, and no request when no control plane is configured.
2. Same socket-reset scenario: the POST retries (500ms/2s backoff); if all attempts fail the runtime emits only a WARN breadcrumb, so no new HOUSTON-APP-595 events after the fix's release.