### PR TITLE
fix(runtime): Gemini MALFORMED_* stop reasons classify as provider_internal (PRODUCT-1601)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -666,6 +666,58 @@ test("'Provider finish_reason: network_error' → provider_internal too", () => 
   expect(err.kind).toBe("provider_internal");
 });
 
+// Gemini ends a turn with finishReason MALFORMED_FUNCTION_CALL /
+// MALFORMED_RESPONSE when the MODEL's own generation broke (an unparseable
+// tool call, a garbled response); pi-ai flattens both to `Provider stopped
+// with: <REASON>` — no status, no body (PRODUCT-1601's verbatim reports).
+// Server-side and transient — Google's guidance is retry — so they must read
+// as provider_internal (Retry card), never the report-bug `unknown` firing a
+// Sentry error per turn.
+test("google 'Provider stopped with: MALFORMED_RESPONSE' → provider_internal, not unknown (PRODUCT-1601)", () => {
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.5-flash-lite",
+    message: "Provider stopped with: MALFORMED_RESPONSE",
+  });
+  expect(err).toEqual({
+    kind: "provider_internal",
+    provider: "google",
+    http_status: null,
+    message: "Provider stopped with: MALFORMED_RESPONSE",
+  });
+});
+
+test("google 'Provider stopped with: MALFORMED_FUNCTION_CALL' → provider_internal too", () => {
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.6-flash",
+    message: "Provider stopped with: MALFORMED_FUNCTION_CALL",
+  });
+  expect(err.kind).toBe("provider_internal");
+});
+
+test("older pi's 'Unhandled stop reason: MALFORMED_RESPONSE' phrasing classifies the same", () => {
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.5-flash",
+    message: "Unhandled stop reason: MALFORMED_RESPONSE",
+  });
+  expect(err.kind).toBe("provider_internal");
+});
+
+// Gemini's policy stops ride the same `Provider stopped with:` prefix but are
+// refusals, not outages — retry does not help and the Retry card would lie.
+// They must keep falling through to `unknown` (the report-bug card), like
+// OpenAI's `content_filter`.
+test("google 'Provider stopped with: SAFETY' stays unknown — a refusal, not an outage", () => {
+  const err = classifyProviderError({
+    provider: "google",
+    model: "gemini-3.6-flash",
+    message: "Provider stopped with: SAFETY",
+  });
+  expect(err.kind).toBe("unknown");
+});
+
 // Codex's WebSocket transport dying mid-turn arrives as the bare string
 // `WebSocket closed <code>` — no status, no body (HOU-848's verbatim report;
 // 584 Sentry events across 137 users read as `unknown`). HOU-1156 first

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -662,6 +662,20 @@ function isServerError(lower: string, status: number | null): boolean {
     // these keep the verdict when the body is truncated (HOU-1156).
     lower.includes("got status: unavailable") ||
     lower.includes("experiencing high demand") ||
+    // Gemini's malformed-generation finish reasons — MALFORMED_FUNCTION_CALL
+    // (the model emitted an unparseable tool call) and MALFORMED_RESPONSE (a
+    // newer value the SDK enum doesn't even carry yet) — arrive flattened as
+    // `Provider stopped with: <REASON>` (older pi: `Unhandled stop reason:
+    // <REASON>`) with no status and no body. The MODEL broke mid-generation,
+    // server-side and transient — Google's own guidance is retry — so the
+    // Retry card is the honest one, never the report-bug `unknown` firing a
+    // Sentry error per turn (PRODUCT-1601). Matched on the reason tokens, NOT
+    // the `Provider stopped with:` prefix: Gemini's policy stops (SAFETY,
+    // RECITATION, BLOCKLIST, …) ride the same prefix and are refusals, not
+    // outages — they must keep falling through to `unknown`, like
+    // `content_filter` above.
+    lower.includes("malformed_function_call") ||
+    lower.includes("malformed_response") ||
     // Codex (ChatGPT OAuth) rides a WebSocket transport; when that socket dies
     // mid-turn pi-ai flattens it to `WebSocket closed <code>` — no status, no
     // body (HOU-848: codes 1006 abnormal closure, 1000 server closed mid-turn,


### PR DESCRIPTION
## Root cause

Gemini turns ending with finishReason `MALFORMED_FUNCTION_CALL` or `MALFORMED_RESPONSE` are flattened by pi-ai to `Provider stopped with: <REASON>` (older pi: `Unhandled stop reason: <REASON>`) with no HTTP status and no body. No branch of `classifyProviderError` matched those strings, so the turn degraded to `kind=unknown` — the report-bug card in chat plus a Sentry **error** per occurrence (Sentry HOUSTON-APP-59E, 9 events / 6 users over 14d).

The remaining events in that Sentry group (`This operation was aborted`) are user cancels from pre-`22a69661` releases, already demoted to warnings by the abort guard in `provider-error-log.ts`; the only class still firing on the current release is MALFORMED_*.

## Fix

`isServerError` now matches the `malformed_function_call` / `malformed_response` reason tokens: the model broke mid-generation, server-side and transient (Google's own guidance is retry), so the honest verdict is `provider_internal` — the Retry card, logged as a warning (`EXPECTED_KINDS`), no Sentry error. Matching is on the reason tokens, **not** the shared `Provider stopped with:` prefix — Gemini's policy stops (SAFETY, RECITATION, BLOCKLIST) are refusals, not outages, and keep falling through to `unknown` (covered by a new test).

## Before

1. Run a Gemini turn (e.g. `gemini-3.5-flash-lite`) that ends with finishReason `MALFORMED_RESPONSE` — or unit-test it: `classifyProviderError({ provider: "google", model: "gemini-3.5-flash-lite", message: "Provider stopped with: MALFORMED_RESPONSE" })`.
2. Result was `{ kind: "unknown", … }` → generic report-bug card, `console.error` → Sentry error event tagged `kind=unknown`.

## After

1. Same input classifies as `{ kind: "provider_internal", http_status: null }` → Retry card in chat.
2. `logProviderError` emits the line at **warn** (`kind=provider_internal` is in `EXPECTED_KINDS`) — no new Sentry error; HOUSTON-APP-59E stops accruing events on releases carrying this fix.
3. `pnpm --filter @houston/runtime test` — the four new PRODUCT-1601 tests pass (incl. the SAFETY stays-unknown guard); full runtime/host/domain suites green.