### PR TITLE
fix(runtime): serve-probe connectivity failures log WARN, never Sentry errors (PRODUCT-1602)

### DIFF
--- a/packages/runtime/src/auth/serve-log.test.ts
+++ b/packages/runtime/src/auth/serve-log.test.ts
@@ -20,30 +20,30 @@ beforeEach(() => {
 });
 
 test("the first failure logs an error; identical repeats demote to warnings", () => {
-  logServeProbeFailure("anthropic", "502: credential expired");
-  logServeProbeFailure("anthropic", "502: credential expired");
-  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
   expect(error).toHaveBeenCalledOnce();
   expect(warn).toHaveBeenCalledTimes(2);
 });
 
 test("a CHANGED failure detail logs a fresh error", () => {
-  logServeProbeFailure("anthropic", "502: credential expired");
-  logServeProbeFailure("anthropic", "fetch failed");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
+  logServeProbeFailure("anthropic", "500: malformed served payload");
   expect(error).toHaveBeenCalledTimes(2);
 });
 
 test("failures dedup per provider, not globally", () => {
-  logServeProbeFailure("anthropic", "502: credential expired");
-  logServeProbeFailure("openai-codex", "502: credential expired");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
+  logServeProbeFailure("openai-codex", "500: credential row corrupt");
   expect(error).toHaveBeenCalledTimes(2);
 });
 
 test("recovery logs once and re-arms the error for the next incident", () => {
-  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
   noteServeProbeOk("anthropic");
   expect(info).toHaveBeenCalledWith("[serve] credential anthropic recovered");
-  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
   expect(error).toHaveBeenCalledTimes(2);
 });
 
@@ -67,7 +67,7 @@ test("a uniformly failed sweep is ONE incident: one error, warnings on repeat, o
 });
 
 test("probes failing ALIKE in one sweep are ONE incident, not one per provider (PRODUCT-1423)", () => {
-  const blip = '500: {"error":"fetch failed"}';
+  const blip = '500: {"error":"credential row corrupt"}';
   logServeProbeFailures([
     { id: "google", detail: blip },
     { id: "openrouter", detail: blip },
@@ -89,7 +89,7 @@ test("probes failing ALIKE in one sweep are ONE incident, not one per provider (
 });
 
 test("a group with any NEWLY failing member logs a fresh error, and recovery re-arms it", () => {
-  const blip = '500: {"error":"fetch failed"}';
+  const blip = '500: {"error":"credential row corrupt"}';
   logServeProbeFailures([
     { id: "google", detail: blip },
     { id: "openrouter", detail: blip },
@@ -110,23 +110,23 @@ test("a group with any NEWLY failing member logs a fresh error, and recovery re-
 
 test("distinct failure details stay distinct incidents; a lone failure keeps the per-provider path", () => {
   logServeProbeFailures([
-    { id: "google", detail: '500: {"error":"fetch failed"}' },
-    { id: "openrouter", detail: '500: {"error":"fetch failed"}' },
-    { id: "anthropic", detail: "502: credential expired" },
+    { id: "google", detail: '500: {"error":"credential row corrupt"}' },
+    { id: "openrouter", detail: '500: {"error":"credential row corrupt"}' },
+    { id: "anthropic", detail: "500: served key rejected" },
   ]);
   expect(error).toHaveBeenCalledTimes(2);
   expect(error).toHaveBeenCalledWith(
-    "[serve] credential anthropic: 502: credential expired",
+    "[serve] credential anthropic: 500: served key rejected",
   );
   // The grouped entry point and the per-provider path share one transition
   // map: the lone failure's identical repeat is the same incident.
-  logServeProbeFailure("anthropic", "502: credential expired");
+  logServeProbeFailure("anthropic", "500: served key rejected");
   expect(error).toHaveBeenCalledTimes(2);
 });
 
 test("the sweep incident is tracked apart from per-provider failures", () => {
   logServeSweepFailure(41, "fetch failed (cause: ECONNREFUSED)");
-  logServeProbeFailure("anthropic", "fetch failed (cause: ECONNREFUSED)");
+  logServeProbeFailure("anthropic", "500: credential row corrupt");
   expect(error).toHaveBeenCalledTimes(2);
   noteServeProbeOk("anthropic");
   expect(info).toHaveBeenCalledWith("[serve] credential anthropic recovered");
@@ -157,4 +157,37 @@ test("a dead-credential group in a sweep stays at warning level per provider", (
   ]);
   expect(error).not.toHaveBeenCalled();
   expect(warn).toHaveBeenCalledTimes(2);
+});
+
+test("connectivity-class failures NEVER log an error (PRODUCT-1602)", () => {
+  const connectivity = [
+    '500: {"error":"fetch failed"}',
+    "fetch failed (cause: ECONNRESET)",
+    "The operation was aborted due to timeout",
+    "502: Bad Gateway",
+    '500: {"error":"credential gateway GET <provider> failed (500): {\\"error\\":\\"gateway error\\"}"}',
+    "fetch failed (cause: UND_ERR_CONNECT_TIMEOUT)",
+  ];
+  for (const detail of connectivity) logServeProbeFailure("openrouter", detail);
+  expect(error).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledTimes(connectivity.length);
+  // Recovery still re-arms the transition map like any other failure class.
+  noteServeProbeOk("openrouter");
+  expect(info).toHaveBeenCalledWith("[serve] credential openrouter recovered");
+});
+
+test("a connectivity group in a sweep stays at warning level per provider (PRODUCT-1602)", () => {
+  const detail = '500: {"error":"fetch failed"}';
+  logServeProbeFailures([
+    { id: "google", detail },
+    { id: "openrouter", detail },
+    { id: "opencode-go", detail },
+  ]);
+  expect(error).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledTimes(3);
+});
+
+test("a NON-connectivity 500 keeps the error path", () => {
+  logServeProbeFailure("openrouter", "500: served key rejected");
+  expect(error).toHaveBeenCalledOnce();
 });

--- a/packages/runtime/src/auth/serve-log.ts
+++ b/packages/runtime/src/auth/serve-log.ts
@@ -26,11 +26,32 @@ const SWEEP_KEY = "*";
  */
 const EXPECTED_DETAIL = /dead credential/;
 
+/**
+ * The NETWORK PATH failing, not Houston: the gateway echoing an upstream
+ * fetch failure through a 500 body, a gateway-tier 502/503/504, a reset or
+ * refused socket, a stalled connect. At fleet scale these are routine — every
+ * cloud release briefly answers the awake fleet this way — so even the
+ * once-per-transition error minted dozens of Sentry events per blip, one per
+ * pod, for a state the next sync heals on its own (PRODUCT-1602, the
+ * HOUSTON-APP-4YV regression). Connectivity failures are warnings here; a
+ * sweep failing uniformly (logServeSweepFailure) stays the error-level
+ * outage signal.
+ */
+const CONNECTIVITY_DETAIL =
+  /fetch failed|gateway error|operation was aborted|credential gateway GET .* failed|^50[234]: |\(cause: (?:ECONN|ETIMEDOUT|EAI_AGAIN|EPIPE|ENETUNREACH|EHOSTUNREACH|UND_ERR_)/;
+
 export function logServeProbeFailure(provider: string, detail: string): void {
   if (EXPECTED_DETAIL.test(detail)) {
     lastFailureDetail.set(provider, detail);
     console.warn(
       `[serve] credential ${provider} dead centrally (user reconnect required): ${detail}`,
+    );
+    return;
+  }
+  if (CONNECTIVITY_DETAIL.test(detail)) {
+    lastFailureDetail.set(provider, detail);
+    console.warn(
+      `[serve] credential ${provider} unreachable (connectivity, next sync retries): ${detail}`,
     );
     return;
   }
@@ -79,7 +100,11 @@ export function logServeProbeFailures(
   }
   for (const [detail, ids] of byDetail) {
     const lone = ids.length === 1 ? ids[0] : undefined;
-    if (lone !== undefined || EXPECTED_DETAIL.test(detail)) {
+    if (
+      lone !== undefined ||
+      EXPECTED_DETAIL.test(detail) ||
+      CONNECTIVITY_DETAIL.test(detail)
+    ) {
       for (const id of ids) logServeProbeFailure(id, detail);
       continue;
     }

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -781,7 +781,7 @@ test("one transient probe failure retries, the provider still applies, and no ER
   }
 });
 
-test("a probe that fails both attempts logs ONE error with the cause code and removes nothing", async () => {
+test("a probe that fails both attempts warns with the cause code and removes nothing", async () => {
   resetServeProbeLog();
   const { fetchImpl, calls } = flakyCodexFetch(() => true);
   const errors = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -815,23 +815,30 @@ test("a probe that fails both attempts logs ONE error with the cause code and re
         expires: 1,
       });
       expect(readServedProvidersAt(manifestPath)).toEqual(["openai-codex"]);
-      // Exactly one ERROR (a persistent failure must still alert), carrying
-      // the nested cause code that `err.message` alone loses.
-      const serveErrors = errors.mock.calls.filter((c) =>
-        String(c[0]).includes("[serve] credential"),
-      );
-      expect(serveErrors.length).toBe(1);
-      expect(String(serveErrors[0]?.[0])).toContain("ECONNRESET");
+      // A socket reset is a connectivity failure — a WARN breadcrumb carrying
+      // the nested cause code that `err.message` alone loses, never a Sentry
+      // error (PRODUCT-1602).
+      expect(
+        errors.mock.calls.filter((c) =>
+          String(c[0]).includes("[serve] credential"),
+        ),
+      ).toEqual([]);
+      expect(
+        warns.mock.calls.some(
+          (c) =>
+            String(c[0]).includes("credential openai-codex unreachable") &&
+            String(c[0]).includes("ECONNRESET"),
+        ),
+      ).toBe(true);
 
-      // The next sync re-attempts the probe; the identical repeat stays a
-      // WARN (serve-log dedup), not a second Sentry event.
+      // The next sync re-attempts the probe and stays warning-level too.
       expect(await syncServedCredential()).toEqual([]);
       expect(calls()).toBe(4);
       expect(
         errors.mock.calls.filter((c) =>
           String(c[0]).includes("[serve] credential"),
-        ).length,
-      ).toBe(1);
+        ),
+      ).toEqual([]);
     });
   } finally {
     errors.mockRestore();
@@ -901,11 +908,13 @@ test("a sweep where EVERY probe is refused logs ONE error, not one per provider 
   }
 }, 30_000);
 
-test("probes caught by ONE gateway blip mid-sweep log ONE error, not one per provider (PRODUCT-1423)", async () => {
+test("probes caught by ONE gateway blip mid-sweep are warnings, never Sentry errors (PRODUCT-1602)", async () => {
   // A control-plane restart seen through the gateway: the probes in flight
   // during the window get `500: {"error":"fetch failed"}` while the rest of
-  // the sweep answers normally. Not uniform, so the PRODUCT-1399 collapse
-  // never fired — HOUSTON-APP-4YV got one Sentry event per caught provider.
+  // the sweep answers normally. A connectivity blip is not a Houston
+  // incident — every release roll answers the whole awake fleet this way, so
+  // even the collapsed once-per-transition error (PRODUCT-1423) minted one
+  // Sentry event per pod per blip.
   resetServeProbeLog();
   const blipped = new Set(["google", "openrouter", "opencode-go"]);
   const fetchImpl = (async (input: RequestInfo | URL) => {
@@ -925,19 +934,19 @@ test("probes caught by ONE gateway blip mid-sweep log ONE error, not one per pro
   try {
     await withServeMode(fetchImpl, async () => {
       expect(await syncServedCredential()).toEqual([]);
-      // ONE event naming every caught provider (in catalog order) and the
-      // shared gateway detail.
-      expect(serveErrors()).toHaveLength(1);
-      const line = serveErrors()[0] ?? "";
-      expect(line).toMatch(/^\[serve\] credential probes for /);
-      for (const id of blipped) expect(line).toContain(id);
-      expect(line).toContain('failed alike: 500: {"error":"fetch failed"}');
-      // The persistent repeat stays a WARN breadcrumb, never a second event.
+      expect(serveErrors()).toHaveLength(0);
+      // Each caught provider leaves a warning breadcrumb with the detail.
+      for (const id of blipped)
+        expect(
+          warns.mock.calls.some(
+            (c) =>
+              String(c[0]).includes(`credential ${id} unreachable`) &&
+              String(c[0]).includes('500: {"error":"fetch failed"}'),
+          ),
+        ).toBe(true);
+      // The persistent repeat stays warning-level too.
       expect(await syncServedCredential()).toEqual([]);
-      expect(serveErrors()).toHaveLength(1);
-      expect(
-        warns.mock.calls.some((c) => String(c[0]).includes("still failing")),
-      ).toBe(true);
+      expect(serveErrors()).toHaveLength(0);
     });
   } finally {
     errors.mockRestore();
@@ -992,10 +1001,11 @@ test("a full-sweep gateway outage whose bodies echo each provider id logs ONE er
   }
 }, 30_000);
 
-test("mid-sweep gateway 500s with echoed provider ids collapse to one group (PRODUCT-1443)", async () => {
+test("mid-sweep gateway 500s with echoed provider ids stay warnings (PRODUCT-1443 / PRODUCT-1602)", async () => {
   // The partial-sweep sibling: only the probes caught by the blip fail, each
-  // with its own id echoed in the body — same detail once normalized, so the
-  // PRODUCT-1423 group collapse fires instead of one event per provider.
+  // with its own id echoed in the body. Normalized (PRODUCT-1443) they share
+  // one detail; as a gateway-echo connectivity failure that detail is
+  // warning-only (PRODUCT-1602).
   resetServeProbeLog();
   const blipped = new Set(["google", "openrouter", "opencode-go"]);
   const fetchImpl = (async (input: RequestInfo | URL) => {
@@ -1018,13 +1028,19 @@ test("mid-sweep gateway 500s with echoed provider ids collapse to one group (PRO
   try {
     await withServeMode(fetchImpl, async () => {
       expect(await syncServedCredential()).toEqual([]);
-      expect(serveErrors()).toHaveLength(1);
-      const line = serveErrors()[0] ?? "";
-      expect(line).toMatch(/^\[serve\] credential probes for /);
-      for (const id of blipped) expect(line).toContain(id);
-      expect(line).toContain(
-        'failed alike: 500: {"error":"credential gateway GET <provider> failed (500): ',
-      );
+      expect(serveErrors()).toHaveLength(0);
+      // The warning carries the NORMALIZED detail — the echoed id replaced —
+      // so the still-failing dedup compares byte-identical strings.
+      for (const id of blipped)
+        expect(
+          warns.mock.calls.some(
+            (c) =>
+              String(c[0]).includes(`credential ${id} unreachable`) &&
+              String(c[0]).includes(
+                "credential gateway GET <provider> failed (500): ",
+              ),
+          ),
+        ).toBe(true);
     });
   } finally {
     errors.mockRestore();


### PR DESCRIPTION
## Summary

PRODUCT-1602 — the HOUSTON-APP-4YV regression (`[serve] credential openrouter: 500: {"error":"fetch failed"}`, 1465 events / 161 users in 14d).

**Root cause:** all four prior collapses (uniform-sweep, same-detail group, id normalization, dead-credential demotion) work as designed — the latest events come from a release that contains every one of them. What remains is scale: each serve-probe connectivity blip (the gateway echoing an upstream fetch failure as a 500 body, a reset socket, a 10s stall) still logs ONE transition error per pod. A brief control-plane/gateway blip touches the whole awake fleet at once — the 08-31 14:03–14:05Z burst is dozens of pods emitting 1–2 events each — so per-pod dedup can never get the group below fleet size. Sibling Sentry groups (5AQ, 5BR, 5BS) are the same mechanism through the group-collapse path.

**Fix:** a connectivity-class failure detail (`fetch failed`, `gateway error`, gateway `credential gateway GET … failed` echoes, 502/503/504, network cause codes, abort timeouts) is the network path failing, not Houston — it now logs a WARN breadcrumb in the per-provider and group paths, never a Sentry error, mirroring the dead-credential demotion and the mission-settle WARN precedent. The behavior contract is unchanged: nothing applied or removed, the next sync re-probes. A sweep failing uniformly (`control plane unreachable for all N providers`) keeps its error — that stays the real outage signal. Non-connectivity 500s (a genuine host bug) still error on transition.

## Verification

Before the fix (reproduces the bug):
1. In `packages/runtime`, run `vitest run -- serve` on `main`: the test "probes caught by ONE gateway blip mid-sweep" asserts a `console.error` (a Sentry event) for a `500: {"error":"fetch failed"}` gateway echo.
2. In Sentry, HOUSTON-APP-4YV shows fleet-wide bursts (many pods, 1–2 events each, same 2-minute window) on releases that already contain every prior collapse fix.

After the fix:
1. `pnpm --filter @houston/runtime test -- serve` — connectivity flavors (gateway 500 echo, ECONNRESET, timeout, 502) log WARN only; a non-connectivity 500 still errors; the uniform-sweep error is unchanged.
2. Post-roll, HOUSTON-APP-4YV should go silent on the new release; gateway blips appear as `[serve] credential <id> unreachable (connectivity, next sync retries): …` WARN lines in pod logs.

Full `@houston/host` / `@houston/runtime` / `@houston/domain` suites and `pnpm check` pass.