### PR TITLE
fix(shell): Claude helper signal death logs WARN with the signal number, never a Sentry error (PRODUCT-1605)

### DIFF
--- a/app/src-tauri/src/claude_login/mod.rs
+++ b/app/src-tauri/src/claude_login/mod.rs
@@ -135,7 +135,10 @@ pub async fn start_claude_login(
     // to the runtime's paste flow.
     if let Some(reason) = cpu::unsupported_reason() {
         let error = format!("Claude sign-in helper cannot run: {reason}");
-        tracing::error!("[claude-login] {error}");
+        // WARN, not error: an unsupported CPU is an environmental fact with a
+        // designed degrade path (paste flow), not something in Houston
+        // breaking — same reasoning as the signal-death arm in `runner`.
+        tracing::warn!("[claude-login] {error}");
         app.emit(
             EVENT_DONE,
             serde_json::json!({ "success": false, "error": error, "helperUnavailable": true }),

--- a/app/src-tauri/src/claude_login/runner.rs
+++ b/app/src-tauri/src/claude_login/runner.rs
@@ -110,13 +110,23 @@ where
             let code = status
                 .code()
                 .map(|c| c.to_string())
-                .unwrap_or_else(|| "signal".to_string());
+                .unwrap_or_else(|| signal_label(&status));
             let mut error = format!("Claude sign-in failed (exit {code})");
             if !tail.trim().is_empty() {
                 error.push_str(": ");
                 error.push_str(tail.trim());
             }
-            tracing::error!("[claude-login] {error}");
+            if helper_unavailable {
+                // WARN, not error: a signal death means this machine cannot run
+                // the helper (SIGILL on pre-AVX2, OOM kill, hardened kernel) and
+                // the frontend already degrades to the paste flow. A Sentry
+                // event per attempt from the same broken machines is noise
+                // (HOUSTON-APP-543 kept regressing on it); the breadcrumb +
+                // backend.log line keeps the diagnosis trail.
+                tracing::warn!("[claude-login] {error}");
+            } else {
+                tracing::error!("[claude-login] {error}");
+            }
             emit(
                 EVENT_DONE,
                 json!({ "success": false, "error": error, "helperUnavailable": helper_unavailable }),
@@ -217,6 +227,24 @@ where
             }
         }
     }
+}
+
+/// Diagnostic label for a signal death: "signal <n>" on Unix (which signal
+/// separates SIGILL/pre-AVX2 from OOM kills and sandbox denials in triage),
+/// bare "signal" where the number is unavailable.
+fn signal_label(status: &ExitStatus) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(sig) = status.signal() {
+            return format!("signal {sig}");
+        }
+    }
+    // Windows ExitStatus::code() is always Some, so this arm is unreachable
+    // there in practice; keep the fn total for any future target.
+    #[cfg(not(unix))]
+    let _ = status;
+    "signal".to_string()
 }
 
 /// Read the next stdout line, or hang forever when there is no pipe. The `None`
@@ -346,7 +374,9 @@ mod tests {
         assert_eq!(done.1["success"], json!(false));
         assert_eq!(done.1["helperUnavailable"], json!(true));
         let error = done.1["error"].as_str().expect("error string");
-        assert!(error.contains("exit signal"), "error was: {error}");
+        // The message names the concrete signal (SIGILL = 4) so triage can
+        // tell an illegal instruction from an OOM kill without the machine.
+        assert!(error.contains("exit signal 4"), "error was: {error}");
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }


### PR DESCRIPTION
## Summary

Fixes the Sentry regression `[claude-login] Claude sign-in failed (exit signal)` (PRODUCT-1605, Sentry HOUSTON-APP-543).

**Root cause:** the original HOUSTON-APP-543 fix (#1205) added the `helperUnavailable` flag and the AVX2 pre-gate, so the frontend already degrades a signal-killed helper to the runtime's paste flow — but the runner kept logging the death at `tracing::error!`, and the `sentry_tracing` layer turns every ERROR into a standalone Sentry event. Each attempt on a machine that can't run the Bun helper (recent 14d events: AVX2-capable Linux boxes, so a non-SIGILL signal — OOM kill / hardened kernel) re-minted the event and Sentry re-flagged the issue as a regression.

**Fix:**
- The signal-death arm in `runner.rs` logs WARN (breadcrumb + backend.log line, no standalone Sentry event) — same reasoning as the abandoned-login timeout downgrade (#1408). Numbered non-zero exits stay ERROR.
- The AVX2 pre-gate in `mod.rs` gets the same downgrade (same environmental family, same degrade path).
- The message now names the concrete signal on Unix (`exit signal 4`) so future triage can tell SIGILL from an OOM kill from the log line alone.

## Verification

Before: run a login whose helper dies from a signal (e.g. point the resolver at a script that `kill -ILL $$`) → Sentry receives an error event `[claude-login] Claude sign-in failed (exit signal)` even though the UI correctly falls back.

After: same scenario → `backend.log` shows `WARN … Claude sign-in failed (exit signal 4)`, no Sentry event; a genuine non-zero helper exit still logs ERROR. Pinned by `run_login_flags_a_signal_killed_helper_as_unavailable` (now asserts the signal number) and `run_login_reports_failure_on_nonzero_exit`; `cargo test` 220 passed.