### PR TITLE
fix(local-model): retire stale tunnel pill after disconnect (PRODUCT-1606)

### DIFF
--- a/app/src-tauri/src/local_bridge/commands.rs
+++ b/app/src-tauri/src/local_bridge/commands.rs
@@ -130,8 +130,12 @@ pub async fn stop_local_bridge(app: AppHandle) -> Result<(), String> {
     // Same serializer: a stop must not race a concurrent start/reconnect, or it
     // could tear down a bridge the other op is mid-way through standing up.
     let _op = BRIDGE_OP.lock().await;
-    stop_internal(&app)?;
-    state::delete()
+    // Delete BEFORE tearing down: stop_internal emits the offline status event,
+    // and the frontend re-probes `saved_bridge_target` on that event to retire
+    // the tunnel pill — emitting first would let the probe still see the
+    // descriptor and leave a stale Reconnect affordance.
+    state::delete()?;
+    stop_internal(&app)
 }
 
 /// Current bridge status. Also delivered live via the `local-bridge-status`

--- a/app/src/hooks/use-local-bridge-status.ts
+++ b/app/src/hooks/use-local-bridge-status.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { listenOsEvent } from "../lib/events";
 import type { BridgeStatus, SavedBridgeTarget } from "../lib/local-model";
-import { sessionOwnsBridge } from "../lib/local-model";
+import {
+  reconnectBlockedByMissingDescriptor,
+  sessionOwnsBridge,
+} from "../lib/local-model";
 import { reconnectLocalModel } from "../lib/local-model-connect";
 import {
   osIsTauri,
@@ -74,7 +77,19 @@ export function useLocalBridgeStatus(enabled = true): LocalBridgeStatus {
         console.error("[local-bridge] saved target read failed", err),
       );
     const off = listenOsEvent<BridgeStatus>("local-bridge-status", (s) => {
-      if (mounted.current) setStatus(s);
+      if (!mounted.current) return;
+      setStatus(s);
+      // The descriptor's lifecycle rides status transitions (an explicit stop
+      // deletes it before emitting offline; a start persists it) — re-probe so
+      // a disconnect retires the pill instead of leaving a stale Reconnect
+      // that can only fail.
+      osSavedBridgeTarget()
+        .then((tgt) => {
+          if (mounted.current) setSavedTarget(tgt);
+        })
+        .catch((err) =>
+          console.error("[local-bridge] saved target re-read failed", err),
+        );
     });
     return () => {
       mounted.current = false;
@@ -85,13 +100,22 @@ export function useLocalBridgeStatus(enabled = true): LocalBridgeStatus {
   const reconnect = useCallback(() => {
     if (!enabled || !osIsTauri() || reconnecting) return;
     setReconnecting(true);
-    reconnectLocalModel()
-      .catch(() => {
+    void (async () => {
+      // Precheck the descriptor: a disconnect (this window or another) may
+      // have deleted it after this pill rendered, and reconnecting then can
+      // only fail. Confirmed-gone means the pill itself is stale — heal the
+      // UI, don't toast an error nobody can act on.
+      const probed = await osSavedBridgeTarget().catch(() => undefined);
+      if (reconnectBlockedByMissingDescriptor(probed)) {
+        if (mounted.current) setSavedTarget(null);
+        return;
+      }
+      await reconnectLocalModel().catch(() => {
         // reconnectLocalModel already toasted the real reason (Report-bug).
-      })
-      .finally(() => {
-        if (mounted.current) setReconnecting(false);
       });
+    })().finally(() => {
+      if (mounted.current) setReconnecting(false);
+    });
   }, [enabled, reconnecting]);
 
   return {

--- a/app/src/lib/local-model.ts
+++ b/app/src/lib/local-model.ts
@@ -205,3 +205,16 @@ export function sessionOwnsBridge(
   if (savedTarget) return true;
   return status != null && status.status !== "offline";
 }
+
+/**
+ * Gate the pill's Reconnect action on a fresh `saved_bridge_target` probe. A
+ * confirmed-absent descriptor (`null`) means an explicit disconnect deleted it
+ * after the pill rendered — the pill itself is stale, so heal the UI instead
+ * of firing a reconnect that can only fail. A failed probe (`undefined`) must
+ * NOT block: proceed and let the reconnect surface the real reason.
+ */
+export function reconnectBlockedByMissingDescriptor(
+  probed: SavedBridgeTarget | null | undefined,
+): boolean {
+  return probed === null;
+}

--- a/app/tests/local-model.test.ts
+++ b/app/tests/local-model.test.ts
@@ -8,6 +8,7 @@ import {
   type DetectedServer,
   defaultEndpointName,
   defaultModelFor,
+  reconnectBlockedByMissingDescriptor,
   reconnectBridgeArgs,
   type SavedBridgeTarget,
   sessionOwnsBridge,
@@ -219,5 +220,25 @@ describe("sessionOwnsBridge (tunnel-vs-direct pill rule)", () => {
   it("is direct (no pill) with no saved target and no active bridge", () => {
     strictEqual(sessionOwnsBridge(null, null), false);
     strictEqual(sessionOwnsBridge(null, { status: "offline" }), false);
+  });
+});
+
+describe("reconnectBlockedByMissingDescriptor (stale-pill reconnect guard)", () => {
+  const target: SavedBridgeTarget = {
+    targetBaseUrl: "http://localhost:1234",
+    transport: "wss",
+    appName: "LM Studio",
+  };
+
+  it("blocks when the probe confirms the descriptor is gone", () => {
+    strictEqual(reconnectBlockedByMissingDescriptor(null), true);
+  });
+
+  it("proceeds when a descriptor exists", () => {
+    strictEqual(reconnectBlockedByMissingDescriptor(target), false);
+  });
+
+  it("proceeds when the probe itself failed — never block on a flaky read", () => {
+    strictEqual(reconnectBlockedByMissingDescriptor(undefined), false);
   });
 });


### PR DESCRIPTION
Fixes PRODUCT-1606 (Sentry HOUSTON-APP-568): `reconnect_local_bridge: no saved local-bridge to reconnect — start one first`.

## Root cause

Disconnecting a local model (`stop_local_bridge`) deletes the persisted bridge descriptor, but `useLocalBridgeStatus` read `saved_bridge_target` only once at mount. After a disconnect the tunnel pill therefore stayed rendered with a stale saved target (`ownsBridge` still true), now showing offline with a live **Reconnect** action. Clicking it invoked `reconnect_local_bridge`, which correctly errors when no descriptor exists — and that error was surfaced through `showErrorToast`, reaching Sentry. The event's breadcrumbs show exactly this: disconnect click → `stop_local_bridge` → ~1.5s later a reconnect click → the error.

## Fix

- `useLocalBridgeStatus` re-probes `saved_bridge_target` on every `local-bridge-status` event, so an explicit disconnect retires the pill as soon as the offline transition lands.
- The pill's Reconnect action prechecks the descriptor first: confirmed-gone (`null`) heals the stale pill and skips the doomed invoke instead of toasting an error nobody can act on; a *failed* probe (`undefined`) never blocks — the reconnect proceeds and surfaces the real reason. Decision extracted as `reconnectBlockedByMissingDescriptor` (unit-tested).
- Native side: `stop_local_bridge` now deletes the descriptor *before* tearing down (which emits the offline event), so the frontend's event-driven re-probe can't race the deletion and still see the descriptor.

## Verification

Before the fix: connect a local model (LM Studio/Ollama) on desktop, open the provider modal, click **Disconnect**, then quickly click the tunnel pill's **Reconnect** while it's still visible → error toast "no saved local-bridge to reconnect — start one first" + a Sentry event.

After the fix: same sequence — the pill disappears when the offline status event lands; a fast Reconnect click during the window is a no-op that removes the pill. No toast, no Sentry event. Normal reconnect (app restart with a saved bridge → pill Retry) still works, since a present descriptor or a failed probe proceeds unchanged.

Tests: `cd app && pnpm test` (3831 pass, incl. 3 new precheck cases), `pnpm tsgo --noEmit`, `cargo check`, `pnpm check` all green.