### PR TITLE
fix(app): rename during pod wake surfaces as waking notice, not a bug (PRODUCT-1607)

### DIFF
--- a/app/src/lib/engine-waking-error.ts
+++ b/app/src/lib/engine-waking-error.ts
@@ -21,31 +21,75 @@
 //    again seconds later (PRODUCT-1403 / HOUSTON-APP-4WQ).
 //
 // Keyed on the exact (status, gateway reason) pairs, NOT on bare 502/503:
-// other bodies on the same statuses ("setup pod unreachable", "agent pod
-// unusable", provider quota pages, self-host proxies) carry different reasons
-// and must keep surfacing as real errors. The read transport
+// other bodies on the same statuses ("setup pod unreachable", provider quota
+// pages, self-host proxies) carry different reasons and must keep surfacing as
+// real errors. The read transport
 // (`packages/web/src/engine-adapter/cp/transient-retry.ts`) parses the same
 // two answers on the wire and gives them the cold-start retry budget first;
 // this classifier decides how the ones that outlive that budget surface.
+//
+// Two client stacks reach the gateway, minting different error shapes (same
+// split as `agent-name-conflict.ts`):
+//
+//  - `HoustonEngineError` (legacy adapter): message is
+//    `"<reason> (engine error <status>)"`, reason verbatim — prefix-matched.
+//  - `AgentsHttpError` (the SDK agent-write path: rename/create/delete):
+//    message is the gateway's RAW JSON body, so the reason is parsed out of
+//    it. Renaming an asleep agent answered the same wake 503 but escaped this
+//    classifier into the red toast + Sentry pipeline because only the legacy
+//    shape was matched (HOUSTON-APP-536).
+//
+// The SDK write branch additionally treats `502 {"error":"agent pod
+// unusable"}` as a wake: on the gateway's agent-write routes that reason is
+// minted exactly when the engine PATCH/seed round-trip to the pod fails at the
+// transport level (`cloud/internal/edge/agents/routes.go` renameAgent) — the
+// observed shape is a rename retried seconds into a cold start, where the pod
+// accepts connections but hasn't answered before the gateway's deadline. The
+// gateway logs every such failure server-side ("agent pod unusable during
+// rename"), so classifying it quiet here loses no observability. On the legacy
+// shape "agent pod unusable" keeps surfacing as a real error: there it arrives
+// from the dispatch path, where a wedged pod is a bug we want reported.
 
 const ENGINE_UNAVAILABLE_503 = "engine unavailable";
 const ENGINE_PROXY_FAILED_502 = "engine proxy failed";
+const AGENT_POD_UNUSABLE_502 = "agent pod unusable";
+
+/** The gateway `error` reason out of an `AgentsHttpError` message, which
+ *  carries the response body verbatim; null when the body isn't gateway JSON
+ *  (an HTML error page, the synthetic `agents request failed: <status>`). */
+function gatewayReason(message: string): string | null {
+  if (!message.startsWith("{")) return null;
+  try {
+    const reason = (JSON.parse(message) as { error?: unknown } | null)?.error;
+    return typeof reason === "string" ? reason : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
- * A gateway "engine unavailable" 503 or "engine proxy failed" 502: the
- * agent's engine pod is warming up, restarting, or otherwise not accepting
- * connections, and the same request succeeds once it does. Matched
- * structurally (name + status + message prefix) so this stays dependency-free;
- * `HoustonEngineError` mints the message as `"<reason> (engine error <status>)"`
- * with the gateway's reason verbatim.
+ * A gateway "the agent's pod is not there right now" answer: the pod is
+ * warming up, restarting, or otherwise not accepting connections, and the same
+ * request succeeds once it does. Matched structurally (name + status + reason)
+ * so this stays dependency-free.
  */
 export function isEngineWakingError(err: unknown): boolean {
-  if (!(err instanceof Error) || err.name !== "HoustonEngineError") {
-    return false;
-  }
+  if (!(err instanceof Error)) return false;
   const status = (err as { status?: unknown }).status;
-  return (
-    (status === 503 && err.message.startsWith(ENGINE_UNAVAILABLE_503)) ||
-    (status === 502 && err.message.startsWith(ENGINE_PROXY_FAILED_502))
-  );
+  if (err.name === "HoustonEngineError") {
+    return (
+      (status === 503 && err.message.startsWith(ENGINE_UNAVAILABLE_503)) ||
+      (status === 502 && err.message.startsWith(ENGINE_PROXY_FAILED_502))
+    );
+  }
+  if (err.name === "AgentsHttpError") {
+    const reason = gatewayReason(err.message);
+    return (
+      (status === 503 && reason === ENGINE_UNAVAILABLE_503) ||
+      (status === 502 &&
+        (reason === ENGINE_PROXY_FAILED_502 ||
+          reason === AGENT_POD_UNUSABLE_502))
+    );
+  }
+  return false;
 }

--- a/app/tests/engine-waking-error.test.ts
+++ b/app/tests/engine-waking-error.test.ts
@@ -73,7 +73,7 @@ describe("isEngineWakingError", () => {
     );
   });
 
-  it("requires the HoustonEngineError shape", () => {
+  it("requires a known error shape", () => {
     strictEqual(
       isEngineWakingError(new Error("engine unavailable (engine error 503)")),
       false,
@@ -85,5 +85,100 @@ describe("isEngineWakingError", () => {
     strictEqual(isEngineWakingError({ status: 503 }), false);
     strictEqual(isEngineWakingError(null), false);
     strictEqual(isEngineWakingError(undefined), false);
+  });
+});
+
+/** The shape the SDK agent-write path throws (`AgentsHttpError`): the message
+ *  is the gateway's raw response body, verbatim. Structural stand-in, same as
+ *  above. */
+function agentsHttpError(status: number, body: string): Error {
+  const err = new Error(body) as Error & { status: number };
+  err.name = "AgentsHttpError";
+  err.status = status;
+  return err;
+}
+
+// HOUSTON-APP-536: renaming an asleep agent goes through the SDK write path,
+// whose error carries the gateway body raw — the wake answers must classify
+// quiet there too, including the rename route's transport-failure 502.
+describe("isEngineWakingError (SDK agent-write shape)", () => {
+  it("matches the wake 503 body", () => {
+    strictEqual(
+      isEngineWakingError(
+        agentsHttpError(
+          503,
+          '{"detail":"agent is waking","error":"engine unavailable"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("matches the proxy-failed 502 body", () => {
+    strictEqual(
+      isEngineWakingError(
+        agentsHttpError(
+          502,
+          '{"detail":"dial tcp: connection refused","error":"engine proxy failed"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("matches the rename route's pod-unusable 502 body", () => {
+    strictEqual(
+      isEngineWakingError(
+        agentsHttpError(
+          502,
+          '{"detail":"engine json: Patch \\"http://agent-x:4318/agents/A\\": context deadline exceeded","error":"agent pod unusable"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("never matches other reasons or statuses", () => {
+    strictEqual(
+      isEngineWakingError(
+        agentsHttpError(503, '{"error":"setup pod unreachable"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(
+        agentsHttpError(503, '{"error":"agent pod unusable"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(
+        agentsHttpError(500, '{"error":"engine unavailable"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(agentsHttpError(409, '{"error":"name taken"}')),
+      false,
+    );
+  });
+
+  it("never matches non-JSON bodies", () => {
+    strictEqual(
+      isEngineWakingError(agentsHttpError(503, "agents request failed: 503")),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(agentsHttpError(502, "<html>Bad Gateway</html>")),
+      false,
+    );
+    strictEqual(isEngineWakingError(agentsHttpError(503, "{not json")), false);
+  });
+
+  it("keeps pod-unusable a real error on the legacy shape (dispatch path)", () => {
+    strictEqual(
+      isEngineWakingError(engineError(502, "agent pod unusable")),
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Root cause

Renaming an agent whose pod is asleep answered the gateway's wake-time bodies — `503 {"error":"engine unavailable","detail":"agent is waking"}`, and on a retry seconds into the cold start `502 {"error":"agent pod unusable","detail":"engine json: Patch …: context deadline exceeded"}` — but the rename write goes through the SDK agent-write path, which throws `AgentsHttpError` carrying the raw JSON body as its message. The waking classifier (`app/src/lib/engine-waking-error.ts`) only matched the legacy `HoustonEngineError` shape (`"<reason> (engine error <status>)"`), so these self-healing pod-wake states escaped into the red bug toast + Sentry pipeline (HOUSTON-APP-536).

## Fix

`isEngineWakingError` now also matches the SDK write shape: it parses the gateway reason out of the raw body and classifies the same (status, reason) pairs as waking — `503 engine unavailable`, `502 engine proxy failed` — plus the agent-write routes' `502 agent pod unusable`, which the gateway mints exactly when its engine PATCH/seed round-trip to the pod fails at the transport level during a rename. The gateway already logs every such failure server-side, so nothing goes silent to us; the user gets the quiet "agent is waking up" notice instead of the red bug pair. On the legacy shape, `agent pod unusable` (the dispatch path) keeps surfacing as a real error, pinned by test.

## Verification

Before: on a cloud workspace, rename an agent whose pod is asleep → red "something went wrong" toast plus a Sentry `rename_agent: {"detail":"agent is waking","error":"engine unavailable"}` event (and on quick retry, the `agent pod unusable` / context-deadline flavor).

After: the same rename shows the deduped "your agent is waking up" notice, no Sentry event; retrying once the pod is awake succeeds. Non-wake failures (name conflict 409, `setup pod unreachable`, non-JSON 5xx bodies) still surface loud, covered in `app/tests/engine-waking-error.test.ts`.

Gates: `pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (3831 pass).

PRODUCT-1607