### PR TITLE
fix(app): warming probe treats agent-gone 404 as gone, not ready (PRODUCT-1604)

### DIFF
--- a/app/src/lib/agent-provisioning.ts
+++ b/app/src/lib/agent-provisioning.ts
@@ -19,9 +19,10 @@ import { queryKeys } from "./query-keys.ts";
 
 /**
  * Small, always-present, side-effect-free per-agent read. This is the typed
- * config doc path (`data/config.ts` / `readAgentJson("config")`) — if that
- * layout ever moves, update this constant with it, or every probe resolves
- * "ready" instantly off the 404 and the provisioning state never shows.
+ * config doc path (`data/config.ts` / `readAgentJson("config")`). A missing
+ * file answers 200 with empty content (`routes/agent-file.ts`), so the
+ * probe's verdict keys on reachability alone — the only 404 an agent-scoped
+ * read can produce is "agent not found" (see {@link probeSaysAgentGone}).
  */
 export const PROVISIONING_PROBE_FILE = ".houston/config/config.json";
 
@@ -175,16 +176,36 @@ export function warmingReadsAnswerEmpty(entry: ProvisioningEntry): boolean {
 /**
  * True when a failed probe means "the engine isn't answering yet, keep
  * waiting": a gateway 502/503/504 (still warming / rolling deploy) or a
- * transport-level failure with no HTTP verdict at all. Any definitive HTTP
- * answer — 200, 404 (file or agent gone), 401 — proves something responded
- * for this agent, so the "being created" state is over either way; if what
- * responded is broken, the user's own requests surface the real error.
+ * transport-level failure with no HTTP verdict at all. Any other definitive
+ * HTTP answer — 200, 401, 500 — proves something responded for this agent, so
+ * the "being created" state is over either way; if what responded is broken,
+ * the user's own requests surface the real error. A 404 is NOT "responded":
+ * see {@link probeSaysAgentGone}.
  */
 export function probeSaysStillStarting(err: unknown): boolean {
   if (!err || typeof err !== "object") return true;
   const status = (err as { status?: unknown }).status;
   if (typeof status !== "number") return true;
   return status === 502 || status === 503 || status === 504;
+}
+
+/**
+ * True when a failed probe means "the server no longer knows this agent"
+ * (HOUSTON-APP-4ZF). The probe read has exactly one 404 path: the
+ * gateway/host resolves the agent id before anything else and answers
+ * `404 { error: "agent not found" }` when it doesn't — a missing probe FILE
+ * answers 200 with empty content (`routes/agent-file.ts`), never 404. So a
+ * 404 here is the write-path twin of `isAgentGoneError`: the LOCAL ROSTER IS
+ * STALE (the agent was deleted or unshared elsewhere while a warming entry —
+ * possibly rehydrated from the localStorage mirror after a relaunch — still
+ * tracked it). Treating it as "ready" flushed the queued sends into the same
+ * 404 (`create_activity: agent not found` in Sentry, a red mission-row toast)
+ * for a state the user can't act on; the honest surface is a healed roster
+ * and a silently dropped entry.
+ */
+export function probeSaysAgentGone(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as { status?: unknown }).status === 404;
 }
 
 /** Parse the persisted map, dropping expired and malformed entries. */
@@ -262,6 +283,9 @@ export interface ProbeDeps {
   isMarked: (agentId: string) => boolean;
   /** Engine answered (with anything) — the agent is reachable. */
   onReady: (agentId: string) => void;
+  /** The server no longer knows the agent ({@link probeSaysAgentGone}):
+   *  drop the entry and heal the roster instead of flushing. */
+  onGone: (agentId: string, err: unknown) => void;
   /** TTL elapsed without the engine ever answering. */
   onTimeout: (agentId: string, error: ProvisioningTimeoutError) => void;
   sleep: (ms: number) => Promise<void>;
@@ -337,6 +361,7 @@ export async function runProvisioningProbe(
         () => "ready" as const,
         (err) => {
           lastError = err;
+          if (probeSaysAgentGone(err)) return "gone" as const;
           return probeSaysStillStarting(err)
             ? ("still-starting" as const)
             : ("ready" as const);
@@ -348,6 +373,10 @@ export async function runProvisioningProbe(
         entry.agentId,
         new ProvisioningTimeoutError(attempts, lastError),
       );
+      return;
+    }
+    if (outcome === "gone") {
+      deps.onGone(entry.agentId, lastError);
       return;
     }
     if (outcome === "ready") {

--- a/app/src/lib/cloud-migration-runner.ts
+++ b/app/src/lib/cloud-migration-runner.ts
@@ -69,6 +69,10 @@ function waitForAgentReady(agentId: string, agentPath: string): Promise<void> {
       readFile: (path, rel) => getEngine().readAgentFile(path, rel),
       isMarked: () => true, // the wizard task is the probe's whole lifetime
       onReady: () => resolve(),
+      // The agent the wizard JUST created answered "agent not found" — the
+      // creation didn't stick. A real failure here, not a stale roster: fail
+      // the step so the wizard surfaces it and Retry re-creates.
+      onGone: (_id, err) => reject(err),
       onTimeout: (_id, lastError) =>
         reject(lastError ?? new Error("the new assistant never became ready")),
       sleep: (ms) => new Promise<void>((r) => setTimeout(r, ms)),

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1420,7 +1420,11 @@ export const tauriActivity = {
       "create_activity",
       () => getEngine().createActivity(agentPath, input),
       undefined,
-      { toast: false },
+      // Agent-gone silenced (HOUSTON-APP-4ZF): a warming flush or mission
+      // create can race an agent deleted/unshared elsewhere — an expected
+      // roster-stale state, not a Houston bug. Both callers catch it: the
+      // flush heals + aborts, the mission path keeps its own toast.
+      { toast: false, silence: isAgentGoneError },
     ),
   update: (
     agentPath: string,

--- a/app/src/lib/warming-sends.ts
+++ b/app/src/lib/warming-sends.ts
@@ -19,6 +19,7 @@ import {
 } from "@houston-ai/engine-client";
 import { getConversationFeed } from "../hooks/use-conversation-vm";
 import { actingUser } from "./acting-user";
+import { isAgentGoneError } from "./agent-gone";
 import type {
   PendingWarmingSend,
   ProvisioningEntry,
@@ -28,6 +29,7 @@ import { showErrorToast } from "./error-toast";
 import i18n from "./i18n";
 import { logger } from "./logger";
 import { refreshMissionTitle } from "./mission-title";
+import { healStaleRosterFromError } from "./roster-heal";
 import { tauriActivity, tauriChat, tauriProvider } from "./tauri";
 import { verifyWarmingSendPin } from "./warming-send-pin";
 
@@ -185,7 +187,18 @@ export async function flushWarmingSends(
         if (Object.keys(patch).length > 0) {
           await getEngine().updateActivity(entry.agentPath, created.id, patch);
         }
-      } catch {
+      } catch (e) {
+        // The agent vanished between the readiness probe and this write
+        // (deleted/unshared elsewhere, HOUSTON-APP-4ZF): every remaining send
+        // is doomed to the same "agent not found" 404. Abort the flush and
+        // heal the roster instead of toasting a state the user can't act on
+        // — the probe's own gone-check catches this before the flush ever
+        // starts; this guards the in-flight race.
+        if (isAgentGoneError(e)) {
+          logger.warn(`[warming-sends] agent gone mid-flush, aborting: ${e}`);
+          healStaleRosterFromError(e);
+          return;
+        }
         showErrorToast(
           "warming_sends_row",
           "mission row create/update failed",
@@ -259,6 +272,13 @@ export async function flushWarmingSends(
         });
       }
     } catch (e) {
+      // Same in-flight race as the row create above: an agent-gone refusal
+      // dooms every remaining send, so stop instead of hammering 404s.
+      if (isAgentGoneError(e)) {
+        logger.warn(`[warming-sends] agent gone mid-flush, aborting: ${e}`);
+        healStaleRosterFromError(e);
+        return;
+      }
       // tauriChat.send already toasted the real reason; keep flushing the
       // rest — one refused turn must not strand the queue.
       logger.error(`[warming-sends] deferred send failed: ${e}`);

--- a/app/src/stores/agent-provisioning.ts
+++ b/app/src/stores/agent-provisioning.ts
@@ -29,7 +29,9 @@ import { getEngine, isCoLocatedEngine, whenEngineReady } from "../lib/engine";
 import { reportError } from "../lib/error-report";
 import { showErrorToast } from "../lib/error-toast";
 import i18n from "../lib/i18n";
+import { logger } from "../lib/logger";
 import { queryClient } from "../lib/query-client";
+import { healStaleRosterFromError } from "../lib/roster-heal";
 import {
   buildWarmingSend,
   flushWarmingSends,
@@ -267,6 +269,20 @@ function startProbe(entry: ProvisioningEntry): void {
           ),
         )
         .finally(() => store.clearProvisioning(id, entry));
+    },
+    onGone: (id, err) => {
+      // The server no longer knows this agent (deleted/unshared elsewhere
+      // while the entry — possibly rehydrated from the localStorage mirror —
+      // still tracked it, HOUSTON-APP-4ZF). Flushing would only fan the same
+      // "agent not found" 404 into every queued write; the honest surface is
+      // the roster without the agent. Silent by the agent-gone contract
+      // (`lib/agent-gone.ts`): log, heal the roster so the ghost disappears,
+      // drop the entry and its queue.
+      logger.warn(
+        `[agent-provisioning] agent gone during warm-up, dropping entry: ${id}`,
+      );
+      healStaleRosterFromError(err);
+      store.clearProvisioning(id, entry);
     },
     onTimeout: (id, error) => {
       // A newer mark (rename, or a fresh create reusing the id) already

--- a/app/tests/agent-provisioning.test.ts
+++ b/app/tests/agent-provisioning.test.ts
@@ -6,6 +6,7 @@ import {
   PROVISIONING_TTL_MS,
   ProvisioningTimeoutError,
   parsePersistedProvisioning,
+  probeSaysAgentGone,
   probeSaysStillStarting,
   runProvisioningProbe,
   warmingFlushRefetchKeys,
@@ -88,11 +89,22 @@ describe("probeSaysStillStarting", () => {
   });
 
   it("treats any definitive HTTP answer as the engine having responded", () => {
-    // 404: probe file (or the agent itself) is gone — either way something
-    // answered for this agent, so "being created" is over.
     strictEqual(probeSaysStillStarting(httpError(404)), false);
     strictEqual(probeSaysStillStarting(httpError(401)), false);
     strictEqual(probeSaysStillStarting(httpError(500)), false);
+  });
+});
+
+describe("probeSaysAgentGone (HOUSTON-APP-4ZF)", () => {
+  it("a 404 means the server no longer knows the agent — a missing probe file answers 200-empty", () => {
+    strictEqual(probeSaysAgentGone(httpError(404)), true);
+  });
+
+  it("everything else is not agent-gone", () => {
+    strictEqual(probeSaysAgentGone(httpError(401)), false);
+    strictEqual(probeSaysAgentGone(httpError(503)), false);
+    strictEqual(probeSaysAgentGone(new TypeError("fetch failed")), false);
+    strictEqual(probeSaysAgentGone(undefined), false);
   });
 });
 
@@ -213,8 +225,9 @@ describe("runProvisioningProbe", () => {
   const HELD = Symbol("held");
 
   function harness(readResults: Array<unknown | Error>) {
-    const calls = { ready: 0, timeout: 0, sleeps: 0, reads: 0 };
+    const calls = { ready: 0, gone: 0, timeout: 0, sleeps: 0, reads: 0 };
     let timeoutError: ProvisioningTimeoutError | undefined;
+    let goneError: unknown;
     let marked = true;
     let clock = 1;
     // The whole-probe TTL deadline is the one sleep longer than a retry
@@ -233,6 +246,11 @@ describe("runProvisioningProbe", () => {
       isMarked: () => marked,
       onReady: () => {
         calls.ready++;
+        marked = false;
+      },
+      onGone: (_id: string, err: unknown) => {
+        calls.gone++;
+        goneError = err;
         marked = false;
       },
       onTimeout: (_id: string, error: ProvisioningTimeoutError) => {
@@ -258,13 +276,24 @@ describe("runProvisioningProbe", () => {
       },
       fireDeadline: () => fireDeadline(),
     };
-    return { deps, calls, timeoutError: () => timeoutError };
+    return {
+      deps,
+      calls,
+      timeoutError: () => timeoutError,
+      goneError: () => goneError,
+    };
   }
 
   it("clears the moment the engine answers", async () => {
     const { deps, calls } = harness(["ok"]);
     await runProvisioningProbe(entry, deps);
-    deepStrictEqual(calls, { ready: 1, timeout: 0, sleeps: 0, reads: 1 });
+    deepStrictEqual(calls, {
+      ready: 1,
+      gone: 0,
+      timeout: 0,
+      sleeps: 0,
+      reads: 1,
+    });
   });
 
   it("retries through warm-up failures, then clears", async () => {
@@ -274,13 +303,40 @@ describe("runProvisioningProbe", () => {
       "ok",
     ]);
     await runProvisioningProbe(entry, deps);
-    deepStrictEqual(calls, { ready: 1, timeout: 0, sleeps: 2, reads: 3 });
+    deepStrictEqual(calls, {
+      ready: 1,
+      gone: 0,
+      timeout: 0,
+      sleeps: 2,
+      reads: 3,
+    });
   });
 
   it("treats a definitive HTTP failure as ready (engine responded)", async () => {
-    const { deps, calls } = harness([httpError(404)]);
+    const { deps, calls } = harness([httpError(401)]);
     await runProvisioningProbe(entry, deps);
-    deepStrictEqual(calls, { ready: 1, timeout: 0, sleeps: 0, reads: 1 });
+    deepStrictEqual(calls, {
+      ready: 1,
+      gone: 0,
+      timeout: 0,
+      sleeps: 0,
+      reads: 1,
+    });
+  });
+
+  it("resolves gone — never ready — when the server no longer knows the agent (HOUSTON-APP-4ZF)", async () => {
+    const err = httpError(404);
+    const { deps, calls, goneError } = harness([err]);
+    await runProvisioningProbe(entry, deps);
+    // Ready would flush the queued sends into the same 404.
+    deepStrictEqual(calls, {
+      ready: 0,
+      gone: 1,
+      timeout: 0,
+      sleeps: 0,
+      reads: 1,
+    });
+    strictEqual(goneError(), err);
   });
 
   it("times out with the last failure once the TTL elapses", async () => {
@@ -292,7 +348,13 @@ describe("runProvisioningProbe", () => {
       return p;
     };
     await runProvisioningProbe(entry, deps);
-    deepStrictEqual(calls, { ready: 0, timeout: 1, sleeps: 1, reads: 1 });
+    deepStrictEqual(calls, {
+      ready: 0,
+      gone: 0,
+      timeout: 1,
+      sleeps: 1,
+      reads: 1,
+    });
     const err = timeoutError();
     ok(err instanceof ProvisioningTimeoutError);
     strictEqual((err.cause as { status?: number }).status, 503);
@@ -308,7 +370,13 @@ describe("runProvisioningProbe", () => {
     await Promise.resolve();
     deps.fireDeadline();
     await probe;
-    deepStrictEqual(calls, { ready: 0, timeout: 1, sleeps: 0, reads: 1 });
+    deepStrictEqual(calls, {
+      ready: 0,
+      gone: 0,
+      timeout: 1,
+      sleeps: 0,
+      reads: 1,
+    });
     // No attempt ever failed, so there is no "last error" — the timeout must
     // still be a real, descriptive Error rather than a forwarded `undefined`
     // (that bare value is what Sentry used to receive).
@@ -328,6 +396,12 @@ describe("runProvisioningProbe", () => {
       return p;
     };
     await runProvisioningProbe(entry, deps);
-    deepStrictEqual(calls, { ready: 0, timeout: 0, sleeps: 1, reads: 1 });
+    deepStrictEqual(calls, {
+      ready: 0,
+      gone: 0,
+      timeout: 0,
+      sleeps: 1,
+      reads: 1,
+    });
   });
 });


### PR DESCRIPTION
## Root cause

Sentry HOUSTON-APP-4ZF: `create_activity: {"error":"agent not found"}` from `flushWarmingSends`.

A provisioning entry (HOU-693 warming state) can outlive its agent: deleted or unshared on another device while the entry — possibly rehydrated from the localStorage mirror after a relaunch — still tracked it. The readiness probe (`runProvisioningProbe`) counted ANY definitive HTTP answer as "engine answered → ready", including the gateway's `404 {"error":"agent not found"}`. It then flushed the queued sends at an agent the server no longer knows, fanning the same 404 into a Sentry `create_activity` error, a red mission-row toast, and a doomed chat send. The regressed event's breadcrumbs show exactly this: the probe read 404s, and 180ms later the activities POST 404s.

A missing probe file answers **200 with empty content** (`routes/agent-file.ts`), so a 404 on the probe has exactly one meaning: the agent is gone — the write-path twin of the `isAgentGoneError` contract already applied to passive reads (PRODUCT-1337/1400).

## Fix

- `lib/agent-provisioning.ts`: new `probeSaysAgentGone` classifier + a distinct `gone` probe verdict with an `onGone` dep.
- `stores/agent-provisioning.ts`: on `gone`, heal the roster and drop the entry silently (log only, no flush, no toast, no Sentry) — the honest surface is the roster without the agent.
- `lib/warming-sends.ts`: the in-flight race (agent deleted between probe and flush) heals + aborts the flush instead of toasting and hammering the remaining sends into 404s.
- `lib/tauri.ts`: `createWithId` silences agent-gone at the call layer (the exact Sentry capture point); both callers keep their own surfacing for every other failure.
- `lib/cloud-migration-runner.ts`: the migration wizard's probe **rejects** on gone — an agent it just created answering 404 is a real failure, not a stale roster.

## Verification

Before the fix: mark an agent as provisioning (or relaunch with a persisted warming entry) whose id the server no longer resolves — the probe resolves "ready", the flush POSTs `/agents/<id>/activities`, and Sentry gets `create_activity: agent not found` plus a red "mission row" toast.

After: same state → probe resolves "gone", the entry and its queue drop silently, the roster reloads and the ghost agent disappears. No toast, no Sentry event. Covered by new unit tests (`app/tests/agent-provisioning.test.ts`: `probeSaysAgentGone` + the `gone` probe outcome; 404 removed from the "ready" verdict).

Checks: `pnpm check` clean, `pnpm tsgo --noEmit` clean (app), `app pnpm test` 3828 pass, `houston-web typecheck` clean.