### PR TITLE
fix(app): waking 502 rejections skip Sentry in the global handler (PRODUCT-1609)

### DIFF
--- a/app/src/lib/error-report.ts
+++ b/app/src/lib/error-report.ts
@@ -1,4 +1,5 @@
 import { classifyAnalyticsError } from "./analytics";
+import { isEngineWakingError } from "./engine-waking-error";
 import i18n from "./i18n";
 import { isNetworkTransportError } from "./network-transport-error";
 import { captureException as sentryCapture } from "./sentry";
@@ -16,13 +17,16 @@ import {
  * silently invisible to crash reporting. Returns immediately; flush failures
  * are logged, never thrown.
  *
- * The one class that is NOT captured: transport-level network failures
- * (device offline / host unreachable — HOU-1085). Those are an expected
- * environment state, not a Houston bug; the engine-call layer classifies the
- * same failure as connectivity and declines to capture, and this layer
- * re-capturing it is what kept the `<command>: Failed to fetch (gateway…)`
- * Sentry family alive after HOU-1085 (HOUSTON-APP-4PQ, PRODUCT-1383). The raw
- * diagnostic still reaches the frontend log via the caller's `console.error`.
+ * Two classes are NOT captured, both expected environment states the
+ * engine-call layer already classifies and declines, where this layer
+ * re-capturing kept a Sentry family alive:
+ *  - transport-level network failures (device offline / host unreachable —
+ *    HOU-1085; HOUSTON-APP-4PQ, PRODUCT-1383 was this layer's leak);
+ *  - gateway waking answers (engine pod provisioning / restarting under a
+ *    roll — HOU-1114, PRODUCT-1403; same one-layer-left failure mode as
+ *    HOUSTON-APP-51C in the global rejection handler).
+ * The raw diagnostic still reaches the frontend log via the caller's
+ * `console.error`.
  */
 export function reportError(
   command: string,
@@ -30,6 +34,7 @@ export function reportError(
   originalError?: unknown,
 ): void {
   if (isNetworkTransportError(originalError)) return;
+  if (isEngineWakingError(originalError)) return;
   markReportedToSentry(originalError);
   const error = createSentryReportError(command, message, originalError);
   void sentryCapture(error, {

--- a/app/src/lib/global-error-handlers.ts
+++ b/app/src/lib/global-error-handlers.ts
@@ -4,7 +4,12 @@ import {
   isBenignAbortRejection,
   isBenignLockRejection,
 } from "./benign-rejections";
-import { showConnectivityErrorToast, showErrorToast } from "./error-toast";
+import { isEngineWakingError } from "./engine-waking-error";
+import {
+  showConnectivityErrorToast,
+  showEngineWakingToast,
+  showErrorToast,
+} from "./error-toast";
 import { isNetworkTransportError } from "./network-transport-error";
 
 /**
@@ -83,6 +88,21 @@ export function installGlobalErrorHandlers(): void {
       event.preventDefault();
       console.error("[global:unhandledrejection] connectivity drop:", message);
       showConnectivityErrorToast("unhandled_rejection", message);
+      return;
+    }
+    // A gateway "the agent's pod is not there right now" answer whose rejected
+    // promise nobody caught (HOUSTON-APP-51C: the mission-approve write hitting
+    // a pod mid engine-roll). The engine-call layer classifies the same failure
+    // as a waking state and shows the deduped waking toast, but `call` rethrows
+    // and card handlers deliberately don't catch — so it landed here, the last
+    // ungated surface, and was re-captured as `unhandled_rejection: engine
+    // proxy failed (engine error 502)`. Same policy as tauri.ts: one waking
+    // notice, no Sentry capture — nothing in Houston broke, the write succeeds
+    // on retry once the pod listens again.
+    if (isEngineWakingError(event.reason)) {
+      event.preventDefault();
+      console.error("[global:unhandledrejection] engine waking:", message);
+      showEngineWakingToast("unhandled_rejection", message);
       return;
     }
     console.error("[global:unhandledrejection]", message, event.reason);

--- a/app/tests/engine-waking-rejection-gate.test.ts
+++ b/app/tests/engine-waking-rejection-gate.test.ts
@@ -1,0 +1,71 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+// HOUSTON-APP-51C: a gateway waking 502 ("engine proxy failed") rejecting from
+// a promise nobody catches — the mission-approve `tauriActivity.update` write
+// hitting a pod mid engine-roll. The engine-call layer classified it as a
+// waking state (PRODUCT-1403) and showed the deduped waking toast, but `call`
+// rethrows and card handlers don't catch, so the same failure landed in
+// `window.onunhandledrejection` — the last surface without the waking gate —
+// and was re-captured to Sentry as `unhandled_rejection: engine proxy failed
+// (engine error 502)`. Same layered-gate shape as the connectivity family
+// (PRODUCT-1383 / PRODUCT-1392, see error-report-connectivity.test.ts).
+//
+// Asserted against the source rather than by calling the functions: both
+// modules pull i18n / analytics / the tauri barrel, none of which load under
+// this suite's `--experimental-strip-types` runner (same constraint and same
+// pattern as error-report-connectivity.test.ts).
+
+const read = (rel: string): string =>
+  readFileSync(join(import.meta.dirname, rel), "utf8");
+
+describe("global rejection handler declines engine-waking failures", () => {
+  const source = read("../src/lib/global-error-handlers.ts");
+
+  it("gates capture + red toast on isEngineWakingError", () => {
+    ok(
+      source.includes('from "./engine-waking-error"'),
+      "global-error-handlers.ts must import the waking classifier",
+    );
+    const body = source.slice(source.indexOf("window.onunhandledrejection ="));
+    const guard = body.indexOf("if (isEngineWakingError(event.reason))");
+    const capture = body.indexOf("analytics.captureException");
+    const redToast = body.indexOf("showErrorToast(");
+    ok(guard !== -1, "the rejection handler must gate on engine waking");
+    ok(
+      body.indexOf("showEngineWakingToast(", guard) !== -1,
+      "the waking branch must surface the deduped waking toast",
+    );
+    ok(
+      capture === -1 || guard < capture,
+      "the waking guard must run before the exception capture",
+    );
+    ok(
+      redToast === -1 || guard < redToast,
+      "the waking guard must run before the red error toast",
+    );
+  });
+});
+
+describe("reportError declines engine-waking failures", () => {
+  const source = read("../src/lib/error-report.ts");
+
+  it("gates the Sentry capture on isEngineWakingError", () => {
+    ok(
+      source.includes('from "./engine-waking-error"'),
+      "error-report.ts must import the waking classifier",
+    );
+    const body = source.slice(source.indexOf("export function reportError("));
+    const guard = body.indexOf(
+      "if (isEngineWakingError(originalError)) return;",
+    );
+    const capture = body.indexOf("sentryCapture");
+    ok(guard !== -1, "reportError must decline engine-waking errors");
+    ok(
+      capture === -1 || guard < capture,
+      "the waking guard must run before the Sentry capture",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

PRODUCT-1609 — Sentry regression `unhandled_rejection: engine proxy failed (engine error 502)` (HOUSTON-APP-51C).

**Root cause:** a gateway waking answer (502 `engine proxy failed` — the pod restarting under an engine roll; same family as 503 `engine unavailable`) rejecting from a promise nobody catches. The regression event is the mission-approve path: `handleApprove` → `tauriActivity.update` → agent-file write PUT → 502. The engine-call layer already classifies this as a waking state and shows the deduped waking toast, but `call` rethrows and card handlers deliberately don't catch — so the rejection landed in `window.onunhandledrejection`, the last surface without the waking gate, and was re-captured to Sentry (plus a red-path report) for a state where nothing in Houston broke.

**Fix:** gate the last two ungated surfaces on `isEngineWakingError`, mirroring the existing connectivity gates:
- `global-error-handlers.ts`: the rejection handler surfaces the deduped waking notice and skips the Sentry capture + red toast.
- `error-report.ts`: `reportError` declines waking errors, same as it declines network transport errors.

## Before the fix
1. On the hosted profile, with an agent whose pod is restarting (an engine roll, or kill the pod), check off a mission card (the Done checkmark) — or any activity write (archive/rename).
2. The write PUT answers 502 `{"error":"engine proxy failed"}`; the waking toast shows, but the rejection also reaches `window.onunhandledrejection` and captures a Sentry `unhandled_rejection: engine proxy failed (engine error 502)` event.

## After the fix
1. Same repro: the single deduped "agent waking up" notice shows, the rejection is logged (`[global:unhandledrejection] engine waking:`) — no Sentry event, no red path.
2. `cd app && pnpm test` — includes the new `tests/engine-waking-rejection-gate.test.ts` asserting both gates sit before the captures.

## Checks
- `pnpm check` ✓, `cd app && pnpm tsgo --noEmit` ✓, `pnpm test` (3839 pass) ✓, `pnpm check-locales` ✓