### PR TITLE
fix(app): provider login during setup-pod wake surfaces as waking, not a bug (PRODUCT-1612)

### DIFF
--- a/app/src/lib/engine-waking-error.ts
+++ b/app/src/lib/engine-waking-error.ts
@@ -21,15 +21,15 @@
 //    again seconds later (PRODUCT-1403 / HOUSTON-APP-4WQ).
 //
 // Keyed on the exact (status, gateway reason) pairs, NOT on bare 502/503:
-// other bodies on the same statuses ("setup pod unreachable", provider quota
-// pages, self-host proxies) carry different reasons and must keep surfacing as
-// real errors. The read transport
-// (`packages/web/src/engine-adapter/cp/transient-retry.ts`) parses the same
-// two answers on the wire and gives them the cold-start retry budget first;
-// this classifier decides how the ones that outlive that budget surface.
+// other bodies on the same statuses (provider quota pages, self-host proxies)
+// carry different reasons and must keep surfacing as real errors. The read
+// transport (`packages/web/src/engine-adapter/cp/transient-retry.ts`) parses
+// the same two answers on the wire and gives them the cold-start retry budget
+// first; this classifier decides how the ones that outlive that budget
+// surface.
 //
-// Two client stacks reach the gateway, minting different error shapes (same
-// split as `agent-name-conflict.ts`):
+// Three client stacks reach the gateway, minting different error shapes (same
+// split as `agent-name-conflict.ts`, plus the runtime client):
 //
 //  - `HoustonEngineError` (legacy adapter): message is
 //    `"<reason> (engine error <status>)"`, reason verbatim — prefix-matched.
@@ -38,6 +38,13 @@
 //    it. Renaming an asleep agent answered the same wake 503 but escaped this
 //    classifier into the red toast + Sentry pipeline because only the legacy
 //    shape was matched (HOUSTON-APP-536).
+//  - `EngineError` (`@houston/runtime-client` — the per-agent runtime and the
+//    pre-agent setup-runtime clients): carries the raw response text in
+//    `body`, so the reason is parsed the same way. First-run provider login
+//    against a setup pod still provisioning answered
+//    `503 {"error":"engine unavailable","detail":"setup pod unreachable"}` but
+//    escaped into the red toast + Sentry pipeline because this shape wasn't
+//    matched (PRODUCT-1612 / HOUSTON-APP-4VN).
 //
 // The SDK write branch additionally treats `502 {"error":"agent pod
 // unusable"}` as a wake: on the gateway's agent-write routes that reason is
@@ -54,13 +61,13 @@ const ENGINE_UNAVAILABLE_503 = "engine unavailable";
 const ENGINE_PROXY_FAILED_502 = "engine proxy failed";
 const AGENT_POD_UNUSABLE_502 = "agent pod unusable";
 
-/** The gateway `error` reason out of an `AgentsHttpError` message, which
- *  carries the response body verbatim; null when the body isn't gateway JSON
+/** The gateway `error` reason out of a raw response body (an `AgentsHttpError`
+ *  message or an `EngineError` `body`); null when it isn't gateway JSON
  *  (an HTML error page, the synthetic `agents request failed: <status>`). */
-function gatewayReason(message: string): string | null {
-  if (!message.startsWith("{")) return null;
+function gatewayReason(body: string): string | null {
+  if (!body.startsWith("{")) return null;
   try {
-    const reason = (JSON.parse(message) as { error?: unknown } | null)?.error;
+    const reason = (JSON.parse(body) as { error?: unknown } | null)?.error;
     return typeof reason === "string" ? reason : null;
   } catch {
     return null;
@@ -89,6 +96,14 @@ export function isEngineWakingError(err: unknown): boolean {
       (status === 502 &&
         (reason === ENGINE_PROXY_FAILED_502 ||
           reason === AGENT_POD_UNUSABLE_502))
+    );
+  }
+  if (err.name === "EngineError") {
+    const body = (err as { body?: unknown }).body;
+    const reason = typeof body === "string" ? gatewayReason(body) : null;
+    return (
+      (status === 503 && reason === ENGINE_UNAVAILABLE_503) ||
+      (status === 502 && reason === ENGINE_PROXY_FAILED_502)
     );
   }
   return false;

--- a/app/tests/engine-waking-error.test.ts
+++ b/app/tests/engine-waking-error.test.ts
@@ -182,3 +182,100 @@ describe("isEngineWakingError (SDK agent-write shape)", () => {
     );
   });
 });
+
+/** The shape `@houston/runtime-client` throws (`EngineError`): the message is
+ *  `engine request failed (<status>): <body>` and `body` carries the raw
+ *  response text. Structural stand-in, same as above. */
+function runtimeEngineError(status: number, body: string): Error {
+  const err = new Error(
+    `engine request failed (${status}): ${body}`,
+  ) as Error & {
+    status: number;
+    body: string;
+  };
+  err.name = "EngineError";
+  err.status = status;
+  err.body = body;
+  return err;
+}
+
+// PRODUCT-1612 / HOUSTON-APP-4VN: first-run provider login runs in the hidden
+// setup runtime through `@houston/runtime-client`, whose error carries the raw
+// gateway body in `body` — the wake answers must classify quiet on this third
+// shape too (a setup pod still provisioning showed the red bug pair + Sentry).
+describe("isEngineWakingError (runtime-client shape)", () => {
+  it("matches the setup-pod wake 503 body (PRODUCT-1612)", () => {
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(
+          503,
+          '{"detail":"setup pod unreachable","error":"engine unavailable"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("matches the agent wake 503 body", () => {
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(
+          503,
+          '{"detail":"agent is waking","error":"engine unavailable"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("matches the proxy-failed 502 body", () => {
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(
+          502,
+          '{"detail":"dial tcp: connection refused","error":"engine proxy failed"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("never matches other reasons or statuses", () => {
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(503, '{"error":"setup pod unreachable"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(502, '{"error":"agent pod unusable"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(500, '{"error":"engine unavailable"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(runtimeEngineError(409, '{"error":"name taken"}')),
+      false,
+    );
+  });
+
+  it("never matches non-JSON or missing bodies", () => {
+    strictEqual(
+      isEngineWakingError(runtimeEngineError(503, "<html>Bad Gateway</html>")),
+      false,
+    );
+    strictEqual(isEngineWakingError(runtimeEngineError(503, "")), false);
+    const bodyless = new Error("engine request failed (503): ") as Error & {
+      status: number;
+    };
+    bodyless.name = "EngineError";
+    bodyless.status = 503;
+    strictEqual(isEngineWakingError(bodyless), false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1612 (Sentry HOUSTON-APP-4VN): `launch_provider_login: engine request failed (503): {"detail":"setup pod unreachable","error":"engine unavailable"}` — 37 events / 16 users in 14d.

**Root cause.** The gateway answers a provider login whose hidden setup pod is still provisioning or cold-booting with `503 {"error":"engine unavailable","detail":"setup pod unreachable"}` — a self-healing wake state (the gateway re-ensures the pod awake once, then answers the retryable 503). The pre-agent login path runs through `@houston/runtime-client`, whose `EngineError` shape (`engine request failed (<status>): <body>`) the waking classifier `isEngineWakingError` never matched — it only knew the `HoustonEngineError` and `AgentsHttpError` shapes. So the wake 503 escaped into the red bug toast + Sentry pipeline instead of the quiet "waking up" notice.

**Fix.** Teach `isEngineWakingError` the third client stack: `EngineError` carries the raw gateway body in `.body`, so parse the `error` reason out of it and match the same (status, reason) wake pairs as the other shapes — `503 engine unavailable` and `502 engine proxy failed`. Other reasons/statuses on this shape keep surfacing as real errors.

## Before (reproduction)

1. Cloud/hosted profile, fresh org (or one whose setup pod was torn down by an agent create).
2. Start first-run onboarding and click Connect on a provider while the setup pod is still provisioning/cold-booting (or with the pod deliberately unreachable).
3. The gateway answers the wake 503 above; the app shows the red "report a bug" toast pair and captures a Sentry event titled `launch_provider_login: engine request failed (503): ...`.

## After (verification)

1. Same steps: the failure now surfaces as the single deduped engine-waking notice, no red bug toast, no Sentry capture; retrying once the pod is up proceeds normally. The raw diagnostic stays in the frontend log tail (`[engine:launch_provider_login] ...`).
2. Unit coverage: `cd app && pnpm test` — new `isEngineWakingError (runtime-client shape)` suite in `app/tests/engine-waking-error.test.ts` covers the setup-pod wake body, the agent wake body, proxy-failed 502, and the negative cases (other reasons, other statuses, non-JSON/missing bodies).

## Checks

- `pnpm check` clean (Biome)
- `cd app && pnpm test` — 3842 pass
- `cd app && pnpm tsgo --noEmit` clean