### PR TITLE
fix(shell): gate dictation on the whisper-cli CPU baseline instead of crashing (PRODUCT-1611)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1391,9 +1391,11 @@ jobs:
       # Build the whisper.cpp dictation sidecar (whisper-cli, MIT) for the matrix
       # target BEFORE tauri build. build.rs::stage_whisper_sidecar copies
       # target/whisper/whisper-cli-<target>.exe to the externalBin name
-      # binaries/whisper-cli-<target>.exe (same pattern as frpc). CPU-only portable
-      # (GGML_NATIVE=OFF), self-contained (static). The `test -x` gate FAILS the
-      # release rather than shipping the loud-fail placeholder.
+      # binaries/whisper-cli-<target>.exe (same pattern as frpc). CPU-only,
+      # self-contained (static), pinned to the AVX2 (Haswell 2013+) baseline on
+      # x86-64 — older CPUs are gated in-app (dictation/cpu.rs), never crashed.
+      # The `test -x` gate FAILS the release rather than shipping the loud-fail
+      # placeholder.
       - name: Build whisper-cli dictation sidecar (${{ matrix.target }})
         shell: bash
         run: |

--- a/app/src-tauri/src/dictation/cpu.rs
+++ b/app/src-tauri/src/dictation/cpu.rs
@@ -1,0 +1,42 @@
+//! CPU capability gate for the bundled `whisper-cli` sidecar.
+//!
+//! The Windows and Linux x86-64 whisper-cli builds carry a Haswell-era (2013+)
+//! instruction baseline — AVX2/FMA/F16C/BMI2, pinned in
+//! `scripts/build-whisper.sh`. On an older x86-64 CPU the child dies instantly
+//! with an illegal-instruction fault (`0xc000001d` on Windows), which read to
+//! the user as an unexplained "didn't work, try again" toast they retried in
+//! vain. Detect the gap BEFORE offering the 181 MB model download or spawning
+//! the sidecar, so the frontend can show honest "this computer can't run voice
+//! typing" copy instead (same pattern as `crate::claude_login`'s helper gate).
+//!
+//! macOS is exempt on both arches: the x86_64 slice is cross-compiled
+//! (arm64 runner via CMAKE_OSX_ARCHITECTURES), which builds ggml's portable
+//! baseline kernels, so pre-AVX2 Intel Macs run it fine.
+
+/// Whether the bundled whisper-cli can execute on this machine's CPU.
+pub(super) fn cpu_supported() -> bool {
+    #[cfg(all(target_arch = "x86_64", not(target_os = "macos")))]
+    {
+        // AVX2 implies the rest of the pinned baseline (FMA/F16C/BMI2 all
+        // arrived with Haswell), so one probe covers it.
+        std::arch::is_x86_feature_detected!("avx2")
+    }
+    #[cfg(not(all(target_arch = "x86_64", not(target_os = "macos"))))]
+    {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_supported_on_capable_hardware() {
+        // Every CI/dev host (Apple Silicon, AVX2-era x86-64) can run the
+        // sidecar; a pre-AVX2 x86-64 has no CI representation, so this pins
+        // the common-path contract instead: no false positives that would
+        // hide voice typing from capable machines.
+        assert!(cpu_supported());
+    }
+}

--- a/app/src-tauri/src/dictation/mod.rs
+++ b/app/src-tauri/src/dictation/mod.rs
@@ -10,6 +10,7 @@
 //! staged by Tauri's `externalBin` and resolved via [`crate::child_guard`],
 //! sharing the same orphan-prevention discipline as the engine/frpc sidecars.
 
+mod cpu;
 mod model;
 mod types;
 mod verify;

--- a/app/src-tauri/src/dictation/model.rs
+++ b/app/src-tauri/src/dictation/model.rs
@@ -54,6 +54,7 @@ pub async fn dictation_model_status(app: AppHandle) -> Result<DictationModelStat
         ready: is_ready(&path),
         model_id: MODEL_ID.to_string(),
         size_bytes: MODEL_SIZE_BYTES,
+        cpu_supported: super::cpu::cpu_supported(),
     })
 }
 

--- a/app/src-tauri/src/dictation/types.rs
+++ b/app/src-tauri/src/dictation/types.rs
@@ -9,6 +9,10 @@ pub struct DictationModelStatus {
     pub ready: bool,
     pub model_id: String,
     pub size_bytes: u64,
+    /// False when this machine's CPU cannot execute the bundled whisper-cli
+    /// (pre-AVX2 x86-64 on Windows/Linux — see [`super::cpu`]). The frontend
+    /// then explains instead of offering the model download.
+    pub cpu_supported: bool,
 }
 
 /// A single progress tick emitted on the `dictation-model-progress` channel
@@ -42,11 +46,13 @@ mod tests {
             ready: true,
             model_id: "ggml-small-q5_1".to_string(),
             size_bytes: 42,
+            cpu_supported: true,
         })
         .unwrap();
         assert!(json.contains("\"ready\":true"));
         assert!(json.contains("\"modelId\":\"ggml-small-q5_1\""));
         assert!(json.contains("\"sizeBytes\":42"));
+        assert!(json.contains("\"cpuSupported\":true"));
     }
 
     #[test]

--- a/app/src-tauri/src/dictation/whisper.rs
+++ b/app/src-tauri/src/dictation/whisper.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 use tauri::ipc::{InvokeBody, Request};
 use tauri::{AppHandle, Manager};
 
-use super::{model, wav};
+use super::{cpu, model, wav};
 use crate::child_guard;
 
 /// Monotonic suffix so concurrent transcriptions never collide on a temp path.
@@ -33,6 +33,14 @@ pub async fn transcribe_audio(app: AppHandle, request: Request<'_>) -> Result<St
             .get("x-dictation-lang")
             .and_then(|v| v.to_str().ok()),
     );
+
+    // Gate BEFORE spawning: on a pre-AVX2 x86-64 the sidecar dies with an
+    // illegal instruction (0xc000001d on Windows). Exact string — the
+    // frontend maps it to translated "this computer can't run voice typing"
+    // copy with no bug report: nothing in Houston broke.
+    if !cpu::cpu_supported() {
+        return Err("dictation-unsupported-cpu".into());
+    }
 
     let model_path = model::model_path(&app)?;
     if std::fs::metadata(&model_path).is_err() {

--- a/app/src/lib/dictation/types.ts
+++ b/app/src/lib/dictation/types.ts
@@ -13,7 +13,15 @@ export interface DictationModelStatus {
   ready: boolean;
   modelId: string;
   sizeBytes: number;
+  /** False when this machine's CPU cannot run the bundled whisper-cli
+   *  (pre-AVX2 x86-64 on Windows/Linux): explain, never offer the download. */
+  cpuSupported: boolean;
 }
+
+/** Exact reject string `transcribe_audio` returns on a CPU that cannot run
+ *  the sidecar (mirrors `dictation/whisper.rs`). An expected machine limit,
+ *  not a bug: mapped to translated copy, never a Sentry report. */
+export const DICTATION_UNSUPPORTED_CPU = "dictation-unsupported-cpu";
 
 /** A single progress tick on the `dictation-model-progress` event, mirroring
  *  `ModelProgress` in the Rust shell (`download_dictation_model`). */

--- a/app/src/lib/dictation/use-dictation-model-setup.ts
+++ b/app/src/lib/dictation/use-dictation-model-setup.ts
@@ -9,7 +9,8 @@
  * is being captured yet.
  */
 import { useCallback, useMemo, useState } from "react";
-import { showErrorToast } from "../error-toast";
+import { useTranslation } from "react-i18next";
+import { showErrorToast, showExpectedStateToast } from "../error-toast";
 import { osDictationModelStatus } from "../os-bridge";
 import { downloadDictationModel } from "./model-download";
 import {
@@ -46,6 +47,7 @@ export interface UseDictationModelSetupResult {
 export function useDictationModelSetup(
   onReady: () => void,
 ): UseDictationModelSetupResult {
+  const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [progressPct, setProgressPct] = useState(0);
@@ -63,6 +65,15 @@ export function useDictationModelSetup(
   const ensureReady = useCallback(async () => {
     try {
       const status = await osDictationModelStatus();
+      // Expected machine limit (pre-AVX2 CPU can't run the sidecar): explain
+      // BEFORE offering the 181 MB download that could never be used.
+      if (!status.cpuSupported) {
+        showExpectedStateToast(
+          t("composer.dictation.unsupportedTitle"),
+          t("composer.dictation.unsupportedBody"),
+        );
+        return;
+      }
       if (status.ready) {
         onReady();
         return;
@@ -72,7 +83,7 @@ export function useDictationModelSetup(
     } catch (err) {
       showErrorToast("dictation_model_status", errorText(err), err);
     }
-  }, [onReady]);
+  }, [onReady, t]);
 
   const confirm = useCallback(async () => {
     setDownloading(true);

--- a/app/src/lib/dictation/use-dictation.ts
+++ b/app/src/lib/dictation/use-dictation.ts
@@ -12,11 +12,12 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useUIStore } from "../../stores/ui";
 import { analytics } from "../analytics";
-import { showErrorToast } from "../error-toast";
+import { showErrorToast, showExpectedStateToast } from "../error-toast";
 import { osTranscribeAudio } from "../os-bridge";
 import { dictationReducer, INITIAL_DICTATION_STATE } from "./dictation-reducer";
 import { type DictationRecording, startDictationRecording } from "./recorder";
 import {
+  DICTATION_UNSUPPORTED_CPU,
   type DictationLangHint,
   dictationErrorText as errorText,
 } from "./types";
@@ -97,6 +98,14 @@ export function useDictation({
         dispatch({ type: "transcribeSettled" });
         if (errorText(err) === "model-not-ready") {
           void reopen();
+        } else if (errorText(err) === DICTATION_UNSUPPORTED_CPU) {
+          // Expected machine limit (the CPU can't run the sidecar — normally
+          // caught by ensureReady, this covers a model downloaded before the
+          // gate existed): explain, no bug report.
+          showExpectedStateToast(
+            t("composer.dictation.unsupportedTitle"),
+            t("composer.dictation.unsupportedBody"),
+          );
         } else {
           // Report-only path first, then authored copy: the user spoke and
           // pressed stop, so a silent drop reads as "it sent nothing"

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -28,7 +28,9 @@
       "setupProgress": "Downloading... {{pct}}%",
       "micDenied": "Houston needs microphone access. Allow it in system settings, then try again.",
       "noMic": "No microphone was found.",
-      "failed": "Voice typing didn't work this time. Please try again."
+      "failed": "Voice typing didn't work this time. Please try again.",
+      "unsupportedTitle": "Voice typing isn't available on this computer",
+      "unsupportedBody": "This computer's processor is too old for voice typing. Everything else keeps working normally."
     }
   },
   "mentions": {

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -28,7 +28,9 @@
       "setupProgress": "Descargando... {{pct}}%",
       "micDenied": "Houston necesita acceso al micrófono. Permítelo en la configuración del sistema y vuelve a intentarlo.",
       "noMic": "No se encontró ningún micrófono.",
-      "failed": "El dictado por voz no funcionó esta vez. Inténtalo de nuevo."
+      "failed": "El dictado por voz no funcionó esta vez. Inténtalo de nuevo.",
+      "unsupportedTitle": "El dictado por voz no está disponible en esta computadora",
+      "unsupportedBody": "El procesador de esta computadora es demasiado antiguo para el dictado por voz. Todo lo demás sigue funcionando con normalidad."
     }
   },
   "mentions": {

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -28,7 +28,9 @@
       "setupProgress": "Baixando... {{pct}}%",
       "micDenied": "O Houston precisa de acesso ao microfone. Permita nas configurações do sistema e tente novamente.",
       "noMic": "Nenhum microfone foi encontrado.",
-      "failed": "A digitação por voz não funcionou desta vez. Tente novamente."
+      "failed": "A digitação por voz não funcionou desta vez. Tente novamente.",
+      "unsupportedTitle": "O ditado por voz não está disponível neste computador",
+      "unsupportedBody": "O processador deste computador é muito antigo para o ditado por voz. Todo o resto continua funcionando normalmente."
     }
   },
   "mentions": {

--- a/scripts/build-whisper.sh
+++ b/scripts/build-whisper.sh
@@ -190,8 +190,29 @@ case "$OS" in
     )
     ;;
   windows | linux)
-    # CPU-only, portable across CPUs (no -march=native), self-contained.
+    # CPU-only, self-contained. GGML_NATIVE=OFF stops -march=native, but it
+    # does NOT make a native x86-64 configure portable: ggml then defaults the
+    # whole SSE4.2/AVX/AVX2/BMI2/FMA/F16C family ON (INS_ENB), so this binary
+    # REQUIRES a Haswell-era (2013+) CPU and dies with an illegal instruction
+    # (0xc000001d on Windows) on anything older. That baseline is deliberate —
+    # AVX2 is a large speedup for ggml's CPU kernels and, unlike macOS/Metal,
+    # the CPU path is the only path here — so pin the flags explicitly to keep
+    # a whisper.cpp bump from silently raising it (e.g. to AVX-512), and keep
+    # them in sync with the pre-flight gate in
+    # app/src-tauri/src/dictation/cpu.rs, which shows older CPUs honest
+    # "not available on this computer" copy instead of a crash.
     CMAKE_FLAGS+=(-DGGML_NATIVE=OFF)
+    if [ "$ARCH" = "x86_64" ]; then
+      CMAKE_FLAGS+=(
+        -DGGML_SSE42=ON
+        -DGGML_AVX=ON
+        -DGGML_AVX2=ON
+        -DGGML_BMI2=ON
+        -DGGML_FMA=ON
+        -DGGML_F16C=ON
+        -DGGML_AVX512=OFF
+      )
+    fi
     # Statically link the MSVC C/C++ runtime. BUILD_SHARED_LIBS=OFF only
     # covers whisper/ggml themselves — MSVC still defaults to /MD, leaving the
     # shipped exe dependent on MSVCP140.dll/VCRUNTIME140.dll, which machines


### PR DESCRIPTION
## Problem (PRODUCT-1611)

Sentry regression `dictation_transcribe: dictation: whisper exited with exit code: 0xc000001d` — STATUS_ILLEGAL_INSTRUCTION on Windows.

Root cause: the Windows/Linux x86-64 `whisper-cli` builds require AVX2. `GGML_NATIVE=OFF` does not produce a portable binary on a native x86-64 configure — ggml's CMake then defaults the whole SSE4.2/AVX/AVX2/BMI2/FMA/F16C flag family ON (`INS_ENB`, verified in whisper.cpp v1.9.1 `ggml/CMakeLists.txt`). On a pre-Haswell (pre-2013) CPU the sidecar dies instantly with an illegal instruction; the user saw an unexplained "didn't work, try again" toast they retried in vain, and every retry filed a Sentry error. The macOS x86_64 slice is unaffected (cross-compiled from the arm64 runner, which builds ggml's portable baseline).

## Fix

Same pattern as the Claude sign-in helper's AVX2 gate: detect the gap before running, treat it as an expected machine limit.

- `app/src-tauri/src/dictation/cpu.rs` (new): AVX2 pre-flight on x86-64 Windows/Linux (AVX2 implies the rest of the Haswell baseline). macOS and arm64 always pass.
- `transcribe_audio` returns the sentinel `dictation-unsupported-cpu` before spawning; `dictation_model_status` now carries `cpuSupported` so the frontend never offers the 181 MB model download to a machine that can't use it.
- Frontend maps both paths to expected-state copy (en/es/pt), with no Sentry report — nothing in Houston broke. All other failures keep the existing report + retry toast.
- `scripts/build-whisper.sh` now pins the x86-64 instruction flags explicitly (deliberate AVX2 baseline; keeps a whisper.cpp bump from silently raising it, e.g. to AVX-512) and documents the contract with the Rust gate.

Keeping the AVX2 build (rather than shipping a portable SSE-only binary) is deliberate: AVX2 is a large speedup for ggml's CPU kernels and the CPU path is the only path on Windows/Linux; slowing every user's transcription for the small pre-2013 cohort would be the wrong trade.

## Before

On a pre-AVX2 Windows machine: mic button → model download offered/completed → record → "Voice typing didn't work this time. Please try again." on every attempt, plus a `dictation_transcribe` Sentry error with exit code 0xc000001d.

## After / verification

1. `cd app/src-tauri && cargo test dictation` — 16 tests green (new: CPU-gate common-path pin, `cpuSupported` serialization).
2. On a pre-AVX2 machine (or by temporarily inverting `cpu_supported()`): mic button → one informational toast "Voice typing isn't available on this computer", no download dialog, no red toast, no Sentry event.
3. On a normal machine: dictation flow unchanged (probe returns `cpuSupported: true`).
4. Gates run: Biome, `app pnpm tsgo --noEmit`, `check-locales` (en/es/pt in sync), app unit tests (3837 pass), `cargo check`, houston-web typecheck + shim parity.

Sidecar builds are unchanged in behavior for supported CPUs; the pinned flags reproduce what CI already emitted implicitly.