### PR TITLE
fix(ci): bake staging store site URL into staging web builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,6 +485,9 @@ jobs:
       # steps aside and publish rides the engine base, while store-catalog reads
       # this value for browse.
       VITE_AGENTSTORE_GATEWAY_URL: ${{ matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL }}
+      # The store SITE base for browse/"view listing" links (falls back to the
+      # prod catalog site when unset — staging-published agents would 404 there).
+      VITE_AGENTSTORE_SITE_URL: ${{ matrix.flavor == 'staging' && 'https://staging-agents.gethouston.ai' || 'https://agents.gethouston.ai' }}
       VITE_CLIENT_METRICS_GATEWAY_URL: ${{ matrix.flavor == 'staging' && secrets.HOSTED_ENGINE_URL_STAGING || secrets.HOSTED_ENGINE_URL }}
     steps:
       - name: Checkout

--- a/.github/workflows/web-staging.yml
+++ b/.github/workflows/web-staging.yml
@@ -88,6 +88,11 @@ jobs:
           # published agents into the real prod catalog and folded QA timings into
           # the prod Prometheus histograms. Same secret as the gateway above.
           VITE_AGENTSTORE_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL_STAGING }}
+          # The store SITE (not API) base for browse/"view listing" links
+          # (web/src/engine-adapter/store-gateway.ts). Falls back to the prod
+          # catalog site when unset, which 404s for staging-published agents.
+          # Public hostname, so a literal — no secret needed.
+          VITE_AGENTSTORE_SITE_URL: https://staging-agents.gethouston.ai
           VITE_CLIENT_METRICS_GATEWAY_URL: ${{ secrets.HOSTED_ENGINE_URL_STAGING }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}


### PR DESCRIPTION
Staging web builds (preview + the staging DMG flavor) bake `VITE_AGENTSTORE_GATEWAY_URL` to the staging gateway but leave `VITE_AGENTSTORE_SITE_URL` unset, so `STORE_SITE_URL` (`packages/web/src/engine-adapter/store-gateway.ts`) falls back to the prod catalog site. Browse/"view listing" links from a staging build then open the prod site, where staging-published agents 404.

The staging store site exists and serves the staging gateway's catalog, so this bakes its hostname into `web-staging.yml` and the `release.yml` staging flavor (prod flavor pinned to the same value as the code fallback, so behavior there is unchanged). Public hostnames, so literals — no new secrets.

Verified against staging: an authenticated publish returns `shareUrl` on the staging site host (composed server-side), the agent resolves on the staging catalog API and 404s on prod, and delete cleans it up.