### PR TITLE
fix(store): integration marks resolve real brand domains and never render broken

### DIFF
--- a/app/src/components/integrations/app-display.ts
+++ b/app/src/components/integrations/app-display.ts
@@ -3,6 +3,7 @@ import type {
   IntegrationToolkit,
 } from "@houston-ai/engine-client";
 import { groupAccounts } from "./connected-apps-model.ts";
+import { curatedIntegrationOf } from "./curated-integrations.ts";
 
 /**
  * Resolving a toolkit slug to a real display name / logo / description (with
@@ -87,7 +88,12 @@ export function connectionRows(
 }
 
 export function fallbackLogo(toolkit: string): string {
-  return `https://www.google.com/s2/favicons?domain=${toolkit}.com&sz=128`;
+  // A curated slug's brand lives on its OWN domain — croma.com is an
+  // unrelated retailer whose green-C favicon shipped on every catalog-miss
+  // surface (skill chips, chat rows) until this looked the entry up.
+  const curated = curatedIntegrationOf(toolkit);
+  const domain = curated ? new URL(curated.website).hostname : `${toolkit}.com`;
+  return `https://www.google.com/s2/favicons?domain=${domain}&sz=128`;
 }
 
 /**

--- a/app/src/components/integrations/app-logo.tsx
+++ b/app/src/components/integrations/app-logo.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@houston-ai/core";
 import { useState } from "react";
 import type { AppDisplay } from "./app-display";
+import { curatedLogoUrl } from "./curated-logos";
 
 const SIZES = {
   xs: "size-4",
@@ -56,7 +57,12 @@ export function AppLogo({
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
   const box = cn(SIZES[size], "shrink-0 rounded-lg", className);
 
-  if (!display.logoUrl || failedUrl === display.logoUrl) {
+  // A curated slug's brand mark ships IN the bundle — every surface that
+  // renders through this component gets it with zero network, instead of a
+  // favicon-proxy round-trip that can fail (and once left Croma a letter).
+  const logoUrl = curatedLogoUrl(display.toolkit) || display.logoUrl;
+
+  if (!logoUrl || failedUrl === logoUrl) {
     return (
       <span className={cn(box, "flex items-center justify-center bg-input")}>
         <span className={cn("font-semibold text-ink-muted", LETTER_SIZE[size])}>
@@ -67,12 +73,12 @@ export function AppLogo({
   }
   return (
     <img
-      src={display.logoUrl}
+      src={logoUrl}
       alt={display.name}
       loading="lazy"
       decoding="async"
       className={cn(box, "object-contain")}
-      onError={() => setFailedUrl(display.logoUrl)}
+      onError={() => setFailedUrl(logoUrl)}
     />
   );
 }

--- a/app/tests/app-display.test.ts
+++ b/app/tests/app-display.test.ts
@@ -145,3 +145,14 @@ describe("custom brand fallbacks (HOU-1049)", () => {
     strictEqual(prettifyCustomSlug("my_api"), "My Api");
   });
 });
+
+describe("fallbackLogo", () => {
+  it("guesses <slug>.com for unknown toolkits", () => {
+    strictEqual(fallbackLogo("slack").includes("domain=slack.com"), true);
+  });
+
+  it("resolves a curated slug's real brand domain, never <slug>.com", () => {
+    // croma.com is an unrelated retailer; the curated entry knows the brand.
+    strictEqual(fallbackLogo("croma").includes("domain=usecroma.com"), true);
+  });
+});

--- a/ui/store/src/components/agent-card.tsx
+++ b/ui/store/src/components/agent-card.tsx
@@ -2,9 +2,10 @@
 
 import { cn } from "@houston-ai/core";
 import { Plus, Sparkle } from "lucide-react";
-import { integrationLogoUrl, resolveIntegrationLabels } from "../integrations";
+import { resolveIntegrationLabels } from "../integrations";
 import type { StoreAgentRow, StoreLinkComponent } from "../types";
 import { AgentTile } from "./agent-tile";
+import { IntegrationMark } from "./integration-mark";
 
 const PlainLink: StoreLinkComponent = (props) => <a {...props} />;
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
@@ -144,11 +145,10 @@ export function IntegrationLogos({
       )}
     >
       {logos.map(({ slug, label }) => (
-        <img
+        <IntegrationMark
           key={slug}
-          src={integrationLogoUrl(slug)}
-          alt={label}
-          title={label}
+          slug={slug}
+          label={label}
           className="size-4"
         />
       ))}

--- a/ui/store/src/components/integration-mark.tsx
+++ b/ui/store/src/components/integration-mark.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { cn } from "@houston-ai/core";
+import { useState } from "react";
+import { integrationLogoUrl } from "../integrations";
+
+/**
+ * One integration's brand mark: the favicon-service image with a letter-tile
+ * fallback. The favicon service answers 404 for a domain it cannot resolve
+ * (guessed `<slug>.com` domains often are not real), and the bare `<img>`s
+ * this replaces rendered those as broken/blank squares on the store cards.
+ * A failed load latches to a quiet letter tile instead — honest, and it keeps
+ * the "works with" row's count truthful.
+ */
+export function IntegrationMark({
+  slug,
+  label,
+  className,
+}: {
+  slug: string;
+  /** The resolved display label; its first letter is the fallback glyph. */
+  label: string;
+  /** Sizing from the call site (`size-4` on cards, `size-5` on the detail). */
+  className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return (
+      <span
+        role="img"
+        aria-label={label}
+        title={label}
+        className={cn(
+          "grid shrink-0 place-items-center rounded bg-chip font-medium text-[9px] text-ink-muted",
+          className,
+        )}
+      >
+        {label.charAt(0).toUpperCase()}
+      </span>
+    );
+  }
+  return (
+    <img
+      src={integrationLogoUrl(slug)}
+      alt={label}
+      title={label}
+      className={cn("shrink-0", className)}
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/ui/store/src/index.ts
+++ b/ui/store/src/index.ts
@@ -42,6 +42,7 @@ export {
   InstallsPanel,
   toInstallsDayBars,
 } from "./components/installs-panel";
+export { IntegrationMark } from "./components/integration-mark";
 export type { OwnedAgentCardLabels } from "./components/owned-agent-card";
 export {
   OWNED_AGENT_CARD_LABELS,

--- a/ui/store/src/integrations.ts
+++ b/ui/store/src/integrations.ts
@@ -55,6 +55,10 @@ const DOMAIN_BY_SLUG = new Map([
   ["TWITTER", "x.com"],
   ["LINEAR", "linear.app"],
   ["QUICKBOOKS", "quickbooks.intuit.com"],
+  // Houston's curated integrations: the brand domain is NOT `<slug>.com` —
+  // croma.com is an unrelated electronics retailer whose green-C favicon
+  // shipped on the store's Croma marks until this entry existed.
+  ["CROMA", "usecroma.com"],
 ]);
 
 export function humanizeIntegrationSlug(slug: string) {
@@ -85,6 +89,12 @@ export function listStoreIntegrations(): CatalogIntegration[] {
 }
 
 export function integrationLogoUrl(slug: string) {
-  const domain = DOMAIN_BY_SLUG.get(slug) ?? `${slug.toLowerCase()}.com`;
+  // Case-insensitive: Composio slugs arrive uppercase ("GMAIL"), Houston's
+  // custom/curated slugs lowercase ("croma") — both must hit the same row.
+  // The guess drops separators too: "ONE_DRIVE" must become onedrive.com,
+  // not the invalid hostname one_drive.com the favicon service 404s.
+  const domain =
+    DOMAIN_BY_SLUG.get(slug.toUpperCase()) ??
+    `${slug.toLowerCase().replace(/[^a-z0-9-]/g, "")}.com`;
   return `https://www.google.com/s2/favicons?domain=${domain}&sz=128`;
 }

--- a/ui/store/src/screens/agent-detail-screen.tsx
+++ b/ui/store/src/screens/agent-detail-screen.tsx
@@ -2,7 +2,8 @@ import type { ReactNode } from "react";
 import type { AgentCardLabels } from "../components/agent-card";
 import { AgentDetailLayout } from "../components/agent-detail-layout";
 import { AgentGrid } from "../components/grids";
-import { integrationLogoUrl, resolveIntegrationLabels } from "../integrations";
+import { IntegrationMark } from "../components/integration-mark";
+import { resolveIntegrationLabels } from "../integrations";
 import type {
   StoreAgentRow,
   StoreLinkComponent,
@@ -81,7 +82,7 @@ export function AgentDetailScreen({
           <ul className="flex flex-wrap gap-x-8 gap-y-4">
             {integrations.map(({ slug, label }) => (
               <li key={slug} className="flex items-center gap-2.5">
-                <img src={integrationLogoUrl(slug)} alt="" className="size-5" />
+                <IntegrationMark slug={slug} label={label} className="size-5" />
                 <span className="text-[15px] text-ink-muted">{label}</span>
               </li>
             ))}

--- a/ui/store/tests/integration-logos.test.ts
+++ b/ui/store/tests/integration-logos.test.ts
@@ -1,0 +1,23 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+import { integrationLogoUrl } from "../src/integrations.ts";
+
+const domainOf = (url: string) => new URL(url).searchParams.get("domain") ?? "";
+
+describe("integrationLogoUrl", () => {
+  it("maps Croma to its real brand domain — croma.com is an unrelated retailer", () => {
+    assert.equal(domainOf(integrationLogoUrl("CROMA")), "usecroma.com");
+  });
+
+  it("resolves the domain map case-insensitively (Houston slugs are lowercase)", () => {
+    assert.equal(domainOf(integrationLogoUrl("croma")), "usecroma.com");
+    assert.equal(domainOf(integrationLogoUrl("gmail")), "mail.google.com");
+    assert.equal(domainOf(integrationLogoUrl("GMAIL")), "mail.google.com");
+  });
+
+  it("guessed domains drop separators — an underscore makes an invalid hostname the favicon service 404s", () => {
+    assert.equal(domainOf(integrationLogoUrl("ONE_DRIVE")), "onedrive.com");
+    assert.equal(domainOf(integrationLogoUrl("NOTION")), "notion.com");
+  });
+});


### PR DESCRIPTION
## What

Two icon bugs on the Agent Store's integration marks (agent cards' "works with" row and the detail page's "Works with" section):

1. **Croma showed the wrong company's logo.** `integrationLogoUrl` guesses favicons from `<slug>.com`, and `croma.com` is an unrelated electronics retailer (the green "C" that shipped). The domain map now carries `CROMA → usecroma.com`, resolves **case-insensitively** (Houston's custom/curated slugs are lowercase, Composio's uppercase — both must hit the same row), and guessed domains drop separators so `ONE_DRIVE`-style slugs stop producing invalid hostnames the favicon service 404s.
2. **Unknown favicons rendered as broken/blank squares.** Both render sites used bare `<img>`s with no error handling, so a 404 from the favicon service painted a broken box. A shared `IntegrationMark` component latches a failed load to a quiet letter tile (chip surface, first letter of the resolved label), keeping the row honest instead of visually broken.

## Testing

- New `ui/store/tests/integration-logos.test.ts`: Croma domain mapping, case-insensitive lookups, separator stripping.
- `@houston-ai/store` 44 tests, agentstore typecheck + 89 tests, workspace typecheck, Biome, `check:parity` — all green.
- Verified live that `s2/favicons?domain=usecroma.com` serves Croma's real brand mark and that unresolvable domains answer 404 (the fallback path).