### PR TITLE
perf(runtime): cap integration_execute results at 64 KB so one dump can't rot the chat

### DIFF
--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -311,7 +311,9 @@ test("a giant execute result is truncated with recovery guidance, never fed whol
     params: { include_payload: true },
   });
   const text = (out.content[0] as { text: string }).text;
-  expect(text.length).toBeLessThan(300 * 1024);
+  // 64 KB budget + the recovery marker: a bloated result must never re-bill
+  // tens of thousands of context tokens on every later request in the chat.
+  expect(text.length).toBeLessThan(66 * 1024);
   expect(text).toContain("[result truncated");
   expect(text).toContain("Re-run the action with tighter parameters");
 });

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -176,15 +176,22 @@ const REQUEST_CONNECTION_GUIDANCE =
   "To let the user connect an app, call the request_connection tool with that app's toolkit (the slug shown in the results). Houston shows the user a one-click connect card in place of the chat input, then automatically sends you a message once the connection is live so you can continue - do not ask the user to confirm.";
 
 /**
- * Ceiling for one integration tool result, aligned with the code sandbox's
- * output limit (code-sandbox DEFAULT_LIMITS.maxOutputBytes). App APIs return
- * unbounded documents — a single GMAIL_FETCH_EMAILS with include_payload can
- * exceed 1 MB of JSON, which alone overflows a model's context window and
- * terminally errors the turn (every event-trigger run on a newsletter inbox
- * died this way, HOU-893). Truncate with an instructive marker instead: the
- * model re-runs the action with tighter parameters rather than the turn dying.
+ * Ceiling for one integration EXECUTE result. App APIs return unbounded
+ * documents — a single GMAIL_FETCH_EMAILS with include_payload can exceed 1 MB
+ * of JSON, which alone overflows a model's context window and terminally
+ * errors the turn (every event-trigger run on a newsletter inbox died this
+ * way, HOU-893). Truncate with an instructive marker instead: the model
+ * re-runs the action with tighter parameters rather than the turn dying.
+ *
+ * 64 KB (~16k tokens), down from the original 256 KB: every result lands in
+ * the conversation permanently and is RE-SENT on every subsequent request, so
+ * one 256 KB dump (~65k tokens) kept burning a quarter of a model window per
+ * turn for the rest of the chat — the dominant driver of subscription-limit
+ * exhaustion on ChatGPT/Codex accounts. Fleet data: p99 of real execute
+ * results is ~29 KB; only the pathological full-payload dumps exceed 64 KB,
+ * and those are exactly the ones the recovery marker exists for.
  */
-const MAX_RESULT_CHARS = 256 * 1024;
+const MAX_RESULT_CHARS = 64 * 1024;
 
 /**
  * Search results get a MUCH tighter ceiling than execute data: they are a


### PR DESCRIPTION
## PRODUCT-1618

### Root cause (investigation summary)

Users on ChatGPT/Codex subscriptions burn their usage windows fast because **unbounded tool results permanently rot the conversation context**: every result lands in history and is re-sent to the model on every subsequent request of that chat. Production session data (Codex-provider agents) showed:

- `integration_search` results up to **169 KB** (~42k tokens) each — already fixed by the search budget shipped in the previous engine release, verified bounded (~23 KB) in sessions written by post-roll pods.
- `integration_execute` results up to **256 KB** (~65k tokens) each — still unbounded in effect: one full-payload dump keeps re-billing a quarter of a model window on every later turn. Fleet distribution: p50 535 chars, p90 1.1 KB, p99 ~29 KB, max 286 KB (n=721).

One sampled 11-user-turn conversation burned **347k uncached input + 3.0M cached-read tokens**, dominated by these dumps. Prompt caching itself is healthy (stable `prompt_cache_key` per session, growing `cacheRead`), so this is a context-size problem, not a caching bug.

### Fix

Lower the execute-result ceiling from 256 KB to **64 KB** (~16k tokens). The existing truncation marker already teaches the model to re-run the action with tighter parameters (fewer results, specific ids/fields, no full payloads), which is the correct behavior for the <1% of results this touches. Same tool objects serve the pi and Claude backends, so all providers benefit.

### Verify before

1. On a build without this change, run an integration action that returns a huge payload (e.g. `GMAIL_FETCH_EMAILS` with `include_payload: true` on a full inbox).
2. Inspect the conversation's session `.jsonl`: the `integration_execute` toolResult is up to ~256 KB, and every later assistant message's `usage` re-reads that context (input + cacheRead ≥ payload size, every turn).

### Verify after

1. Same action: the toolResult text is cut at 64 KB with the `[result truncated: ... 64 KB tool-result limit ...]` marker, and the model re-runs with tighter parameters.
2. `pnpm --filter @houston/runtime test` — 1535 tests green, including the updated "giant execute result is truncated" test asserting the 64 KB bound.