### PR TITLE
fix(app): web file downloads open a blob tab instead of saving (PRODUCT-1619)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -187,13 +187,26 @@ export default function App() {
   // routes through the same `openUrl`) would otherwise have it opened a SECOND
   // time — two browser tabs for one click (PRODUCT-1231). `defaultPrevented`
   // is precisely the signal "somebody already dealt with this".
+  //
+  // It must also SKIP download anchors and object URLs. `saveBlob` hands a
+  // Blob to browser builds via a synthetic `<a download href="blob:…">` click;
+  // preventing that default kills the download and "opening" a blob: URL just
+  // renders the bytes in a tab (a blob: URL is meaningless to any other
+  // process anyway).
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (e.defaultPrevented) return;
       const anchor = (e.target as HTMLElement).closest("a[href]");
       if (!anchor) return;
+      if (anchor.hasAttribute("download")) return;
       const href = anchor.getAttribute("href");
-      if (!href || href.startsWith("#") || href.startsWith("javascript:"))
+      if (
+        !href ||
+        href.startsWith("#") ||
+        href.startsWith("javascript:") ||
+        href.startsWith("blob:") ||
+        href.startsWith("data:")
+      )
         return;
       e.preventDefault();
       tauriSystem.openUrl(href);

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -152,3 +152,34 @@ test("the agent row owns Download all in browser builds", async ({ page }) => {
     page.getByRole("menuitem", { name: "Download all" }),
   ).toBeVisible();
 });
+
+// `saveBlob` hands the browser a synthetic `<a download href="blob:…">` click.
+// The app-level anchor safety net used to intercept it, which cancelled the
+// download and window.open'd the blob into a fresh tab instead. Pin the whole
+// contract: the click yields a real browser download with the file's bytes,
+// and no extra page opens.
+test("Download in the file preview saves the bytes and never opens a tab", async ({
+  page,
+  context,
+}) => {
+  await openFiles(page);
+
+  const extraPages: unknown[] = [];
+  context.on("page", (p) => extraPages.push(p));
+
+  await row(page, "sales.csv").getByText("sales.csv").click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("a,b")).toBeVisible();
+
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    dialog.getByRole("button", { name: "Download" }).click(),
+  ]);
+  // Headless Chromium names blob downloads with a GUID — assert bytes, not
+  // suggestedFilename().
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(chunk as Buffer);
+  expect(Buffer.concat(chunks).toString()).toBe("a,b\n1,2\n");
+  expect(extraPages).toHaveLength(0);
+});


### PR DESCRIPTION
## Root cause

The document-level anchor safety net in `app/src/App.tsx` catches every anchor click whose default wasn't prevented and routes the href through `openUrl`. `saveBlob` (`app/src/lib/save-blob.ts`) hands a Blob to browser builds via a synthetic `<a download href="blob:…">` click — which bubbles to that listener with `defaultPrevented === false`. The listener `preventDefault()`'d it (cancelling the browser's download machinery) and `window.open`'d the blob URL, so every web download opened a tab rendering the raw bytes instead of saving.

Desktop was unaffected: `saveBlob` takes the native save-dialog path under Tauri. Nothing caught this because `files.spec.ts` only asserted the Download **menu item is visible**, never that a download happens.

## Fix

The safety net now skips anchors carrying a `download` attribute and `blob:`/`data:` hrefs (an object URL is meaningless to any other process, so routing it to `openUrl` is never right). Affects every web download surface: file preview Download, Files row Download / Download all, portable agent export.

## Tests

New e2e in `files.spec.ts` pins the full contract: clicking Download in the file preview yields a real browser `download` event whose bytes match the file, and no extra page opens. Verified red on the unfixed code, green with the fix. `pnpm check`, workspace typecheck, shim-parity guard, app unit tests, and the files e2e project all pass.

## Verify

**Before:** on the web app, open any file in the Files preview and click Download → a new tab opens at `blob:https://…` showing the file contents; nothing is saved.
**After:** the same click triggers a normal browser download (save prompt / downloads bar); no tab opens.

PRODUCT-1619