### PR TITLE
feat(store): add the Legal category to the Agent Store vocabulary

### DIFF
--- a/app/src/lib/store-categories.ts
+++ b/app/src/lib/store-categories.ts
@@ -27,6 +27,7 @@ export const STORE_CATEGORIES = [
   "data",
   "education",
   "finance",
+  "legal",
   "customer-support",
   "personal",
   "fun",

--- a/app/src/locales/en/portable.json
+++ b/app/src/locales/en/portable.json
@@ -191,6 +191,7 @@
       "data": "Data & Spreadsheets",
       "education": "Education & Learning",
       "finance": "Finance & Money",
+      "legal": "Legal",
       "customer-support": "Customer Support",
       "personal": "Personal & Lifestyle",
       "fun": "Fun & Games",

--- a/app/src/locales/es/portable.json
+++ b/app/src/locales/es/portable.json
@@ -191,6 +191,7 @@
       "data": "Datos y hojas de cálculo",
       "education": "Educación y aprendizaje",
       "finance": "Finanzas y dinero",
+      "legal": "Legal",
       "customer-support": "Atención al cliente",
       "personal": "Personal y estilo de vida",
       "fun": "Diversión y juegos",

--- a/app/src/locales/pt/portable.json
+++ b/app/src/locales/pt/portable.json
@@ -191,6 +191,7 @@
       "data": "Dados e planilhas",
       "education": "Educação e aprendizagem",
       "finance": "Finanças e dinheiro",
+      "legal": "Jurídico",
       "customer-support": "Suporte ao cliente",
       "personal": "Pessoal e estilo de vida",
       "fun": "Diversão e jogos",

--- a/app/tests/store-categories.test.ts
+++ b/app/tests/store-categories.test.ts
@@ -20,6 +20,7 @@ const SEED_SLUGS = [
   "data",
   "education",
   "finance",
+  "legal",
   "customer-support",
   "personal",
   "fun",
@@ -28,7 +29,7 @@ const SEED_SLUGS = [
 
 describe("STORE_CATEGORIES", () => {
   it("matches the seeded store vocabulary exactly and in order", () => {
-    strictEqual(STORE_CATEGORIES.length, 14);
+    strictEqual(STORE_CATEGORIES.length, 15);
     deepStrictEqual([...STORE_CATEGORIES], SEED_SLUGS);
   });
 


### PR DESCRIPTION
Adds `legal` ("Legal") to the Agent Store category vocabulary on the houston side: the publish wizard's select (after Finance), the typed `StoreCategory` union, and the translated labels (en "Legal", es "Legal", pt "Jurídico") the browse filter reuses through `resolveStoreCategoryLabel`.

The runtime vocabulary is served by the gateway, which gains the matching entry in its own change (gethouston/cloud#337). Ship order does not matter: the browse filter labels unknown gateway slugs with the gateway-provided name, and a publish with `legal` only needs the gateway entry live.

Tests: vocabulary pin updated (15 entries), app 3,862 tests, `check-locales`, typechecks, Biome — green.