### PR TITLE
fix(shell): demote log-bridged updater and TLS errors to Sentry breadcrumbs (PRODUCT-1634)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "keyring",
+ "log",
  "notify-rust",
  "objc2",
  "objc2-app-kit",
@@ -2107,6 +2108,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
+ "tracing-log",
  "tracing-subscriber",
  "windows-sys 0.59.0",
 ]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -39,6 +39,10 @@ sentry = "0.42"
 # Layer is a no-op until sentry::init has run, so safe to register
 # unconditionally in logging.rs even when SENTRY_DSN is empty.
 sentry-tracing = "0.42"
+# `NormalizeEvent`: recovers the real target of `log`-bridged records (Tauri
+# plugins, rustls) inside the Sentry event mapper (src/sentry_filter.rs).
+# Already in the tree via tracing-subscriber's `tracing-log` feature.
+tracing-log = "0.2"
 # keyring v3 backends are OPT-IN per platform. Without a Linux feature the
 # crate silently compiles its in-memory mock on Linux — auth_set_item
 # "succeeds" into a throwaway object and every session evaporates on quit
@@ -123,3 +127,8 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Securit
 # XDG/D-Bus-only — on Windows we use the WinRT toast's `on_activated` callback
 # to catch the click. This is the crate notify-rust uses under the hood.
 tauri-winrt-notification = "0.7"
+
+[dev-dependencies]
+# `log::error!(target: ...)` in sentry_filter tests: drives the real
+# log → tracing bridge the way Tauri plugins and rustls do in production.
+log = "0.4"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod loopback_util;
 mod notification;
 mod notification_settings;
 mod oauth_loopback;
+mod sentry_filter;
 mod shell_env;
 mod store_deep_link;
 mod window_focus;

--- a/app/src-tauri/src/logging.rs
+++ b/app/src-tauri/src/logging.rs
@@ -15,11 +15,10 @@ static GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 ///   - `sentry_tracing::layer()` → INFO+ events become Sentry breadcrumbs;
 ///     ERROR events become standalone Sentry events. No-op if `sentry::init`
 ///     hasn't been called (e.g. empty SENTRY_DSN), so safe to always include.
-///     Exception: `tauri_plugin_updater` ERRORs stay breadcrumbs — the plugin
-///     logs one on every failed background update poll (machine offline,
-///     GitHub down, transient non-2xx from the release manifest), and the
-///     frontend already owns that failure (5-min poll retry, install-error
-///     card), so a standalone Sentry event per poll is noise.
+///     Which records are demoted (updater polls, OS trust-store rejections)
+///     lives in `crate::sentry_filter`; it hooks `event_mapper` rather than
+///     `event_filter` because `log`-bridged records carry the static target
+///     `"log"` in their metadata and only the mapper can see the real one.
 ///
 /// Result: when a Rust panic or explicit `tracing::error!` lands in Sentry,
 /// the last ~100 INFO/WARN log lines auto-attach as breadcrumbs — the
@@ -30,7 +29,7 @@ static GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 /// may contain file paths (e.g. `binary.display()`) and agent names. This
 /// is a conscious tradeoff — debug value > privacy for crash data on a
 /// beta product. Revisit if leak surface becomes a real concern; sanitize
-/// via `sentry_tracing::layer().event_mapper(...)` at that point.
+/// inside `crate::sentry_filter::map_event` at that point.
 ///
 /// Call once at app startup, before any other code runs.
 pub fn init(data_dir: &Path) {
@@ -57,33 +56,8 @@ pub fn init(data_dir: &Path) {
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)
-        .with(sentry_tracing::layer().event_filter(|metadata| {
-            if demote_error_to_breadcrumb(metadata.target()) {
-                sentry_tracing::EventFilter::Breadcrumb
-            } else {
-                sentry_tracing::default_event_filter(metadata)
-            }
-        }))
+        .with(sentry_tracing::layer().event_mapper(crate::sentry_filter::map_event))
         .init();
-}
-
-/// Targets whose ERROR logs must NOT become standalone Sentry events.
-///
-/// `tauri_plugin_updater` fires `log::error!` on every unsuccessful update
-/// check — including the expected ones (offline, GitHub unreachable or
-/// returning a transient non-2xx for the channel manifest). The check
-/// failure is fully handled in the frontend updater hooks, so Sentry only
-/// needs the breadcrumb trail, not an event per 5-minute poll
-/// (Sentry HOUSTON-APP-14).
-///
-/// `rustls_platform_verifier` fires `log::error!` internally whenever the
-/// OS trust store rejects a peer certificate (e.g. a machine behind a
-/// misconfigured corporate MITM proxy whose root even Windows won't chain).
-/// The failing request already returns `Err` and its caller owns surfacing
-/// it, so the verifier's own log line is a duplicate — one Sentry event per
-/// retry from a handful of broken machines (Sentry HOUSTON-APP-PE).
-fn demote_error_to_breadcrumb(target: &str) -> bool {
-    target.starts_with("tauri_plugin_updater") || target.starts_with("rustls_platform_verifier")
 }
 
 fn logs_dir() -> PathBuf {
@@ -174,27 +148,6 @@ fn tail_file(path: &Path, n: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn updater_plugin_errors_are_demoted_to_breadcrumbs() {
-        assert!(demote_error_to_breadcrumb("tauri_plugin_updater::updater"));
-        assert!(demote_error_to_breadcrumb("tauri_plugin_updater"));
-    }
-
-    #[test]
-    fn tls_platform_verifier_errors_are_demoted_to_breadcrumbs() {
-        assert!(demote_error_to_breadcrumb(
-            "rustls_platform_verifier::verification::windows"
-        ));
-        assert!(demote_error_to_breadcrumb("rustls_platform_verifier"));
-    }
-
-    #[test]
-    fn app_errors_still_become_sentry_events() {
-        assert!(!demote_error_to_breadcrumb("houston_app"));
-        assert!(!demote_error_to_breadcrumb("houston_app::engine_supervisor"));
-        assert!(!demote_error_to_breadcrumb("tauri_plugin_sentry"));
-    }
 
     #[test]
     fn latest_log_matching_uses_newest_rotated_backend_log() {

--- a/app/src-tauri/src/sentry_filter.rs
+++ b/app/src-tauri/src/sentry_filter.rs
@@ -1,0 +1,191 @@
+//! Decides what each tracing record becomes in Sentry: a standalone event,
+//! a breadcrumb, or nothing.
+//!
+//! Records bridged from the `log` crate (every Tauri plugin, reqwest, rustls,
+//! `rustls-platform-verifier`…) reach tracing through `tracing_log::LogTracer`
+//! with the STATIC target `"log"`; the real module path only exists in the
+//! event's fields (`log.target`). A `SentryLayer::event_filter` closure sees
+//! that static `Metadata`, so any target-based rule silently matches nothing
+//! for exactly the crates it was written for. This module therefore hooks
+//! `event_mapper`, which receives the whole event and can recover the emitting
+//! target via `NormalizeEvent::normalized_metadata`.
+use sentry_tracing::{breadcrumb_from_event, event_from_event, EventFilter, EventMapping};
+use tracing::{Event, Subscriber};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+/// `event_mapper` for `sentry_tracing::layer()`: same shape as the layer's
+/// built-in mapping (ERROR → event, WARN/INFO → breadcrumb, below → ignored),
+/// except that demoted targets never become standalone events.
+pub fn map_event<S>(event: &Event<'_>, _ctx: Context<'_, S>) -> EventMapping
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    // Span attributes are not enabled on the layer, so no span context is
+    // attached — identical to the layer's default path.
+    let no_span: Option<&Context<'_, S>> = None;
+    let filter = filter_for(event);
+    let mut items = Vec::with_capacity(2);
+    if filter.contains(EventFilter::Breadcrumb) {
+        items.push(EventMapping::Breadcrumb(breadcrumb_from_event(
+            event, no_span,
+        )));
+    }
+    if filter.contains(EventFilter::Event) {
+        items.push(EventMapping::Event(event_from_event(event, no_span)));
+    }
+    EventMapping::Combined(items.into())
+}
+
+/// Resolves the Sentry action for one record from its EFFECTIVE target.
+pub fn filter_for(event: &Event<'_>) -> EventFilter {
+    let normalized = event.normalized_metadata();
+    let metadata = normalized.as_ref().unwrap_or_else(|| event.metadata());
+    if demote_error_to_breadcrumb(metadata.target()) {
+        EventFilter::Breadcrumb
+    } else {
+        sentry_tracing::default_event_filter(metadata)
+    }
+}
+
+/// Targets whose ERROR logs must NOT become standalone Sentry events.
+///
+/// `tauri_plugin_updater` fires `log::error!` on every unsuccessful update
+/// check — including the expected ones (offline, GitHub unreachable or
+/// returning a transient non-2xx for the channel manifest). The check
+/// failure is fully handled in the frontend updater hooks, so Sentry only
+/// needs the breadcrumb trail, not an event per 5-minute poll
+/// (Sentry HOUSTON-APP-14, HOUSTON-APP-S).
+///
+/// `rustls_platform_verifier` fires `log::error!` internally whenever the
+/// OS trust store rejects a peer certificate (e.g. a machine behind a
+/// misconfigured corporate MITM proxy whose root even Windows won't chain).
+/// The failing request already returns `Err` and its caller owns surfacing
+/// it, so the verifier's own log line is a duplicate — one Sentry event per
+/// retry from a handful of broken machines (Sentry HOUSTON-APP-PE).
+pub fn demote_error_to_breadcrumb(target: &str) -> bool {
+    target.starts_with("tauri_plugin_updater") || target.starts_with("rustls_platform_verifier")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex, Once};
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[test]
+    fn updater_plugin_errors_are_demoted_to_breadcrumbs() {
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater::updater"));
+        assert!(demote_error_to_breadcrumb("tauri_plugin_updater"));
+    }
+
+    #[test]
+    fn tls_platform_verifier_errors_are_demoted_to_breadcrumbs() {
+        assert!(demote_error_to_breadcrumb(
+            "rustls_platform_verifier::verification::windows"
+        ));
+        assert!(demote_error_to_breadcrumb("rustls_platform_verifier"));
+    }
+
+    #[test]
+    fn app_errors_still_become_sentry_events() {
+        assert!(!demote_error_to_breadcrumb("houston_app"));
+        assert!(!demote_error_to_breadcrumb(
+            "houston_app::engine_supervisor"
+        ));
+        assert!(!demote_error_to_breadcrumb("tauri_plugin_sentry"));
+    }
+
+    /// Records every decision `filter_for` makes, keyed by message, so tests
+    /// can emit through the real `log` → tracing bridge and assert on the
+    /// outcome the Sentry layer would act on.
+    struct Recorder(Arc<Mutex<Vec<(String, EventFilter)>>>);
+
+    impl<S: Subscriber> tracing_subscriber::Layer<S> for Recorder {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut message = String::new();
+            event.record(
+                &mut |field: &tracing::field::Field, value: &dyn std::fmt::Debug| {
+                    if field.name() == "message" {
+                        message = format!("{value:?}");
+                    }
+                },
+            );
+            self.0
+                .lock()
+                .expect("recorder")
+                .push((message, filter_for(event)));
+        }
+    }
+
+    fn install_log_bridge() {
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| tracing_log::LogTracer::init().expect("install log bridge"));
+    }
+
+    fn decisions(emit: impl FnOnce()) -> Vec<(String, EventFilter)> {
+        install_log_bridge();
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(Recorder(sink.clone()));
+        tracing::subscriber::with_default(subscriber, emit);
+        let out = sink.lock().expect("recorder").clone();
+        out
+    }
+
+    fn decision_for<'a>(all: &'a [(String, EventFilter)], needle: &str) -> &'a EventFilter {
+        &all.iter()
+            .find(|(message, _)| message.contains(needle))
+            .unwrap_or_else(|| panic!("no decision recorded for {needle}"))
+            .1
+    }
+
+    #[test]
+    fn log_bridged_verifier_error_is_demoted_by_its_real_target() {
+        let all = decisions(|| {
+            log::error!(
+                target: "rustls_platform_verifier::verification::windows",
+                "failed to verify TLS certificate: invalid peer certificate: UnknownIssuer"
+            );
+        });
+        let decision = decision_for(&all, "UnknownIssuer");
+        assert!(decision.contains(EventFilter::Breadcrumb));
+        assert!(!decision.contains(EventFilter::Event));
+    }
+
+    #[test]
+    fn log_bridged_updater_error_is_demoted_by_its_real_target() {
+        let all = decisions(|| {
+            log::error!(target: "tauri_plugin_updater::updater", "failed to check for updates");
+        });
+        let decision = decision_for(&all, "check for updates");
+        assert!(decision.contains(EventFilter::Breadcrumb));
+        assert!(!decision.contains(EventFilter::Event));
+    }
+
+    #[test]
+    fn log_bridged_error_from_other_crates_still_becomes_an_event() {
+        let all = decisions(|| {
+            log::error!(target: "tauri_plugin_sentry", "plugin exploded");
+        });
+        assert!(decision_for(&all, "plugin exploded").contains(EventFilter::Event));
+    }
+
+    #[test]
+    fn native_tracing_error_still_becomes_an_event() {
+        let all = decisions(|| {
+            tracing::error!("engine sidecar crashed");
+        });
+        assert!(decision_for(&all, "sidecar crashed").contains(EventFilter::Event));
+    }
+
+    #[test]
+    fn info_records_stay_breadcrumbs_and_debug_is_ignored() {
+        let all = decisions(|| {
+            log::info!(target: "tauri_plugin_updater::updater", "checking for updates");
+            tracing::debug!("noise");
+        });
+        assert!(decision_for(&all, "checking for updates").contains(EventFilter::Breadcrumb));
+        assert!(decision_for(&all, "noise").is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-PE (`failed to verify TLS certificate: invalid peer certificate: UnknownIssuer`) kept producing standalone events after the demotion shipped in v0.6.11 (`be3bb987e`), including from a `houston-app@0.6.12` install on 2026-09-01 that contains that fix.

**Root cause.** Both demotions (`tauri_plugin_updater`, `rustls_platform_verifier`) were implemented as a `SentryLayer::event_filter` closure that matches on `metadata.target()`. Records emitted through the `log` crate (every Tauri plugin, rustls, reqwest) reach tracing via `tracing_log::LogTracer`, and those events carry the static target `"log"` in their `Metadata`; the real module path is stored in the `log.target` field. The prefix match never fired for the crates it targeted. Sentry confirms it: every event in the issue is tagged `logger: log` with `log.target: rustls_platform_verifier::verification::windows` in the tracing-fields context.

**Fix.** New `app/src-tauri/src/sentry_filter.rs` hooks `event_mapper` instead, resolves the effective target with `tracing_log::NormalizeEvent::normalized_metadata`, and then applies the same mapping as the layer's default path (ERROR → event, WARN/INFO → breadcrumb, below → ignored) with the demoted targets forced to breadcrumbs. `logging.rs` just installs the mapper. `tracing-log` becomes a direct dependency (already in the tree via tracing-subscriber); `log` is a dev-dependency for the tests.

This also fixes the updater-poll families that were demoted the same broken way (HOUSTON-APP-S, HOUSTON-APP-14).

Linear: PRODUCT-1634

## Verification

Before the fix (on `main`):
1. Emit a `log::error!(target: "rustls_platform_verifier::verification::windows", ...)` under the app's subscriber (the new test `log_bridged_verifier_error_is_demoted_by_its_real_target` does this through the real `LogTracer` bridge). The mapping resolves to `EventFilter::Event` because `event.metadata().target()` is `"log"`.
2. Production symptom: on a Windows machine whose OS trust store rejects the proxy root, every 5-minute update poll produces a new HOUSTON-APP-PE event tagged `logger: log`.

After the fix:
1. `cd app/src-tauri && cargo test --lib -- sentry_filter` passes: bridged verifier and updater errors resolve to `Breadcrumb` only; bridged errors from other crates and native `tracing::error!` still resolve to `Event`; INFO stays breadcrumb, DEBUG is ignored.
2. `cargo check` and `cargo clippy --lib --tests` clean; full crate suite `cargo test --lib` green (226 passed).
3. After release: HOUSTON-APP-PE / -S / -14 receive no new events from releases containing this change; the verifier line shows up only in the breadcrumb trail of real events.
