### PR TITLE
fix(runtime): classify NVIDIA summarization 410s, Harmony parse errors, and gRPC throttling (PRODUCT-1636)

### DIFF
--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -511,6 +511,10 @@ test("extractHttpStatus reads parenthesized, leading, and labelled forms", () =>
   expect(extractHttpStatus("OpenAI API error (429): boom")).toBe(429);
   expect(extractHttpStatus('401 {"type":"error"}')).toBe(401);
   expect(extractHttpStatus("request failed with status 503")).toBe(503);
+  // The OpenAI SDK's body-less form behind a compaction prefix (PRODUCT-1636).
+  expect(
+    extractHttpStatus("Summarization failed: 410 status code (no body)"),
+  ).toBe(410);
   // The Claude Agent SDK's canonical failure text (PRODUCT-1307).
   expect(
     extractHttpStatus(
@@ -1068,6 +1072,54 @@ test("a body-less 410 from another provider stays unknown", () => {
     message: "410 status code (no body)",
   });
   expect(err.kind).toBe("unknown");
+});
+
+test("NVIDIA body-less 410 wrapped by pi's compaction → model_unavailable, same as the chat turn (PRODUCT-1636)", () => {
+  // Verbatim HOUSTON-APP-57B: the retired llama row 410s on the chat turn
+  // (classified above) AND on pi's manual `compact()` summarization request,
+  // which prefixes the identical text — the leading-status parse never saw
+  // past the prefix, so 222 of the bucket's 230 events read `unknown`.
+  for (const message of [
+    "Summarization failed: 410 status code (no body)",
+    "Turn prefix summarization failed: 410 status code (no body)",
+    "Summarization failed: 404 status code (no body)",
+  ]) {
+    const err = classifyProviderError({
+      provider: "nvidia",
+      model: "meta/llama-3.1-70b-instruct",
+      message,
+    });
+    expect(err.kind).toBe("model_unavailable");
+    if (err.kind === "model_unavailable")
+      expect(err.suggested_fallback).toBe("openai/gpt-oss-120b");
+  }
+});
+
+test("NVIDIA gpt-oss 'Unknown role: final' (server-side Harmony parse of a malformed generation) → provider_internal (PRODUCT-1636)", () => {
+  // Verbatim: NVIDIA NIM's gpt-oss-120b rejected its OWN output's message
+  // header mid-stream; the OpenAI SDK raised the `{"error":…}` chunk with no
+  // status and pi flattened it to the bare text. Transient — retry helps.
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "openai/gpt-oss-120b",
+    message: "Unknown role: final",
+  });
+  expect(err).toMatchObject({
+    kind: "provider_internal",
+    provider: "nvidia",
+    http_status: null,
+  });
+});
+
+test("NVIDIA 'ResourceExhausted: … request limit reached' (gRPC throttling, no HTTP status) → rate_limited (PRODUCT-1636)", () => {
+  const err = classifyProviderError({
+    provider: "nvidia",
+    model: "openai/gpt-oss-120b",
+    message:
+      "ResourceExhausted: Worker local total request limit reached (37/16)",
+  });
+  expect(err.kind).toBe("rate_limited");
+  if (err.kind === "rate_limited") expect(err.retry_after_seconds).toBeNull();
 });
 
 test("Alibaba DashScope free-tier exhaustion → quota_exhausted, never a rate-limit countdown", () => {

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -624,7 +624,15 @@ function isRateLimited(lower: string, status: number | null): boolean {
     // Bare "quota" belongs here (per-minute quota bodies are throttling);
     // plan-allowance exhaustion is claimed earlier by `isPlanLimit` (HOU-1154).
     lower.includes("throttl") ||
-    lower.includes("quota")
+    lower.includes("quota") ||
+    // gRPC's canonical throttling status, which maps to HTTP 429 by
+    // definition. NVIDIA NIM surfaces its per-worker concurrency cap as
+    // `ResourceExhausted: Worker local total request limit reached (37/16)`
+    // with no HTTP status and none of the wording above, so it degraded to
+    // `unknown` (PRODUCT-1636). The wait-a-moment card is the honest one.
+    lower.includes("resourceexhausted") ||
+    lower.includes("resource_exhausted") ||
+    lower.includes("request limit reached")
   );
 }
 
@@ -676,6 +684,17 @@ function isServerError(lower: string, status: number | null): boolean {
     // `content_filter` above.
     lower.includes("malformed_function_call") ||
     lower.includes("malformed_response") ||
+    // gpt-oss served through an OpenAI-compatible gateway (NVIDIA NIM) speaks
+    // the Harmony format server-side; when the model emits a malformed
+    // message header (`<|start|>final` instead of `<|start|>assistant
+    // <|channel|>final`) the server's Harmony parser rejects its OWN output
+    // with `Unknown role: final`, sent as a mid-stream `{"error":…}` chunk
+    // that the OpenAI SDK raises with no status and pi flattens to the bare
+    // text. Same shape as Gemini's MALFORMED_* above: the model broke
+    // mid-generation, transient, retry helps — never the report-bug
+    // `unknown` (PRODUCT-1636). Matched with the colon so an account /
+    // permission "role" body can never trip it.
+    lower.includes("unknown role:") ||
     // Codex (ChatGPT OAuth) rides a WebSocket transport; when that socket dies
     // mid-turn pi-ai flattens it to `WebSocket closed <code>` — no status, no
     // body (HOU-848: codes 1006 abnormal closure, 1000 server closed mid-turn,
@@ -847,6 +866,17 @@ export function extractHttpStatus(message: string): number | null {
     const n = Number(lead[1]);
     if (n >= 100 && n <= 599) return n;
   }
+  // The OpenAI SDK's body-less flattening — `<status> status code (no body)`
+  // — normally LEADS the message (caught above), but pi's compaction wraps
+  // the same text as `Summarization failed: 410 status code (no body)`, and
+  // the leading match never sees past the prefix. Without this, NVIDIA's
+  // body-less 404/410 model gate (`isNvidiaFunctionGated`) classified fine on
+  // a chat turn and degraded to `unknown` the moment the SAME rejection hit
+  // the summarizer — a Sentry error per compaction attempt on a retired
+  // model, hundreds per user, instead of the switch-model card
+  // (PRODUCT-1636: 222 of the bucket's 230 events).
+  const statusCode = message.match(/\b([1-5]\d{2}) status code\b/);
+  if (statusCode) return Number(statusCode[1]);
   // "api error" is the Claude Agent SDK's canonical failure text ("API Error:
   // 401 OAuth access token has been revoked"). Without it a revoked-token
   // failure surfacing on the SDK's thrown/result seams (message only, no

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -626,6 +626,52 @@ test("a resolveModel failure names no provider and never marks or reports one", 
 });
 
 /**
+ * A throw AFTER resolution is classified against the model the turn resolved
+ * onto, not the pin's (which an unpinned chat never has). pi's manual
+ * `compact()` rejects with the summarizer's provider text; NVIDIA's body-less
+ * 410 model gate needs a model to name on the switch-model card, and with
+ * `model: null` it fell through to `unknown` — a Sentry error per compaction
+ * attempt instead of the card (PRODUCT-1636).
+ */
+test("a thrown summarization failure classifies on the RESOLVED model when the turn is unpinned (PRODUCT-1636)", async () => {
+  resolution.run = () => ({
+    provider: "nvidia",
+    id: "meta/llama-3.1-70b-instruct",
+    contextWindow: 128_000,
+    reasoning: false,
+  });
+  const id = "exec-throw-summarization";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv(
+    () => {
+      throw new Error("Summarization failed: 410 status code (no body)");
+    },
+    { provider: "openai" },
+  );
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  unsub();
+
+  const frame = events.find(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+  expect(frame?.data).toMatchObject({
+    kind: "model_unavailable",
+    provider: "nvidia",
+    model: "meta/llama-3.1-70b-instruct",
+    suggested_fallback: "openai/gpt-oss-120b",
+  });
+  expect(persistedProviderError(id)).toMatchObject({
+    kind: "model_unavailable",
+    model: "meta/llama-3.1-70b-instruct",
+  });
+});
+
+/**
  * ...but a turn that CARRIED a pin is not provider-less: the pin is the user's
  * own statement of what to run on, honest evidence even when the resolution
  * failed (a routine pinned to a provider whose saved model id went stale). The

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -246,6 +246,17 @@ export async function execTurn(
    */
   let turnProvider: string | undefined;
   /**
+   * The model id the turn RESOLVED onto — the twin of `turnProvider` for the
+   * catch's classification. A thrown failure after resolution (pi's manual
+   * `compact()` rejecting with "Summarization failed: …" on the active model)
+   * used to be classified with the PIN's model only, which an unpinned chat
+   * never carries: the model-keyed branches (NVIDIA's per-account gate needs a
+   * model to name on the switch-model card) fell through to `unknown`, and
+   * the log line read `model=?` (PRODUCT-1636). Undefined ONLY when
+   * `resolveModel` itself threw, where the pin is the next-best evidence.
+   */
+  let turnModel: string | undefined;
+  /**
    * WHO a failed turn names when `resolveModel` never returned a provider. The
    * turn's PIN is the next-best evidence: it is the user's (or the routine's)
    * own statement of what this turn was to run on, so a routine pinned to
@@ -280,6 +291,7 @@ export async function execTurn(
     // canonical id (resolveModel already applied canonicalPinProvider), so the
     // catch's health mark and revocation report name the row that actually ran.
     turnProvider = model.provider;
+    turnModel = model.id;
     // The turn's execution mode: the pin's, else execute. Never inherited from
     // Settings. Routine fire paths pin auto; an actually unpinned turn is execute.
     // Held in a MUTABLE ref: a mid-turn Mode-pill switch (`POST
@@ -663,6 +675,7 @@ export async function execTurn(
     // terminal surface, same as the streamed path — so the live chat renders
     // the card (and auto-continues after reconnect) instead of raw error
     // text. An unrecognized throw keeps the generic error frame.
+    const attributedModel = turnModel ?? pin?.model ?? null;
     const thrown =
       providerError ??
       classifyProviderError({
@@ -673,14 +686,14 @@ export async function execTurn(
         // the error's own evidence), and it renders the generic "connect an AI
         // provider" card rather than naming a provider this turn never reached.
         provider: attributedProvider(""),
-        model: pin?.model ?? null,
+        model: attributedModel,
         message: errMessage(err),
       });
     // The streamed path logged when it classified; a THROWN failure only
     // becomes visible to Sentry if this catch logs it too — before this,
     // every thrown `unknown` was a card in a user's chat that we never heard
     // about (HOU-1156).
-    if (!providerError) logProviderError(thrown, { model: pin?.model ?? null });
+    if (!providerError) logProviderError(thrown, { model: attributedModel });
     // An auth throw with NOTHING streamed = pi's prompt-time credential guard,
     // which raises BEFORE recording the user message in pi's session store —
     // neither the live context nor a rebuild will ever see it. Carry the text


### PR DESCRIPTION
## Summary

PRODUCT-1636 / Sentry HOUSTON-APP-57B is the `(provider=nvidia, kind=unknown)` fingerprint bucket, not one failure. Tallying all 230 events:

| events | verbatim text | what it is |
|---|---|---|
| 222 | `Summarization failed: 410 status code (no body)` | retired llama row, body-less 410 on pi's `compact()` summarization request |
| 1 | `Unknown role: final` | NVIDIA NIM's server-side Harmony parser rejecting gpt-oss-120b's own malformed message header mid-stream |
| 2 | `ResourceExhausted: Worker local total request limit reached (37/16)` | gRPC throttling, no HTTP status |
| 2 | `This operation was aborted` | already a warning via `EXPECTED_UNKNOWN_DETAIL`, kept as is |
| 3 | 404 no-body / `Turn prefix summarization failed` / stale pre-fallback model id | same family as the 410s |

### Root cause

The chat-turn shape `410 status code (no body)` already classified as `model_unavailable` (HOU-890). The same rejection on the summarizer failed twice over:

1. `extractHttpStatus` only read a **leading** status; the `Summarization failed: ` prefix hid it, so the NVIDIA gate branch (which needs status 404/410) never matched.
2. `execTurn`'s catch classified a thrown failure with the **pin's** model, which an unpinned chat never carries, so the gate branch (which needs a model to name on the switch-model card) fell through to `unknown` and the log line read `model=?`.

Every compaction attempt on the retired model then fired a Sentry error and showed the report-bug card instead of the switch-model card. PR #1435 stopped the 410s for the retired llama rows by falling back to gpt-oss-120b, which is exactly where the one `Unknown role: final` event came from afterwards.

### Fix

- `extractHttpStatus` reads the OpenAI SDK's `<NNN> status code` shape anywhere in the message.
- `execTurn` classifies a thrown failure against the model the turn **resolved** onto (`turnModel`), falling back to the pin only when resolution itself threw.
- `Unknown role:` → `provider_internal` (transient malformed generation, retry card; same treatment as Gemini's MALFORMED_* in PRODUCT-1601).
- `ResourceExhausted` / `request limit reached` → `rate_limited`.

All three kinds are in `EXPECTED_KINDS`, so they become warning breadcrumbs instead of Sentry errors.

## Verification

Before (on `main`):
```
cd packages/runtime && pnpm exec vitest run src/ai/provider-error.test.ts src/session/exec-turn.test.ts
```
with this PR's tests cherry-picked fails on 4 tests: the summarization-wrapped 410s classify `unknown`, `Unknown role: final` classifies `unknown`, `ResourceExhausted` classifies `unknown`, and the exec-turn thrown summarization test yields no `model_unavailable` frame.

After:
- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` — host 1631 passed, runtime 1541 passed, domain 200 passed.
- `pnpm check` exits 0; `pnpm --filter @houston/runtime typecheck` clean.
- In Sentry, HOUSTON-APP-57B should stop receiving `Summarization failed: … status code (no body)`, `Unknown role:`, and `ResourceExhausted` events once the engine rolls; they surface as `[provider_error] … kind=model_unavailable|provider_internal|rate_limited` warnings in the engine log instead.
