### PR TITLE
fix(web): the web entry owns host mode on the self-host boot path (PRODUCT-1627)

### DIFF
--- a/packages/web/src/boot-globals.ts
+++ b/packages/web/src/boot-globals.ts
@@ -1,0 +1,41 @@
+/**
+ * The web entry's host-mode boot contract.
+ *
+ * BOTH web boot paths — the managed cloud (a baked control plane) and the
+ * self-host Connect screen — run the desktop UI against the Houston host
+ * through the v3 adapter, and the adapter decides host mode from
+ * `window.__HOUSTON_CP__` at CONSTRUCTION (`engine-adapter/client/context.ts`,
+ * plus `cp/fetch.ts` and `shims/tauri-core.ts`). Nothing re-reads the flag
+ * later, so it has to be on the window before the app module graph loads.
+ *
+ * The self-host path used to get the flag only as a side effect of app code:
+ * `app/src/lib/engine.ts` bakes it at module eval to close the desktop sidecar
+ * race (HOU-546). That made a web boot contract depend on an app-side
+ * statement — if it ever moved, went lazy, or got gated, self-host web would
+ * boot OUT of host mode and every control-plane-routed read (routines, skills)
+ * would silently answer an empty list with no error. The entry owns its own
+ * contract here; the app-side bake stays for desktop.
+ */
+import type { EngineConfig } from "./engine-config";
+
+/** The window fields the boot contract writes (a subset of `Window`). */
+export interface HostModeGlobals {
+  __HOUSTON_CP__?: boolean;
+  __HOUSTON_ENGINE__?: EngineConfig;
+}
+
+/**
+ * Publish host mode (and the engine endpoint, when one is already known) on the
+ * target window. Call BEFORE importing the app tree.
+ *
+ * `engine` is null on a first self-host visit: the Connect screen prompts for
+ * the URL + token and stores them itself, so the global stays absent rather
+ * than holding a placeholder endpoint the adapter would try to reach.
+ */
+export function applyHostModeGlobals(
+  target: HostModeGlobals,
+  engine: EngineConfig | null,
+): void {
+  target.__HOUSTON_CP__ = true;
+  if (engine) target.__HOUSTON_ENGINE__ = engine;
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -12,6 +12,7 @@
  */
 import { applyBootTheme } from "@houston/app/lib/theme-boot";
 import { createRoot } from "react-dom/client";
+import { applyHostModeGlobals } from "./boot-globals";
 import { currentDeployEnvironment } from "./deploy-environment";
 import {
   type EngineConfig,
@@ -64,15 +65,19 @@ if (controlPlaneUrl && window.location.pathname.startsWith("/admin")) {
   // tree), so they MUST be set before that import — otherwise EngineGate hangs
   // on the "Loading your workspace" splash. CloudApp keeps the token in sync with the
   // live session; the engine adapter reads it live per request.
-  window.__HOUSTON_CP__ = true;
-  window.__HOUSTON_ENGINE__ = { baseUrl: controlPlaneUrl, token: "" };
+  applyHostModeGlobals(window, { baseUrl: controlPlaneUrl, token: "" });
   void import("./cloud-login").then(({ CloudApp }) =>
     createRoot(rootEl).render(<CloudApp controlPlaneUrl={controlPlaneUrl} />),
   );
 } else {
-  // Resolve the engine config before the app graph loads (app/src/lib/engine.ts
-  // reads window.__HOUSTON_ENGINE__ at import): a stored config wins, else a URL
-  // baked via VITE_NEW_ENGINE_URL, else null → the Connect screen prompts.
+  // Self-host: resolve the engine config before the app graph loads
+  // (app/src/lib/engine.ts reads window.__HOUSTON_ENGINE__ at import) — a
+  // stored config wins, else a URL baked via VITE_NEW_ENGINE_URL, else null
+  // → the Connect screen prompts. Host mode is published by the SAME call as
+  // the cloud branch above (PRODUCT-1627): this branch used to inherit the
+  // flag only from an app/src module-load side effect, and an adapter built
+  // before that side effect ran would read empty routines/skills lists with
+  // no error at all.
   const stored = readStoredEngineConfig(NEW_ENGINE_STORAGE_KEY);
   const initial: EngineConfig | null =
     stored ??
@@ -82,7 +87,7 @@ if (controlPlaneUrl && window.location.pathname.startsWith("/admin")) {
           token: env.VITE_NEW_ENGINE_TOKEN ?? "",
         }
       : null);
-  if (initial) window.__HOUSTON_ENGINE__ = initial;
+  applyHostModeGlobals(window, initial);
   void import("./new-engine/root").then(({ NewEngineRoot }) =>
     createRoot(rootEl).render(<NewEngineRoot initialConfig={initial} />),
   );

--- a/packages/web/tests/boot-host-mode.test.ts
+++ b/packages/web/tests/boot-host-mode.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  applyHostModeGlobals,
+  type HostModeGlobals,
+} from "../src/boot-globals";
+import { HoustonClient } from "../src/engine-adapter/client";
+
+/**
+ * PRODUCT-1627: the web entry owns the host-mode boot contract on BOTH paths.
+ *
+ * The adapter reads `window.__HOUSTON_CP__` once, in its constructor, and a
+ * client built without it routes routines/skills to a silent `[]` (see
+ * `client/routines-skills-mixin.ts`) — no request, no error, an empty screen.
+ * The self-host branch used to inherit the flag purely from an app/src
+ * module-load side effect (`app/src/lib/engine.ts`, HOU-546), with nothing
+ * pinning the coupling. These tests assert host mode holds on the web entry's
+ * own globals, with no app module loaded.
+ */
+
+const HOST = "https://selfhost.example";
+
+let calls: string[];
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  calls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    calls.push(String(input));
+    return new Response(
+      JSON.stringify({ items: [{ id: "r1", name: "Daily digest" }] }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete (globalThis as { window?: HostModeGlobals }).window;
+  vi.restoreAllMocks();
+});
+
+/** Stand in for the browser window the entry writes to, then reads back. */
+function bootWindow(engine: { baseUrl: string; token: string } | null) {
+  const win: HostModeGlobals = {};
+  applyHostModeGlobals(win, engine);
+  (globalThis as { window?: HostModeGlobals }).window = win;
+  return win;
+}
+
+test("self-host boot with a stored config publishes host mode and the endpoint", () => {
+  const win = bootWindow({ baseUrl: HOST, token: "tok" });
+  expect(win.__HOUSTON_CP__).toBe(true);
+  expect(win.__HOUSTON_ENGINE__).toEqual({ baseUrl: HOST, token: "tok" });
+});
+
+test("self-host boot with no config yet still publishes host mode", () => {
+  // First visit: the Connect screen prompts. Host mode must not wait for it,
+  // and no placeholder endpoint may be invented.
+  const win = bootWindow(null);
+  expect(win.__HOUSTON_CP__).toBe(true);
+  expect(win.__HOUSTON_ENGINE__).toBeUndefined();
+});
+
+test("a client built on those globals routes routines, not a silent empty list", async () => {
+  bootWindow({ baseUrl: HOST, token: "tok" });
+  // No `controlPlane` option — exactly how app/src/lib/engine.ts builds it, so
+  // the window flag is the only thing deciding host mode.
+  const client = new HoustonClient({ baseUrl: HOST, token: "tok" });
+  const routines = await client.listRoutines("Houston/Assistant");
+  expect(calls).toEqual([`${HOST}/agents/Houston%2FAssistant/routines`]);
+  expect(routines).toEqual([{ id: "r1", name: "Daily digest" }]);
+});
+
+test("without the flag the same call silently answers [] — the bug being pinned", async () => {
+  (globalThis as { window?: HostModeGlobals }).window = {};
+  const client = new HoustonClient({ baseUrl: HOST, token: "tok" });
+  expect(await client.listRoutines("Houston/Assistant")).toEqual([]);
+  expect(calls).toHaveLength(0);
+});


### PR DESCRIPTION
## Root cause

The web engine adapter decides host mode from `window.__HOUSTON_CP__` **once, in its constructor** (`engine-adapter/client/context.ts`; also read by `cp/fetch.ts` and `shims/tauri-core.ts`). Nothing re-reads it later.

`packages/web/src/main.tsx` set the flag explicitly only on the **managed-cloud** branch. The **self-host / Connect-screen** branch inherited it from a module-load side effect in `app/src/lib/engine.ts` — a bake added to close the desktop sidecar race (HOU-546), not a web boot statement.

So a web boot contract depended on an app-side line. If that bake ever moved, went lazy, or got gated, self-host web would boot out of host mode and every control-plane-routed read would fall into the `return []` arm of `client/routines-skills-mixin.ts`: routines and skills render empty, no request, no error. No unit test or e2e pinned the coupling (the only e2e references seed the flag themselves, which masks the real boot path).

## Fix

- New `packages/web/src/boot-globals.ts` — `applyHostModeGlobals(target, engine)` publishes host mode plus the engine endpoint (absent, not a placeholder, when the Connect screen still has to prompt).
- `main.tsx` calls it on **both** branches, so the web entry owns its own boot contract. The app-side bake stays for desktop.

**No behavior change on any shipping path:**

| Path | Before | After |
|---|---|---|
| Managed cloud web | `__HOUSTON_CP__ = true` + `__HOUSTON_ENGINE__` set inline | same two globals, same order, via the helper |
| Managed cloud `/admin` | flag never set (app tree never mounts) | unchanged — the helper is not called there |
| Desktop (Tauri) | `app/src/main.tsx` + the `app/src/lib/engine.ts` bake | untouched |
| Self-host web | flag set by the `app/src/lib/engine.ts` side effect | same value, set earlier by the entry itself |

## Tests

`packages/web/tests/boot-host-mode.test.ts` (4 tests) asserts host mode holds on the entry's own globals with **no app module loaded**: both self-host shapes (stored config, and first visit with no config), a `HoustonClient` built with no `controlPlane` option routing `listRoutines` to a real `/agents/:id/routines` request, and the silent-`[]` failure mode when the flag is absent.

## Verification

**Before the fix** (reproduces the latent failure the issue describes):

```bash
git stash push -u -m repro-1627   # drop the fix
# comment out the `window.__HOUSTON_CP__ = true` bake in app/src/lib/engine.ts
pnpm --filter houston-web dev     # no VITE_CONTROL_PLANE_URL -> self-host path
```
Connect to a host, open an agent: Routines and Skills are empty, with no error and no `/routines` request in the network panel. Managed cloud (`VITE_CONTROL_PLANE_URL=…`) is unaffected, which is what hid this.

**After:**

```bash
pnpm --filter houston-web exec vitest run tests/boot-host-mode.test.ts   # 4 passed
pnpm --filter houston-web test                                          # 429 passed
pnpm --filter houston-web typecheck
pnpm check && pnpm check:boundaries && pnpm check:parity
```
Same manual repro with the `app/src/lib/engine.ts` bake commented out: routines and skills load normally — the entry sets the flag itself.

PRODUCT-1627
