### PR TITLE
fix(runtime): read the Claude CLI's Keychain credential on macOS hosts (PRODUCT-1626)

### DIFF
--- a/packages/runtime/src/auth/anthropic-cli-credential.ts
+++ b/packages/runtime/src/auth/anthropic-cli-credential.ts
@@ -1,0 +1,78 @@
+import { rmSync } from "node:fs";
+import {
+  discardKeychainCredential,
+  readKeychainCredential,
+} from "./anthropic-cli-keychain";
+import {
+  type CliMintedOauth,
+  parseMintedCredential,
+  readMintedFile,
+} from "./anthropic-cli-output";
+
+/**
+ * Where the CLI login left its minted credential, and how to destroy every
+ * copy afterwards (anthropic-cli-login.ts's post-exit half).
+ *
+ * Read order, scoped to the throwaway login dir: the credential file first
+ * (Linux pods, Docker self-host, Windows, some macOS setups), then the macOS
+ * Keychain item the CLI writes on darwin instead. A file that exists but holds
+ * no usable credential (a logout husk) falls through to the Keychain; its
+ * concrete problem is what surfaces when the Keychain is empty too.
+ */
+
+export type MintedCredentialDeps = {
+  // Test seams; production reads the real dir / Keychain.
+  readCredentialFile?: (dir: string) => string | null;
+  readKeychain?: (dir: string) => Promise<string | null>;
+  cleanupDir?: (dir: string) => void;
+  discardKeychain?: (dir: string) => Promise<void>;
+};
+
+export async function readMintedCredential(
+  dir: string,
+  deps: MintedCredentialDeps,
+): Promise<CliMintedOauth> {
+  const raw = (deps.readCredentialFile ?? readMintedFile)(dir);
+  let fileProblem: Error | null = null;
+  if (raw !== null) {
+    try {
+      return parseMintedCredential(raw);
+    } catch (e) {
+      fileProblem = e as Error;
+    }
+  }
+  const fromKeychain = await (deps.readKeychain ?? readKeychainCredential)(dir);
+  if (fromKeychain !== null) return parseMintedCredential(fromKeychain);
+  if (fileProblem) throw fileProblem;
+  throw new Error(
+    "Claude sign-in finished but no credential was stored — the CLI wrote " +
+      "neither a credential file nor a Keychain item Houston can read here; " +
+      "paste an API token instead",
+  );
+}
+
+/**
+ * Remove the login dir and the Keychain item. Both copies carry the refresh
+ * token; a leftover would be a second-rotator seed, so a failure is loud —
+ * but never fatal to a login that already stored its credential.
+ */
+export async function discardMintedCredential(
+  dir: string,
+  deps: MintedCredentialDeps,
+): Promise<void> {
+  try {
+    (deps.cleanupDir ?? ((d) => rmSync(d, { recursive: true, force: true })))(
+      dir,
+    );
+  } catch (e) {
+    console.error("[oauth:anthropic] could not remove the login dir:", e);
+  }
+  try {
+    await (deps.discardKeychain ?? discardKeychainCredential)(dir);
+  } catch (e) {
+    console.error(
+      "[oauth:anthropic] could not remove the login's Keychain item:",
+      e,
+    );
+  }
+}

--- a/packages/runtime/src/auth/anthropic-cli-keychain.test.ts
+++ b/packages/runtime/src/auth/anthropic-cli-keychain.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "vitest";
+import {
+  discardKeychainCredential,
+  keychainServiceFor,
+  readKeychainCredential,
+  type SecurityRun,
+} from "./anthropic-cli-keychain";
+
+const DIR = "/Users/daniel/.dev-houston/claude-login";
+/** Known vector shared with the desktop shell's `credential.rs` test. */
+const SERVICE = "Claude Code-credentials-3d1329c5";
+const VALID = JSON.stringify({
+  claudeAiOauth: {
+    accessToken: "sk-ant-oat01-access",
+    refreshToken: "sk-ant-ort01-refresh",
+    expiresAt: 123,
+  },
+});
+const HUSK = JSON.stringify({
+  claudeAiOauth: { accessToken: "", refreshToken: "", expiresAt: 0 },
+});
+
+/** Script `security` by argv; records every invocation. */
+function fakeSecurity(
+  script: (args: string[]) => { code: number; stdout?: string },
+): { run: SecurityRun; calls: string[][] } {
+  const calls: string[][] = [];
+  return {
+    calls,
+    run: async (args) => {
+      calls.push(args);
+      const r = script(args);
+      return { code: r.code, stdout: r.stdout ?? "" };
+    },
+  };
+}
+
+test("keychainServiceFor hashes the CLAUDE_CONFIG_DIR string like the CLI", () => {
+  expect(keychainServiceFor(DIR)).toBe(SERVICE);
+  expect(keychainServiceFor("/a/claude-login")).not.toBe(
+    keychainServiceFor("/b/claude-login"),
+  );
+});
+
+test("read: the username's dir-scoped item wins, output returned verbatim", async () => {
+  const sec = fakeSecurity(() => ({ code: 0, stdout: `${VALID}\n` }));
+  const got = await readKeychainCredential(DIR, {
+    platform: "darwin",
+    user: "daniel",
+    run: sec.run,
+  });
+  expect(got).toBe(`${VALID}\n`);
+  expect(sec.calls).toEqual([
+    ["find-generic-password", "-s", SERVICE, "-a", "daniel", "-w"],
+  ]);
+});
+
+test("read: a husk under the username falls through to any account", async () => {
+  const sec = fakeSecurity((args) =>
+    args.includes("-a")
+      ? { code: 0, stdout: HUSK }
+      : { code: 0, stdout: VALID },
+  );
+  const got = await readKeychainCredential(DIR, {
+    platform: "darwin",
+    user: "daniel",
+    run: sec.run,
+  });
+  expect(got).toBe(VALID);
+  expect(sec.calls).toHaveLength(2);
+  expect(sec.calls[1]).toEqual(["find-generic-password", "-s", SERVICE, "-w"]);
+});
+
+test("read: absent item (exit 44) resolves null; no username skips -a", async () => {
+  const sec = fakeSecurity(() => ({ code: 44 }));
+  const got = await readKeychainCredential(DIR, {
+    platform: "darwin",
+    user: null,
+    run: sec.run,
+  });
+  expect(got).toBeNull();
+  expect(sec.calls).toEqual([["find-generic-password", "-s", SERVICE, "-w"]]);
+});
+
+test("read + discard: no-ops off macOS without touching security", async () => {
+  const sec = fakeSecurity(() => ({ code: 0, stdout: VALID }));
+  expect(
+    await readKeychainCredential(DIR, { platform: "linux", run: sec.run }),
+  ).toBeNull();
+  await discardKeychainCredential(DIR, { platform: "linux", run: sec.run });
+  expect(sec.calls).toEqual([]);
+});
+
+test("discard: deletes every item under the service until exit 44", async () => {
+  let remaining = 2;
+  const sec = fakeSecurity(() => ({ code: remaining-- > 0 ? 0 : 44 }));
+  await discardKeychainCredential(DIR, { platform: "darwin", run: sec.run });
+  expect(sec.calls).toHaveLength(3);
+  expect(sec.calls[0]).toEqual(["delete-generic-password", "-s", SERVICE]);
+});
+
+test("discard: an unexpected security exit is an error, not a silent leftover", async () => {
+  const sec = fakeSecurity(() => ({ code: 36 }));
+  await expect(
+    discardKeychainCredential(DIR, { platform: "darwin", run: sec.run }),
+  ).rejects.toThrow(/exited 36/);
+});

--- a/packages/runtime/src/auth/anthropic-cli-keychain.ts
+++ b/packages/runtime/src/auth/anthropic-cli-keychain.ts
@@ -1,0 +1,131 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+
+/**
+ * macOS Keychain access for the CLI-driven Claude login
+ * (anthropic-cli-login.ts). On darwin the bundled Claude CLI stores the
+ * credential it mints in the Keychain instead of `<dir>/.credentials.json`,
+ * under the service `Claude Code-credentials-<sha256(CLAUDE_CONFIG_DIR)[..8]>`
+ * and the username as the account. This mirrors the desktop shell's
+ * `claude_login/credential.rs` + `discard.rs` (same CLI, same scheme); keep
+ * the two in sync.
+ *
+ * Only the DIR-SCOPED service is ever read: the bare `Claude Code-credentials`
+ * item belongs to the user's own `~/.claude` install, and storing THAT would
+ * make Houston and their personal CLI rotate one refresh-token family and sign
+ * each other out. Off macOS every function is a no-op.
+ */
+
+const KEYCHAIN_SERVICE_BASE = "Claude Code-credentials";
+/** `security` exits 44 (`errSecItemNotFound`) when no item matches. */
+const SECURITY_NOT_FOUND = 44;
+/** The CLI writes one item per account; past this `security` is misbehaving. */
+const MAX_KEYCHAIN_DELETES = 8;
+
+/** One `security` invocation: its exit code and stdout (test seam). */
+export type SecurityRun = (
+  args: string[],
+) => Promise<{ code: number; stdout: string }>;
+
+export type KeychainDeps = {
+  platform?: NodeJS.Platform;
+  /** The login's Keychain account; `null` means "no username known". */
+  user?: string | null;
+  run?: SecurityRun;
+};
+
+/**
+ * The CLI's Keychain service for a `CLAUDE_CONFIG_DIR`: the hash input is the
+ * dir string EXACTLY as the spawn passed it in the env (no normalization).
+ */
+export function keychainServiceFor(configDir: string): string {
+  const digest = createHash("sha256").update(configDir).digest("hex");
+  return `${KEYCHAIN_SERVICE_BASE}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * Read the credential JSON the CLI cached for `configDir`, or null when there
+ * is none (also off macOS). The username's item is tried first — an
+ * env-scrubbed SDK subprocess can leave an emptied husk under another account
+ * — and a hit without a usable access token is skipped, not returned. Throws
+ * only when `security` itself cannot run.
+ */
+export async function readKeychainCredential(
+  configDir: string,
+  deps: KeychainDeps = {},
+): Promise<string | null> {
+  if ((deps.platform ?? process.platform) !== "darwin") return null;
+  const run = deps.run ?? runSecurity;
+  const service = keychainServiceFor(configDir);
+  const user = deps.user === undefined ? (process.env.USER ?? null) : deps.user;
+  const accounts: Array<string | null> = user ? [user, null] : [null];
+  for (const account of accounts) {
+    const { code, stdout } = await run([
+      "find-generic-password",
+      "-s",
+      service,
+      ...(account ? ["-a", account] : []),
+      "-w",
+    ]);
+    if (code === 0 && hasAccessToken(stdout)) return stdout;
+  }
+  return null;
+}
+
+/**
+ * Delete every Keychain item the CLI cached for `configDir`. Idempotent:
+ * nothing cached is success. Once the credential is stored in auth.json the
+ * Keychain copy is a second refresh-token holder, and anything that ever
+ * refreshed it would trip Anthropic's reuse detection and revoke the family.
+ */
+export async function discardKeychainCredential(
+  configDir: string,
+  deps: KeychainDeps = {},
+): Promise<void> {
+  if ((deps.platform ?? process.platform) !== "darwin") return;
+  const run = deps.run ?? runSecurity;
+  const service = keychainServiceFor(configDir);
+  for (let i = 0; i < MAX_KEYCHAIN_DELETES; i++) {
+    // No `-a`: each call deletes the FIRST item under the service regardless
+    // of account; loop until none remain.
+    const { code } = await run(["delete-generic-password", "-s", service]);
+    if (code === SECURITY_NOT_FOUND) return;
+    if (code !== 0)
+      throw new Error(`security delete-generic-password exited ${code}`);
+  }
+  throw new Error(
+    `more than ${MAX_KEYCHAIN_DELETES} Keychain items under ${service}`,
+  );
+}
+
+/** `{claudeAiOauth:{accessToken}}` with a non-empty token — never logged. */
+function hasAccessToken(raw: string): boolean {
+  try {
+    const parsed = JSON.parse(raw) as {
+      claudeAiOauth?: { accessToken?: unknown };
+    };
+    const token = parsed.claudeAiOauth?.accessToken;
+    return typeof token === "string" && token.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run `security`. A non-zero exit resolves with its code (absent item, a
+ * locked keychain); a spawn failure or a hung GUI prompt (timeout) rejects.
+ */
+function runSecurity(
+  args: string[],
+): Promise<{ code: number; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    execFile("security", args, { timeout: 10_000 }, (err, stdout) => {
+      if (!err) return resolve({ code: 0, stdout });
+      const code = (err as { code?: unknown }).code;
+      if (typeof code === "number") return resolve({ code, stdout });
+      reject(
+        new Error(`could not run the macOS security tool: ${err.message}`),
+      );
+    });
+  });
+}

--- a/packages/runtime/src/auth/anthropic-cli-login.test.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.test.ts
@@ -61,20 +61,23 @@ type Harness = {
   authInfos: Array<{ url: string; instructions?: string }>;
   stored: { tokens: string[]; oauth: Array<Record<string, unknown>> };
   cleaned: string[];
+  keychainDiscarded: string[];
   login: Promise<void>;
   paste: (value: string) => void;
 };
 
-/** Drive runAnthropicLogin against a FakeChild with injected fs seams. */
+/** Drive runAnthropicLogin against a FakeChild with injected fs/Keychain seams. */
 function harness(opts?: {
   binary?: string | null;
   credentialFile?: string | null;
+  keychain?: string | null;
   pasteNever?: boolean;
 }): Harness {
   const child = new FakeChild();
   const authInfos: Harness["authInfos"] = [];
   const stored: Harness["stored"] = { tokens: [], oauth: [] };
   const cleaned: string[] = [];
+  const keychainDiscarded: string[] = [];
   let paste!: (value: string) => void;
   const pastePromise = new Promise<string>((r) => {
     paste = r;
@@ -93,12 +96,15 @@ function harness(opts?: {
     cleanupDir: (dir) => void cleaned.push(dir),
     readCredentialFile: () =>
       opts?.credentialFile === undefined ? MINTED : opts.credentialFile,
+    readKeychain: async () => opts?.keychain ?? null,
+    discardKeychain: async (dir) => void keychainDiscarded.push(dir),
   };
   return {
     child,
     authInfos,
     stored,
     cleaned,
+    keychainDiscarded,
     paste,
     login: runAnthropicLogin(cb, deps),
   };
@@ -127,7 +133,37 @@ test("CLI login: URL surfaced, code relayed to stdin, minted oauth stored", asyn
   ]);
   expect(h.stored.tokens).toEqual([]);
   expect(h.cleaned).toEqual(["/tmp/fake-login-dir"]); // the refresh-bearing dir never lingers
+  expect(h.keychainDiscarded).toEqual(["/tmp/fake-login-dir"]);
   expect(h.child.killed).toBe(true);
+});
+
+test("CLI login: no credential file but a Keychain item (macOS host) stores oauth", async () => {
+  const h = harness({ credentialFile: null, keychain: MINTED });
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  h.paste("the-code");
+  await tick();
+  h.child.exit(0);
+  await h.login;
+  expect(h.stored.oauth).toEqual([
+    {
+      access: "sk-ant-oat01-access",
+      refresh: "sk-ant-ort01-refresh",
+      expires: 1755555555555,
+    },
+  ]);
+  // The Keychain copy is a second refresh-token holder — destroyed after the store.
+  expect(h.keychainDiscarded).toEqual(["/tmp/fake-login-dir"]);
+});
+
+test("CLI login: a logout-husk file falls through to the Keychain", async () => {
+  const husk = JSON.stringify({ claudeAiOauth: { accessToken: "" } });
+  const h = harness({ credentialFile: husk, keychain: MINTED });
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  h.child.exit(0);
+  await h.login;
+  expect(h.stored.oauth).toHaveLength(1);
 });
 
 test("CLI login: a co-located listener settles the flow with no code", async () => {
@@ -164,14 +200,15 @@ test("CLI login: nonzero exit after the code fails loud, tokens scrubbed", async
   expect(h.stored.oauth).toEqual([]);
 });
 
-test("CLI login: exit 0 without a readable credential file fails loud", async () => {
-  const h = harness({ credentialFile: null });
+test("CLI login: exit 0 with neither a credential file nor a Keychain item fails loud", async () => {
+  const h = harness({ credentialFile: null, keychain: null });
   h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
   await tick();
   h.paste("the-code");
   await tick();
   h.child.exit(0);
-  await expect(h.login).rejects.toThrow(/no credential file/);
+  await expect(h.login).rejects.toThrow(/no credential was stored/);
+  expect(h.keychainDiscarded).toEqual(["/tmp/fake-login-dir"]);
 });
 
 test("CLI death before the URL falls back to the token paste flow", async () => {

--- a/packages/runtime/src/auth/anthropic-cli-login.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.ts
@@ -1,7 +1,12 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnCli } from "./anthropic-cli-binary";
+import {
+  discardMintedCredential,
+  type MintedCredentialDeps,
+  readMintedCredential,
+} from "./anthropic-cli-credential";
 import type {
   AnthropicLoginCallbacks,
   CliMintedOauth,
@@ -10,8 +15,6 @@ import type {
 import {
   CliUnavailableError,
   extractVisitUrl,
-  parseMintedCredential,
-  readMintedFile,
   scrubTokens,
   wireLines,
 } from "./anthropic-cli-output";
@@ -35,8 +38,10 @@ import {
  *      The callback page cannot reach the CLI's listener from another machine,
  *      so it shows a code the user pastes back (`completeLogin` → stdin here);
  *      a co-located listener may catch it seamlessly — the CLI just exits 0.
- *   3. On exit 0, persist the minted OAuth credential (access+refresh) via
- *      `storeOauth` as a standard pi `oauth` auth.json entry — the EXISTING
+ *   3. On exit 0, read the minted OAuth credential back — the login dir's
+ *      credential file, or on macOS the Keychain item the CLI writes instead
+ *      (anthropic-cli-credential.ts) — and persist it via `storeOauth` as a
+ *      standard pi `oauth` auth.json entry, destroying every other copy. The EXISTING
  *      chain takes over: capture exports it, the gateway stores + rotates it
  *      centrally (the family's ONLY rotator), Gate #2 scrubs the local refresh,
  *      serve keeps it warm. On self-host there is no gateway and pi itself
@@ -46,18 +51,16 @@ import {
  * token flow (kill the child, store an api_key) — the old escape hatch.
  */
 
-export type AnthropicLoginDeps = {
+export type AnthropicLoginDeps = MintedCredentialDeps & {
   /** The spawnable CLI, or null to go straight to the token paste flow. */
   binary: string | null;
   /** Persist a pasted `sk-ant-…` value as pi's `api_key` variant. */
   storeToken: (key: string) => void;
   /** Persist the CLI-minted subscription credential as pi's `oauth` variant. */
   storeOauth: (cred: CliMintedOauth) => void;
-  // Test seams; production uses the real spawn/tmpdir/fs.
+  // Test seams; production uses the real spawn/tmpdir.
   spawnChild?: (binary: string, configDir: string) => LoginChild;
   mkLoginDir?: () => string;
-  cleanupDir?: (dir: string) => void;
-  readCredentialFile?: (dir: string) => string | null;
 };
 
 /**
@@ -93,9 +96,6 @@ async function runAnthropicCliLogin(
   deps: AnthropicLoginDeps,
   binary: string,
 ): Promise<void> {
-  const cleanup =
-    deps.cleanupDir ??
-    ((d: string) => rmSync(d, { recursive: true, force: true }));
   const dir = (
     deps.mkLoginDir ??
     (() => mkdtempSync(join(tmpdir(), "houston-claude-login-")))
@@ -109,13 +109,7 @@ async function runAnthropicCliLogin(
     } catch {
       // Already exited — nothing to kill.
     }
-    try {
-      cleanup(dir);
-    } catch (e) {
-      // The dir holds a refresh-bearing credential copy; a leftover would be
-      // a second-rotator seed. Loud; the tmpdir lifecycle still bounds it.
-      console.error("[oauth:anthropic] could not remove the login dir:", e);
-    }
+    await discardMintedCredential(dir, deps);
   }
 }
 
@@ -188,12 +182,5 @@ async function driveCliLogin(
       `Claude sign-in failed (exit ${code}): ${scrubTokens(tail.join(" | "))}`,
     );
 
-  const raw = (deps.readCredentialFile ?? readMintedFile)(dir);
-  if (raw === null)
-    throw new Error(
-      "Claude sign-in finished but no credential file was written — this " +
-        "platform's CLI likely stores credentials in a system keychain Houston " +
-        "cannot read here; connect from the desktop app instead",
-    );
-  deps.storeOauth(parseMintedCredential(raw));
+  deps.storeOauth(await readMintedCredential(dir, deps));
 }


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1626.

**Root cause.** The browser-driven Claude subscription connect spawns the bundled Claude CLI (`claude auth login --claudeai`) next to the runtime with `CLAUDE_CONFIG_DIR` pointed at a throwaway dir, then reads `<dir>/.credentials.json` back. On macOS the CLI does not write that file: it stores the minted credential in the macOS Keychain under the dir-scoped service `Claude Code-credentials-<sha256(dir)[..8]>`. So a browser tab against a Mac-hosted engine (self-host on a Mac, or `pnpm dev` reached from a browser) completed the sign-in at Anthropic and then failed with "no credential file was written". Managed cloud pods and Docker self-host are Linux and were never affected.

**Fix.** After the CLI exits 0 the runtime now reads the credential file first and, when that is absent or a logout husk, the dir-scoped Keychain item (username account first, then any account, husks skipped), and stores it through the same `storeOauth` path. The Keychain copy is deleted alongside the login dir so no second refresh-token holder lingers. This mirrors the desktop shell's `claude_login/credential.rs` + `discard.rs` scheme (same hash vector). Off macOS every Keychain call is a no-op, so the Linux path is byte-for-byte the old behavior.

- `packages/runtime/src/auth/anthropic-cli-keychain.ts`: service hashing, `security find-generic-password` / `delete-generic-password` wrappers.
- `packages/runtime/src/auth/anthropic-cli-credential.ts`: file-then-Keychain read, file + Keychain discard.
- `packages/runtime/src/auth/anthropic-cli-login.ts`: uses the two above.

## Before

1. Run the host on a Mac (`pnpm dev`, or a Mac self-host) and open the web app in a browser.
2. Settings > Providers > Claude > Connect with subscription, open the URL, finish the Anthropic sign-in, paste the code.
3. The CLI exits 0, `security find-generic-password -s "Claude Code-credentials-<hash>"` shows the minted item, and Houston reports "Claude sign-in finished but no credential file was written".

## After

1. Same steps; the connect completes and Claude shows as connected.
2. `auth.json` holds an `anthropic` `oauth` entry; the login dir and its Keychain item are gone (`security find-generic-password -s "Claude Code-credentials-<hash>"` exits 44).
3. Linux (cloud pod / Docker): unchanged, the file path is still taken and no `security` call is made.

## Tests

- New `anthropic-cli-keychain.test.ts`: hash vector shared with the desktop shell, account fallback, husk skipping, exit-44 handling, delete loop, off-macOS no-op.
- `anthropic-cli-login.test.ts`: Keychain-only host stores oauth and discards the item; husk file falls through; neither source fails loud.
- `pnpm check`, `pnpm typecheck`, `pnpm check:boundaries`, runtime/host/domain vitest all green.