### PR TITLE
fix(host): run-now fires as the presser's acting identity (PRODUCT-1637)

### DIFF
--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -1,5 +1,6 @@
-import type { ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Capabilities } from "@houston/protocol";
+import { ACTING_AS_HEADER } from "../auth/acting";
 import type { SharedEndpointStore } from "../credentials/remote-shared-endpoint-store";
 import { canUseAgent } from "../domain/access";
 import type {
@@ -137,3 +138,24 @@ export function channelFor(
 
 export const noChannel = (res: ServerResponse, runtime: WorkspaceRuntime) =>
   json(res, 503, { error: `${runtime} runtime not configured` });
+
+/**
+ * The acting identity a per-agent route may act on (C2/C5) — the ONE gate the
+ * credential routes and the run-now route share, so no route can reopen the
+ * hole by reading the header itself. The gateway is the trust boundary: it
+ * mints `x-houston-acting-as`, and no pod can verify the signature. Off the
+ * gateway (desktop / self-host) clients reach this host directly, so an
+ * inbound header is untrusted client input — honoring it would let any client
+ * file the user's credential into a per-user scope (`auth-users/<hash>.json`)
+ * instead of the workspace's shared `auth.json`, leaving every agent reading
+ * as disconnected. Same stance as the routine actor in agents.ts and as
+ * ProxyChannel's relay (channel/proxy.ts).
+ */
+export function trustedActingAs(
+  deps: AgentRouteDeps,
+  req: IncomingMessage,
+): string | undefined {
+  if (!deps.gatewayFronted) return undefined;
+  const value = req.headers[ACTING_AS_HEADER];
+  return Array.isArray(value) ? value[0] : value;
+}

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -35,6 +35,7 @@ import {
   channelFor,
   DEFAULT_PATHS,
   noChannel,
+  trustedActingAs,
 } from "./agent-authz";
 import { handleAgentData } from "./agent-data";
 import { handleAgentFile } from "./agent-file";
@@ -57,27 +58,6 @@ import { handleTriggerStatus } from "./trigger-status";
 // The deps bag + authz helpers moved to agent-authz.ts (shared with
 // routine-runs.ts); re-exported so existing importers keep working.
 export type { AgentRouteDeps } from "./agent-authz";
-
-/**
- * The acting identity a credential route may act on (C2/C5) — the ONE gate the
- * credential routes below share, so a fifth route cannot reopen the hole by
- * reading the header itself. The gateway is the trust boundary: it mints
- * `x-houston-acting-as`, and no pod can verify the signature. Off the gateway
- * (desktop / self-host) clients reach this host directly, so an inbound header
- * is untrusted client input — honoring it would let any client file the user's
- * credential into a per-user scope (`auth-users/<hash>.json`) instead of the
- * workspace's shared `auth.json`, leaving every agent reading as disconnected.
- * Same stance as the routine actor below and as ProxyChannel's relay
- * (channel/proxy.ts).
- */
-function trustedActingAs(
-  deps: AgentRouteDeps,
-  req: IncomingMessage,
-): string | undefined {
-  if (!deps.gatewayFronted) return undefined;
-  const value = req.headers[ACTING_AS_HEADER];
-  return Array.isArray(value) ? value[0] : value;
-}
 
 /**
  * The agent as the wire serves it: the record plus the deployment extras — the
@@ -744,7 +724,8 @@ export async function handleAgents(
 
   // Routine-run routes (run-now / cancel) — matched before the generic
   // dispatch below; the runtime has no routine routes. See routine-runs.ts.
-  if (await handleRoutineRuns(deps, userId, method, path, res)) return true;
+  if (await handleRoutineRuns(deps, userId, method, path, req, res))
+    return true;
 
   const activity = path.match(/^\/agents\/([^/]+)\/activity$/);
   if (activity && method === "GET") {

--- a/packages/host/src/routes/routine-runs.ts
+++ b/packages/host/src/routes/routine-runs.ts
@@ -1,4 +1,4 @@
-import type { ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { loadRoutines } from "@houston/domain";
 import { cancelRoutineRun } from "../schedule/cancel";
 import { ChannelRoutineFirer } from "../schedule/firer";
@@ -9,6 +9,7 @@ import {
   channelFor,
   DEFAULT_PATHS,
   noChannel,
+  trustedActingAs,
 } from "./agent-authz";
 import { json } from "./http";
 
@@ -22,6 +23,7 @@ export async function handleRoutineRuns(
   userId: string,
   method: string,
   path: string,
+  req: IncomingMessage,
   res: ServerResponse,
 ): Promise<boolean> {
   // Run a routine ON DEMAND: fire it now through the SAME firer + record path
@@ -59,7 +61,21 @@ export async function handleRoutineRuns(
     // ChannelRoutineFirer takes for the scheduler. fireRoutineRun records the
     // run, then fires; a fire failure marks the run errored AND rethrows, so
     // we answer 502 (never 200).
-    const firer = new ChannelRoutineFirer(deps.channels);
+    //
+    // The run acts as the person who pressed the button: on a managed pod the
+    // gateway-minted acting-as token rides along, so the turn resolves THEIR
+    // credential scope — the same identity the gateway's own pool run-now
+    // mints, and the identity the routine screen's connection badge probed.
+    // Without it the firer falls back to the creator's bare sub, which a pod
+    // cannot elevate (HOU-976 D10), so the run landed on the TEAM credential:
+    // in a team space where the presser connected a provider personally, the
+    // badge said "connected" and the run failed "creator has no account
+    // connected". Scheduled fires never had this gap (the control plane
+    // mints the creator's token for them).
+    const firer = new ChannelRoutineFirer(
+      deps.channels,
+      trustedActingAs(deps, req),
+    );
     try {
       const { runId } = await fireRoutineRun(
         {

--- a/packages/host/src/routes/run-routine.test.ts
+++ b/packages/host/src/routes/run-routine.test.ts
@@ -30,7 +30,13 @@ const verifier: TokenVerifier = {
 
 /** A channel that records every fireTurn; optionally throws to exercise the error path. */
 class SpyChannel implements RuntimeChannel {
-  fired: { conversationId: string; text: string; pin?: TurnPin }[] = [];
+  fired: {
+    conversationId: string;
+    text: string;
+    pin?: TurnPin;
+    actingUser?: string;
+    actingAs?: string;
+  }[] = [];
   throwMessage: string | null = null;
   async dispatch() {}
   async fireTurn(
@@ -38,8 +44,10 @@ class SpyChannel implements RuntimeChannel {
     conversationId: string,
     text: string,
     pin?: TurnPin,
+    actingUser?: string,
+    actingAs?: string,
   ): Promise<void> {
-    this.fired.push({ conversationId, text, pin });
+    this.fired.push({ conversationId, text, pin, actingUser, actingAs });
     if (this.throwMessage) throw new Error(this.throwMessage);
   }
   async cancelTurn() {
@@ -85,6 +93,13 @@ const auth = (who: string) => ({
   "Content-Type": "application/json",
 });
 
+/** A gateway-minted acting-as header value naming `sub` (payload only; the
+ *  pod never verifies the signature). */
+function actingAs(sub: string): string {
+  const payload = Buffer.from(JSON.stringify({ sub })).toString("base64url");
+  return `acting-v1.${payload}.signature`;
+}
+
 async function makeRoutine(
   over: Partial<{ prompt: string; suppress_when_silent: boolean }> = {},
 ): Promise<Routine> {
@@ -101,7 +116,7 @@ async function makeRoutine(
   return (await created.json()) as Routine;
 }
 
-beforeEach(async () => {
+async function boot(over: Partial<ControlPlaneDeps> = {}): Promise<void> {
   store = new MemoryWorkspaceStore();
   vfs = new MemoryVfs();
   channel = new SpyChannel();
@@ -113,6 +128,7 @@ beforeEach(async () => {
     channels: { gke: channel },
     vfs,
     capabilities: CAPS,
+    ...over,
   };
   if (server) await new Promise<void>((r) => server.close(() => r()));
   server = createControlPlaneServer(deps);
@@ -125,7 +141,9 @@ beforeEach(async () => {
     body: JSON.stringify({ name: "Helper" }),
   });
   agentId = ((await created.json()) as { id: string }).id;
-});
+}
+
+beforeEach(() => boot());
 
 test("fires the routine now: records a running run and calls fireTurn with the prompt", async () => {
   const routine = await makeRoutine({ prompt: "send the weekly digest" });
@@ -284,4 +302,49 @@ test("two simultaneous run-now requests: one fires, one 409s, exactly one run ro
   if (!agent) throw new Error("expected at least one agent to exist");
   const { items } = await loadRoutineRuns(vfs, workspaceRoot(ws, agent));
   expect(items).toHaveLength(1);
+});
+
+test("on a gateway-fronted host the run acts as the presser: the acting-as token reaches the firer", async () => {
+  // A managed pod: the gateway stamps the presser's minted identity on the
+  // proxied request, and the run must resolve THAT credential scope — the one
+  // the routine screen's connection badge probed — not the team's.
+  await boot({ gatewayFronted: true, ownerSub: "owner-1" });
+  const routine = await makeRoutine();
+  const token = actingAs("member-7");
+
+  const res = await fetch(
+    `${base}/agents/${agentId}/routines/${routine.id}/run`,
+    {
+      method: "POST",
+      headers: { ...auth("alice"), "x-houston-acting-as": token },
+    },
+  );
+  expect(res.status).toBe(200);
+  expect(channel.fired).toHaveLength(1);
+  const fired = channel.fired[0];
+  if (!fired) throw new Error("expected channel.fired[0] to exist");
+  expect(fired.actingAs).toBe(token);
+  // The minted token REPLACES the bare creator sub (ChannelRoutineFirer's
+  // contract): never both, or the runtime would read two identities.
+  expect(fired.actingUser).toBeUndefined();
+});
+
+test("off the gateway an inbound acting-as header is ignored: the run keeps the creator's bare sub", async () => {
+  // Desktop / self-host: clients reach this host directly, so the header is
+  // untrusted client input. The firer's creator fallback stays in force.
+  const routine = await makeRoutine();
+
+  const res = await fetch(
+    `${base}/agents/${agentId}/routines/${routine.id}/run`,
+    {
+      method: "POST",
+      headers: { ...auth("alice"), "x-houston-acting-as": actingAs("mallory") },
+    },
+  );
+  expect(res.status).toBe(200);
+  const fired = channel.fired[0];
+  if (!fired) throw new Error("expected channel.fired[0] to exist");
+  expect(fired.actingAs).toBeUndefined();
+  expect(fired.actingUser).toBe(routine.created_by);
+  expect(routine.created_by).toBe("alice");
 });


### PR DESCRIPTION
## Summary

PRODUCT-1637: after switching a routine's provider to a personally connected account, the routine screen's badge said "Connected" but every hand-pressed run failed with "The routine's creator has no Claude account connected."

**Root cause.** The pod's "Run now" route built its `ChannelRoutineFirer` with no acting identity, so the firer fell back to the creator's bare sub. A pod cannot elevate a bare sub, so the turn resolved the **team** credential scope. In a team space where the presser connected the provider personally, the team row has nothing for that provider and the run fails with `no_credentials`. The badge probes the viewer's own (personal) scope, so it could never agree with this path. Scheduled fires were unaffected because the control plane mints the creator's acting-as token for them; the same routine's scheduled run the day before succeeded on the new provider.

**Fix.** Run-now now forwards the gateway-minted `x-houston-acting-as` header to the firer, so the run acts as the person who pressed the button, matching the gateway's own pool run-now which mints for the presser. The trust gate (`trustedActingAs`, gateway-fronted hosts only) moves from `routes/agents.ts` into `routes/agent-authz.ts` so both route families share it. Off the gateway the header stays untrusted and the creator fallback is unchanged.

## Verification

Before the fix (cloud, a team space, routine pinned to a provider only the presser connected personally):
1. Open the routine, set its model to that provider; the connection badge reads "Connected".
2. Press "Run now".
3. The run row fails: "The routine's creator has no <provider> account connected." The pod's `runtime.log` shows `[serve] applied central credentials:` listing only the org row's providers for that turn.

After the fix:
1. Same setup, press "Run now".
2. The run starts on the presser's credential scope and completes; `runtime.log` shows the same provider list a chat turn from that user gets.

Tests: `run-routine.test.ts` gains two cases (gateway-fronted host forwards the token and drops the bare creator sub; a non-gateway host ignores the header). `pnpm --filter @houston/host test`, `pnpm --filter @houston/host typecheck`, `pnpm check`, `pnpm check:boundaries` pass.

Not changed here: the pod-local cron backstop and trigger fires still run on the team scope by design (pods cannot mint identity).
