### PR TITLE
fix(chat): keep a Stop on a waking pod out of the red toast (PRODUCT-1624)

### DIFF
--- a/app/src/components/board/use-agent-board-send.ts
+++ b/app/src/components/board/use-agent-board-send.ts
@@ -12,6 +12,7 @@ import { perfSpans } from "../../lib/perf-spans";
 import { queryKeys } from "../../lib/query-keys";
 import { formatVisibleMessageText } from "../../lib/queued-chat";
 import { showSendFailedToast } from "../../lib/send-error-toast";
+import { showStopFailedToast } from "../../lib/stop-error-toast";
 import { tauriAttachments, tauriChat } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
 import { useAgentProvisioningStore } from "../../stores/agent-provisioning";
@@ -259,14 +260,9 @@ export function useAgentBoardSend({
         .then(() => {
           queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
         })
-        .catch((err) => {
-          addToast({
-            title: t("chat:errors.stopSession", { error: String(err) }),
-            variant: "error",
-          });
-        });
+        .catch(showStopFailedToast);
     },
-    [path, queryClient, addToast, t],
+    [path, queryClient],
   );
 
   return { effectiveLoading, createConversation, sendMessageNow, stopSession };

--- a/app/src/components/board/use-mc-actions.ts
+++ b/app/src/components/board/use-mc-actions.ts
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { armMissionDoneCelebration } from "../../lib/mission-done-celebration";
 import { canDropMission } from "../../lib/mission-selection";
 import { queryKeys } from "../../lib/query-keys";
+import { showStopFailedToast } from "../../lib/stop-error-toast";
 import { tauriActivity, tauriChat } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
@@ -96,14 +97,9 @@ export function useMcActions({
             queryKey: queryKeys.allConversations(paths),
           });
         })
-        .catch((err) => {
-          addToast({
-            title: t("dashboard:errors.stopSession", { error: String(err) }),
-            variant: "error",
-          });
-        });
+        .catch(showStopFailedToast);
     },
-    [mc.items, qc, paths, addToast, t],
+    [mc.items, qc, paths],
   );
 
   const sessionKeyFor = useCallback(

--- a/app/src/lib/stop-error-toast.ts
+++ b/app/src/lib/stop-error-toast.ts
@@ -1,0 +1,30 @@
+import { useUIStore } from "../stores/ui";
+import { isEngineWakingError } from "./engine-waking-error";
+import i18n from "./i18n";
+import { isNetworkTransportError } from "./network-transport-error";
+
+/**
+ * The ONE toast for a Stop that failed (`tauriChat.stop`). Shared by every
+ * stop catch (agent board, Mission Control) so the quiet states branch in one
+ * place.
+ *
+ * `call("stop_session")` already surfaces every failure before rethrowing: a
+ * waking pod (the gateway's "engine unavailable" 503 / "engine proxy failed"
+ * 502) and a connectivity drop each get their deduped informational toast
+ * there, and a real bug is reported. The catch then used to add a SECOND, red
+ * "Couldn't stop the task: <raw gateway body>" toast on top of the waking
+ * notice: a user who pressed Stop while their pod was still cold-starting saw
+ * "your agent is waking up" and a red box quoting a DNS dial error at once,
+ * and read the pair as the conversation being broken. Those two states are
+ * not something a Stop can fix (the held send lands once the pod answers), so
+ * the red toast is skipped for them; everything else keeps the actionable
+ * "couldn't stop" toast as its only user-visible surface (no-silent-failures
+ * rule).
+ */
+export function showStopFailedToast(err: unknown): void {
+  if (isEngineWakingError(err) || isNetworkTransportError(err)) return;
+  useUIStore.getState().addToast({
+    title: i18n.t("chat:errors.stopSession", { error: String(err) }),
+    variant: "error",
+  });
+}

--- a/app/src/locales/en/dashboard.json
+++ b/app/src/locales/en/dashboard.json
@@ -54,8 +54,7 @@
   },
   "errors": {
     "noAgentForMission": "Pick an agent before starting a task.",
-    "partialMissionLoad": "Some tasks could not load. We are trying again.",
-    "stopSession": "Couldn't stop the task: {{error}}"
+    "partialMissionLoad": "Some tasks could not load. We are trying again."
   },
   "agentPicker": {
     "title": "Which agent should run this?",

--- a/app/src/locales/es/dashboard.json
+++ b/app/src/locales/es/dashboard.json
@@ -54,8 +54,7 @@
   },
   "errors": {
     "noAgentForMission": "Elige un agente antes de iniciar una tarea.",
-    "partialMissionLoad": "Algunas tareas no se pudieron cargar. Lo estamos intentando de nuevo.",
-    "stopSession": "No se pudo detener la tarea: {{error}}"
+    "partialMissionLoad": "Algunas tareas no se pudieron cargar. Lo estamos intentando de nuevo."
   },
   "agentPicker": {
     "title": "¿Qué agente debería ejecutar esto?",

--- a/app/src/locales/pt/dashboard.json
+++ b/app/src/locales/pt/dashboard.json
@@ -54,8 +54,7 @@
   },
   "errors": {
     "noAgentForMission": "Escolha um agente antes de iniciar uma tarefa.",
-    "partialMissionLoad": "Algumas tarefas não puderam carregar. Estamos tentando novamente.",
-    "stopSession": "Não foi possível parar a tarefa: {{error}}"
+    "partialMissionLoad": "Algumas tarefas não puderam carregar. Estamos tentando novamente."
   },
   "agentPicker": {
     "title": "Qual agente deve fazer isso?",

--- a/app/tests/stop-error-toast-gate.test.ts
+++ b/app/tests/stop-error-toast-gate.test.ts
@@ -1,0 +1,69 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+// A Stop pressed while the agent's pod is still cold-starting: the cancel POST
+// answers the gateway's waking 502 ("engine proxy failed", the pod's service
+// name not resolving yet). `call("stop_session")` classified it and showed the
+// deduped "your agent is waking up" notice, then rethrew — and the stop catch
+// added a SECOND, red "Couldn't stop the task: <raw dial error>" toast on top,
+// so the user read the pair as the conversation being broken. Same
+// layered-gate shape as the rejection handler (engine-waking-rejection-gate
+// .test.ts): every catch that toasts after `call()` must decline the quiet
+// classes `call()` already surfaced.
+//
+// Asserted against the source: the helper pulls i18n and the Zustand store,
+// neither of which loads under this suite's `--experimental-strip-types`
+// runner (same constraint as error-toast-not-shown.test.ts).
+
+const read = (rel: string): string =>
+  readFileSync(join(import.meta.dirname, rel), "utf8");
+
+describe("showStopFailedToast declines already-surfaced failures", () => {
+  const source = read("../src/lib/stop-error-toast.ts");
+  const body = source.slice(
+    source.indexOf("export function showStopFailedToast("),
+  );
+  const guard = body.indexOf(
+    "if (isEngineWakingError(err) || isNetworkTransportError(err)) return;",
+  );
+  const toast = body.indexOf("addToast(");
+
+  it("imports both quiet-class classifiers", () => {
+    ok(source.includes('from "./engine-waking-error"'));
+    ok(source.includes('from "./network-transport-error"'));
+  });
+
+  it("gates the red toast on waking and connectivity", () => {
+    ok(guard !== -1, "the helper must decline waking/connectivity errors");
+    ok(toast !== -1, "every other failure keeps its toast");
+    ok(guard < toast, "the guard must run before the toast");
+  });
+
+  it("keeps the authored stop copy for real failures", () => {
+    ok(body.includes('i18n.t("chat:errors.stopSession"'));
+  });
+});
+
+describe("every Stop catch routes through the shared helper", () => {
+  for (const rel of [
+    "../src/components/board/use-agent-board-send.ts",
+    "../src/components/board/use-mc-actions.ts",
+  ]) {
+    it(`${rel} uses showStopFailedToast`, () => {
+      const source = read(rel);
+      ok(source.includes('from "../../lib/stop-error-toast"'));
+      const stop = source.slice(source.indexOf("tauriChat"));
+      const stopCall = stop.indexOf(".stop(");
+      ok(stopCall !== -1, "the stop call must exist");
+      const after = stop.slice(stopCall);
+      const catchAt = after.indexOf(".catch(showStopFailedToast)");
+      ok(catchAt !== -1, "the stop catch must be the shared helper");
+      ok(
+        !after.slice(0, catchAt).includes("errors.stopSession"),
+        "no inline stop toast may remain ahead of the helper",
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1624.

**Root cause.** A Stop pressed while the agent's pod is still cold-starting makes the cancel POST answer the gateway's waking 502 (`{"error":"engine proxy failed","detail":"... dial tcp: lookup agent-<id>...: no such host"}`). `call("stop_session")` in `app/src/lib/tauri.ts` already classifies that as a wake state and shows the deduped "Houston, your agent is waking up" notice, then rethrows. Both Stop catches (agent board `use-agent-board-send.ts`, Mission Control `use-mc-actions.ts`) then added a **second, red** `Couldn't stop the task: EngineError: engine request failed (502): {...}` toast quoting the raw gateway body. The user saw the info toast and a red box with a DNS dial error at once and read the conversation as broken. The held send in fact landed once the pod answered (the completion notification for the same mission arrived ~30s after the failed Stop in the local frontend log).

The pending `ask_user` card the conversation had ended on is not involved: the same Stop on the same waking pod fails identically with no pending interaction.

**Fix.** One `showStopFailedToast` (`app/src/lib/stop-error-toast.ts`, mirroring `showSendFailedToast`) that declines `isEngineWakingError` / `isNetworkTransportError` (already surfaced upstream) and keeps the authored `chat:errors.stopSession` toast for every other failure. Both call sites route through it. The now-unused `dashboard:errors.stopSession` string is dropped from en/es/pt.

**Test.** `app/tests/stop-error-toast-gate.test.ts` pins the guard order in the helper and that both Stop catches use it (source assertion, same pattern as `engine-waking-rejection-gate.test.ts`).

## Before

1. Sign in on the hosted profile and open a mission on an agent whose pod is asleep (idle long enough to scale to zero).
2. Send a message right away. The composer goes busy and the thinking indicator cycles while the gateway holds the send for the cold start.
3. Press the Stop square (or Esc) before the pod is up.
4. Observe two toasts: the info "your agent is waking up" notice **and** a red "Couldn't stop the task: EngineError: engine request failed (502): {"detail":"Post ... /cancel: dial tcp: lookup ... no such host","error":"engine proxy failed"}".

## After

1. Same steps 1 to 3.
2. Only the info "your agent is waking up" toast shows. No red toast. The frontend log still records `[engine:stop_session] engine request failed (502)` and `[toast:stop_session] ...`.
3. Once the pod is up, the held send runs and the reply arrives; the conversation continues normally.
4. A real Stop failure (any non-waking, non-connectivity error) still shows "Couldn't stop the task: ...".

## Checks

- `pnpm check` (Biome) exits 0
- `cd app && pnpm tsgo --noEmit` exits 0
- `cd app && pnpm test`: 3867 pass, 0 fail
- `cd app && pnpm check-locales`: all locales in sync
