### PR TITLE
fix(chat): keep the waking 502 board-status persist out of the feed (PRODUCT-1638)

### DIFF
--- a/packages/web/src/engine-adapter/feed-output.ts
+++ b/packages/web/src/engine-adapter/feed-output.ts
@@ -1,3 +1,5 @@
+import { isEngineWakingError } from "@houston/app/lib/engine-waking-error";
+import { isNetworkTransportError } from "@houston/app/lib/network-transport-error";
 import type {
   BoardStatus,
   FeedOutput,
@@ -40,7 +42,8 @@ function remapProvider(item: unknown): unknown {
  * Build a bus-backed FeedOutput. `setActivityStatus` is the board-card persist
  * seam (localStorage in standalone web, the control plane in cloud); a failure
  * surfaces in the feed as a system message rather than hanging the card in
- * "running".
+ * "running" — except the two quiet classes, which are expected environment
+ * states the surfacing layer already covers (see `persistBoardStatus`).
  */
 export function createBusFeedOutput(
   setActivityStatus: (
@@ -80,6 +83,17 @@ export function createBusFeedOutput(
           pendingInteraction ?? null,
         );
       } catch (e) {
+        // A send into an asleep mission starts the turn on the client, and the
+        // turn-start persist ("running") lands on a pod still cold-starting:
+        // the gateway answers its waking 502/503. Nothing is broken and there
+        // is nothing to "try again" — the waking notice already covers the
+        // state and the settle re-persists the status once the pod is up — so
+        // that answer (and a plain connectivity drop) must not put a line in
+        // the transcript. Same quiet classes as `tauri.ts` / `reportError`.
+        if (isEngineWakingError(e) || isNetworkTransportError(e)) {
+          console.warn("[feed-output] board status update deferred:", e);
+          return;
+        }
         // The raw cause is dev speak — log it, show product voice (HOU-721).
         console.error("[feed-output] board status update failed:", e);
         emitEvent("FeedItem", {

--- a/packages/web/tests/feed-output.test.ts
+++ b/packages/web/tests/feed-output.test.ts
@@ -128,3 +128,66 @@ test("a failing board persist surfaces in the feed, not silently", async () => {
   });
   expect(surfaced).toBe(true);
 });
+
+/** The shape `HoustonEngineError` mints for a gateway answer (structural
+ *  stand-in, matching app/tests/engine-waking-error.test.ts). */
+function engineError(status: number, reason: string): Error {
+  const err = new Error(`${reason} (engine error ${status})`) as Error & {
+    status: number;
+  };
+  err.name = "HoustonEngineError";
+  err.status = status;
+  return err;
+}
+
+function systemMessages(events: BusEvent[]): unknown[] {
+  return events
+    .filter(
+      (e) =>
+        e.type === "FeedItem" && e.data?.item?.feed_type === "system_message",
+    )
+    .map((e) => e.data?.item?.data);
+}
+
+// PRODUCT-1638: the turn-start persist on an asleep pod answers the gateway's
+// waking 502/503. That is not a failure the user can act on — the waking
+// notice already covers it and the settle re-persists — so it must not push
+// "Couldn't update the board status" into the transcript.
+test("a waking 502/503 on the board persist stays out of the feed", async () => {
+  const { events, stop } = collect();
+  const out = createBusFeedOutput(async (_a, _s, status) => {
+    if (status === "running") throw engineError(502, "engine proxy failed");
+    throw engineError(503, "engine unavailable");
+  });
+  await out.persistBoardStatus("Houston/Bo", "c1", "running");
+  await out.persistBoardStatus("Houston/Bo", "c1", "needs_you");
+  stop();
+
+  expect(systemMessages(events)).toEqual([]);
+});
+
+// A plain connectivity drop (device offline / host unreachable) is the same
+// quiet class: the connectivity surface already owns it.
+test("a transport failure on the board persist stays out of the feed", async () => {
+  const { events, stop } = collect();
+  const out = createBusFeedOutput(async () => {
+    throw new TypeError("Load failed");
+  });
+  await out.persistBoardStatus("Houston/Bo", "c1", "running");
+  stop();
+
+  expect(systemMessages(events)).toEqual([]);
+});
+
+// Other gateway answers on the same statuses are real failures and keep the
+// existing system message — a false quiet here silently drops a report.
+test("a non-waking 502 on the board persist still surfaces in the feed", async () => {
+  const { events, stop } = collect();
+  const out = createBusFeedOutput(async () => {
+    throw engineError(502, "agent pod unusable");
+  });
+  await out.persistBoardStatus("Houston/Bo", "c1", "running");
+  stop();
+
+  expect(systemMessages(events)).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

Sending a message into a mission whose pod is asleep starts the turn on the client. The SDK's turn-start `persistBoardStatus` PATCHes the activity to `running`, and on a cold-starting pod that answers the gateway's waking `502 engine proxy failed`. The web adapter's `FeedOutput` (`packages/web/src/engine-adapter/feed-output.ts`) caught that like any other persist failure and pushed a `system_message` ("Couldn't update the board status. Please try again.") into the transcript. Nothing was broken: the waking notice already covers the state, and the settle re-persists the status once the pod is up, so there is nothing to try again.

The catch now runs the same quiet-class classifiers the rest of the surfacing layer uses (`isEngineWakingError`, `isNetworkTransportError`). A waking 502/503 or a transport-level connectivity failure logs a warning and emits nothing; every other failure keeps the existing system message.

Fixes PRODUCT-1638 (follow-up from PRODUCT-1624).

## Before

1. Open a cloud mission whose agent pod is asleep (idle long enough to scale to zero).
2. Send a message.
3. While the pod cold-starts, the transcript shows "Couldn't update the board status. Please try again." alongside the waking notice. The frontend log shows `[feed-output] board status update failed: HoustonEngineError: engine proxy failed (engine error 502)`.

## After

1. Same steps: only the waking notice shows, the transcript stays clean, and the reply lands once the pod is up.
2. The frontend log shows `[feed-output] board status update deferred: ...` at warn level instead.
3. A non-waking persist failure (for example `502 agent pod unusable`) still surfaces the system message.

## Verification

- `pnpm --filter houston-web test` (3 new cases in `tests/feed-output.test.ts`: waking 502/503 quiet, transport failure quiet, non-waking 502 still surfaces)
- `pnpm --filter houston-web typecheck`
- `pnpm check`, `pnpm check:boundaries`