### PR TITLE
fix(chat): show authored toast copy instead of raw error bodies (PRODUCT-1639)

### DIFF
--- a/app/src/components/board/use-board-selection-ui.tsx
+++ b/app/src/components/board/use-board-selection-ui.tsx
@@ -2,6 +2,7 @@ import type { KanbanColumnConfig, KanbanItem } from "@houston-ai/board";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { fireMissionDoneConfetti } from "../../lib/confetti";
+import { logAndReportError } from "../../lib/error-report";
 import {
   celebratesMissionDone,
   DONE_STATUS,
@@ -152,8 +153,9 @@ export function useBoardSelectionUI({
         await op();
         return true;
       } catch (err) {
+        logAndReportError("bulk_update_missions", err);
         addToast({
-          title: t("board:bulk.error", { error: String(err) }),
+          title: t("board:bulk.error"),
           variant: "error",
         });
         return false;

--- a/app/src/components/board/use-mc-actions.ts
+++ b/app/src/components/board/use-mc-actions.ts
@@ -2,6 +2,7 @@ import type { KanbanItem } from "@houston-ai/board";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { logAndReportError } from "../../lib/error-report";
 import { armMissionDoneCelebration } from "../../lib/mission-done-celebration";
 import { canDropMission } from "../../lib/mission-selection";
 import { queryKeys } from "../../lib/query-keys";
@@ -127,8 +128,9 @@ export function useMcActions({
         qc.invalidateQueries({ queryKey: queryKeys.allConversations(paths) });
         qc.invalidateQueries({ queryKey: queryKeys.activity(agentPath) });
       } catch (err) {
+        logAndReportError("move_mission", err);
         addToast({
-          title: t("board:dnd.moveError", { error: String(err) }),
+          title: t("board:dnd.moveError"),
           variant: "error",
         });
         return;

--- a/app/src/components/settings/sections/notifications.tsx
+++ b/app/src/components/settings/sections/notifications.tsx
@@ -2,7 +2,10 @@ import { Switch } from "@houston-ai/core";
 import { Bell } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { genericErrorDescription } from "../../../lib/error-report";
+import {
+  genericErrorDescription,
+  logAndReportError,
+} from "../../../lib/error-report";
 import {
   type NotificationRowState,
   notificationRowState,
@@ -87,10 +90,9 @@ export function NotificationsSection() {
     try {
       await osOpenNotificationSettings();
     } catch (err) {
+      logAndReportError("open_notification_settings", err);
       addToast({
-        title: t("common:notifications.openSettingsFailed", {
-          error: String(err),
-        }),
+        title: t("common:notifications.openSettingsFailed"),
         variant: "error",
       });
     }

--- a/app/src/lib/notification-nudge.ts
+++ b/app/src/lib/notification-nudge.ts
@@ -11,6 +11,7 @@
 
 import type { TFunction } from "i18next";
 import type { ToastItem } from "../stores/ui";
+import { logAndReportError } from "./error-report";
 import { logger } from "./logger";
 import {
   shouldShowCatchNet,
@@ -70,10 +71,9 @@ async function runPermissionCta(deps: NudgeDeps): Promise<void> {
           label: t("common:notifications.openSettings"),
           onClick: () => {
             osOpenNotificationSettings().catch((err) => {
+              logAndReportError("open_notification_settings", err);
               addToast({
-                title: t("common:notifications.openSettingsFailed", {
-                  error: String(err),
-                }),
+                title: t("common:notifications.openSettingsFailed"),
                 variant: "error",
               });
             });
@@ -84,8 +84,9 @@ async function runPermissionCta(deps: NudgeDeps): Promise<void> {
       addToast({ title: t("common:notifications.blockedBrowser") });
     }
   } catch (err) {
+    logAndReportError("request_notification_permission", err);
     addToast({
-      title: t("common:notifications.requestFailed", { error: String(err) }),
+      title: t("common:notifications.requestFailed"),
       variant: "error",
     });
   }

--- a/app/src/lib/send-error-toast.ts
+++ b/app/src/lib/send-error-toast.ts
@@ -1,4 +1,5 @@
 import { useUIStore } from "../stores/ui";
+import { logAndReportError } from "./error-report";
 import { showExpectedStateToast } from "./error-toast";
 import i18n from "./i18n";
 import { isStaleAttachmentError } from "./stale-attachment";
@@ -16,6 +17,10 @@ import { isStaleAttachmentError } from "./stale-attachment";
  * DOMException, which reads as "Houston is broken" and gives no way out.
  * Sentry capture for it is silenced at the `save_attachments` call in
  * `tauri.ts`; the raw diagnostic still reaches the frontend log there.
+ *
+ * Every other failure shows authored copy only: the raw error (an
+ * `EngineError` quoting an HTTP status, a JSON body, a cluster hostname) goes
+ * to the frontend log and Sentry via `logAndReportError`, never into the toast.
  */
 export function showSendFailedToast(err: unknown): void {
   if (isStaleAttachmentError(err)) {
@@ -25,8 +30,9 @@ export function showSendFailedToast(err: unknown): void {
     );
     return;
   }
+  logAndReportError("send_message", err);
   useUIStore.getState().addToast({
-    title: i18n.t("chat:errors.sessionStart", { error: String(err) }),
+    title: i18n.t("chat:errors.sessionStart"),
     variant: "error",
   });
 }

--- a/app/src/lib/stop-error-toast.ts
+++ b/app/src/lib/stop-error-toast.ts
@@ -1,5 +1,6 @@
 import { useUIStore } from "../stores/ui";
 import { isEngineWakingError } from "./engine-waking-error";
+import { logAndReportError } from "./error-report";
 import i18n from "./i18n";
 import { isNetworkTransportError } from "./network-transport-error";
 
@@ -19,12 +20,14 @@ import { isNetworkTransportError } from "./network-transport-error";
  * not something a Stop can fix (the held send lands once the pod answers), so
  * the red toast is skipped for them; everything else keeps the actionable
  * "couldn't stop" toast as its only user-visible surface (no-silent-failures
- * rule).
+ * rule). The toast is authored copy only: the raw gateway body (a DNS dial
+ * error naming a pod service) goes to the log and Sentry, never on screen.
  */
 export function showStopFailedToast(err: unknown): void {
   if (isEngineWakingError(err) || isNetworkTransportError(err)) return;
+  logAndReportError("stop_session", err);
   useUIStore.getState().addToast({
-    title: i18n.t("chat:errors.stopSession", { error: String(err) }),
+    title: i18n.t("chat:errors.stopSession"),
     variant: "error",
   });
 }

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -68,7 +68,7 @@
     "delete": "Delete",
     "clear": "Clear selection",
     "cancel": "Cancel",
-    "error": "Couldn't update the selected tasks: {{error}}",
+    "error": "Couldn't update the selected tasks. Please try again.",
     "confirmMove": {
       "title": "Move tasks?",
       "description_one": "Move {{count}} task to {{target}}?",
@@ -97,6 +97,6 @@
     "emptyDescription": "Archived tasks appear here. Reply to one to bring it back."
   },
   "dnd": {
-    "moveError": "Couldn't move the task: {{error}}"
+    "moveError": "Couldn't move the task. Please try again."
   }
 }

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -114,10 +114,10 @@
     "goToMain": "Go to main mission"
   },
   "errors": {
-    "sessionStart": "Failed to start session: {{error}}",
+    "sessionStart": "Couldn't send your message. Please try again.",
     "staleAttachmentTitle": "We couldn't read an attached file",
     "staleAttachmentBody": "A file you attached changed or was deleted on your device after you added it. Remove it from your message and attach it again.",
-    "stopSession": "Couldn't stop the task: {{error}}",
+    "stopSession": "Couldn't stop the task. Please try again.",
     "modelPersistFailed": "Failed to save model preference",
     "modelNotAllowed": "This model isn't allowed for this agent",
     "missionRowFailed": "We could not save this task to your board. Your message was still sent.",

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -68,7 +68,7 @@
     "blocked": "Notifications are blocked. Open your system settings to turn them on.",
     "blockedBrowser": "Notifications are blocked. Turn them on in your browser settings.",
     "openSettings": "Open System Settings",
-    "openSettingsFailed": "Could not open system settings. {{error}}",
-    "requestFailed": "Could not turn on notifications. {{error}}"
+    "openSettingsFailed": "Could not open system settings. Please try again.",
+    "requestFailed": "Could not turn on notifications. Please try again."
   }
 }

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -68,7 +68,7 @@
     "delete": "Eliminar",
     "clear": "Quitar selección",
     "cancel": "Cancelar",
-    "error": "No se pudieron actualizar las tareas seleccionadas: {{error}}",
+    "error": "No se pudieron actualizar las tareas seleccionadas. Inténtalo de nuevo.",
     "confirmMove": {
       "title": "¿Mover tareas?",
       "description_one": "¿Mover {{count}} tarea a {{target}}?",
@@ -97,6 +97,6 @@
     "emptyDescription": "Las tareas archivadas aparecen aquí. Responde a una para reactivarla."
   },
   "dnd": {
-    "moveError": "No se pudo mover la tarea: {{error}}"
+    "moveError": "No se pudo mover la tarea. Inténtalo de nuevo."
   }
 }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -114,10 +114,10 @@
     "goToMain": "Ir a la misión principal"
   },
   "errors": {
-    "sessionStart": "No se pudo iniciar la sesión: {{error}}",
+    "sessionStart": "No se pudo enviar tu mensaje. Inténtalo de nuevo.",
     "staleAttachmentTitle": "No pudimos leer un archivo adjunto",
     "staleAttachmentBody": "Un archivo que adjuntaste cambió o se eliminó de tu dispositivo después de agregarlo. Quítalo del mensaje y adjúntalo de nuevo.",
-    "stopSession": "No se pudo detener la tarea: {{error}}",
+    "stopSession": "No se pudo detener la tarea. Inténtalo de nuevo.",
     "modelPersistFailed": "No se pudo guardar la preferencia de modelo",
     "modelNotAllowed": "Este modelo no está permitido para este agente",
     "missionRowFailed": "No pudimos guardar esta tarea en tu tablero. Tu mensaje sí fue enviado.",

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -68,7 +68,7 @@
     "blocked": "Las notificaciones están bloqueadas. Abre la configuración del sistema para activarlas.",
     "blockedBrowser": "Las notificaciones están bloqueadas. Actívalas en la configuración de tu navegador.",
     "openSettings": "Abrir configuración del sistema",
-    "openSettingsFailed": "No se pudo abrir la configuración del sistema. {{error}}",
-    "requestFailed": "No se pudieron activar las notificaciones. {{error}}"
+    "openSettingsFailed": "No se pudo abrir la configuración del sistema. Inténtalo de nuevo.",
+    "requestFailed": "No se pudieron activar las notificaciones. Inténtalo de nuevo."
   }
 }

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -68,7 +68,7 @@
     "delete": "Excluir",
     "clear": "Limpar seleção",
     "cancel": "Cancelar",
-    "error": "Não foi possível atualizar as tarefas selecionadas: {{error}}",
+    "error": "Não foi possível atualizar as tarefas selecionadas. Tente novamente.",
     "confirmMove": {
       "title": "Mover tarefas?",
       "description_one": "Mover {{count}} tarefa para {{target}}?",
@@ -97,6 +97,6 @@
     "emptyDescription": "As tarefas arquivadas aparecem aqui. Responda a uma para reativá-la."
   },
   "dnd": {
-    "moveError": "Não foi possível mover a tarefa: {{error}}"
+    "moveError": "Não foi possível mover a tarefa. Tente novamente."
   }
 }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -114,10 +114,10 @@
     "goToMain": "Ir para a missão principal"
   },
   "errors": {
-    "sessionStart": "Não foi possível iniciar a sessão: {{error}}",
+    "sessionStart": "Não foi possível enviar sua mensagem. Tente novamente.",
     "staleAttachmentTitle": "Não conseguimos ler um arquivo anexado",
     "staleAttachmentBody": "Um arquivo que você anexou foi alterado ou excluído do seu dispositivo depois de adicionado. Remova-o da mensagem e anexe-o novamente.",
-    "stopSession": "Não foi possível parar a tarefa: {{error}}",
+    "stopSession": "Não foi possível parar a tarefa. Tente novamente.",
     "modelPersistFailed": "Não foi possível salvar a preferência de modelo",
     "modelNotAllowed": "Este modelo não é permitido para este agente",
     "missionRowFailed": "Não conseguimos salvar esta tarefa no seu quadro. Sua mensagem foi enviada.",

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -68,7 +68,7 @@
     "blocked": "As notificações estão bloqueadas. Abra as configurações do sistema para ativá-las.",
     "blockedBrowser": "As notificações estão bloqueadas. Ative-as nas configurações do seu navegador.",
     "openSettings": "Abrir configurações do sistema",
-    "openSettingsFailed": "Não foi possível abrir as configurações do sistema. {{error}}",
-    "requestFailed": "Não foi possível ativar as notificações. {{error}}"
+    "openSettingsFailed": "Não foi possível abrir as configurações do sistema. Tente novamente.",
+    "requestFailed": "Não foi possível ativar as notificações. Tente novamente."
   }
 }

--- a/app/tests/toast-copy-no-raw-error.test.ts
+++ b/app/tests/toast-copy-no-raw-error.test.ts
@@ -1,0 +1,70 @@
+import { deepStrictEqual } from "node:assert";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, it } from "node:test";
+
+// A toast is authored product copy, never a raw diagnostic. Before this guard,
+// six locale keys carried `{{error}}` and their catch blocks filled it with
+// `String(err)`, so a Stop on a cold pod read "Couldn't stop the task:
+// EngineError: engine request failed (502): {"detail":"Post \"http://agent-…
+// .svc.cluster.local:4318/…\": dial tcp: lookup … no such host"}": class
+// names, HTTP statuses, JSON, and cluster hostnames in a red box for a
+// non-technical user. The raw error belongs to the reporting paths
+// (`logAndReportError` / `showErrorToast`), which every rewritten catch still
+// calls. Two source-level checks keep the shape from coming back:
+//  - no locale string interpolates `{{error}}` (in any language, so a
+//    translation can't reintroduce it either);
+//  - no `t(...)` / `i18n.t(...)` call in app/src passes an `error:` variable.
+
+const SRC = join(import.meta.dirname, "..", "src");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+function leafStrings(value: unknown, path: string, out: [string, string][]) {
+  if (typeof value === "string") out.push([path, value]);
+  else if (value && typeof value === "object") {
+    for (const [k, v] of Object.entries(value))
+      leafStrings(v, `${path}.${k}`, out);
+  }
+}
+
+describe("toast copy never interpolates a raw error", () => {
+  it("no locale string carries {{error}}", () => {
+    const offenders: string[] = [];
+    const localesDir = join(SRC, "locales");
+    for (const file of walk(localesDir).filter((f) => f.endsWith(".json"))) {
+      const leaves: [string, string][] = [];
+      leafStrings(
+        JSON.parse(readFileSync(file, "utf8")),
+        relative(localesDir, file),
+        leaves,
+      );
+      for (const [path, text] of leaves) {
+        if (/\{\{\s*error\s*\}\}/.test(text)) offenders.push(path);
+      }
+    }
+    deepStrictEqual(offenders, []);
+  });
+
+  it("no t() call in app/src passes an `error:` variable", () => {
+    // Matches `t("ns:key", { error: ... })` and `i18n.t("key", {\n error: ...`
+    // across lines; `[^}]*` keeps the scan inside the options object.
+    const interpolatedError =
+      /\bt\(\s*["'`][^"'`]*["'`]\s*,\s*\{[^}]*\berror\s*:/g;
+    const offenders: string[] = [];
+    for (const file of walk(SRC)) {
+      if (!/\.(ts|tsx)$/.test(file) || /\.test\.tsx?$/.test(file)) continue;
+      const source = readFileSync(file, "utf8");
+      if (interpolatedError.test(source)) offenders.push(relative(SRC, file));
+      interpolatedError.lastIndex = 0;
+    }
+    deepStrictEqual(offenders, []);
+  });
+});


### PR DESCRIPTION
Fixes PRODUCT-1639. Stacked on #1465 (PRODUCT-1624), which moves the Stop catch into the shared `showStopFailedToast` helper this sweep rewrites; GitHub retargets this PR to `main` once #1465 merges.

## Root cause

Six locale keys interpolated `{{error}}` and their catch blocks filled it with `String(err)`:

| key | action |
|---|---|
| `chat:errors.sessionStart` | send a message |
| `chat:errors.stopSession` | stop a task |
| `board:dnd.moveError` | drag a card to another column |
| `board:bulk.error` | bulk move / archive / delete |
| `common:notifications.openSettingsFailed` | open system notification settings |
| `common:notifications.requestFailed` | request notification permission |

An `EngineError` stringifies to its class name, the HTTP status, and the gateway's JSON body, so a Stop against a cold pod rendered a red toast quoting a `dial tcp: lookup agent-… no such host` line with a cluster service name and a resolver IP. That is unreadable for a non-technical user and leaks infrastructure internals into the UI.

## Fix

- The six keys carry plain authored copy in en / es / pt ("Couldn't stop the task. Please try again." and the like). No key was added or removed, so no i18n type churn.
- Each rewritten catch calls `logAndReportError(<command>, err)` before toasting, so the raw diagnostic still reaches the frontend log and Sentry. The helper dedupes against the engine-call layer's own capture, so nothing is double-reported.
- New `app/tests/toast-copy-no-raw-error.test.ts` walks every locale JSON (all languages, so a translation can't reintroduce it) and every `.ts`/`.tsx` under `app/src`, failing on any `{{error}}` string or any `t()` / `i18n.t()` call that passes an `error:` variable. Verified it fails when either shape is put back.

## Verification

Before (on `main`): in the web app or desktop app, open a cloud agent whose pod is asleep (or point the host URL at a dead port), send a message, press Stop while it is pending. The red toast reads `Couldn't stop the task: EngineError: engine request failed (502): {"detail":"Post \"http://agent-…svc.cluster.local:4318/…\"…`. Alternatively, drag a board card between columns with the host unreachable and read the `moveError` toast.

After (this branch): the same actions show "Couldn't stop the task. Please try again." / "Couldn't move the task. Please try again." in the app language, with the raw error in the frontend log (`[stop_session] …`) and a Sentry event tagged with that command.

Gates run locally: `pnpm check` (Biome), `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (3869 pass), `cd app && pnpm check-locales`.
