### PR TITLE
fix(app): make the in-app setup completable on the phone shell (PRODUCT-1631)

### DIFF
--- a/app/src/components/board/mobile-board-controls.tsx
+++ b/app/src/components/board/mobile-board-controls.tsx
@@ -6,6 +6,7 @@ import { openMissionChat } from "../../lib/mission-chat";
 import { startNewMission } from "../../lib/new-mission";
 import type { Agent } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
+import { tourAnchor } from "../shell/workspace-tour-steps";
 
 const chipClass =
   "shrink-0 rounded-full px-3 py-1.5 text-sm font-medium transition-colors active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus";
@@ -78,6 +79,7 @@ export function MobileBoardControls({
         {modeToggle}
         <button
           type="button"
+          {...tourAnchor("newMission")}
           aria-label={t("shell:sidebar.newMission")}
           onClick={compose}
           className="flex size-10 shrink-0 items-center justify-center rounded-full text-ink-muted transition-colors active:scale-95 hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus"

--- a/app/src/components/onboarding/first-run-screen.tsx
+++ b/app/src/components/onboarding/first-run-screen.tsx
@@ -13,7 +13,9 @@ import { isMac } from "../../lib/platform";
  * page even for a dark-mode user (that decision stands — the pre-workspace flow
  * is deliberately always light), and so every `--ht-*` token inside resolves to
  * its light value regardless of the app theme. A `z-10` content slot floats on
- * top; children never need to re-declare the stacking.
+ * top; children never need to re-declare the stacking. The slot is `min-h-0`
+ * so a screen taller than a short phone viewport scrolls INSIDE its card
+ * instead of growing the slot past the `h-dvh` frame and off the screen.
  */
 export function FirstRunScreen({
   children,
@@ -41,7 +43,9 @@ export function FirstRunScreen({
           className="absolute inset-x-0 top-0 z-20 h-7"
         />
       )}
-      <div className="relative z-10 flex flex-1 flex-col">{children}</div>
+      <div className="relative z-10 flex min-h-0 flex-1 flex-col">
+        {children}
+      </div>
     </div>
   );
 }

--- a/app/src/components/onboarding/in-app-drawer-spotlight.tsx
+++ b/app/src/components/onboarding/in-app-drawer-spotlight.tsx
@@ -1,0 +1,45 @@
+import { useIsMobile } from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import { useUIStore } from "../../stores/ui";
+import { tourSelector } from "../shell/workspace-tour-steps.ts";
+import { TutorialSpotlight } from "../tutorial";
+import { drawerSpotPhase } from "./in-app-mobile-targets";
+
+/**
+ * A spotlight on a sidebar row (AI Models, Integrations, New agent).
+ *
+ * On desktop the rail is always on the glass, so this IS the plain spotlight.
+ * Below md the rail is hosted in a drawer (a Sheet) behind the top bar's
+ * hamburger: while the drawer is shut the row is not in the DOM, so the step
+ * first rings the hamburger, and once the drawer is open it rings the row
+ * INSIDE it in the in-dialog mode — the Sheet is a Radix dialog, the same
+ * layering the create-agent dialog coaching rides. Tapping the row navigates
+ * and closes the drawer, and the step advances on the app state it always
+ * advanced on. A structural fork (`useIsMobile`): the target tree differs,
+ * not its layout.
+ */
+export function DrawerSpotlight(props: {
+  selector: string;
+  title: string;
+  hint?: string;
+  aside?: string;
+  asideCta?: string;
+  onAsideCta?: () => void;
+}) {
+  const { t } = useTranslation("setup");
+  const isMobile = useIsMobile();
+  const drawerOpen = useUIStore((s) => s.mobileSidebarOpen);
+  const phase = drawerSpotPhase({ isMobile, drawerOpen });
+  if (phase === "rail") return <TutorialSpotlight {...props} />;
+  if (phase === "inDrawer") return <TutorialSpotlight inDialog {...props} />;
+  return (
+    <TutorialSpotlight
+      selector={tourSelector("mobileMenu")}
+      title={t("inApp.steps.openMenu.title")}
+      hint={t("inApp.steps.openMenu.hint")}
+      aside={props.aside}
+      asideCta={props.asideCta}
+      onAsideCta={props.onAsideCta}
+    />
+  );
+}

--- a/app/src/components/onboarding/in-app-mobile-targets.ts
+++ b/app/src/components/onboarding/in-app-mobile-targets.ts
@@ -1,0 +1,58 @@
+import { tourSelector } from "../shell/workspace-tour-steps.ts";
+
+/**
+ * Where the in-app onboarding's spot steps point on the PHONE, kept pure so
+ * the fork unit-tests without React (`app/tests/in-app-mobile-targets.test.ts`).
+ *
+ * Below md the shell is a different tree, not a narrower one: the sidebar rail
+ * lives in a drawer behind the top bar's hamburger, the board's New task is
+ * the phone board's own compose control, and composing is a pushed chat
+ * screen rather than the board's side panel. A step that names a desktop
+ * control by selector alone points at nothing there — and with nothing to
+ * ring, the veil's blockers cover the whole screen, the hamburger included.
+ */
+
+/** A sidebar-row step's three shapes: the rail on the glass (desktop), the
+ *  hamburger while the drawer is shut, the row inside the open drawer. */
+export type DrawerSpotPhase = "rail" | "openMenu" | "inDrawer";
+
+export function drawerSpotPhase(args: {
+  isMobile: boolean;
+  drawerOpen: boolean;
+}): DrawerSpotPhase {
+  if (!args.isMobile) return "rail";
+  return args.drawerOpen ? "inDrawer" : "openMenu";
+}
+
+/** What the send step is ringing: the New task control, the desktop board's
+ *  side panel, or the phone's pushed draft chat. */
+export type SendMissionSurface = "button" | "panel" | "chat";
+
+export function sendMissionSurface(args: {
+  panelOpen: boolean;
+  chatOpen: boolean;
+}): SendMissionSurface {
+  if (args.chatOpen) return "chat";
+  if (args.panelOpen) return "panel";
+  return "button";
+}
+
+const MISSION_PANEL = '[data-testid="mission-panel"]';
+const MISSION_CHAT = '[data-testid="mission-chat-screen"]';
+
+/**
+ * The send step's selector. The New task control is scoped to the ACTIVE
+ * screen (kept-alive views keep their own), and the spotlight itself takes
+ * the visible match, so the desktop button hidden beside the phone's compose
+ * never wins. In email mode the composer arrives prewritten and locked, and
+ * the hole narrows to the send button alone.
+ */
+export function sendMissionSelector(
+  surface: SendMissionSurface,
+  emailMode: boolean,
+): string {
+  if (surface === "button")
+    return `[data-screen-active='true'] ${tourSelector("newMission")}`;
+  const root = surface === "chat" ? MISSION_CHAT : MISSION_PANEL;
+  return emailMode ? `${root} button[type="submit"]` : root;
+}

--- a/app/src/components/onboarding/in-app-onboarding-agent-steps.tsx
+++ b/app/src/components/onboarding/in-app-onboarding-agent-steps.tsx
@@ -6,6 +6,11 @@ import {
   TutorialSpotlight,
   tutorialSelector,
 } from "../tutorial";
+import { DrawerSpotlight } from "./in-app-drawer-spotlight";
+import {
+  sendMissionSelector,
+  sendMissionSurface,
+} from "./in-app-mobile-targets";
 import type { useInAppOnboarding } from "./use-in-app-onboarding";
 import { useNamingPhase } from "./use-naming-phase";
 import { useSetupChecklist } from "./use-setup-checklist";
@@ -41,7 +46,7 @@ export function InAppOnboardingAgentSteps({
       );
     case "createAgent":
       return (
-        <TutorialSpotlight
+        <DrawerSpotlight
           selector={tourSelector("newAgent")}
           title={t("inApp.steps.createAgent.title")}
           hint={t("inApp.steps.createAgent.hint")}
@@ -98,25 +103,24 @@ export function InAppOnboardingAgentSteps({
           checklist={checklist}
         />
       );
-    case "sendMission":
-      // The hole follows the user's own progress: the New task button first;
-      // the moment THEIR click opens the composer panel (`userPanelOpen` — a
-      // lingering panel is closed first, so the lesson's click is never
-      // skipped), the panel. In email mode the composer arrives prewritten
-      // and locked, and the hole narrows to the SEND BUTTON alone — the rest
-      // of the panel (close, composer, pickers) stays blocked, and the cues
-      // point at exactly the control to press.
+    case "sendMission": {
+      // The hole follows the user's own progress: the New task control
+      // first; the moment THEIR tap opens a composer (the desktop board's
+      // panel, or the phone's pushed draft chat — a lingering one is closed
+      // first, so the lesson's click is never skipped), that surface. In
+      // email mode the composer arrives prewritten and locked, and the hole
+      // narrows to the SEND BUTTON alone — the rest stays blocked, and the
+      // cues point at exactly the control to press.
+      const surface = sendMissionSurface({
+        panelOpen: o.userPanelOpen,
+        chatOpen: o.userChatOpen,
+      });
+      const composing = surface !== "button";
       return (
         <TutorialSpotlight
-          selector={
-            o.userPanelOpen
-              ? o.emailMode
-                ? '[data-testid="mission-panel"] button[type="submit"]'
-                : '[data-testid="mission-panel"]'
-              : `[data-screen-active='true'] ${tourSelector("newMission")}`
-          }
+          selector={sendMissionSelector(surface, o.emailMode)}
           title={
-            o.userPanelOpen
+            composing
               ? t(
                   o.emailMode
                     ? "inApp.steps.sendMission.sendTitle"
@@ -125,7 +129,7 @@ export function InAppOnboardingAgentSteps({
               : t("inApp.steps.sendMission.title")
           }
           hint={
-            o.userPanelOpen
+            composing
               ? t(
                   o.emailMode
                     ? "inApp.steps.sendMission.sendHint"
@@ -139,13 +143,17 @@ export function InAppOnboardingAgentSteps({
           }
         />
       );
+    }
     case "emailSending":
       // Watch-only: the agent is working, nothing to click. If it errors or
       // takes too long, the addendum offers the way onward (the task WAS
       // sent) — a watch beat must never be a dead end.
       return (
         <TutorialSpotlight
-          selector='[data-testid="mission-panel"]'
+          selector={sendMissionSelector(
+            o.userChatOpen ? "chat" : "panel",
+            false,
+          )}
           title={t("inApp.steps.emailSending.title")}
           hint={t("inApp.steps.emailSending.hint")}
           aside={o.emailStuck ? t("inApp.steps.emailSending.stuck") : undefined}

--- a/app/src/components/onboarding/in-app-onboarding.tsx
+++ b/app/src/components/onboarding/in-app-onboarding.tsx
@@ -10,6 +10,7 @@ import {
   TutorialSpotlight,
   tutorialSelector,
 } from "../tutorial";
+import { DrawerSpotlight } from "./in-app-drawer-spotlight";
 import { InAppOnboardingAgentSteps } from "./in-app-onboarding-agent-steps";
 import { useInAppOnboarding } from "./use-in-app-onboarding";
 import { useSetupChecklist } from "./use-setup-checklist";
@@ -68,7 +69,7 @@ export function InAppOnboarding() {
       );
     case "openAiHub":
       return (
-        <TutorialSpotlight
+        <DrawerSpotlight
           selector={tourSelector("nav-ai-hub")}
           title={t("inApp.steps.openAiHub.title")}
         />
@@ -112,7 +113,7 @@ export function InAppOnboarding() {
       );
     case "openIntegrations":
       return (
-        <TutorialSpotlight
+        <DrawerSpotlight
           selector={tourSelector("nav-integrations")}
           title={t("inApp.steps.openIntegrations.title")}
         />

--- a/app/src/components/onboarding/in-app-resume.ts
+++ b/app/src/components/onboarding/in-app-resume.ts
@@ -1,0 +1,55 @@
+import type { InAppStep } from "./in-app-onboarding-flow";
+
+/**
+ * Where an interrupted in-app setup picks up, pure so it unit-tests without
+ * React (`app/tests/in-app-resume.test.ts`).
+ *
+ * `onboarding_pending` brings a quit-mid-setup user back INTO the flow, but
+ * the flow used to restart at its welcome beat every time. On a phone that is
+ * not a rare path: leaving the tab to fetch a sign-in code (claude.ai, an
+ * authenticator) is enough for the browser to evict and reload the page, and
+ * the user came back to "Start setup" with the paste dialog gone. The current
+ * step is mirrored on the device and the run re-enters at the last SAFE beat
+ * of the sequence it was in — a spot step re-armed by its own intro or
+ * sidebar beat, never a step whose in-memory prerequisites (the agent-count
+ * baseline, the send discipline, an open dialog) the reload dropped.
+ */
+export function resumeStepFor(saved: string | null | undefined): InAppStep {
+  switch (saved) {
+    case "welcome":
+    case "connectAiIntro":
+    case "integrationsIntro":
+    case "createAgentIntro":
+    case "agentCreated":
+    case "sendMissionIntro":
+    case "academyReveal":
+      return saved;
+    // The AI sequence: the sidebar beat self-advances on the hub, and the
+    // connect beat re-snapshots whether the AI got connected while away.
+    case "openAiHub":
+    case "connectAi":
+    case "aiConnected":
+      return "openAiHub";
+    case "openIntegrations":
+    case "connectIntegration":
+    case "integrationConnected":
+      return "openIntegrations";
+    // The intro's "Show me" seeds the agent-count baseline the spot needs.
+    case "createAgent":
+    case "createAgentDialog":
+      return "createAgentIntro";
+    // The intro's "Show me" re-arms the send discipline and the email task.
+    case "sendMission":
+    case "missionSent":
+    case "emailSending":
+    case "emailSent":
+      return "sendMissionIntro";
+    default:
+      return "welcome";
+  }
+}
+
+/** Per-user device key for the mirrored step; `null` uid = the local user. */
+export function inAppResumeKey(uid: string | null): string {
+  return `houston.onboarding.in-app-step.${uid ?? "local"}`;
+}

--- a/app/src/components/onboarding/setup-card.tsx
+++ b/app/src/components/onboarding/setup-card.tsx
@@ -11,7 +11,8 @@ export { OptionCard } from "./option-card";
  * and each onboarding step read as a single coherent flow rather than a pile of
  * mismatched screens. Modeled on the Discord server-onboarding pattern: a
  * centered card with a small step eyebrow, one clear question, the content, and
- * a Back / helper / Next footer.
+ * a Back / helper / Next footer (stacked with Next on top below md, where a
+ * long Next label would otherwise run off the card).
  *
  * Always a plain white card ({@link https://…|`bg-card`}) that floats on the
  * calm grey {@link FirstRunScreen} background: a hairline `border-line` and a
@@ -82,13 +83,13 @@ export function SetupCard({
         <div className="mt-6 flex min-h-0 flex-1 flex-col">{children}</div>
 
         {(onBack || onNext || helper) && (
-          <div className="mt-8 flex items-center justify-between gap-4">
+          <div className="mt-6 flex flex-col-reverse gap-3 md:mt-8 md:flex-row md:items-center md:justify-between md:gap-4">
             <div className="shrink-0">
               {onBack && (
                 <Button
                   type="button"
                   variant="secondary"
-                  className="rounded-full"
+                  className="w-full rounded-full md:w-auto"
                   onClick={onBack}
                 >
                   <ArrowLeft className="size-4" />
@@ -97,7 +98,7 @@ export function SetupCard({
               )}
             </div>
             {helper && (
-              <p className="flex-1 text-right text-xs text-ink-muted">
+              <p className="text-center text-xs text-ink-muted md:flex-1 md:text-right">
                 {helper}
               </p>
             )}
@@ -105,7 +106,7 @@ export function SetupCard({
               {onNext && (
                 <Button
                   type="button"
-                  className="rounded-full"
+                  className="w-full rounded-full md:w-auto"
                   onClick={onNext}
                   disabled={nextDisabled || nextLoading}
                 >

--- a/app/src/components/onboarding/setup-card.tsx
+++ b/app/src/components/onboarding/setup-card.tsx
@@ -20,6 +20,11 @@ export { OptionCard } from "./option-card";
  * FirstRunScreen wrapper pins `data-theme="light"`, so the card reads the same
  * bright light way in both app themes.
  *
+ * Below md the card IS the screen: full-bleed, full-height, no frame and no
+ * gutter, with the phone's own padding (the floating 680px card wasted a
+ * third of a phone viewport and shrank the questions into it). The safe-area
+ * insets pad the wrapper, inert on desktop and un-notched phones.
+ *
  * Houston-monochrome: selection uses the near-black foreground, never a
  * decorative accent (design-system color restraint).
  */
@@ -58,7 +63,7 @@ export function SetupCard({
   nextLoading,
 }: SetupCardProps) {
   return (
-    <div className="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-6">
+    <div className="relative flex min-h-0 flex-1 flex-col items-center justify-center overflow-hidden pt-safe pb-safe md:px-6">
       {/* Fixed height + flex-1 content so the card stays the SAME size across
           every step and the footer never jumps as content changes. Keyed by
           title so React remounts (and the CSS entrance replays) on each step
@@ -67,7 +72,7 @@ export function SetupCard({
           background — no glass, no backdrop-blur. */}
       <div
         key={title}
-        className="setup-step-in relative z-10 flex h-[680px] max-h-[88dvh] w-full max-w-2xl flex-col rounded-2xl border border-line bg-card p-8 text-ink shadow-[0_4px_24px_rgba(0,0,0,0.06)]"
+        className="setup-step-in relative z-10 flex min-h-0 w-full flex-1 flex-col bg-card p-5 text-ink md:h-[680px] md:max-h-[88dvh] md:max-w-2xl md:flex-initial md:rounded-2xl md:border md:border-line md:p-8 md:shadow-[0_4px_24px_rgba(0,0,0,0.06)]"
       >
         {icon && <div className="mb-4">{icon}</div>}
         {eyebrow && (

--- a/app/src/components/onboarding/survey-screen.tsx
+++ b/app/src/components/onboarding/survey-screen.tsx
@@ -41,6 +41,14 @@ const PROBLEM_ID = "onboarding-survey-problem";
  * Mounted twice over a user's life: as the first-run intro ahead of the
  * create-your-assistant flow, and as an in-app prompt that fills the gaps for
  * anyone who only ever answered the job question.
+ *
+ * The card is a fixed frame (`SetupCard`), so the column SCROLLS when it is
+ * taller than the frame — a short phone viewport under browser chrome. It is
+ * centered by auto margins rather than `justify-center`, which would keep
+ * centering an overflowing column and push the logo above the card's top
+ * edge and Continue below its bottom, out of reach. Keyed by step so each
+ * question opens at its top: Continue sits at the bottom of the scroll, and
+ * the next question would otherwise inherit that position, headline hidden.
  */
 export function OnboardingSurveyScreen({
   mode,
@@ -69,60 +77,66 @@ export function OnboardingSurveyScreen({
     <FirstRunScreen>
       <SetupCard>
         <div
-          className={cn(
-            "flex min-h-0 flex-1 flex-col items-center justify-center text-center",
-            framed ? "gap-6" : "gap-8",
-          )}
+          key={flow.step}
+          data-testid="survey-scroll"
+          className="flex min-h-0 flex-1 flex-col overflow-y-auto"
         >
-          <SurveyHeader
-            framed={framed}
-            heading={
-              framed
-                ? {
-                    title: t("onboardingSurvey.completion.title"),
-                    subtitle: t("onboardingSurvey.completion.subtitle"),
-                  }
-                : copy.question
-            }
-            question={copy.question}
-            steps={flow.plan}
-            current={flow.index}
-          />
+          <div
+            className={cn(
+              "m-auto flex w-full flex-col items-center text-center",
+              framed ? "gap-6" : "gap-6 md:gap-8",
+            )}
+          >
+            <SurveyHeader
+              framed={framed}
+              heading={
+                framed
+                  ? {
+                      title: t("onboardingSurvey.completion.title"),
+                      subtitle: t("onboardingSurvey.completion.subtitle"),
+                    }
+                  : copy.question
+              }
+              question={copy.question}
+              steps={flow.plan}
+              current={flow.index}
+            />
 
-          <SurveyAnswer
-            step={flow.step}
-            copy={copy}
-            segment={flow.segment}
-            industry={flow.industry}
-            goal={flow.goal}
-            otherText={flow.otherText}
-            onSegment={flow.chooseSegment}
-            onIndustry={flow.chooseIndustry}
-            onOther={flow.writeOther}
-            onGoal={flow.writeGoal}
-            disabled={flow.saving}
-            errorId={invalid ? PROBLEM_ID : null}
-          />
+            <SurveyAnswer
+              step={flow.step}
+              copy={copy}
+              segment={flow.segment}
+              industry={flow.industry}
+              goal={flow.goal}
+              otherText={flow.otherText}
+              onSegment={flow.chooseSegment}
+              onIndustry={flow.chooseIndustry}
+              onOther={flow.writeOther}
+              onGoal={flow.writeGoal}
+              disabled={flow.saving}
+              errorId={invalid ? PROBLEM_ID : null}
+            />
 
-          {invalid && (
-            <p id={PROBLEM_ID} className="text-xs text-danger" role="alert">
-              {invalid}
-            </p>
-          )}
+            {invalid && (
+              <p id={PROBLEM_ID} className="text-xs text-danger" role="alert">
+                {invalid}
+              </p>
+            )}
 
-          {flow.error && (
-            <p className="text-xs text-danger" role="alert">
-              {flow.error}
-            </p>
-          )}
+            {flow.error && (
+              <p className="text-xs text-danger" role="alert">
+                {flow.error}
+              </p>
+            )}
 
-          <SurveyFooter
-            saving={flow.saving}
-            canContinue={flow.canContinue}
-            onBack={flow.canGoBack ? flow.back : null}
-            onContinue={flow.submit}
-            onDismiss={framed ? (onDismiss ?? null) : null}
-          />
+            <SurveyFooter
+              saving={flow.saving}
+              canContinue={flow.canContinue}
+              onBack={flow.canGoBack ? flow.back : null}
+              onContinue={flow.submit}
+              onDismiss={framed ? (onDismiss ?? null) : null}
+            />
+          </div>
         </div>
       </SetupCard>
     </FirstRunScreen>

--- a/app/src/components/onboarding/survey-screen.tsx
+++ b/app/src/components/onboarding/survey-screen.tsx
@@ -79,7 +79,9 @@ export function OnboardingSurveyScreen({
         <div
           key={flow.step}
           data-testid="survey-scroll"
-          className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+          // Bled to the card's edge on the phone so the scrollbar rides the
+          // screen edge, not the answers; the padding puts the content back.
+          className="-mx-5 flex min-h-0 flex-1 flex-col overflow-y-auto px-5 md:mx-0 md:px-0"
         >
           <div
             className={cn(

--- a/app/src/components/onboarding/use-in-app-onboarding.ts
+++ b/app/src/components/onboarding/use-in-app-onboarding.ts
@@ -9,10 +9,10 @@ import {
   isMissionBoardSurface,
 } from "../../lib/top-level-views";
 import { useUIStore } from "../../stores/ui";
-import type { InAppStep } from "./in-app-onboarding-flow";
 import { useGuidedEmailTask } from "./use-guided-email-task";
 import { useInAppAdvance } from "./use-in-app-advance";
 import { useInAppOnboardingSignals } from "./use-in-app-signals";
+import { useInAppStep } from "./use-in-app-step";
 import { useSendMissionDiscipline } from "./use-send-mission-discipline";
 import { useSetupChapterAward } from "./use-setup-chapter-award";
 
@@ -28,8 +28,9 @@ import { useSetupChapterAward } from "./use-setup-chapter-award";
  * Durable lifecycle: a FIRST-RUN arming marks `onboarding_pending` (see
  * `ArmInAppOnboarding`) so a quit mid-flow resumes the setup on the next
  * boot — the agent's creation flips the zero-agent first-run signal, so the
- * pending flag is the only resume contract. Every finish clears it and
- * stamps `onboarding_completed`.
+ * pending flag is the only resume contract. The step itself is mirrored on
+ * the device ({@link useInAppStep}) so that re-entry lands where the run was.
+ * Every finish clears both and stamps `onboarding_completed`.
  */
 export function useInAppOnboarding() {
   const { t } = useTranslation("setup");
@@ -37,7 +38,7 @@ export function useInAppOnboarding() {
   const firstRun = useUIStore((s) => s.inAppOnboardingFirstRun);
   const viewMode = useUIStore((s) => s.viewMode);
   const createDialogOpen = useUIStore((s) => s.createAgentDialogOpen);
-  const [step, setStep] = useState<InAppStep>("welcome");
+  const [step, setStep, clearResumeStep] = useInAppStep(firstRun);
   const signals = useInAppOnboardingSignals();
   const email = useGuidedEmailTask();
   const send = useSendMissionDiscipline({
@@ -113,6 +114,7 @@ export function useInAppOnboarding() {
     const source = firstRun ? "in_app" : "in_app_replay";
     analytics.track("onboarding_completed", { source });
     awardSetupChapter(source);
+    clearResumeStep();
     void clearPending();
     void markCompleted();
     setActive(false);

--- a/app/src/components/onboarding/use-in-app-onboarding.ts
+++ b/app/src/components/onboarding/use-in-app-onboarding.ts
@@ -125,6 +125,7 @@ export function useInAppOnboarding() {
   return {
     step,
     userPanelOpen: send.userPanelOpen,
+    userChatOpen: send.userChatOpen,
     emailStuck: send.emailStuck,
     integrationsOn: signals.integrationsOn,
     canCreateAgents: signals.canCreateAgents,

--- a/app/src/components/onboarding/use-in-app-step.ts
+++ b/app/src/components/onboarding/use-in-app-step.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import { useSession } from "../../hooks/use-session";
+import type { InAppStep } from "./in-app-onboarding-flow";
+import { inAppResumeKey, resumeStepFor } from "./in-app-resume";
+
+/**
+ * The in-app setup's current step, mirrored on the device for a FIRST-RUN
+ * run so a reload re-enters the flow where it was ({@link resumeStepFor})
+ * rather than at welcome. A replay from the help menu always starts fresh
+ * and mirrors nothing. The mirror is per signed-in user, like the survey's
+ * device copies, and `clear` is every finish's job.
+ *
+ * localStorage is best-effort: disabled or full storage only costs the
+ * resume (the run itself never depends on it), so those paths stay quiet.
+ */
+export function useInAppStep(
+  firstRun: boolean,
+): [InAppStep, (step: InAppStep) => void, () => void] {
+  const { data: session } = useSession();
+  const uid = session?.uid ?? null;
+  const [step, setStep] = useState<InAppStep>(() =>
+    firstRun ? resumeStepFor(readLocal(inAppResumeKey(uid))) : "welcome",
+  );
+
+  useEffect(() => {
+    if (firstRun) writeLocal(inAppResumeKey(uid), step);
+  }, [firstRun, uid, step]);
+
+  const clear = useCallback(() => {
+    writeLocal(inAppResumeKey(uid), null);
+  }, [uid]);
+
+  return [step, setStep, clear];
+}
+
+function readLocal(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null; /* disabled storage — the run starts at welcome */
+  }
+}
+
+function writeLocal(key: string, value: string | null): void {
+  try {
+    if (value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+  } catch {
+    /* quota / disabled storage — only the resume is lost */
+  }
+}

--- a/app/src/components/onboarding/use-send-mission-discipline.ts
+++ b/app/src/components/onboarding/use-send-mission-discipline.ts
@@ -18,7 +18,9 @@ const EMAIL_WAIT_PATIENCE_MS = 120_000;
  *
  * - Panel: the taught mechanic is the New task CLICK, so a lingering chat
  *   panel is closed (through the board's registered closer, bounded) before
- *   panel-opens count as the user's own.
+ *   panel-opens count as the user's own. The phone's pushed chat screen is
+ *   the same surface in its phone shape: a lingering one is popped, and the
+ *   user's own compose push counts like a panel open.
  * - Baseline: mission ids snapshot only once the cross-agent sweep has
  *   SETTLED for the current roster — an empty in-flight sweep would make
  *   every pre-existing mission read as "just sent".
@@ -37,6 +39,7 @@ export function useSendMissionDiscipline(args: {
   const { active, watching, missionRows, missionRowsSettled, emailAgentPath } =
     args;
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
+  const chatOpen = useUIStore((s) => s.chatAgentId !== null);
   const [panelReady, setPanelReady] = useState(false);
   const [awaitingBaseline, setAwaitingBaseline] = useState(false);
   const [baselineIds, setBaselineIds] = useState<Set<string> | null>(null);
@@ -45,13 +48,15 @@ export function useSendMissionDiscipline(args: {
   // Close any lingering panel, bounded; then panel-opens are the user's.
   useEffect(() => {
     if (!active || panelReady) return;
-    if (!missionPanelOpen) {
+    if (!missionPanelOpen && !chatOpen) {
       setPanelReady(true);
       return;
     }
     let attempts = 0;
     const close = () => {
-      useUIStore.getState().onPanelClose?.();
+      const ui = useUIStore.getState();
+      if (ui.chatAgentId !== null) ui.closeMissionChat();
+      ui.onPanelClose?.();
       attempts += 1;
       if (attempts >= CLOSE_ATTEMPTS_MAX) {
         window.clearInterval(id);
@@ -61,7 +66,7 @@ export function useSendMissionDiscipline(args: {
     close();
     const id = window.setInterval(close, 300);
     return () => window.clearInterval(id);
-  }, [active, panelReady, missionPanelOpen]);
+  }, [active, panelReady, missionPanelOpen, chatOpen]);
 
   // Baseline only from a settled sweep.
   useEffect(() => {
@@ -103,6 +108,7 @@ export function useSendMissionDiscipline(args: {
 
   return {
     userPanelOpen: panelReady && missionPanelOpen,
+    userChatOpen: panelReady && chatOpen,
     missionSent: newMissionRow !== undefined,
     emailSent,
     emailStuck,

--- a/app/src/components/shell/mobile-top-bar.tsx
+++ b/app/src/components/shell/mobile-top-bar.tsx
@@ -2,6 +2,7 @@ import { Menu, SquarePen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { startNewMission } from "../../lib/new-mission";
 import { useUIStore } from "../../stores/ui";
+import { tourAnchor } from "./workspace-tour-steps";
 
 const iconButtonClass =
   "flex size-10 items-center justify-center rounded-full text-ink-muted transition-colors hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus";
@@ -27,6 +28,7 @@ export function MobileTopBar() {
     >
       <button
         type="button"
+        {...tourAnchor("mobileMenu")}
         aria-label={t("sidebar.openMenu")}
         onClick={() => setMobileSidebarOpen(true)}
         className={iconButtonClass}

--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -65,7 +65,9 @@ export function NamingStep({
   }, [color, onColorChange]);
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 px-6 py-16">
+    // Scrolls when taller than the dialog (a phone, keyboard up), centered by
+    // auto margins so a fitting column still sits in the middle on desktop.
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-10 md:px-6 md:py-16">
       <button
         type="button"
         onClick={onBack}
@@ -76,114 +78,119 @@ export function NamingStep({
 
       <DialogTitle className="sr-only">{t("naming.dialogTitle")}</DialogTitle>
 
-      {/* Avatar preview */}
-      <div className="flex flex-col items-center gap-4 mb-8">
-        <HoustonAvatar color={resolvedColor} diameter={80} />
+      <div className="m-auto flex w-full flex-col items-center">
+        {/* Avatar preview */}
+        <div className="flex flex-col items-center gap-4 mb-8">
+          <HoustonAvatar color={resolvedColor} diameter={80} />
 
-        <div className="text-center">
-          <p className="text-lg font-semibold">{selectedName}</p>
-          <p className="text-sm text-ink-muted mt-1">{t("naming.tagline")}</p>
+          <div className="text-center">
+            <p className="text-lg font-semibold">{selectedName}</p>
+            <p className="text-sm text-ink-muted mt-1">{t("naming.tagline")}</p>
+          </div>
         </div>
-      </div>
 
-      {/* Color palette + form: ONE anchored block, so the tutorial's ring
+        {/* Color palette + form: ONE anchored block, so the tutorial's ring
           wraps exactly what "pick a color and give it a name" means and its
           chip can sit in the modal's side whitespace instead of on the copy. */}
-      <div
-        {...tutorialAnchor("createAgentNaming")}
-        className="flex w-full flex-col items-center"
-      >
-        {/* Color palette */}
-        <div className="flex items-center gap-2 mb-6">
-          {AGENT_COLORS.map((c) => {
-            const swatch = colorValue(c);
-            const isSelected =
-              color === c.id || color === c.light || color === c.dark;
-            return (
-              <button
-                key={c.id}
-                type="button"
-                onClick={() => onColorChange(c.id)}
-                className={cn(
-                  "h-7 w-7 rounded-full flex items-center justify-center transition-all duration-150",
-                  isSelected
-                    ? "ring-2 ring-offset-2 ring-ink/30"
-                    : "hover:scale-110",
-                )}
-                style={{ backgroundColor: swatch }}
-              >
-                {isSelected && <Check className="h-3.5 w-3.5 text-white" />}
-              </button>
-            );
-          })}
-        </div>
+        <div
+          {...tutorialAnchor("createAgentNaming")}
+          className="flex w-full flex-col items-center"
+        >
+          {/* Color palette: two rows of five on a phone (ten swatches outgrow
+            the card in one row), the single row at md+. */}
+          <div className="mb-6 grid grid-cols-5 gap-2 md:flex md:items-center">
+            {AGENT_COLORS.map((c) => {
+              const swatch = colorValue(c);
+              const isSelected =
+                color === c.id || color === c.light || color === c.dark;
+              return (
+                <button
+                  key={c.id}
+                  type="button"
+                  onClick={() => onColorChange(c.id)}
+                  className={cn(
+                    "h-7 w-7 rounded-full flex items-center justify-center transition-all duration-150",
+                    isSelected
+                      ? "ring-2 ring-offset-2 ring-ink/30"
+                      : "hover:scale-110",
+                  )}
+                  style={{ backgroundColor: swatch }}
+                >
+                  {isSelected && <Check className="h-3.5 w-3.5 text-white" />}
+                </button>
+              );
+            })}
+          </div>
 
-        <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
-          <Input
-            autoFocus
-            value={name}
-            onChange={(e) => onNameChange(e.target.value)}
-            placeholder={t("naming.namePlaceholder")}
-            className="text-center rounded-full"
-          />
+          <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => onNameChange(e.target.value)}
+              placeholder={t("naming.namePlaceholder")}
+              className="text-center rounded-full"
+            />
 
-          {/* Link existing project — opt-in via agent features */}
-          {showLinkProject && (
-            <div className="flex flex-col items-center gap-1.5">
-              {existingPath ? (
-                <div className="flex items-center gap-2 text-xs text-ink-muted bg-chip rounded-full px-3 py-1.5">
-                  <FolderOpen className="size-3" />
-                  <span className="truncate max-w-[200px]">
-                    {existingPath.split("/").pop()}
-                  </span>
+            {/* Link existing project — opt-in via agent features */}
+            {showLinkProject && (
+              <div className="flex flex-col items-center gap-1.5">
+                {existingPath ? (
+                  <div className="flex items-center gap-2 text-xs text-ink-muted bg-chip rounded-full px-3 py-1.5">
+                    <FolderOpen className="size-3" />
+                    <span className="truncate max-w-[200px]">
+                      {existingPath.split("/").pop()}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => onExistingPathChange(null)}
+                      className="text-ink-muted hover:text-ink ml-1"
+                    >
+                      &times;
+                    </button>
+                  </div>
+                ) : (
                   <button
                     type="button"
-                    onClick={() => onExistingPathChange(null)}
-                    className="text-ink-muted hover:text-ink ml-1"
-                  >
-                    &times;
-                  </button>
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={async () => {
-                    const { tauriAgents } = await import("../../lib/tauri");
-                    const picked = await tauriAgents.pickDirectory();
-                    if (picked) {
-                      onExistingPathChange(picked);
-                      if (!name.trim()) {
-                        const folderName =
-                          picked.replace(/\/$/, "").split("/").pop() ?? "";
-                        onNameChange(folderName);
+                    onClick={async () => {
+                      const { tauriAgents } = await import("../../lib/tauri");
+                      const picked = await tauriAgents.pickDirectory();
+                      if (picked) {
+                        onExistingPathChange(picked);
+                        if (!name.trim()) {
+                          const folderName =
+                            picked.replace(/\/$/, "").split("/").pop() ?? "";
+                          onNameChange(folderName);
+                        }
                       }
-                    }
-                  }}
-                  className="text-xs text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5"
-                >
-                  <FolderOpen className="size-3" />
-                  {t("naming.linkExistingProject")}
-                </button>
-              )}
-            </div>
-          )}
-
-          {error && <p className="text-xs text-danger text-center">{error}</p>}
-          <Button
-            type="submit"
-            disabled={!name.trim() || nameInvalid || creating}
-            className="w-full rounded-full"
-          >
-            {creating ? (
-              <>
-                <Spinner className="size-4" />
-                {t("naming.createAgent")}
-              </>
-            ) : (
-              t("naming.createAgent")
+                    }}
+                    className="text-xs text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5"
+                  >
+                    <FolderOpen className="size-3" />
+                    {t("naming.linkExistingProject")}
+                  </button>
+                )}
+              </div>
             )}
-          </Button>
-        </form>
+
+            {error && (
+              <p className="text-xs text-danger text-center">{error}</p>
+            )}
+            <Button
+              type="submit"
+              disabled={!name.trim() || nameInvalid || creating}
+              className="w-full rounded-full"
+            >
+              {creating ? (
+                <>
+                  <Spinner className="size-4" />
+                  {t("naming.createAgent")}
+                </>
+              ) : (
+                t("naming.createAgent")
+              )}
+            </Button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/app/src/components/shell/workspace-tour-steps.ts
+++ b/app/src/components/shell/workspace-tour-steps.ts
@@ -8,7 +8,10 @@
  * (the space switcher), `sidebar-rail.tsx` (`newAgent`), `sidebar-footer.tsx`
  * (`nav-settings`), `sidebar-help-menu.tsx` (`appTour`, the help control the
  * in-app setup is started from), `@houston-ai/layout`'s sidebar (`agents`),
- * `workspace-shell.tsx` (`main`) and `new-mission-button.tsx` (`newMission`).
+ * `workspace-shell.tsx` (`main`), `new-mission-button.tsx` and the phone
+ * board's `mobile-board-controls.tsx` (`newMission`, one per breakpoint — the
+ * spotlight takes the visible one), and `mobile-top-bar.tsx` (`mobileMenu`,
+ * the hamburger the phone's drawer-hosted rows are reached through).
  *
  * The vocabulary is shared: the in-app onboarding spotlights these anchors
  * (`in-app-onboarding.tsx`) and the e2e specs address the shell by them.
@@ -26,6 +29,7 @@ export const TOUR_TARGETS = [
   "newAgent",
   "nav-agent-store",
   "appTour",
+  "mobileMenu",
 ] as const;
 
 export type TourTarget = (typeof TOUR_TARGETS)[number];

--- a/app/src/components/tutorial/tutorial-spotlight-geometry.ts
+++ b/app/src/components/tutorial/tutorial-spotlight-geometry.ts
@@ -70,6 +70,19 @@ function placeBeside(
   return null;
 }
 
+/**
+ * The first VISIBLE element a selector matches. Some anchors exist twice in
+ * the tree — a desktop control CSS-hidden on the phone beside the phone's
+ * own — and `querySelector` would hand back the hidden one first, leaving the
+ * hole shut over a control the user can see.
+ */
+function firstVisible(selector: string): Element | null {
+  for (const el of document.querySelectorAll(selector)) {
+    if (el.getBoundingClientRect().width > 0) return el;
+  }
+  return null;
+}
+
 const sameRect = (a: Rect | null, b: Rect | null) =>
   a === b ||
   (a !== null &&
@@ -165,7 +178,7 @@ export function useSpotlightRects(
         : null;
     };
     const measure = () => {
-      const next = toRect(document.querySelector(selector), PAD);
+      const next = toRect(firstVisible(selector), PAD);
       setHole((prev) => (sameRect(prev, next) ? prev : next));
       // The Radix dialog content (`data-state` excludes the coach chip, which
       // is a bare role="dialog").

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -9,6 +9,10 @@
         "body": "Your agents need an AI to work. I'll show you where to connect it.",
         "cta": "Show me"
       },
+      "openMenu": {
+        "title": "Open the menu",
+        "hint": "Tap the menu button, top left"
+      },
       "openAiHub": {
         "title": "Click AI Models"
       },

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -9,6 +9,10 @@
         "body": "Tus agentes necesitan una IA para trabajar. Te muestro dónde conectarla.",
         "cta": "Muéstrame"
       },
+      "openMenu": {
+        "title": "Abre el menú",
+        "hint": "Toca el botón de menú arriba a la izquierda"
+      },
       "openAiHub": {
         "title": "Haz clic en Modelos de IA"
       },

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -9,6 +9,10 @@
         "body": "Seus agentes precisam de uma IA para trabalhar. Vou mostrar onde conectá-la.",
         "cta": "Me mostre"
       },
+      "openMenu": {
+        "title": "Abra o menu",
+        "hint": "Toque no botão de menu no canto superior esquerdo"
+      },
       "openAiHub": {
         "title": "Clique em Modelos de IA"
       },

--- a/app/tests/in-app-mobile-targets.test.ts
+++ b/app/tests/in-app-mobile-targets.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  drawerSpotPhase,
+  sendMissionSelector,
+  sendMissionSurface,
+} from "../src/components/onboarding/in-app-mobile-targets.ts";
+
+test("a sidebar-row step is the plain rail spotlight on desktop, drawer state notwithstanding", () => {
+  assert.equal(drawerSpotPhase({ isMobile: false, drawerOpen: false }), "rail");
+  assert.equal(drawerSpotPhase({ isMobile: false, drawerOpen: true }), "rail");
+});
+
+test("on the phone the step rings the hamburger while the drawer is shut, then the row inside it", () => {
+  assert.equal(
+    drawerSpotPhase({ isMobile: true, drawerOpen: false }),
+    "openMenu",
+  );
+  assert.equal(
+    drawerSpotPhase({ isMobile: true, drawerOpen: true }),
+    "inDrawer",
+  );
+});
+
+test("the send step rings the New task control until the user's own composer is up", () => {
+  assert.equal(
+    sendMissionSurface({ panelOpen: false, chatOpen: false }),
+    "button",
+  );
+  assert.equal(
+    sendMissionSurface({ panelOpen: true, chatOpen: false }),
+    "panel",
+  );
+  // The phone's pushed draft chat is the composer surface there.
+  assert.equal(
+    sendMissionSurface({ panelOpen: false, chatOpen: true }),
+    "chat",
+  );
+});
+
+test("the New task selector is scoped to the active screen so kept-alive views never win", () => {
+  assert.equal(
+    sendMissionSelector("button", false),
+    "[data-screen-active='true'] [data-tour-target='newMission']",
+  );
+  assert.equal(
+    sendMissionSelector("button", true),
+    "[data-screen-active='true'] [data-tour-target='newMission']",
+  );
+});
+
+test("a composer surface is ringed whole, or its send button alone in email mode", () => {
+  assert.equal(
+    sendMissionSelector("panel", false),
+    '[data-testid="mission-panel"]',
+  );
+  assert.equal(
+    sendMissionSelector("panel", true),
+    '[data-testid="mission-panel"] button[type="submit"]',
+  );
+  assert.equal(
+    sendMissionSelector("chat", false),
+    '[data-testid="mission-chat-screen"]',
+  );
+  assert.equal(
+    sendMissionSelector("chat", true),
+    '[data-testid="mission-chat-screen"] button[type="submit"]',
+  );
+});

--- a/app/tests/in-app-resume.test.ts
+++ b/app/tests/in-app-resume.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { InAppStep } from "../src/components/onboarding/in-app-onboarding-flow.ts";
+import {
+  inAppResumeKey,
+  resumeStepFor,
+} from "../src/components/onboarding/in-app-resume.ts";
+
+test("narration beats resume in place", () => {
+  for (const step of [
+    "welcome",
+    "connectAiIntro",
+    "integrationsIntro",
+    "createAgentIntro",
+    "agentCreated",
+    "sendMissionIntro",
+    "academyReveal",
+  ] as const) {
+    assert.equal(resumeStepFor(step), step);
+  }
+});
+
+test("a sequence resumes at its re-arming beat, never inside a spot the reload disarmed", () => {
+  const expect: Record<InAppStep, InAppStep> = {
+    welcome: "welcome",
+    connectAiIntro: "connectAiIntro",
+    openAiHub: "openAiHub",
+    connectAi: "openAiHub",
+    aiConnected: "openAiHub",
+    integrationsIntro: "integrationsIntro",
+    openIntegrations: "openIntegrations",
+    connectIntegration: "openIntegrations",
+    integrationConnected: "openIntegrations",
+    createAgentIntro: "createAgentIntro",
+    createAgent: "createAgentIntro",
+    createAgentDialog: "createAgentIntro",
+    agentCreated: "agentCreated",
+    sendMissionIntro: "sendMissionIntro",
+    sendMission: "sendMissionIntro",
+    missionSent: "sendMissionIntro",
+    emailSending: "sendMissionIntro",
+    emailSent: "sendMissionIntro",
+    academyReveal: "academyReveal",
+  };
+  for (const [step, resumed] of Object.entries(expect)) {
+    assert.equal(resumeStepFor(step), resumed, step);
+  }
+});
+
+test("nothing saved, or an unknown step from an older build, starts at welcome", () => {
+  assert.equal(resumeStepFor(null), "welcome");
+  assert.equal(resumeStepFor(undefined), "welcome");
+  assert.equal(resumeStepFor(""), "welcome");
+  assert.equal(resumeStepFor("retiredStep"), "welcome");
+});
+
+test("the device key is scoped per signed-in user, with a local fallback", () => {
+  assert.equal(inAppResumeKey("u-1"), "houston.onboarding.in-app-step.u-1");
+  assert.equal(inAppResumeKey(null), "houston.onboarding.in-app-step.local");
+  assert.notEqual(inAppResumeKey("u-1"), inAppResumeKey("u-2"));
+});

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -66,7 +66,10 @@ phone layout from rotting. The tier-1 set walks the core journey — sign-in
 (`mobile/sign-in.spec.ts`, against the identity-ON server via
 `test.use({ baseURL: AUTH_WEB_URL })`), boot + overflow smoke, Agents home,
 mission chat push, hardware back, board pager + tab bar, and Routines
-(`mobile/routines.spec.ts`: list → a routine's own screen). Specs `.tap()`
+(`mobile/routines.spec.ts`: list → a routine's own screen), and first-run
+(`mobile/onboarding.spec.ts`: the survey, then the whole in-app setup over
+the phone shell — drawer rows, provider connect, first agent, first task).
+Specs `.tap()`
 rather than `.click()` and assert zero horizontal overflow
 (`document.documentElement.scrollWidth - clientWidth <= 0`).
 

--- a/packages/web/e2e/mobile/onboarding.spec.ts
+++ b/packages/web/e2e/mobile/onboarding.spec.ts
@@ -137,3 +137,51 @@ test("the disclaimer's accept button fits inside the phone card", async ({
   await accept.tap();
   await expect(page.getByRole("button", { name: "Open menu" })).toBeVisible();
 });
+
+test.describe("short phone viewport", () => {
+  // A small phone under Safari's chrome: the card's 88dvh frame is shorter
+  // than the survey column, which then has to scroll rather than overflow
+  // the frame at both ends (the logo above the card, Continue below it).
+  test.use({ viewport: { width: 375, height: 600 } });
+
+  test("the survey scrolls inside its card instead of overflowing it", async ({
+    page,
+    request,
+  }) => {
+    await resetToFirstRun(request);
+    await page.goto("/");
+    const heading = page.getByRole("heading", {
+      name: "What best describes your work?",
+    });
+    await expect(heading).toBeVisible();
+
+    const scroll = page.getByTestId("survey-scroll");
+    const [frame, top] = await Promise.all([
+      scroll.boundingBox(),
+      heading.boundingBox(),
+    ]);
+    if (!frame || !top) throw new Error("survey card did not lay out");
+    expect(top.y).toBeGreaterThanOrEqual(frame.y);
+    expect(
+      await scroll.evaluate((el) => el.scrollHeight > el.clientHeight),
+    ).toBe(true);
+
+    // Continue is reachable by scrolling, and advances — and the next
+    // question opens at ITS top, not at the scroll position Continue left.
+    await page.getByRole("button", { name: "Operations" }).tap();
+    const next = page.getByRole("button", { name: "Continue" });
+    await next.scrollIntoViewIfNeeded();
+    await next.tap();
+    const industry = page.getByRole("heading", {
+      name: "What industry do you work in?",
+    });
+    await expect(industry).toBeVisible();
+    const [frame2, top2] = await Promise.all([
+      scroll.boundingBox(),
+      industry.boundingBox(),
+    ]);
+    if (!frame2 || !top2) throw new Error("industry step did not lay out");
+    expect(top2.y).toBeGreaterThanOrEqual(frame2.y);
+    expect(await scroll.evaluate((el) => el.scrollTop)).toBe(0);
+  });
+});

--- a/packages/web/e2e/mobile/onboarding.spec.ts
+++ b/packages/web/e2e/mobile/onboarding.spec.ts
@@ -1,0 +1,139 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+import { completeSurvey, resetToFirstRun } from "../support/onboarding";
+
+/**
+ * First-run on a phone, end to end: the survey, then the game-style in-app
+ * setup over the REAL phone shell. Below md the rail lives in a drawer and
+ * composing is a pushed chat, so the sidebar-row steps ring the hamburger
+ * first and then the row inside the open drawer, and the send step follows
+ * the compose tap into the draft chat. Every advance is app state — the hub
+ * opening, a provider confirmed, the roster growing, a mission row landing —
+ * never a Next button. This is the tier-1 gate that keeps the phone from
+ * dead-ending a new user in a mandatory setup they cannot finish.
+ */
+
+/** The narration card's one action. */
+function centerCta(page: Page, title: string): Locator {
+  return page.getByRole("dialog", { name: title }).getByRole("button");
+}
+
+/** A drawer-row step on the phone: hamburger → the row inside the drawer. */
+async function tapDrawerRow(page: Page, rowTitle: string, target: string) {
+  await expect(
+    page.getByRole("dialog", { name: "Open the menu" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Open menu" }).tap();
+  // The open Sheet is a modal, so Radix marks everything outside it
+  // `aria-hidden` — the coach chip included — hence `includeHidden` for the
+  // in-drawer beat (the a11y shape the in-dialog coaching has always had).
+  await expect(
+    page.getByRole("dialog", { name: rowTitle, includeHidden: true }),
+  ).toBeVisible();
+  await page.locator(`[data-tour-target='${target}']`).tap();
+}
+
+test("the guided setup completes on a phone: drawer rows, provider connect, first agent, first task", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(90_000);
+  await resetToFirstRun(request);
+  await page.goto("/");
+  await completeSurvey(page);
+
+  await expect(
+    page.getByRole("heading", { name: "Welcome to Houston!" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Start setup" }).tap();
+  await page.getByRole("button", { name: "Show me" }).tap();
+
+  // AI Models is a drawer row on the phone.
+  await tapDrawerRow(page, "Click AI Models", "nav-ai-hub");
+  await expect(
+    page.getByRole("heading", { name: "AI Providers" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("dialog", { name: "Pick the AI you already use." }),
+  ).toBeVisible();
+
+  // Connect on the real hub (the api-key path; the fake host accepts any key).
+  const search = page.getByPlaceholder("Search AI models and providers");
+  await search.tap();
+  await search.fill("openrouter");
+  await page.getByRole("button", { name: "Connect OpenRouter" }).tap();
+  await page.getByPlaceholder("Paste your API key").fill("sk-or-e2e-phone");
+  await page.getByRole("button", { name: "Connect", exact: true }).tap();
+  await centerCta(page, "Your AI is connected!").tap();
+  await centerCta(page, "Create your first agent").tap();
+
+  // New agent is a drawer row too; the dialog coaching is unchanged.
+  await tapDrawerRow(page, "Click New agent", "newAgent");
+  // In-dialog coaching sits outside the modal (aria-hidden), as on desktop.
+  await expect(page.getByText("Click Create new")).toBeVisible();
+  await page.getByRole("button", { name: "Create new", exact: true }).tap();
+  await page
+    .getByPlaceholder("e.g. Product manager, Sales, Jerry")
+    .fill("Aurora");
+  await page.getByRole("button", { name: "Create Agent" }).tap();
+  await centerCta(page, "Agent created!").tap();
+  await centerCta(page, "Give it work").tap();
+
+  // New task is the phone board's own compose control; the tap pushes the
+  // draft chat and the ring follows it there.
+  await expect(
+    page.getByRole("dialog", { name: "Click New task" }),
+  ).toBeVisible();
+  // Two anchors share the name on the phone board (the CSS-hidden desktop
+  // button beside the phone's compose); the spotlight rings the visible one.
+  await page
+    .locator("[data-screen-active='true'] [data-tour-target='newMission']")
+    .filter({ visible: true })
+    .tap();
+  await expect(
+    page.getByRole("dialog", { name: "Tell it what you need." }),
+  ).toBeVisible();
+  const composer = page
+    .getByTestId("mission-chat-screen")
+    .getByPlaceholder("What should the agent work on?");
+  await composer.fill("Say hello");
+  await composer.press("Enter");
+
+  // The finale, then the Academy reveal closes the run and lands there.
+  await centerCta(page, "Task sent!").tap();
+  await centerCta(page, "Chapter 1 complete!").tap();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Open menu" })).toBeVisible();
+
+  const overflow = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});
+
+test("the disclaimer's accept button fits inside the phone card", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.removeItem("houston.pref.legal_acceptance");
+  });
+  await page.goto("/");
+
+  const accept = page.getByRole("button", {
+    name: "I understand and want to continue",
+  });
+  await expect(accept).toBeVisible();
+  const card = page.locator(".setup-step-in");
+  const [button, frame] = await Promise.all([
+    accept.boundingBox(),
+    card.boundingBox(),
+  ]);
+  if (!button || !frame) throw new Error("disclaimer card did not lay out");
+  expect(button.x + button.width).toBeLessThanOrEqual(frame.x + frame.width);
+  expect(button.x).toBeGreaterThanOrEqual(frame.x);
+
+  await accept.tap();
+  await expect(page.getByRole("button", { name: "Open menu" })).toBeVisible();
+});

--- a/packages/web/e2e/mobile/onboarding.spec.ts
+++ b/packages/web/e2e/mobile/onboarding.spec.ts
@@ -72,6 +72,17 @@ test("the guided setup completes on a phone: drawer rows, provider connect, firs
   // In-dialog coaching sits outside the modal (aria-hidden), as on desktop.
   await expect(page.getByText("Click Create new")).toBeVisible();
   await page.getByRole("button", { name: "Create new", exact: true }).tap();
+  // The color palette wraps inside the phone dialog instead of running off
+  // its right edge (ten swatches outgrow a phone-width card in one row).
+  const naming = page.locator("[data-tutorial-target='createAgentNaming']");
+  const frame = await naming.boundingBox();
+  if (!frame) throw new Error("naming step did not lay out");
+  for (const swatch of await naming.locator("button[type='button']").all()) {
+    const box = await swatch.boundingBox();
+    if (!box) throw new Error("swatch did not lay out");
+    expect(box.x + box.width).toBeLessThanOrEqual(frame.x + frame.width + 1);
+    expect(box.x).toBeGreaterThanOrEqual(frame.x - 1);
+  }
   await page
     .getByPlaceholder("e.g. Product manager, Sales, Jerry")
     .fill("Aurora");

--- a/packages/web/e2e/mobile/onboarding.spec.ts
+++ b/packages/web/e2e/mobile/onboarding.spec.ts
@@ -191,3 +191,46 @@ test.describe("short phone viewport", () => {
     expect(await scroll.evaluate((el) => el.scrollTop)).toBe(0);
   });
 });
+
+test("a reload mid-setup resumes the sequence, not the welcome beat", async ({
+  page,
+  request,
+}) => {
+  // Phones evict a background tab: leaving to fetch a sign-in code and
+  // coming back reloads the app. The run must re-enter at the connect
+  // sequence (its sidebar beat, which self-advances on the hub), never at
+  // "Start setup" with the work so far forgotten.
+  await resetToFirstRun(request);
+  await page.goto("/");
+  await completeSurvey(page);
+  await page.getByRole("button", { name: "Start setup" }).tap();
+  await page.getByRole("button", { name: "Show me" }).tap();
+  await tapDrawerRow(page, "Click AI Models", "nav-ai-hub");
+  await expect(
+    page.getByRole("dialog", { name: "Pick the AI you already use." }),
+  ).toBeVisible();
+
+  await page.reload();
+
+  await expect(
+    page.getByRole("dialog", { name: "Open the menu" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Welcome to Houston!" }),
+  ).toHaveCount(0);
+  await tapDrawerRow(page, "Click AI Models", "nav-ai-hub");
+  await expect(
+    page.getByRole("dialog", { name: "Pick the AI you already use." }),
+  ).toBeVisible();
+
+  // The connect itself still lands, and the run carries on from there.
+  const search = page.getByPlaceholder("Search AI models and providers");
+  await search.tap();
+  await search.fill("openrouter");
+  await page.getByRole("button", { name: "Connect OpenRouter" }).tap();
+  await page.getByPlaceholder("Paste your API key").fill("sk-or-e2e-resume");
+  await page.getByRole("button", { name: "Connect", exact: true }).tap();
+  await expect(
+    page.getByRole("dialog", { name: "Your AI is connected!" }),
+  ).toBeVisible();
+});

--- a/packages/web/e2e/mobile/onboarding.spec.ts
+++ b/packages/web/e2e/mobile/onboarding.spec.ts
@@ -155,6 +155,12 @@ test.describe("short phone viewport", () => {
     });
     await expect(heading).toBeVisible();
 
+    // The card IS the screen on the phone: full width, no floating frame.
+    const card = await page.locator(".setup-step-in").boundingBox();
+    if (!card) throw new Error("survey card did not lay out");
+    expect(card.x).toBe(0);
+    expect(card.width).toBe(375);
+
     const scroll = page.getByTestId("survey-scroll");
     const [frame, top] = await Promise.all([
       scroll.boundingBox(),


### PR DESCRIPTION
## Summary

Linear: PRODUCT-1631

On the mobile web app the guided first-run setup could not be finished. Three spot steps pointed at desktop-rail controls that do not exist on the phone screen:

- **Click AI Models** / **Click New agent**: the rows live inside the closed sidebar drawer. With no target in the DOM the veil covered the whole screen and its blocker panels swallowed taps on the hamburger and the tab bar.
- **Click New task**: pointed at the desktop button, CSS-hidden on the phone; the phone's compose control carried no anchor.

The setup is mandatory (no dismiss) and `onboarding_pending` resumes it on reload, so a phone user was stuck on that device.

## Fix

- `DrawerSpotlight` (`app/src/components/onboarding/in-app-drawer-spotlight.tsx`): on the phone a sidebar-row step first rings the hamburger ("Open the menu"), then the row inside the open drawer in the existing in-dialog mode (the Sheet is a Radix dialog, same layering as the create-agent dialog coaching). Desktop renders the plain spotlight. Structural fork via `useIsMobile()`.
- New tour anchor `mobileMenu` on the top bar's hamburger; `newMission` on the phone board's compose control. The spotlight geometry now takes the first **visible** match, so the CSS-hidden desktop New task button beside it never wins.
- The send step follows the compose tap into the phone's pushed draft chat (`userChatOpen`), and the discipline pops a lingering chat before the lesson's tap counts, the way it already closed a lingering desktop panel. Pure helpers in `in-app-mobile-targets.ts`.
- `SetupCard` footer stacks on the phone (Next on top, full width; desktop row unchanged at `md:`): the disclaimer's "I understand and want to continue" ran off the card.
- Copy: `inApp.steps.openMenu` in en/es/pt.
- The create-agent naming step fits a phone: the ten color swatches are a five-by-two grid below `md` (single row at `md+`), and the step scrolls inside the dialog instead of overflowing it.
- Below `md` the first-run `SetupCard` is the screen: full-bleed, full-height, phone padding and safe-area insets, no floating frame or gutter (the desktop card was just shrunk onto the phone and wasted a third of the viewport). Every desktop value sits on the `md:` layer; the desktop visual baseline is unchanged.
- A reload mid-setup resumes the run at its sequence instead of "Start setup": the step is mirrored on the device per user (`use-in-app-step.ts`, `in-app-resume.ts`) and re-entry lands at the last safe beat (a spot step re-armed by its intro or sidebar beat). Phones evict a background tab when the user leaves to fetch a sign-in code; the runtime keeps the pending login for ten minutes and re-launching returns it, so tapping Connect again reopens the paste dialog and the code completes.
- The survey column scrolls inside its card on short phone viewports (it was vertically centered in the fixed-height card with no scrolling, so under browser chrome it overflowed at both ends: logo above the card, Continue below it and unreachable). Keyed by step so each question opens at its top.

## Tests

- `packages/web/e2e/mobile/onboarding.spec.ts`: survey → welcome → AI Models via the drawer → OpenRouter key connect → New agent via the drawer → coached dialog → New task on the phone board → draft chat send → finale → Academy reveal; plus the disclaimer footer fitting the card, a 375x600 short-viewport test that the card fills the screen, the survey scrolls and each step opens at its top, and an assertion that every color swatch in the naming step lies inside the dialog. Runs in the `mobile` CI project.
- `app/tests/in-app-mobile-targets.test.ts` for the pure phase/selector helpers; `app/tests/in-app-resume.test.ts` for the resume mapping.
- Mobile e2e: a reload at the connect step re-enters at "Open the menu", not welcome, and the connect still lands.
- Gates run: `pnpm check`, `tsgo --noEmit` (app, web, e2e), `check-locales`, `check:parity`, app unit tests (3867 pass), the full `mobile` Playwright project (23 pass) and the desktop onboarding/tour/agent-onboarding specs.

## Before

1. In `packages/web`, run `pnpm exec playwright test --project=mobile mobile/onboarding` on `main` (or open the web app at a width below 768px with zero agents).
2. Complete the survey, tap "Start setup", then "Show me".
3. "Click AI Models" appears with nothing highlighted; the hamburger and tab bar do not respond. Reloading lands on the same step.

## After

1. Same setup on this branch: "Open the menu" rings the hamburger; tapping it opens the drawer with the AI Models row ringed; tapping the row opens the hub and the connect step follows.
2. Connect any provider, then walk "Create your first agent" (drawer → New agent → dialog) and "Give it work" (the board's compose control → draft chat → send). The run ends on "Chapter 1 complete!".
3. Clear the disclaimer acceptance on a phone width: the accept button sits inside the card, above Back.
4. On a short phone viewport (e.g. iPhone SE, or Safari with its bars) the survey scrolls inside the card; the logo stays at the top and Continue is reachable.
5. `pnpm exec playwright test --project=mobile mobile/onboarding` passes.



