### PR TITLE
fix(runtime): feed the stall watchdog from backend liveness, not the wire stream (PRODUCT-1632)

### DIFF
--- a/packages/runtime/src/backends/claude/session.test.ts
+++ b/packages/runtime/src/backends/claude/session.test.ts
@@ -428,3 +428,40 @@ test("getContextUsage is undefined before a turn, then reflects the last usage",
   await session.prompt("go");
   expect(session.getContextUsage()).toEqual({ tokens: 100 });
 });
+
+function toolInputDeltaMsg(partialJson: string, sessionId = "s"): SDKMessage {
+  return {
+    type: "stream_event",
+    event: {
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "input_json_delta", partial_json: partialJson },
+    },
+    session_id: sessionId,
+    parent_tool_use_id: null,
+  } as unknown as SDKMessage;
+}
+
+test("subscribeLiveness ticks per SDK message, including tool-input deltas the wire drops (PRODUCT-1632)", async () => {
+  const session = make({
+    query: arrayQuery([
+      toolInputDeltaMsg('{"command":"cat > /tmp/brain.py'),
+      toolInputDeltaMsg(" << 'PYEOF'"),
+      textMsg("ok"),
+    ]),
+  });
+  const wire: WireEvent[] = [];
+  let ticks = 0;
+  session.subscribe((e) => wire.push(e));
+  const unsub = session.subscribeLiveness(() => ticks++);
+
+  await session.prompt("write it");
+
+  // Two input deltas produced no wire frame at all; the text delta produced one.
+  expect(wire).toEqual([{ type: "text", data: "ok" }]);
+  expect(ticks).toBe(3);
+
+  unsub();
+  await session.prompt("again");
+  expect(ticks).toBe(3);
+});

--- a/packages/runtime/src/backends/claude/session.ts
+++ b/packages/runtime/src/backends/claude/session.ts
@@ -87,6 +87,7 @@ const DANGLING_RESUME_RE = /No conversation found with session ID/i;
  */
 export class ClaudeSession implements HarnessSession {
   private readonly listeners = new Set<(e: WireEvent) => void>();
+  private readonly livenessListeners = new Set<() => void>();
   private disposed = false;
   private aborting = false;
   private abortController: AbortController | undefined;
@@ -118,8 +119,24 @@ export class ClaudeSession implements HarnessSession {
     };
   }
 
+  /**
+   * Every SDK message the query yields, before translation. `translate` drops
+   * `input_json_delta` (a tool call's streamed input) until the block closes,
+   * so a long file write is wire-silent; the liveness channel still ticks.
+   */
+  subscribeLiveness(listener: () => void): () => void {
+    this.livenessListeners.add(listener);
+    return () => {
+      this.livenessListeners.delete(listener);
+    };
+  }
+
   private emit(e: WireEvent): void {
     for (const l of this.listeners) l(e);
+  }
+
+  private tickLiveness(): void {
+    for (const l of this.livenessListeners) l();
   }
 
   async prompt(text: string): Promise<void> {
@@ -196,6 +213,7 @@ export class ClaudeSession implements HarnessSession {
     try {
       for await (const msg of this.deps.query({ prompt: text, options })) {
         if (this.aborting) break;
+        this.tickLiveness();
         if (hasSessionId(msg)) capturedSessionId = msg.session_id;
         for (const wire of translator.translate(msg)) {
           if (wire.type === "provider_error") {

--- a/packages/runtime/src/backends/pi/session.test.ts
+++ b/packages/runtime/src/backends/pi/session.test.ts
@@ -272,3 +272,36 @@ test("dispose is idempotent: the underlying session is torn down once", () => {
 
   expect(stub.disposeCount).toBe(1);
 });
+
+function toolcallDelta(delta: string): AgentSessionEvent {
+  return {
+    type: "message_update",
+    message: assistantMessage(usage({})),
+    assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0, delta },
+  } as unknown as AgentSessionEvent;
+}
+
+test("subscribeLiveness ticks on a toolcall_delta that subscribe drops (PRODUCT-1632)", () => {
+  const { stub, session } = make();
+  const wire: WireEvent[] = [];
+  let ticks = 0;
+  session.subscribe((e) => wire.push(e));
+  const unsub = session.subscribeLiveness(() => ticks++);
+
+  // A model streaming a big tool input: pure toolcall_delta traffic. The wire
+  // dialect has no frame for it — so the wire is silent — but the model is
+  // alive, and the liveness channel must say so.
+  stub.emit(toolcallDelta('{"command":"cat > /tmp/brain.py'));
+  stub.emit(toolcallDelta(" << 'PYEOF'"));
+  expect(wire).toEqual([]);
+  expect(ticks).toBe(2);
+
+  // A wire-visible event ticks liveness too (it is every raw event).
+  stub.emit(textDelta("done"));
+  expect(wire).toEqual([{ type: "text", data: "done" }]);
+  expect(ticks).toBe(3);
+
+  unsub();
+  stub.emit(toolcallDelta("}"));
+  expect(ticks).toBe(3);
+});

--- a/packages/runtime/src/backends/pi/session.ts
+++ b/packages/runtime/src/backends/pi/session.ts
@@ -26,6 +26,16 @@ export class PiSession implements HarnessSession {
     });
   }
 
+  /**
+   * Every pi `AgentSessionEvent`, untranslated. The `toWire` mapping drops
+   * `toolcall_delta` (a tool call's streamed input), so a turn spent writing a
+   * big file emits nothing on `subscribe` for its whole generation; this is
+   * the channel that still ticks then.
+   */
+  subscribeLiveness(listener: () => void): () => void {
+    return this.session.subscribe(() => listener());
+  }
+
   prompt(text: string): Promise<void> {
     return this.session.prompt(text);
   }

--- a/packages/runtime/src/backends/types.ts
+++ b/packages/runtime/src/backends/types.ts
@@ -41,6 +41,18 @@ export interface ResolvedModel {
 export interface HarnessSession {
   /** Subscribe to this session's wire events. Returns an unsubscribe fn. */
   subscribe(listener: (e: WireEvent) => void): () => void;
+  /**
+   * Subscribe to the backend's RAW liveness: fired for every event the harness
+   * receives from the model stream, including the ones the wire dialect drops.
+   * The wire stream is not a liveness signal — a tool call's input streams as
+   * partial-JSON deltas that map to NO WireEvent (the tool only surfaces as
+   * `tool_start` once its input is complete), so a model writing a large file
+   * is wire-silent for minutes while very much alive. The stall watchdog
+   * (session/stall-watchdog.ts) listens here so it never aborts such a turn.
+   * Optional so test fakes stay minimal; a backend without it leaves the
+   * watchdog on wire events alone.
+   */
+  subscribeLiveness?(listener: () => void): () => void;
   /** Run one turn; resolves at turn end. Provider errors surface as WireEvents. */
   prompt(text: string): Promise<void>;
   /** Abort the in-flight turn (the user's Stop), then settle. */

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -206,7 +206,14 @@ export async function execTurn(
   // must attach to the final session, not the one we entered with). Undefined
   // until then; the finally guards on it.
   let unsub: (() => void) | undefined;
+  // The backend's raw liveness feed, alongside the wire subscription. The wire
+  // stream alone starves the watchdog: a tool call's input streams as deltas
+  // that map to no WireEvent, so a model writing a large file (a 60 KB bash
+  // heredoc, 30k+ output tokens) was wire-silent past the stall window and got
+  // aborted mid-generation as "stopped responding" (PRODUCT-1632, Bedrock).
+  let unsubLiveness: (() => void) | undefined;
   const subscribeSession = () => {
+    unsubLiveness = conv.session.subscribeLiveness?.(() => watchdog.touch());
     unsub = conv.session.subscribe((wire: WireEvent) => {
       if (wire.type === "text") assistantText += wire.data;
       else if (wire.type === "thinking") thinkingText += wire.data;
@@ -778,6 +785,7 @@ export async function execTurn(
     // Undefined only if resolveModel/switchBackendIfNeeded threw before we
     // subscribed (a bad pin) — nothing to tear down in that case.
     unsub?.();
+    unsubLiveness?.();
     // PRODUCT-1355 (layer 3): a turn that died on a REVOKED token leaves a
     // Claude session whose next spawn would 401 identically — evict it so the
     // user's next attempt after reconnecting rebuilds on the fresh credential.

--- a/packages/runtime/src/session/stall-watchdog.test.ts
+++ b/packages/runtime/src/session/stall-watchdog.test.ts
@@ -123,3 +123,38 @@ test("a non-positive or non-finite timeout disables the watchdog entirely", () =
   }
   expect(stalls).toBe(0);
 });
+
+test("touch resets the clock without a wire event — a tool call's streamed input keeps the turn alive", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  // The model is writing a large tool input: the backend's liveness channel
+  // ticks (toolcall_delta / input_json_delta) while the wire stream is silent.
+  for (let i = 0; i < 5; i++) {
+    vi.advanceTimersByTime(900);
+    wd.touch();
+  }
+  expect(stalls).toBe(0);
+  // Then genuinely silent → trips.
+  vi.advanceTimersByTime(1000);
+  expect(stalls).toBe(1);
+});
+
+test("touch never re-arms the clock while a tool is running", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  wd.onEvent(toolStart("bash"));
+  // Liveness ticks during a tool run (the SDK still streams status) must not
+  // start a clock the tool exemption is supposed to hold off.
+  wd.touch();
+  vi.advanceTimersByTime(60_000);
+  expect(stalls).toBe(0);
+  wd.onEvent(toolEnd("bash"));
+  vi.advanceTimersByTime(1000);
+  expect(stalls).toBe(1);
+});

--- a/packages/runtime/src/session/stall-watchdog.ts
+++ b/packages/runtime/src/session/stall-watchdog.ts
@@ -25,6 +25,13 @@ export interface StallWatchdog {
   arm(): void;
   /** Feed one wire event: resets the idle clock, tracks tool depth. */
   onEvent(event: WireEvent): void;
+  /**
+   * Proof of life with no wire event behind it: resets the idle clock only.
+   * Fed by the backend's liveness channel (`HarnessSession.subscribeLiveness`)
+   * — a tool call's streamed input reaches the wire as nothing until the call
+   * completes, so a model writing a large file would otherwise look dead.
+   */
+  touch(): void;
   /** Stop watching + clear any pending timer (call in a `finally`). Idempotent. */
   disarm(): void;
 }
@@ -61,6 +68,9 @@ export function createStallWatchdog(opts: {
     onEvent(event) {
       if (event.type === "tool_start") toolDepth++;
       else if (event.type === "tool_end" && toolDepth > 0) toolDepth--;
+      reset();
+    },
+    touch() {
       reset();
     },
     disarm() {

--- a/packages/runtime/src/session/turn-resilience.test.ts
+++ b/packages/runtime/src/session/turn-resilience.test.ts
@@ -94,6 +94,49 @@ class StallSession implements HarnessSession {
   }
 }
 
+/** A session whose model spends longer than the stall window streaming a tool
+ *  call's INPUT — pure toolcall_delta traffic, which maps to no WireEvent — and
+ *  then answers. Only the liveness channel ticks during that stretch. */
+class ToolInputSession implements HarnessSession {
+  aborted = false;
+  private listeners = new Set<(e: WireEvent) => void>();
+  private liveness = new Set<() => void>();
+  subscribe(l: (e: WireEvent) => void): () => void {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+  subscribeLiveness(l: () => void): () => void {
+    this.liveness.add(l);
+    return () => {
+      this.liveness.delete(l);
+    };
+  }
+  async prompt(): Promise<void> {
+    // Three stall windows of tool-input deltas, each tick well inside the
+    // window: the wire stays silent the whole time.
+    for (let i = 0; i < 6; i++) {
+      await new Promise<void>((r) => setTimeout(r, STALL_MS / 2));
+      for (const l of this.liveness) l();
+    }
+    for (const l of this.listeners) l({ type: "text", data: "written" });
+  }
+  async abort(): Promise<void> {
+    this.aborted = true;
+  }
+  dispose(): void {
+    this.listeners.clear();
+    this.liveness.clear();
+  }
+  async setModel(): Promise<void> {}
+  async compact(): Promise<void> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 100 };
+  }
+}
+
 /** A trivial session that answers instantly — stands in for a healthy backend so
  *  runTurn can build a conversation without a network. */
 class QuietSession implements HarnessSession {
@@ -175,6 +218,30 @@ test("a turn whose provider goes silent is aborted at the stall window and surfa
   expect(pe?.data.kind).toBe("provider_internal");
   // No false success: the empty turn must NOT settle as done.
   expect(events.some((e) => e.type === "done")).toBe(false);
+});
+
+test("a turn streaming a long tool input (wire-silent, liveness ticking) is never aborted as stalled (PRODUCT-1632)", async () => {
+  vi.useFakeTimers();
+  state.model = OPENAI;
+  const session = new ToolInputSession();
+  const conv = convWith(session);
+
+  const events: WireEvent[] = [];
+  const unsub = subscribe("conv-tool-input", (e) => events.push(e));
+  const done = execTurn(conv, "conv-tool-input", "turn-1", "write it", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  // Well past the stall window — 3x — with only tool-input deltas flowing.
+  await vi.advanceTimersByTimeAsync(STALL_MS * 3 + 1);
+  await done;
+  unsub();
+
+  expect(session.aborted).toBe(false);
+  expect(events.some((e) => e.type === "provider_error")).toBe(false);
+  expect(events.some((e) => e.type === "text")).toBe(true);
+  expect(events.some((e) => e.type === "done")).toBe(true);
 });
 
 test("a turn both stalled AND stopped settles as a user stop, never a synthesized provider error", async () => {


### PR DESCRIPTION
## Root cause

PRODUCT-1632 — Amazon Bedrock chats died with the "Amazon Bedrock is having a problem / try again in a moment" card. The persisted turns on the user's pod carry the runtime's own stall message (`The AI provider stopped responding (no response for 300s)`), five times in one conversation, and the pi session log shows every one was killed mid-generation: two aborted with `Truncated event message received` (a Bedrock event frame half-read at the moment of abort) and the aborted tool calls held 15–38 KB of partially streamed input.

The stall watchdog (`session/stall-watchdog.ts`) was fed **wire events only**. A tool call's input streams as partial-JSON deltas — pi `toolcall_delta`, Claude SDK `input_json_delta` — and both wire translators drop those (the call only surfaces as `tool_start` once its input is complete). So a model writing a large file (this conversation's successful turns emitted 60 KB bash heredocs, 30k+ output tokens each) was wire-silent past the 300s window while very much alive, and the watchdog aborted it. Bedrock was the provider it happened on, not the cause; the same gap exists on every backend.

## Fix

- `HarnessSession.subscribeLiveness?(listener)` — the backend's raw liveness: every event received from the model stream, including the ones the wire dialect drops. Optional, so the test fakes stay minimal.
- `PiSession` forwards every `AgentSessionEvent`; `ClaudeSession` ticks per SDK message.
- `StallWatchdog.touch()` resets the idle clock without a wire event (still held off while a tool runs).
- `execTurn` subscribes liveness alongside the wire subscription and tears both down in the finally.

The wire dialect is unchanged — no new frame reaches clients.

## Tests

- `stall-watchdog.test.ts`: `touch()` keeps a wire-silent turn alive; `touch()` never re-arms during a tool run.
- `pi/session.test.ts`, `claude/session.test.ts`: tool-input deltas produce no wire frame but tick liveness.
- `turn-resilience.test.ts`: a turn streaming only tool-input deltas for 3× the stall window is never aborted and settles as a clean `done`. Verified red without the exec-turn change, green with it.

`pnpm check`, `@houston/runtime` + `@houston/host` + `@houston/domain` tests, `typecheck`, `check:boundaries` all pass.

## Before (reproduce)

1. Connect Amazon Bedrock (or any provider) and pick Claude Sonnet 4.6.
2. Ask the agent for a task whose single tool call takes longer than 5 minutes of output — e.g. "write a 1500-line Python script to /tmp/brain.py in one bash heredoc" on a long conversation (slower tokens/s).
3. At 300s the turn dies with the "having a problem / try again" card; the session jsonl records `stopReason: aborted`, `Request was aborted` or `Truncated event message received`, and a tool call with partial `arguments`.

## After (verify)

1. Same prompt: the turn keeps streaming through the tool-input phase, the tool executes, the turn completes.
2. `pnpm --filter @houston/runtime exec vitest run src/session/turn-resilience.test.ts` — the PRODUCT-1632 case passes; the original silent-stream case still aborts at the window.