### PR TITLE
fix(chat): capture waking and offline failures in Sentry low-noise, escalate a stuck wake (PRODUCT-1640)

### DIFF
--- a/app/src/hooks/queries/all-conversations-sweep.ts
+++ b/app/src/hooks/queries/all-conversations-sweep.ts
@@ -117,12 +117,14 @@ function surfacePartialSweep(
       showEngineWakingToast(
         "list_all_conversations_partial",
         `missions ${still} for ${failedAgents.length} waking agent(s): ${named}`,
+        reason,
       );
       return;
     case "connectivity":
       showConnectivityErrorToast(
         "list_all_conversations_partial",
         `missions ${still} for ${failedAgents.length} agent(s) while offline: ${named}`,
+        reason,
       );
       return;
     case "error":

--- a/app/src/lib/error-report.ts
+++ b/app/src/lib/error-report.ts
@@ -1,7 +1,7 @@
 import { classifyAnalyticsError } from "./analytics";
-import { isEngineWakingError } from "./engine-waking-error";
 import i18n from "./i18n";
-import { isNetworkTransportError } from "./network-transport-error";
+import { classifyQuietError } from "./quiet-error-class";
+import { reportQuietError } from "./quiet-error-report";
 import { captureException as sentryCapture } from "./sentry";
 import { createSentryReportError } from "./sentry-report-error";
 import {
@@ -17,24 +17,29 @@ import {
  * silently invisible to crash reporting. Returns immediately; flush failures
  * are logged, never thrown.
  *
- * Two classes are NOT captured, both expected environment states the
- * engine-call layer already classifies and declines, where this layer
- * re-capturing kept a Sentry family alive:
+ * Two classes take the LOW-NOISE path instead of a per-event capture, both
+ * expected environment states the engine-call layer already classifies:
  *  - transport-level network failures (device offline / host unreachable —
  *    HOU-1085; HOUSTON-APP-4PQ, PRODUCT-1383 was this layer's leak);
  *  - gateway waking answers (engine pod provisioning / restarting under a
  *    roll — HOU-1114, PRODUCT-1403; same one-layer-left failure mode as
  *    HOUSTON-APP-51C in the global rejection handler).
- * The raw diagnostic still reaches the frontend log via the caller's
- * `console.error`.
+ * Declining them outright (the PRODUCT-1446 policy) kept deploy-day bursts
+ * from filing hundreds of issues, but it also meant a raw gateway body a user
+ * never saw existed only in their local log (PRODUCT-1640). They now capture
+ * as a burst-collapsed warning in ONE fingerprinted issue per class, via
+ * `reportQuietError`, which can never file a new issue per event.
  */
 export function reportError(
   command: string,
   message: string,
   originalError?: unknown,
 ): void {
-  if (isNetworkTransportError(originalError)) return;
-  if (isEngineWakingError(originalError)) return;
+  const quiet = classifyQuietError(originalError);
+  if (quiet) {
+    reportQuietError(quiet, command, message, originalError);
+    return;
+  }
   markReportedToSentry(originalError);
   const error = createSentryReportError(command, message, originalError);
   void sentryCapture(error, {

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -3,6 +3,7 @@ import { useUIStore } from "../stores/ui";
 import { analytics, classifyAnalyticsError } from "./analytics";
 import { createBurstGate } from "./error-burst";
 import i18n from "./i18n";
+import { reportQuietError } from "./quiet-error-report";
 import {
   captureException as sentryCapture,
   sentrySuppressedInDev,
@@ -41,17 +42,20 @@ export function showExpectedStateToast(
  * Surface a transport-level network failure (device offline, host unreachable
  * — HOU-1085) as ONE informational connectivity toast. A connectivity drop
  * fails every live query at once, so the toast dedupes on its (constant)
- * displayed body: the burst reads as one problem. No Sentry capture and no
- * green "report sent" toast — nothing in Houston broke and there is nothing
- * for us to fix; the raw diagnostic still reaches the frontend log via the
- * caller's `logger.error` plus the `[toast:…]` line here. The analytics event
- * fires only past the dedupe, mirroring `showErrorToast`.
+ * displayed body: the burst reads as one problem. No green "report sent"
+ * toast — nothing in Houston broke and there is nothing for us to fix — but
+ * the drop still reaches Sentry as a burst-collapsed warning in the single
+ * fingerprinted `offline` issue (PRODUCT-1640), so its raw diagnostic is
+ * findable beyond the caller's `logger.error` and the `[toast:…]` line here.
+ * The analytics event fires only past the dedupe, mirroring `showErrorToast`.
  */
 export function showConnectivityErrorToast(
   command: string,
   message: string,
+  originalError?: unknown,
 ): void {
   console.error(`[toast:${command}] ${message}`);
+  reportQuietError("offline", command, message, originalError);
   const description = i18n.t("shell:errorToast.offlineDescription");
   if (!errorBurst.isFirst(description, Date.now())) return;
   analytics.track("app_error_shown", {
@@ -117,14 +121,22 @@ export function showUpdateCheckStuckToast(
  * toast. The agent's engine pod is provisioning (a just-installed store
  * agent), cold-starting, or restarting under a roll; every per-agent call fails the
  * same way until it wakes, so the toast dedupes on its constant displayed body
- * and the burst reads as one state, not a storm. No Sentry capture and no
- * green "report sent" toast: nothing in Houston broke and the request
- * self-heals on retry; the raw diagnostic still reaches the frontend log via
- * the caller's `logger.error` plus the `[toast:…]` line here. The analytics
- * event fires only past the dedupe, mirroring `showErrorToast`.
+ * and the burst reads as one state, not a storm. No green "report sent"
+ * toast: nothing in Houston broke and the request self-heals on retry. The
+ * answer still reaches Sentry as a burst-collapsed warning in the single
+ * fingerprinted `engine_waking` issue, carrying the raw gateway body, and
+ * feeds the per-agent stuck-wake escalation (PRODUCT-1640) — `context` is the
+ * engine-call context, whose `agentPath` / `agentId` keys that tracker. The
+ * analytics event fires only past the dedupe, mirroring `showErrorToast`.
  */
-export function showEngineWakingToast(command: string, message: string): void {
+export function showEngineWakingToast(
+  command: string,
+  message: string,
+  originalError?: unknown,
+  context?: Record<string, unknown>,
+): void {
   console.error(`[toast:${command}] ${message}`);
+  reportQuietError("engine_waking", command, message, originalError, context);
   const description = i18n.t("shell:errorToast.engineWakingDescription");
   if (!errorBurst.isFirst(description, Date.now())) return;
   analytics.track("app_error_shown", {

--- a/app/src/lib/global-error-handlers.ts
+++ b/app/src/lib/global-error-handlers.ts
@@ -79,7 +79,8 @@ export function installGlobalErrorHandlers(): void {
     // A transport-level network failure whose rejected promise nobody caught
     // (PRODUCT-1392: the `/v1/events` global stream dropping on device
     // offline / sleep-wake). Same HOU-1085 policy as the engine-call and
-    // caller-toast layers — ONE deduped connectivity toast, no Sentry capture:
+    // caller-toast layers — ONE deduped connectivity toast, and only the
+    // low-noise fingerprinted `offline` warning in Sentry (PRODUCT-1640):
     // nothing in Houston broke. This handler was the last ungated surface, and
     // it kept the `unhandled_rejection: Load failed` Sentry family alive after
     // both other layers were gated. console.error (patched) so the drop still
@@ -87,7 +88,7 @@ export function installGlobalErrorHandlers(): void {
     if (isNetworkTransportError(event.reason)) {
       event.preventDefault();
       console.error("[global:unhandledrejection] connectivity drop:", message);
-      showConnectivityErrorToast("unhandled_rejection", message);
+      showConnectivityErrorToast("unhandled_rejection", message, event.reason);
       return;
     }
     // A gateway "the agent's pod is not there right now" answer whose rejected
@@ -97,12 +98,13 @@ export function installGlobalErrorHandlers(): void {
     // and card handlers deliberately don't catch — so it landed here, the last
     // ungated surface, and was re-captured as `unhandled_rejection: engine
     // proxy failed (engine error 502)`. Same policy as tauri.ts: one waking
-    // notice, no Sentry capture — nothing in Houston broke, the write succeeds
-    // on retry once the pod listens again.
+    // notice and only the low-noise fingerprinted `engine_waking` warning in
+    // Sentry (PRODUCT-1640) — nothing in Houston broke, the write succeeds on
+    // retry once the pod listens again.
     if (isEngineWakingError(event.reason)) {
       event.preventDefault();
       console.error("[global:unhandledrejection] engine waking:", message);
-      showEngineWakingToast("unhandled_rejection", message);
+      showEngineWakingToast("unhandled_rejection", message, event.reason);
       return;
     }
     console.error("[global:unhandledrejection]", message, event.reason);

--- a/app/src/lib/quiet-error-class.ts
+++ b/app/src/lib/quiet-error-class.ts
@@ -1,0 +1,76 @@
+// The two "quiet" failure classes of the error-surfacing layer, and the
+// context a low-noise Sentry event for one of them carries. Dependency-free
+// (only the two classifiers) so it is node-testable directly
+// (app/tests/quiet-error-class.test.ts).
+//
+// A quiet class is an expected environment state — the agent's pod waking
+// (`isEngineWakingError`) or the device offline (`isNetworkTransportError`) —
+// that the user sees as ONE informational toast, never the bug pair. Until
+// PRODUCT-1640 the same classes were declined by every Sentry path outright,
+// so a raw gateway body (a DNS dial error against a cold pod, say) existed
+// only in the user's local frontend log: hidden from the user had become
+// hidden from us. They now capture as a warning with a FIXED fingerprint per
+// class (`quiet-error-report.ts`), so each class is one Sentry issue with a
+// count and searchable bodies, and a deploy roll can never file new issues.
+
+import { isEngineWakingError } from "./engine-waking-error.ts";
+import { isNetworkTransportError } from "./network-transport-error.ts";
+
+/** Doubles as the Sentry fingerprint, so the value is the issue's identity. */
+export type QuietErrorClass = "engine_waking" | "offline";
+
+export function classifyQuietError(err: unknown): QuietErrorClass | null {
+  if (isEngineWakingError(err)) return "engine_waking";
+  if (isNetworkTransportError(err)) return "offline";
+  return null;
+}
+
+export interface QuietErrorDetails {
+  /** HTTP status of the gateway answer; null for a transport drop. */
+  status: number | null;
+  /** The raw response body, whatever shape the client stack kept it in. */
+  body: string | null;
+}
+
+/**
+ * The status and RAW body off any of the three gateway error shapes
+ * (`HoustonEngineError` keeps the parsed JSON on `body`, `AgentsHttpError`
+ * carries the raw text as its message, the runtime client's `EngineError`
+ * keeps the raw text on `body`) — the searchable payload the Sentry event
+ * exists to carry. A transport `TypeError` has no status and its message IS
+ * the diagnostic.
+ */
+export function quietErrorDetails(err: unknown): QuietErrorDetails {
+  if (!(err instanceof Error)) return { status: null, body: null };
+  const status = (err as { status?: unknown }).status;
+  const body = (err as { body?: unknown }).body;
+  const rawBody =
+    typeof body === "string"
+      ? body
+      : body !== null && body !== undefined
+        ? JSON.stringify(body)
+        : err.message;
+  return { status: typeof status === "number" ? status : null, body: rawBody };
+}
+
+/**
+ * The agent a failed call was scoped to, when anything on the way knows it:
+ * the `agentId` the gateway fetch stamps on a per-agent `HoustonEngineError`
+ * first — it is the SAME id the fetch reports successes under, so an episode
+ * keyed on it is the one a later success closes — else the engine-call
+ * `context` (some `call()` sites pass `agentPath` / `agentId`). Null for
+ * calls no layer could scope (the SDK agent-write path, the runtime client):
+ * those still capture, they just cannot feed the per-agent stuck-wake tracker.
+ */
+export function agentKeyOf(
+  err: unknown,
+  context?: Record<string, unknown>,
+): string | null {
+  const stamped = (err as { agentId?: unknown } | null)?.agentId;
+  if (typeof stamped === "string" && stamped) return stamped;
+  for (const key of ["agentId", "agentPath"]) {
+    const value = context?.[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return null;
+}

--- a/app/src/lib/quiet-error-report.ts
+++ b/app/src/lib/quiet-error-report.ts
@@ -1,0 +1,87 @@
+import { classifyAnalyticsError } from "./analytics";
+import { createBurstGate } from "./error-burst";
+import {
+  agentKeyOf,
+  type QuietErrorClass,
+  quietErrorDetails,
+} from "./quiet-error-class";
+import { captureQuietEvent } from "./sentry-quiet";
+import { createSentryReportError } from "./sentry-report-error";
+import { markReportedToSentry } from "./sentry-reported-mark";
+import { wakingStuckTracker } from "./waking-stuck-tracker";
+
+/**
+ * The Sentry half of a quiet-class failure (PRODUCT-1640): the user got the
+ * deduped informational toast (or nothing, for a `{ toast: false }` path), we
+ * get ONE warning-level event per burst in the class's single fingerprinted
+ * issue, carrying the command, agent, status and raw gateway body.
+ *
+ * Burst-collapsed on (class, command, agent) with the toast layer's window:
+ * a dozen concurrent reads of one waking agent are one occurrence of one
+ * problem, and counting them twelve times would only inflate the issue's
+ * numbers against a Sentry quota. Distinct commands and distinct agents still
+ * count separately, so the issue's event list reads as a per-agent timeline.
+ *
+ * For the waking class the answer also feeds the per-agent stuck-wake tracker;
+ * an agent answering nothing but waking past the threshold escalates once, as
+ * an error-level `waking_stuck` event with the first and last raw bodies.
+ */
+const captureBurst = createBurstGate();
+
+export function reportQuietError(
+  kind: QuietErrorClass,
+  command: string,
+  message: string,
+  err: unknown,
+  context?: Record<string, unknown>,
+): void {
+  markReportedToSentry(err);
+  const { status, body } = quietErrorDetails(err);
+  const agent = agentKeyOf(err, context);
+  const now = Date.now();
+  if (captureBurst.isFirst(`${kind}:${command}:${agent ?? ""}`, now)) {
+    captureQuietEvent(createSentryReportError(command, message, err), {
+      level: "warning",
+      fingerprint: [kind],
+      tags: {
+        source: command,
+        quiet_class: kind,
+        error_kind: classifyAnalyticsError(message),
+        ...(agent ? { agent_id: agent } : {}),
+        ...(status !== null ? { http_status: String(status) } : {}),
+      },
+      extra: { command, agent_id: agent, http_status: status, body },
+    });
+  }
+  if (kind !== "engine_waking" || !agent) return;
+  const stuck = wakingStuckTracker.noteWaking(agent, body ?? message, now);
+  if (!stuck) return;
+  console.error(
+    `[waking_stuck] ${agent} has answered waking for ${Math.round(stuck.sinceMs / 1000)}s (${stuck.answers} answers): ${stuck.lastBody}`,
+  );
+  captureQuietEvent(
+    createSentryReportError(
+      "waking_stuck",
+      `agent answering waking for ${Math.round(stuck.sinceMs / 1000)}s: ${stuck.lastBody}`,
+      err,
+    ),
+    {
+      level: "error",
+      fingerprint: ["waking_stuck"],
+      tags: {
+        source: command,
+        quiet_class: "waking_stuck",
+        agent_id: agent,
+        ...(status !== null ? { http_status: String(status) } : {}),
+      },
+      extra: {
+        command,
+        agent_id: agent,
+        since_ms: stuck.sinceMs,
+        answers: stuck.answers,
+        first_body: stuck.firstBody,
+        last_body: stuck.lastBody,
+      },
+    },
+  );
+}

--- a/app/src/lib/sentry-quiet.ts
+++ b/app/src/lib/sentry-quiet.ts
@@ -1,0 +1,38 @@
+import * as Sentry from "@sentry/browser";
+
+/**
+ * Low-noise Sentry captures for the error-surfacing layer's quiet classes
+ * (PRODUCT-1640). Split from `sentry.ts` because these are a different
+ * contract from `captureException` there: that one confirms delivery (it
+ * flushes and waits for the 2xx, the price of the old "report sent" toast),
+ * this one is fire-and-forget, and — the point — it FIXES the grouping. A
+ * fingerprint of one constant per class makes the whole class ONE issue with
+ * a count, so a deploy roll that fails hundreds of reads across the fleet
+ * adds events to that issue and never files a new one. The raw gateway body
+ * rides as `extra`, where Sentry's event search can still find it.
+ *
+ * No-op until `initSentry` ran (dev builds without the send-in-dev opt-in,
+ * forks with no DSN), same as every other capture.
+ */
+export interface QuietCaptureOptions {
+  /** `Sentry.captureException` level: warning for the classes themselves,
+   *  error for the stuck-wake escalation. */
+  level: "warning" | "error";
+  /** Constant grouping key(s): the class name, never per-event data. */
+  fingerprint: string[];
+  tags: Record<string, string>;
+  extra: Record<string, unknown>;
+}
+
+export function captureQuietEvent(
+  error: Error,
+  options: QuietCaptureOptions,
+): void {
+  if (!Sentry.isInitialized()) return;
+  Sentry.captureException(error, {
+    level: options.level,
+    fingerprint: options.fingerprint,
+    tags: options.tags,
+    extra: options.extra,
+  });
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -261,11 +261,12 @@ async function surfaceError(
   // drop fails EVERY live gateway query at once with WebKit's "Load failed";
   // that burst must read as one connectivity notice, not a storm of red bug
   // toasts and a pile of un-actionable Sentry issues. The toast dedupes on its
-  // constant body; no Sentry capture — nothing in Houston broke, and the raw
-  // diagnostic is already in the log tail above.
+  // constant body; Sentry gets one burst-collapsed warning in the fixed
+  // `offline` issue (PRODUCT-1640) — nothing in Houston broke, but the raw
+  // diagnostic must stay findable beyond the log tail above.
   if (isNetworkTransportError(err)) {
     const { showConnectivityErrorToast } = await import("./error-toast");
-    showConnectivityErrorToast(label, message);
+    showConnectivityErrorToast(label, message, err);
     return;
   }
 
@@ -275,11 +276,13 @@ async function surfaceError(
   // bug pair while the agent was in fact starting fine) — or its "engine proxy
   // failed" 502, the pod restarting under an engine roll (PRODUCT-1403). The
   // request succeeds once the pod listens again; surface it as one deduped
-  // "waking up" notice, no Sentry. The raw diagnostic is already in the log
-  // tail above.
+  // "waking up" notice. Sentry gets one burst-collapsed warning in the fixed
+  // `engine_waking` issue carrying the raw gateway body, and the answer feeds
+  // the per-agent stuck-wake escalation (PRODUCT-1640) — `context` supplies
+  // the agent for the `call()` sites that pass one.
   if (isEngineWakingError(err)) {
     const { showEngineWakingToast } = await import("./error-toast");
-    showEngineWakingToast(label, message);
+    showEngineWakingToast(label, message, err, context);
     return;
   }
 

--- a/app/src/lib/waking-stuck-tracker.ts
+++ b/app/src/lib/waking-stuck-tracker.ts
@@ -1,0 +1,111 @@
+/**
+ * Per-agent "still waking" bookkeeping for the stuck-wake escalation
+ * (PRODUCT-1640). Dependency-free so it unit-tests under node:test
+ * (app/tests/waking-stuck-tracker.test.ts); the executor is
+ * `quiet-error-report.ts`.
+ *
+ * Every waking answer (HOU-1114 / PRODUCT-1403) is an expected state and is
+ * captured only as a low-noise warning. But an agent that answers NOTHING but
+ * waking for longer than the gateway's own 300s `ensureAwake` hold is no longer
+ * "still starting": the pod is crashlooping or never scheduled, and that is a
+ * bug we want as an error-level Sentry event — exactly ONE per stuck episode,
+ * carrying the first and last raw bodies so the shape of the failure (a DNS
+ * dial error turning into a refused connection, say) is readable from the
+ * issue.
+ *
+ * An episode is a run of waking answers from one agent with no gap longer
+ * than `gapMs` between consecutive answers: a burst hours apart is two cold
+ * starts, not one stuck wake. Any successful call to the agent
+ * (`noteSuccess`, fed by the gateway fetch) ends the episode outright.
+ */
+
+/** Above the gateway's 300s `ensureAwake` hold: a wake the gateway itself
+ *  gave up on is the earliest point a client can call it stuck. */
+export const WAKING_STUCK_THRESHOLD_MS = 5 * 60_000;
+
+/** The longest silence between two waking answers that still counts as the
+ *  same episode. Passive per-agent reads re-fire on events and focus, and
+ *  each failing read spends up to ~15s in the transport's cold-start retry
+ *  budget, so a healthy failing loop answers well inside this. */
+export const WAKING_EPISODE_GAP_MS = 2 * 60_000;
+
+export interface WakingStuck {
+  agentKey: string;
+  /** Raw body of the first waking answer of the episode. */
+  firstBody: string;
+  /** Raw body of the answer that crossed the threshold. */
+  lastBody: string;
+  /** How long the agent had been answering waking when it was called stuck. */
+  sinceMs: number;
+  /** Waking answers seen in the episode, this one included. */
+  answers: number;
+}
+
+export interface WakingStuckTracker {
+  /**
+   * Record a waking answer. Returns the escalation exactly once per episode —
+   * on the first answer past the threshold — and null otherwise.
+   */
+  noteWaking(agentKey: string, body: string, now: number): WakingStuck | null;
+  /** A call to the agent succeeded: whatever episode was open is over. */
+  noteSuccess(agentKey: string): void;
+}
+
+interface Episode {
+  firstAt: number;
+  lastAt: number;
+  firstBody: string;
+  answers: number;
+  escalated: boolean;
+}
+
+export function createWakingStuckTracker(
+  options: { thresholdMs?: number; gapMs?: number } = {},
+): WakingStuckTracker {
+  const thresholdMs = options.thresholdMs ?? WAKING_STUCK_THRESHOLD_MS;
+  const gapMs = options.gapMs ?? WAKING_EPISODE_GAP_MS;
+  const episodes = new Map<string, Episode>();
+  return {
+    noteWaking(agentKey, body, now) {
+      const open = episodes.get(agentKey);
+      const episode =
+        open && now - open.lastAt <= gapMs
+          ? open
+          : {
+              firstAt: now,
+              lastAt: now,
+              firstBody: body,
+              answers: 0,
+              escalated: false,
+            };
+      episode.lastAt = now;
+      episode.answers += 1;
+      episodes.set(agentKey, episode);
+      // Evict episodes that have gone quiet, so the map only ever holds the
+      // agents currently answering waking.
+      for (const [key, e] of episodes) {
+        if (now - e.lastAt > gapMs) episodes.delete(key);
+      }
+      if (episode.escalated || now - episode.firstAt < thresholdMs) return null;
+      episode.escalated = true;
+      return {
+        agentKey,
+        firstBody: episode.firstBody,
+        lastBody: body,
+        sinceMs: now - episode.firstAt,
+        answers: episode.answers,
+      };
+    },
+    noteSuccess(agentKey) {
+      episodes.delete(agentKey);
+    },
+  };
+}
+
+/**
+ * The process-wide tracker: waking answers are noted by the app's quiet-error
+ * report (`quiet-error-report.ts`), successes by the gateway fetch
+ * (`engine-adapter/cp/fetch.ts`), which is the one place that sees every
+ * per-agent call land.
+ */
+export const wakingStuckTracker = createWakingStuckTracker();

--- a/app/tests/engine-waking-rejection-gate.test.ts
+++ b/app/tests/engine-waking-rejection-gate.test.ts
@@ -13,6 +13,11 @@ import { describe, it } from "node:test";
 // (engine error 502)`. Same layered-gate shape as the connectivity family
 // (PRODUCT-1383 / PRODUCT-1392, see error-report-connectivity.test.ts).
 //
+// PRODUCT-1640 flipped the Sentry half: the gate no longer DECLINES capture,
+// it routes the class to the low-noise fingerprinted capture
+// (`reportQuietError`), so the raw gateway body is findable in ONE
+// `engine_waking` issue while the red toast and per-event issues stay gone.
+//
 // Asserted against the source rather than by calling the functions: both
 // modules pull i18n / analytics / the tauri barrel, none of which load under
 // this suite's `--experimental-strip-types` runner (same constraint and same
@@ -35,8 +40,11 @@ describe("global rejection handler declines engine-waking failures", () => {
     const redToast = body.indexOf("showErrorToast(");
     ok(guard !== -1, "the rejection handler must gate on engine waking");
     ok(
-      body.indexOf("showEngineWakingToast(", guard) !== -1,
-      "the waking branch must surface the deduped waking toast",
+      body.indexOf(
+        'showEngineWakingToast("unhandled_rejection", message, event.reason)',
+        guard,
+      ) !== -1,
+      "the waking branch must surface the deduped waking toast WITH the rejection, so the toast layer can capture it low-noise",
     );
     ok(
       capture === -1 || guard < capture,
@@ -49,23 +57,66 @@ describe("global rejection handler declines engine-waking failures", () => {
   });
 });
 
-describe("reportError declines engine-waking failures", () => {
+describe("reportError routes engine-waking failures to the quiet capture", () => {
   const source = read("../src/lib/error-report.ts");
 
-  it("gates the Sentry capture on isEngineWakingError", () => {
+  it("gates the per-event Sentry capture on classifyQuietError", () => {
     ok(
-      source.includes('from "./engine-waking-error"'),
-      "error-report.ts must import the waking classifier",
+      source.includes('from "./quiet-error-class"') &&
+        source.includes('from "./quiet-error-report"'),
+      "error-report.ts must import the quiet classifier and the quiet report",
     );
     const body = source.slice(source.indexOf("export function reportError("));
-    const guard = body.indexOf(
-      "if (isEngineWakingError(originalError)) return;",
+    const guard = body.indexOf("classifyQuietError(originalError)");
+    const quiet = body.indexOf(
+      "reportQuietError(quiet, command, message, originalError)",
     );
     const capture = body.indexOf("sentryCapture");
-    ok(guard !== -1, "reportError must decline engine-waking errors");
+    ok(guard !== -1, "reportError must classify quiet errors");
+    ok(quiet !== -1, "a quiet class must take the fingerprinted capture");
     ok(
       capture === -1 || guard < capture,
-      "the waking guard must run before the Sentry capture",
+      "the quiet guard must run before the per-event Sentry capture",
+    );
+    ok(
+      !body.includes("isEngineWakingError(originalError)) return"),
+      "a waking answer must never be declined outright again (PRODUCT-1640)",
+    );
+  });
+});
+
+describe("the waking toast captures low-noise", () => {
+  const source = read("../src/lib/error-toast.ts");
+
+  it("showEngineWakingToast reports the quiet class before the dedupe", () => {
+    const body = source.slice(
+      source.indexOf("export function showEngineWakingToast("),
+    );
+    const report = body.indexOf(
+      'reportQuietError("engine_waking", command, message, originalError, context)',
+    );
+    const dedupe = body.indexOf("errorBurst.isFirst(");
+    ok(report !== -1, "the waking toast must capture the quiet class");
+    ok(
+      dedupe === -1 || report < dedupe,
+      "the capture must run before the toast dedupe, which drops repeats",
+    );
+  });
+});
+
+describe("the quiet capture pins its grouping", () => {
+  const source = read("../src/lib/quiet-error-report.ts");
+
+  it("fingerprints on the class alone, at warning level", () => {
+    ok(
+      source.includes("fingerprint: [kind]"),
+      "the class must be the whole fingerprint — one issue per class",
+    );
+    ok(source.includes('level: "warning"'), "the class captures as a warning");
+    ok(
+      source.includes('fingerprint: ["waking_stuck"]') &&
+        source.includes('level: "error"'),
+      "the stuck-wake escalation must be its own error-level issue",
     );
   });
 });

--- a/app/tests/error-report-connectivity.test.ts
+++ b/app/tests/error-report-connectivity.test.ts
@@ -10,6 +10,11 @@ import { describe, it } from "node:test";
 // 859 events / 171 users of pure "user was offline" noise, plus a red
 // "sign out failed" toast stacked on the connectivity toast.
 //
+// PRODUCT-1640 flipped the Sentry half: the gate no longer DECLINES capture,
+// it routes the class to the low-noise fingerprinted capture
+// (`reportQuietError`), so an offline drop's raw diagnostic is findable in ONE
+// `offline` issue while the red toast and per-event issues stay gone.
+//
 // Asserted against the source rather than by calling the functions: both
 // modules pull i18n / analytics / the tauri barrel, none of which load under
 // this suite's `--experimental-strip-types` runner (same constraint and same
@@ -18,23 +23,44 @@ import { describe, it } from "node:test";
 const read = (rel: string): string =>
   readFileSync(join(import.meta.dirname, rel), "utf8");
 
-describe("reportError declines connectivity failures (HOU-1085 policy)", () => {
+describe("reportError routes connectivity failures to the quiet capture", () => {
   const source = read("../src/lib/error-report.ts");
 
-  it("gates the Sentry capture on isNetworkTransportError", () => {
+  it("gates the per-event Sentry capture on classifyQuietError", () => {
     ok(
-      source.includes('from "./network-transport-error"'),
-      "error-report.ts must import the connectivity classifier",
+      source.includes('from "./quiet-error-class"'),
+      "error-report.ts must import the quiet classifier",
     );
     const body = source.slice(source.indexOf("export function reportError("));
-    const guard = body.indexOf(
-      "if (isNetworkTransportError(originalError)) return;",
-    );
+    const guard = body.indexOf("classifyQuietError(originalError)");
     const capture = body.indexOf("sentryCapture");
-    ok(guard !== -1, "reportError must decline network transport errors");
+    ok(guard !== -1, "reportError must classify quiet errors");
     ok(
       capture === -1 || guard < capture,
-      "the connectivity guard must run before the Sentry capture",
+      "the quiet guard must run before the per-event Sentry capture",
+    );
+    ok(
+      !body.includes("isNetworkTransportError(originalError)) return"),
+      "an offline drop must never be declined outright again (PRODUCT-1640)",
+    );
+  });
+});
+
+describe("the connectivity toast captures low-noise", () => {
+  const source = read("../src/lib/error-toast.ts");
+
+  it("showConnectivityErrorToast reports the quiet class before the dedupe", () => {
+    const body = source.slice(
+      source.indexOf("export function showConnectivityErrorToast("),
+    );
+    const report = body.indexOf(
+      'reportQuietError("offline", command, message, originalError)',
+    );
+    const dedupe = body.indexOf("errorBurst.isFirst(");
+    ok(report !== -1, "the connectivity toast must capture the quiet class");
+    ok(
+      dedupe === -1 || report < dedupe,
+      "the capture must run before the toast dedupe, which drops repeats",
     );
   });
 });
@@ -59,8 +85,11 @@ describe("global rejection handler declines connectivity failures", () => {
     const redToast = body.indexOf("showErrorToast(");
     ok(guard !== -1, "the rejection handler must gate on connectivity");
     ok(
-      body.indexOf("showConnectivityErrorToast(", guard) !== -1,
-      "the connectivity branch must surface the deduped connectivity toast",
+      body.indexOf(
+        'showConnectivityErrorToast("unhandled_rejection", message, event.reason)',
+        guard,
+      ) !== -1,
+      "the connectivity branch must surface the deduped connectivity toast WITH the rejection, so the toast layer can capture it low-noise",
     );
     ok(
       capture === -1 || guard < capture,

--- a/app/tests/quiet-error-class.test.ts
+++ b/app/tests/quiet-error-class.test.ts
@@ -1,0 +1,117 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  agentKeyOf,
+  classifyQuietError,
+  quietErrorDetails,
+} from "../src/lib/quiet-error-class.ts";
+
+// PRODUCT-1640: the low-noise Sentry event for a quiet class must carry the
+// RAW gateway body and the agent, off whichever client stack minted the error.
+
+function named(
+  name: string,
+  message: string,
+  fields: Record<string, unknown> = {},
+): Error {
+  const err = new Error(message);
+  err.name = name;
+  return Object.assign(err, fields);
+}
+
+const dial = "dial tcp: lookup agent-abc.svc.cluster.local: no such host";
+
+describe("classifyQuietError", () => {
+  it("names the waking and offline classes, nothing else", () => {
+    strictEqual(
+      classifyQuietError(
+        named("HoustonEngineError", "engine unavailable (engine error 503)", {
+          status: 503,
+        }),
+      ),
+      "engine_waking",
+    );
+    strictEqual(classifyQuietError(new TypeError("Load failed")), "offline");
+    strictEqual(
+      classifyQuietError(
+        named("HoustonEngineError", "agent not found (engine error 404)", {
+          status: 404,
+        }),
+      ),
+      null,
+    );
+    strictEqual(classifyQuietError(new TypeError("x is not a function")), null);
+  });
+});
+
+describe("quietErrorDetails", () => {
+  it("serializes the parsed gateway JSON a HoustonEngineError keeps", () => {
+    const body = { error: "engine proxy failed", detail: dial };
+    deepStrictEqual(
+      quietErrorDetails(
+        named("HoustonEngineError", "engine proxy failed (engine error 502)", {
+          status: 502,
+          body,
+        }),
+      ),
+      { status: 502, body: JSON.stringify(body) },
+    );
+  });
+
+  it("takes the raw text an AgentsHttpError carries as its message", () => {
+    const raw = '{"error":"engine unavailable"}';
+    deepStrictEqual(
+      quietErrorDetails(named("AgentsHttpError", raw, { status: 503 })),
+      { status: 503, body: raw },
+    );
+  });
+
+  it("takes the raw text the runtime client keeps on body", () => {
+    const raw = `{"error":"engine proxy failed","detail":"${dial}"}`;
+    deepStrictEqual(
+      quietErrorDetails(
+        named("EngineError", `engine request failed (502): ${raw}`, {
+          status: 502,
+          body: raw,
+        }),
+      ),
+      { status: 502, body: raw },
+    );
+  });
+
+  it("has no status for a transport drop, and no body for a non-error", () => {
+    deepStrictEqual(quietErrorDetails(new TypeError("Load failed")), {
+      status: null,
+      body: "Load failed",
+    });
+    deepStrictEqual(quietErrorDetails("boom"), { status: null, body: null });
+  });
+});
+
+describe("agentKeyOf", () => {
+  const stamped = named("HoustonEngineError", "engine unavailable", {
+    status: 503,
+    agentId: "agent-from-fetch",
+  });
+
+  it("prefers the fetch-stamped agent (the id successes reset), then the context", () => {
+    strictEqual(
+      agentKeyOf(stamped, { agentPath: "ws/agent" }),
+      "agent-from-fetch",
+    );
+    const unstamped = named("EngineError", "engine request failed (503)", {
+      status: 503,
+    });
+    strictEqual(
+      agentKeyOf(unstamped, { agentId: "ctx-id", agentPath: "p" }),
+      "ctx-id",
+    );
+    strictEqual(agentKeyOf(unstamped, { agentPath: "ws/agent" }), "ws/agent");
+    strictEqual(agentKeyOf(unstamped, { fileCount: 3 }), null);
+  });
+
+  it("is null when no layer scoped the call", () => {
+    strictEqual(agentKeyOf(new TypeError("Load failed")), null);
+    strictEqual(agentKeyOf(undefined, { agentPath: "" }), null);
+  });
+});

--- a/app/tests/waking-stuck-tracker.test.ts
+++ b/app/tests/waking-stuck-tracker.test.ts
@@ -1,0 +1,111 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  createWakingStuckTracker,
+  WAKING_EPISODE_GAP_MS,
+  WAKING_STUCK_THRESHOLD_MS,
+} from "../src/lib/waking-stuck-tracker.ts";
+
+// PRODUCT-1640: an agent answering nothing but waking past the gateway's own
+// 300s ensure-awake hold is a crashlooping or unscheduled pod — one
+// error-level Sentry event per episode, carrying the first and last raw
+// bodies. Everything short of that stays a warning in the fixed
+// `engine_waking` issue.
+
+const MIN = 60_000;
+const first = '{"error":"engine unavailable","detail":"agent is waking"}';
+const last =
+  '{"error":"engine proxy failed","detail":"dial tcp: lookup agent-abc.svc.cluster.local: no such host"}';
+
+describe("createWakingStuckTracker", () => {
+  it("stays quiet below the threshold", () => {
+    const t = createWakingStuckTracker();
+    strictEqual(t.noteWaking("a", first, 0), null);
+    strictEqual(t.noteWaking("a", first, MIN), null);
+    strictEqual(t.noteWaking("a", first, WAKING_STUCK_THRESHOLD_MS - 1), null);
+  });
+
+  it("escalates ONCE at the threshold with the first and last bodies", () => {
+    const t = createWakingStuckTracker();
+    t.noteWaking("a", first, 0);
+    t.noteWaking("a", "middle", MIN);
+    t.noteWaking("a", "middle", 2 * MIN);
+    t.noteWaking("a", "middle", 3 * MIN);
+    t.noteWaking("a", "middle", 4 * MIN);
+    deepStrictEqual(t.noteWaking("a", last, WAKING_STUCK_THRESHOLD_MS), {
+      agentKey: "a",
+      firstBody: first,
+      lastBody: last,
+      sinceMs: WAKING_STUCK_THRESHOLD_MS,
+      answers: 6,
+    });
+    strictEqual(
+      t.noteWaking("a", last, WAKING_STUCK_THRESHOLD_MS + MIN),
+      null,
+      "the same episode never escalates twice",
+    );
+  });
+
+  it("keeps agents independent", () => {
+    const t = createWakingStuckTracker();
+    for (let at = 0; at < WAKING_STUCK_THRESHOLD_MS; at += MIN) {
+      t.noteWaking("a", first, at);
+      if (at >= MIN) t.noteWaking("b", first, at);
+    }
+    strictEqual(
+      t.noteWaking("b", last, WAKING_STUCK_THRESHOLD_MS),
+      null,
+      "b only started answering at 1min",
+    );
+    strictEqual(
+      t.noteWaking("a", last, WAKING_STUCK_THRESHOLD_MS)?.agentKey,
+      "a",
+    );
+  });
+
+  it("a success ends the episode", () => {
+    const t = createWakingStuckTracker();
+    for (let at = 0; at <= 4 * MIN; at += MIN) t.noteWaking("a", first, at);
+    t.noteSuccess("a");
+    // Answers resume right away: the count restarts from here.
+    const restart = 4 * MIN + 1;
+    for (
+      let at = restart;
+      at < restart + WAKING_STUCK_THRESHOLD_MS;
+      at += MIN
+    ) {
+      strictEqual(t.noteWaking("a", first, at), null);
+    }
+    const stuck = t.noteWaking("a", last, restart + WAKING_STUCK_THRESHOLD_MS);
+    strictEqual(stuck?.sinceMs, WAKING_STUCK_THRESHOLD_MS);
+    strictEqual(stuck?.answers, 6);
+  });
+
+  it("a silence longer than the gap starts a new episode", () => {
+    const t = createWakingStuckTracker();
+    t.noteWaking("a", first, 0);
+    const resumed = WAKING_EPISODE_GAP_MS + 1;
+    for (
+      let at = resumed;
+      at < resumed + WAKING_STUCK_THRESHOLD_MS;
+      at += MIN
+    ) {
+      strictEqual(
+        t.noteWaking("a", first, at),
+        null,
+        "the pre-gap answer must not count toward the new episode",
+      );
+    }
+    strictEqual(
+      t.noteWaking("a", last, resumed + WAKING_STUCK_THRESHOLD_MS)?.sinceMs,
+      WAKING_STUCK_THRESHOLD_MS,
+    );
+  });
+
+  it("a silence exactly at the gap still continues the episode", () => {
+    const t = createWakingStuckTracker({ thresholdMs: 2 * MIN, gapMs: MIN });
+    t.noteWaking("a", first, 0);
+    t.noteWaking("a", first, MIN);
+    strictEqual(t.noteWaking("a", last, 2 * MIN)?.answers, 3);
+  });
+});

--- a/packages/web/src/engine-adapter/client/errors.ts
+++ b/packages/web/src/engine-adapter/client/errors.ts
@@ -8,6 +8,10 @@
 export class HoustonEngineError extends Error {
   public status: number;
   public body: unknown;
+  /** The agent a per-agent gateway route (`/agents/:id/*`) was scoped to,
+   *  stamped by `cpFetch`; absent for every other route. The error-surfacing
+   *  layer keys its per-agent stuck-wake tracker on it (PRODUCT-1640). */
+  public agentId?: string;
 
   constructor(status: number, body: unknown) {
     // Carry the host's own explanation into the message: the v3 host answers

--- a/packages/web/src/engine-adapter/cp/fetch.ts
+++ b/packages/web/src/engine-adapter/cp/fetch.ts
@@ -1,3 +1,4 @@
+import { wakingStuckTracker } from "@houston/app/lib/waking-stuck-tracker";
 import { appVersionHeader } from "../app-version";
 import { HoustonEngineError, SIGNED_OUT_ERROR } from "../client/errors";
 import { hasSessionRefresher, refreshLiveToken } from "../session-refresh";
@@ -31,6 +32,17 @@ export interface ControlPlaneConfig {
 
 /** The per-agent route prefix the control plane proxies to a pod. */
 export const agentPath = (id: string) => `/agents/${encodeURIComponent(id)}`;
+
+/** Inverse of {@link agentPath}: the agent a route is scoped to, or null. */
+export function agentIdOfPath(path: string): string | null {
+  const match = /^\/agents\/([^/?#]+)/.exec(path);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
 
 /**
  * The current control-plane bearer: the live Supabase access token off the
@@ -160,10 +172,16 @@ export async function cpFetch(
       ...init?.headers,
     },
   });
+  const agentId = agentIdOfPath(path);
   if (!res.ok) {
     // Surface the real failure (auth, not-found, server) — never swallow.
     const body = await res.json().catch(() => ({}));
-    throw new HoustonEngineError(res.status, body);
+    const err = new HoustonEngineError(res.status, body);
+    if (agentId) err.agentId = agentId;
+    throw err;
   }
+  // A per-agent call landing is the one signal that ends a stuck-wake episode
+  // (PRODUCT-1640): the pod answered, whatever it was doing before.
+  if (agentId) wakingStuckTracker.noteSuccess(agentId);
   return res;
 }


### PR DESCRIPTION
## Summary

PRODUCT-1640. The waking class (503 `engine unavailable`, 502 `engine proxy failed`) and the connectivity class (transport `TypeError`) were declined outright by every Sentry path: `reportError`, `surfaceError` in `lib/tauri.ts`, and the global rejection handler. That burst protection was deliberate, but it meant a raw gateway body the user never saw existed only in their local frontend log.

Both classes now capture to Sentry low-noise, and an agent that never stops answering waking escalates once as an error.

### What changed

- **`quiet-error-report.ts`** (new): the one capture path for both classes. `warning` level, fixed fingerprint per class (`engine_waking` / `offline`), so each class is exactly one Sentry issue with a count and a deploy roll can never file a new issue. Tags: `source` (command), `quiet_class`, `agent_id`, `http_status`. Extra: the raw gateway body. Burst-collapsed on (class, command, agent) with the toast layer's 5s window, so a dozen concurrent reads of one waking agent are one event.
- **`waking-stuck-tracker.ts`** (new, pure): per-agent episodes of waking answers. An agent answering nothing but waking for 5 minutes (above the gateway's 300s ensure-awake hold) escalates ONCE as an `error`-level `waking_stuck` event with the agent id, first and last raw bodies, duration and answer count. An episode ends on any successful per-agent call (`cpFetch` reports those), or after 2 minutes of silence.
- **`quiet-error-class.ts`** (new, pure): the class classifier plus status/raw-body extraction across the three gateway error shapes, and the agent key resolution.
- **`sentry-quiet.ts`** (new): the fire-and-forget `Sentry.captureException` with level/fingerprint/tags/extra. No-op until `initSentry` ran, like every other capture.
- **Surfaces**: `showEngineWakingToast` / `showConnectivityErrorToast` take the original error (and the waking one the call context) and report the quiet class before the toast dedupe. `reportError` routes quiet classes there instead of returning. `surfaceError`, the global rejection handler, and the partial-sweep surface pass the error through.
- **`cpFetch`**: stamps `agentId` on a per-agent `HoustonEngineError` and reports per-agent successes to the tracker.

The deduped info toasts and the PostHog `app_error_shown` behavior are untouched.

### Deviations from the ticket

- Captures are burst-collapsed per (class, command, agent) rather than one event per failure. The count then reflects distinct occurrences, not concurrent fan-out, which keeps a deploy roll from inflating the issue against quota. Distinct commands and agents still count separately.
- The stuck tracker keys on the gateway agent id stamped by `cpFetch` (the same id its successes reset). Failures from the SDK agent-write path and the runtime client carry no agent, so they capture as warnings but do not feed the tracker. The open agent's passive reads go through `cpFetch`, so a stuck pod is still caught.

### Tests

- `engine-waking-rejection-gate.test.ts` and `error-report-connectivity.test.ts` flipped: they now assert the quiet classes are routed to the fingerprinted capture, never declined, and that the capture runs before the toast dedupe.
- `waking-stuck-tracker.test.ts` (new): threshold, once-per-episode, per-agent independence, success reset, gap reset.
- `quiet-error-class.test.ts` (new): classification, raw body across all three error shapes, agent key precedence.

Gates: `pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (3883 pass), `pnpm --filter houston-web typecheck`, `pnpm --filter houston-web test` (432 pass), `pnpm check:boundaries`.

## Before

1. Sign in to the hosted profile, open an agent whose pod is asleep, press Stop (or wait for a passive read) so the gateway answers a waking 502/503.
2. The "your agent is waking up" toast shows. In Sentry, search `quiet_class:engine_waking`: nothing. The raw `dial tcp: lookup agent-<id>...: no such host` body exists only in the local frontend log.
3. Same with the device offline: the connectivity toast shows, Sentry has nothing.

## After

1. Repeat step 1. The same toast shows. In Sentry, one issue fingerprinted `engine_waking` (level warning) gains an event tagged `source:<command>`, `agent_id`, `http_status`, with the raw gateway body under `extra.body`.
2. Take the device offline and trigger a call: one issue fingerprinted `offline` gains an event with the transport message.
3. Deploy roll: the `engine_waking` issue's count rises; no new issues appear.
4. Keep an agent's pod down for over 5 minutes with the agent open: one `error`-level `waking_stuck` event appears, tagged with the agent id, carrying `first_body` / `last_body` / `since_ms` / `answers`. Once the pod answers, further waking answers start a fresh episode.
