### PR TITLE
fix(providers): serve Bedrock only ids a plain API key can invoke (PRODUCT-1641)

### DIFF
--- a/packages/host/src/providers/bedrock-catalog.test.ts
+++ b/packages/host/src/providers/bedrock-catalog.test.ts
@@ -1,0 +1,95 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { expect, test } from "vitest";
+import { PROVIDERS } from "../providers";
+import {
+  BEDROCK_PROVIDER_ID,
+  invokableBedrockModels,
+  isInvokableBedrockModelId,
+} from "./bedrock-catalog";
+import { buildProviderCatalog } from "./pi-catalog";
+
+function bedrockModel(id: string): Model<Api> {
+  return {
+    id,
+    name: id,
+    api: "bedrock-converse-stream",
+    provider: BEDROCK_PROVIDER_ID,
+    baseUrl: "",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  } as Model<Api>;
+}
+
+test("keeps global inference profiles and Amazon's own models, in order", () => {
+  const kept = invokableBedrockModels([
+    bedrockModel("amazon.nova-pro-v1:0"),
+    bedrockModel("anthropic.claude-sonnet-4-6"),
+    bedrockModel("global.anthropic.claude-sonnet-4-6"),
+    bedrockModel("au.anthropic.claude-opus-5"),
+    bedrockModel("global.openai.gpt-5.6-sol"),
+    bedrockModel("us.anthropic.claude-opus-5"),
+  ]).map((m) => m.id);
+  expect(kept).toEqual([
+    "amazon.nova-pro-v1:0",
+    "global.anthropic.claude-sonnet-4-6",
+    "global.openai.gpt-5.6-sol",
+  ]);
+});
+
+test("bare Claude foundation ids and regional profiles are not invokable", () => {
+  // Bedrock 400s both on a valid key: the bare id with "on-demand throughput
+  // isn't supported", the off-region profile with "The provided model
+  // identifier is invalid" (the two failure cards from PRODUCT-1641).
+  for (const id of [
+    "anthropic.claude-fable-5",
+    "anthropic.claude-sonnet-4-6",
+    "au.anthropic.claude-opus-5",
+    "eu.anthropic.claude-opus-5",
+    "jp.anthropic.claude-opus-5",
+    "us.anthropic.claude-opus-5",
+    "meta.llama3-3-70b-instruct-v1:0",
+  ]) {
+    expect(isInvokableBedrockModelId(id), id).toBe(false);
+  }
+  for (const id of [
+    "global.anthropic.claude-sonnet-4-6",
+    "global.anthropic.claude-opus-5",
+    "amazon.nova-pro-v1:0",
+    "amazon.nova-lite-v1:0",
+  ]) {
+    expect(isInvokableBedrockModelId(id), id).toBe(true);
+  }
+});
+
+test("the served catalog offers Bedrock only invokable ids", () => {
+  const bedrock = buildProviderCatalog().find(
+    (p) => p.id === BEDROCK_PROVIDER_ID,
+  );
+  expect(bedrock).toBeDefined();
+  const ids = bedrock?.models.map((m) => m.id) ?? [];
+  expect(ids.length).toBeGreaterThan(0);
+  for (const id of ids) expect(isInvokableBedrockModelId(id), id).toBe(true);
+  // The ids the user confirmed working on a plain Bedrock API key survive.
+  expect(ids).toContain("global.anthropic.claude-sonnet-4-6");
+  expect(ids).toContain("amazon.nova-pro-v1:0");
+  // The two ids from the PRODUCT-1641 failure cards are gone.
+  expect(ids).not.toContain("anthropic.claude-fable-5");
+  expect(ids).not.toContain("au.anthropic.claude-opus-5");
+});
+
+test("every curated host Bedrock id (incl. the default) survives the filter", () => {
+  // The host's curated list and connect default must never name an id the
+  // catalog no longer serves — otherwise the picker's default row vanishes.
+  const curated = PROVIDERS.find((p) => p.id === BEDROCK_PROVIDER_ID);
+  expect(curated).toBeDefined();
+  const served = new Set(
+    buildProviderCatalog()
+      .find((p) => p.id === BEDROCK_PROVIDER_ID)
+      ?.models.map((m) => m.id) ?? [],
+  );
+  for (const id of curated?.models ?? []) expect(served.has(id), id).toBe(true);
+  expect(served.has(curated?.defaultModel ?? "")).toBe(true);
+});

--- a/packages/host/src/providers/bedrock-catalog.ts
+++ b/packages/host/src/providers/bedrock-catalog.ts
@@ -1,0 +1,40 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+/**
+ * Narrow pi-ai's `amazon-bedrock` catalog to the ids a plain Bedrock API key can
+ * actually invoke. pi-ai lists ~120 Bedrock ids, most of which Bedrock refuses
+ * on demand, and the picker dedupes a model's variants down to the SHORTEST id
+ * (`dedupeModelEntries` in app/src/lib/providers.ts) — which for Bedrock is
+ * exactly the broken one:
+ *
+ * - Bare `anthropic.claude-*` foundation ids: Bedrock serves Claude 4.x and
+ *   newer ONLY through inference profiles, so every on-demand invocation of a
+ *   bare id fails with "Invocation of model ID … with on-demand throughput
+ *   isn't supported" (the default-model half was PRODUCT-1477; the picker
+ *   half is this filter).
+ * - Regional profiles (`au.` / `eu.` / `jp.` / `us.`): each exists only in its
+ *   own region's endpoint, so from the endpoint the runtime targets the
+ *   others answer "The provided model identifier is invalid". Keeping `us.`
+ *   would also let the picker's shortest-id dedupe prefer it over the
+ *   `global.` twin, hiding the curated/default id.
+ *
+ * Kept: `global.` cross-region inference profiles (region-agnostic, and the
+ * ids the host/runtime defaults and the frontend overrides already name) and
+ * Amazon's own `amazon.` Nova models (on-demand foundation ids, verified live
+ * on a user's key alongside `global.anthropic.claude-sonnet-4-6`).
+ */
+const INVOKABLE_BEDROCK_ID_PREFIXES = ["global.", "amazon."] as const;
+
+export const BEDROCK_PROVIDER_ID = "amazon-bedrock";
+
+/** Whether a Bedrock model id is one a plain Bedrock API key can invoke. */
+export function isInvokableBedrockModelId(id: string): boolean {
+  return INVOKABLE_BEDROCK_ID_PREFIXES.some((prefix) => id.startsWith(prefix));
+}
+
+/** Pure: drop the Bedrock ids Bedrock itself refuses. Preserves catalog order. */
+export function invokableBedrockModels<M extends Model<Api>>(
+  models: readonly M[],
+): M[] {
+  return models.filter((m) => isInvokableBedrockModelId(m.id));
+}

--- a/packages/host/src/providers/pi-catalog.ts
+++ b/packages/host/src/providers/pi-catalog.ts
@@ -22,6 +22,7 @@ import type {
   CatalogProvider,
   ProviderCatalog,
 } from "@houston/protocol";
+import { BEDROCK_PROVIDER_ID, invokableBedrockModels } from "./bedrock-catalog";
 import { piOAuthProviders } from "./pi-oauth";
 import { QWEN_PROVIDER_ID, qwenModels } from "./qwen-dashscope";
 
@@ -141,6 +142,10 @@ function providerDisplayName(
  * runs the same local-profile host/runtime as desktop and its egress reaches
  * every provider's public :443 endpoint, so a hosted user sees the full catalog
  * too. Deterministic — no clock, no IO.
+ *
+ * The one per-provider shaping is Bedrock, whose pi-ai list is mostly ids
+ * Bedrock itself refuses (see ./bedrock-catalog); the catalog is the RUNNABLE
+ * set, so those never reach a picker.
  */
 export function buildProviderCatalog(): ProviderCatalog {
   const oauthProviders = piOAuthProviders();
@@ -155,7 +160,11 @@ export function buildProviderCatalog(): ProviderCatalog {
     catalog.push(
       piProviderToCatalog(
         id,
-        id === "minimax" ? withMinimaxTokenPlan(models) : models,
+        id === "minimax"
+          ? withMinimaxTokenPlan(models)
+          : id === BEDROCK_PROVIDER_ID
+            ? invokableBedrockModels(models)
+            : models,
         oauthIds.has(id),
         providerDisplayName(id, oauthNames),
       ),

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -457,6 +457,42 @@ test("Bedrock bare-foundation-id on-demand rejection → model_unavailable, neve
       "Validation error: Invocation of model ID anthropic.claude-sonnet-4-6 with on-demand throughput isn\u2019t supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
   });
   expect(err.kind).toBe("model_unavailable");
+  // The switch-model card names the id that works on a plain Bedrock key.
+  if (err.kind === "model_unavailable")
+    expect(err.suggested_fallback).toBe("global.anthropic.claude-sonnet-4-6");
+});
+
+test("Bedrock off-region profile 'provided model identifier is invalid' → model_unavailable + global fallback (PRODUCT-1641)", () => {
+  // Verbatim from a user's pod picking `au.anthropic.claude-opus-5` — an
+  // inference profile that exists only in the AU endpoint. Classified
+  // `unknown` before: the report-bug card and a Sentry error per attempt for
+  // a valid key whose only problem was the pick.
+  const message = "Validation error: The provided model identifier is invalid.";
+  const err = classifyProviderError({
+    provider: "amazon-bedrock",
+    model: "au.anthropic.claude-opus-5",
+    message,
+    status: 400,
+  });
+  expect(err).toEqual({
+    kind: "model_unavailable",
+    provider: "amazon-bedrock",
+    model: "au.anthropic.claude-opus-5",
+    reason: "unknown",
+    suggested_fallback: "global.anthropic.claude-sonnet-4-6",
+    message,
+  });
+});
+
+test("Bedrock's own fallback never self-suggests", () => {
+  const err = classifyProviderError({
+    provider: "amazon-bedrock",
+    model: "global.anthropic.claude-sonnet-4-6",
+    message: "Validation error: The provided model identifier is invalid.",
+  });
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable")
+    expect(err.suggested_fallback).toBeNull();
 });
 
 test("OpenAI model_not_found → model_unavailable, no fallback for a non-Copilot provider", () => {

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -169,6 +169,13 @@ const MODEL_UNAVAILABLE_PATTERNS = [
   // on the apostrophe-free phrase: AWS spells "isn't" with U+2019, which the
   // "is not supported" pattern above can never hit (PRODUCT-1477).
   "on-demand throughput",
+  // Bedrock's off-region inference-profile rejection — 400 `The provided
+  // model identifier is invalid.` for a profile id that exists only in
+  // another region's endpoint (`au.anthropic.claude-opus-5` from the US
+  // endpoint). Bedrock checks the key before the model id, so the credential
+  // is fine and only THIS id is uninvokable — the switch-model card, never
+  // the report-bug card plus a Sentry error per attempt (PRODUCT-1641).
+  "provided model identifier is invalid",
   // GitHub Copilot's newer 400 body — `The requested model is not available
   // for integrator "vscode-chat". Available models: […]` — same plan-doesn't-
   // serve-this-model failure as its older `model_not_supported` code (HOU-977).
@@ -347,6 +354,16 @@ const MOONSHOT_BROAD_FALLBACK = "kimi-k2.6";
  * (PRODUCT-1517).
  */
 const XIAOMI_BROAD_FALLBACK = "mimo-v2.5-pro";
+
+/**
+ * The Bedrock model offered as the one-click switch target when a pick is one
+ * Bedrock cannot invoke (a bare `anthropic.*` foundation id, an off-region
+ * profile): the `global.` cross-region profile works from every endpoint and
+ * is the id verified live on a plain Bedrock API key (PRODUCT-1641). Twin of
+ * the runtime's `config.bedrockModel` default, duplicated on purpose like
+ * COPILOT_BASE_FALLBACK so this classifier stays pure.
+ */
+const BEDROCK_BROAD_FALLBACK = "global.anthropic.claude-sonnet-4-6";
 
 /**
  * The OpenAI-compatible (custom endpoint) provider id — duplicated from
@@ -562,7 +579,9 @@ function broadFallback(provider: string, model: string): string | null {
         ? MOONSHOT_BROAD_FALLBACK
         : provider === "xiaomi"
           ? XIAOMI_BROAD_FALLBACK
-          : null;
+          : provider === "amazon-bedrock"
+            ? BEDROCK_BROAD_FALLBACK
+            : null;
   return fallback && fallback !== model ? fallback : null;
 }
 


### PR DESCRIPTION
## Summary

Linear: PRODUCT-1641

A Bedrock user switching models in the chat picker hit two failure cards on a valid key. The host served pi-ai's full `amazon-bedrock` list (118 ids), and the picker folds a model's variants down to the shortest id, which for Bedrock is exactly the one Bedrock refuses:

- Bare `anthropic.claude-*` foundation ids: Bedrock serves Claude 4.x+ only through inference profiles, so these 400 with "on-demand throughput isn't supported" (the default-model half of this was PRODUCT-1477; the picker still offered them).
- Off-region inference profiles (`au.` / `eu.` / `jp.`, e.g. `au.anthropic.claude-opus-5`, the lexically-first survivor of the dedupe for Opus 5): 400 "The provided model identifier is invalid", which classified `unknown` (report-bug card + a Sentry error per attempt).

## Fix

- **Host catalog** (`packages/host/src/providers/bedrock-catalog.ts`, applied in `buildProviderCatalog`): `amazon-bedrock` now serves only `global.` cross-region profiles and Amazon's own `amazon.` Nova models. `us.` profiles are dropped too: keeping them would let the picker's shortest-id dedupe prefer `us.` over the `global.` twin and hide the curated/default `global.anthropic.claude-sonnet-4-6` row, and `global.` works from every endpoint region.
- **Classifier** (`packages/runtime/src/ai/provider-error.ts`): "provided model identifier is invalid" is now `model_unavailable`, and Bedrock gets `global.anthropic.claude-sonnet-4-6` as the suggested fallback (both for this body and the on-demand-throughput one), so the user sees the switch-model card with a one-click target.

Not done: a connect-time probe of every kept id. The kept set is the curated default (`global.anthropic.claude-sonnet-4-6`), Nova, and the other `global.` profiles.

## Tests

- `bedrock-catalog.test.ts`: pure filter, the two failing ids from the report are absent from the served catalog, every curated host Bedrock id + default survives.
- `provider-error.test.ts`: verbatim "provided model identifier is invalid" → `model_unavailable` with the global fallback; the existing on-demand-throughput case now asserts the fallback; the fallback never self-suggests.
- Ran: `pnpm check`, host + runtime vitest suites, `app` `tsgo --noEmit`, `provider-overrides-drift.test.ts`.

## Verify

Before: connect Bedrock with a plain API key, open the chat model picker, pick Claude Sonnet 4.6 (row id `anthropic.claude-sonnet-4-6`) or Claude Opus 5 (row id `au.anthropic.claude-opus-5`), send a message. Both fail; Opus 5 shows the generic report-bug card.

After: `GET /v1/catalog` lists only `global.*` and `amazon.*` ids under `amazon-bedrock`; the picker's Claude rows are the `global.` profiles and each completes a turn. A persisted off-region pick (e.g. an agent still on `au.anthropic.claude-opus-5`) now shows the switch-model card offering Claude Sonnet 4.6.

