### PR TITLE
fix(chat): show the message instantly when sending to an asleep agent (PRODUCT-1643)

### DIFF
--- a/app/src/components/board/use-agent-board-send.ts
+++ b/app/src/components/board/use-agent-board-send.ts
@@ -116,6 +116,8 @@ export function useAgentBoardSend({
             );
             return buildAttachmentPrompt(text, files, saved);
           },
+          // A composer send: the bubble must show before the row lands.
+          optimistic: true,
         },
       );
       // The turn stream pushes the user bubble into the conversation VM

--- a/app/src/components/board/use-mc-actions.ts
+++ b/app/src/components/board/use-mc-actions.ts
@@ -22,9 +22,9 @@ import type { SendOverrides } from "./board-source";
 /**
  * Mission Control's card/composer actions, routed to the right agent. Create
  * resolves the target agent via {@link planNewMission}; send delegates to
- * `mc.handleSendMessage` (which re-resolves provider/model from the target
- * activity, so composer overrides are intentionally ignored); stop resolves
- * its agent from the session metadata.
+ * `mc.handleSendMessage` (which resolves provider/model from the cached
+ * target activity, falling back to the composer's pick); stop resolves its
+ * agent from the session metadata.
  */
 export function useMcActions({
   mc,
@@ -69,17 +69,17 @@ export function useMcActions({
     [activeAgent, mc.handleCreateConversation, addToast, t],
   );
 
-  // Cross-agent: ignore the composer's provider/model overrides, re-resolve
-  // them from the activity (see useMissionControl). `mentions` are NOT an
-  // override in that sense — they are what this very message said — so they
-  // ride through.
+  // Cross-agent: the composer's provider/model are the chat panel's pick for
+  // the OPEN mission (its row's pin once loaded, the agent default until
+  // then); useMissionControl prefers the cached row's own pin and otherwise
+  // sends what the picker shows — never a pod read before the bubble.
   const sendMessageNow = useCallback(
     (
       sessionKey: string,
       text: string,
       files: File[],
       overrides: SendOverrides,
-    ) => mc.handleSendMessage(sessionKey, text, files, overrides.mentions),
+    ) => mc.handleSendMessage(sessionKey, text, files, overrides),
     [mc.handleSendMessage],
   );
 

--- a/app/src/components/mission-control-send.ts
+++ b/app/src/components/mission-control-send.ts
@@ -75,3 +75,27 @@ export function resolveMissionControlSendOverrides(
     modeOverride: DEFAULT_TURN_MODE,
   };
 }
+
+/**
+ * The follow-up's pin WITHOUT a pod round trip (PRODUCT-1643). Against an
+ * asleep pod the activity read used to ride the whole cold start before the
+ * turn stream could show the user's bubble, so the composer froze for seconds
+ * after Enter. The list is already in the query cache whenever the chat panel
+ * has been open a beat (it mounts the same query), so:
+ *
+ *  - cached and the row is found -> the row's own pin, exactly as before;
+ *  - otherwise -> the composer's effective pick, which the chat panel derives
+ *    from that same row when loaded and from the agent default until then —
+ *    so picker and wire still agree, and nothing awaits the pod.
+ */
+export function resolveFollowUpOverrides(
+  sessionKey: string,
+  cachedActivities: ActivityOverrideSource[] | undefined,
+  composer: SendOverrides,
+): SendOverrides {
+  const fromRow = resolveActivityOverride(sessionKey, cachedActivities);
+  if (fromRow.providerOverride === undefined) {
+    return { ...composer, modeOverride: DEFAULT_TURN_MODE };
+  }
+  return { ...fromRow, modeOverride: DEFAULT_TURN_MODE };
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1246,6 +1246,8 @@ export function useAgentChatPanel({
               );
             },
             title: friendlyTitle,
+            // A composer send: the bubble must show before the row lands.
+            optimistic: true,
           },
         );
         queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -11,6 +11,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import type { Activity } from "../data/activity";
 import { useAllConversations } from "../hooks/queries";
 import { useUserProfiles } from "../hooks/queries/use-user-profiles";
 import { useCapabilities } from "../hooks/use-capabilities";
@@ -43,9 +44,11 @@ import {
 import { DEFAULT_TURN_MODE } from "../lib/turn-mode";
 import type { Agent } from "../lib/types";
 import { mergeWarmingRows } from "../lib/warming-board-rows";
+import { useAgentProvisioningStore } from "../stores/agent-provisioning";
+import type { SendOverrides } from "./board/board-source";
 import { agentsByPath, missionCardAgentName } from "./board/mission-card-agent";
 import { useMcOpenConversation } from "./board/use-mc-open-conversation";
-import { resolveMissionControlSendOverrides } from "./mission-control-send";
+import { resolveFollowUpOverrides } from "./mission-control-send";
 import { AgentCardAvatar } from "./shell/agent-card-avatar";
 
 export function useMissionControl(agents: Agent[]) {
@@ -278,34 +281,63 @@ export function useMissionControl(agents: Agent[]) {
       sessionKey: string,
       text: string,
       files: File[],
-      mentions?: MessageMention[],
+      overrides: SendOverrides,
     ) => {
       const entry = sessionMapRef.current[sessionKey];
       if (!entry) return;
       const { agentPath, activityId } = entry;
+      const scopeId = `activity-${activityId}`;
+      // The pod is warming or was detected asleep (HOU-693 / HOU-730): park
+      // the send with the queue the per-agent board uses — the bubble renders
+      // now and the wire send fires when the readiness probe clears. A held
+      // wire send would die with infrastructure timeouts or a reload. The
+      // flush re-reads the mission's own pin once the pod answers, so the
+      // composer's guess below is never final (PRODUCT-1643).
+      const agentId = agentsByFolderPath.get(agentPath)?.id;
+      const queuedWarm = agentId
+        ? useAgentProvisioningStore.getState().queueWarmingSend(agentId, {
+            agentPath,
+            sessionKey,
+            text,
+            buildPrompt:
+              files.length > 0
+                ? async () => {
+                    const saved = await tauriAttachments.save(scopeId, files);
+                    return buildAttachmentPrompt(text, files, saved);
+                  }
+                : undefined,
+            provider: overrides.providerOverride,
+            model: overrides.modelOverride,
+            mode: DEFAULT_TURN_MODE,
+            mentions: overrides.mentions,
+          })
+        : false;
+      if (queuedWarm) {
+        setLoading((prev) => ({ ...prev, [sessionKey]: true }));
+        return;
+      }
       try {
-        const paths = await tauriAttachments.save(
-          `activity-${activityId}`,
-          files,
-        );
+        const paths = await tauriAttachments.save(scopeId, files);
         const prompt = buildAttachmentPrompt(text, files, paths);
-        // Mission Control is cross-agent: the activity's stored provider/model
-        // is the per-activity override that the chat picker is showing. The
-        // engine session router only reads agent config when no override is
-        // sent, so dropping the activity's choice here routes the message to
-        // whatever CLI the agent defaults to (e.g. agent=openai but activity
-        // was created with Opus -> spawns codex instead of claude). Look the
-        // activity up and forward its override pair to keep picker and wire
-        // in agreement.
-        const list = await tauriActivity.list(agentPath);
-        const overrides = resolveMissionControlSendOverrides(sessionKey, list);
+        // Mission Control is cross-agent: the mission's stored provider/model
+        // is the per-activity override the chat picker shows, and the engine
+        // session router only reads agent config when no override is sent —
+        // dropping it would route the message to the agent's default brain.
+        // Resolved from the CACHED activity list (the chat panel mounts that
+        // query), never a pod read: against an asleep pod that read rode the
+        // whole cold start before the bubble could show (PRODUCT-1643).
+        const sendOverrides = resolveFollowUpOverrides(
+          sessionKey,
+          queryClient.getQueryData<Activity[]>(queryKeys.activity(agentPath)),
+          overrides,
+        );
         // The turn stream pushes the user bubble into the conversation VM
         // itself — no app-side optimistic push. If the conversation is
         // mid-turn the adapter holds this send; the queued bubble shows the
         // user's words, not the built prompt.
         await tauriChat.send(agentPath, prompt, sessionKey, {
-          ...overrides,
-          mentions,
+          ...sendOverrides,
+          mentions: overrides.mentions,
           queuedPreview: {
             text,
             attachmentNames: files.map((f) => f.name),
@@ -315,13 +347,13 @@ export function useMissionControl(agents: Agent[]) {
       } catch (err) {
         setLoading((prev) => ({ ...prev, [sessionKey]: false }));
         // The send failed BEFORE a turn stream existed (attachment save,
-        // activity lookup, refused start) — nothing wrote to the VM, so
-        // surface it as a toast, same as the create path below.
+        // refused start) — nothing wrote to the VM, so surface it as a
+        // toast, same as the create path below.
         showSendFailedToast(err);
         throw err;
       }
     },
-    [],
+    [agentsByFolderPath, queryClient],
   );
 
   // Blank "New mission" create path for Mission Control. Mirrors the
@@ -370,6 +402,8 @@ export function useMissionControl(agents: Agent[]) {
               );
               return buildAttachmentPrompt(text, files, saved);
             },
+            // A composer send: the bubble must show before the row lands.
+            optimistic: true,
           },
         );
         setLoading((prev) => ({ ...prev, [sessionKey]: true }));

--- a/app/src/lib/create-mission-now.ts
+++ b/app/src/lib/create-mission-now.ts
@@ -1,0 +1,195 @@
+/**
+ * Mission creation that answers the instant the user sends (PRODUCT-1643).
+ *
+ * The normal `createMission` awaits the board row's read-modify-write before
+ * starting the turn. Against an asleep hosted pod every per-agent request is
+ * held for the whole cold start, so the composer froze with the user's text
+ * still in it and no bubble for seconds — read as a dead send button. The
+ * asleep check (HOU-730) only routes to the warming queue once it has
+ * concluded, and never for a pod that fell asleep while the chat stayed open.
+ *
+ * This path needs nothing from the pod before the message is on screen:
+ *
+ *  1. The activity id is generated client-side (the host honors it, HOU-693)
+ *     and the board-row POST fires without being awaited — an id-upsert, so
+ *     it lands whenever the pod answers.
+ *  2. The turn starts right away: the turn stream pushes the user's bubble
+ *     synchronously and the thinking indicator takes over, while the wire
+ *     send rides the same gateway hold as the row write.
+ *
+ * The caller gets the id/sessionKey back immediately, so the panel opens on
+ * the new conversation with the message visible. A row is not a precondition
+ * for a turn (a turn with no card is a transient session); the turn's own
+ * status writes match the row by session key once it has landed.
+ */
+
+import { isAgentGoneError } from "./agent-gone";
+import { analytics } from "./analytics";
+import type {
+  CreateMissionAgent,
+  CreateMissionOptions,
+  CreateMissionResult,
+} from "./create-mission";
+import { getEngine } from "./engine";
+import { showErrorToast } from "./error-toast";
+import i18n from "./i18n";
+import { logger } from "./logger";
+import { fallbackMissionTitle, refreshMissionTitle } from "./mission-title";
+import { healStaleRosterFromError } from "./roster-heal";
+import { showSendFailedToast } from "./send-error-toast";
+import { tauriActivity, tauriChat } from "./tauri";
+
+/** The identity a mission is born with, decided before anything hits the wire. */
+export interface MissionIdentity {
+  conversationId: string;
+  sessionKey: string;
+  title: string;
+  description: string;
+  /** Source text for the async AI title pass; absent = keep `title`. */
+  titleText?: string;
+}
+
+/**
+ * Land the board row through the host's single id-honoring POST. Resolves the
+ * landed id (differs from ours only under version skew — an engine predating
+ * client-supplied ids assigned its own, so its row is stamped with our session
+ * key to keep the card opening this chat), or null after toasting: losing the
+ * card must never lose the message.
+ */
+async function landMissionRow(
+  agent: CreateMissionAgent,
+  opts: CreateMissionOptions,
+  mission: MissionIdentity,
+): Promise<string | null> {
+  try {
+    const created = await tauriActivity.createWithId(agent.folderPath, {
+      id: mission.conversationId,
+      title: mission.title,
+      description: mission.description,
+      agent: opts.agentMode,
+      provider: opts.providerOverride,
+      model: opts.modelOverride,
+    });
+    if (created.id !== mission.conversationId) {
+      await getEngine().updateActivity(agent.folderPath, created.id, {
+        session_key: mission.sessionKey,
+      });
+    }
+    return created.id;
+  } catch (e) {
+    // The agent vanished under the send (deleted/unshared elsewhere): an
+    // expected roster-stale state, healed like the warming flush does — not a
+    // bug toast the user can't act on.
+    if (isAgentGoneError(e)) {
+      healStaleRosterFromError(e);
+      return null;
+    }
+    showErrorToast(
+      "create_mission_now",
+      "mission row create/update failed",
+      e,
+      {
+        userMessage: i18n.t("chat:errors.missionRowFailed"),
+      },
+    );
+    return null;
+  }
+}
+
+/**
+ * Fire the row write and the turn for an already-identified mission, awaiting
+ * neither. Shared by the optimistic create below and the warming path's
+ * "turned ready between the check and the queue" fallback.
+ */
+export function startMissionNow(
+  agent: CreateMissionAgent,
+  text: string,
+  opts: CreateMissionOptions,
+  mission: MissionIdentity,
+): void {
+  const row = landMissionRow(agent, opts, mission);
+  void (async () => {
+    let prompt = text;
+    if (opts.buildPrompt) {
+      try {
+        prompt = await opts.buildPrompt(mission.conversationId);
+      } catch (e) {
+        // The attachment save failed: nothing was sent, so the row must not
+        // keep a fake running mission on the board (createMission's rollback).
+        void row
+          .then((id) =>
+            id ? tauriActivity.delete(agent.folderPath, id) : null,
+          )
+          .catch((cleanupErr) => {
+            logger.error(`[create-mission-now] rollback failed: ${cleanupErr}`);
+          });
+        throw e;
+      }
+    }
+    await tauriChat.send(agent.folderPath, prompt, mission.sessionKey, {
+      providerOverride: opts.providerOverride,
+      modelOverride: opts.modelOverride,
+      effortOverride: opts.effortOverride,
+      modeOverride: opts.modeOverride,
+      mentions: opts.mentions,
+      // `buildPrompt` swaps in a prompt the user should not see (a hidden setup
+      // directive, or attachment paths appended to their words) — so the bubble
+      // renders the clean `text` instead, live and on every history reload.
+      displayText: opts.buildPrompt ? text : undefined,
+    });
+    // The AI title pass needs the row: it lands whenever the pod answers.
+    const landedId = await row;
+    if (landedId && mission.titleText !== undefined) {
+      void refreshMissionTitle({
+        agentPath: agent.folderPath,
+        activityId: landedId,
+        text: mission.titleText,
+        provider: opts.providerOverride,
+        model: opts.modelOverride,
+      });
+    }
+  })().catch((e) => {
+    // The send failed BEFORE a turn stream existed (attachment save, refused
+    // start) — nothing wrote to the VM, so the toast is its only surface.
+    showSendFailedToast(e);
+  });
+  analytics.track("mission_created", {
+    agent_mode: opts.agentMode,
+    provider: opts.providerOverride,
+    model: opts.modelOverride,
+  });
+}
+
+/** `createMission` for a composer send: identity now, wire in the background. */
+export function createMissionNow(
+  agent: CreateMissionAgent,
+  text: string,
+  opts: CreateMissionOptions = {},
+): CreateMissionResult {
+  const titleText = opts.titleText ?? text;
+  const title = opts.title ?? fallbackMissionTitle(titleText);
+  const description = text;
+  const conversationId = crypto.randomUUID();
+  const sessionKey = `activity-${conversationId}`;
+  startMissionNow(agent, text, opts, {
+    conversationId,
+    sessionKey,
+    title,
+    description,
+    titleText: opts.title ? undefined : titleText,
+  });
+  return {
+    conversationId,
+    sessionKey,
+    conversation: {
+      id: conversationId,
+      title,
+      description,
+      agentName: agent.name,
+      agentColor: agent.color,
+      status: "running",
+      updatedAt: new Date().toISOString(),
+      agentPath: agent.folderPath,
+    },
+  };
+}

--- a/app/src/lib/create-mission-warming.ts
+++ b/app/src/lib/create-mission-warming.ts
@@ -26,11 +26,8 @@ import type {
   CreateMissionOptions,
   CreateMissionResult,
 } from "./create-mission";
-import { getEngine } from "./engine";
-import { showErrorToast } from "./error-toast";
-import i18n from "./i18n";
-import { fallbackMissionTitle, refreshMissionTitle } from "./mission-title";
-import { tauriActivity, tauriChat } from "./tauri";
+import { startMissionNow } from "./create-mission-now";
+import { fallbackMissionTitle } from "./mission-title";
 
 export function createMissionWhileWarming(
   agent: CreateMissionAgent,
@@ -76,63 +73,22 @@ export function createMissionWhileWarming(
     });
   if (!queued) {
     // The agent turned ready between the caller's provisioning check and the
-    // queue — the engine answers now: write the row and send like any turn.
-    void (async () => {
-      try {
-        const created = await tauriActivity.createWithId(agent.folderPath, {
-          id: conversationId,
-          title,
-          description,
-          agent: opts.agentMode,
-          provider: opts.providerOverride,
-          model: opts.modelOverride,
-        });
-        if (created.id !== conversationId) {
-          // Version skew: the engine predates client-supplied ids (HOU-693) —
-          // stamp our session key on its row so the card opens this chat.
-          await getEngine().updateActivity(agent.folderPath, created.id, {
-            session_key: sessionKey,
-          });
-        }
-      } catch {
-        showErrorToast(
-          "create_mission_warming",
-          "mission row create/update failed",
-          undefined,
-          { userMessage: i18n.t("chat:errors.missionRowFailed") },
-        );
-      }
-      const prompt = opts.buildPrompt
-        ? await opts.buildPrompt(conversationId)
-        : text;
-      await tauriChat.send(agent.folderPath, prompt, sessionKey, {
-        providerOverride: opts.providerOverride,
-        modelOverride: opts.modelOverride,
-        effortOverride: opts.effortOverride,
-        modeOverride: opts.modeOverride,
-        mentions: opts.mentions,
-      });
-      // The engine answers now, so the AI title pass runs like the normal
-      // path's (createMission fires it right after the first send).
-      if (!opts.title) {
-        void refreshMissionTitle({
-          agentPath: agent.folderPath,
-          activityId: conversationId,
-          text: titleText,
-          provider: opts.providerOverride,
-          model: opts.modelOverride,
-        });
-      }
-    })().catch(() => {
-      // tauriChat.send toasted the real reason already.
+    // queue — the engine answers now: write the row and send like any turn,
+    // awaiting neither (the caller already has the mission's identity).
+    startMissionNow(agent, text, opts, {
+      conversationId,
+      sessionKey,
+      title,
+      description,
+      titleText: opts.title ? undefined : titleText,
+    });
+  } else {
+    analytics.track("mission_created", {
+      agent_mode: opts.agentMode,
+      provider: opts.providerOverride,
+      model: opts.modelOverride,
     });
   }
-
-  analytics.track("mission_created", {
-    agent_mode: opts.agentMode,
-    provider: opts.providerOverride,
-    model: opts.modelOverride,
-  });
 
   return {
     conversationId,

--- a/app/src/lib/create-mission.ts
+++ b/app/src/lib/create-mission.ts
@@ -7,6 +7,7 @@
 import type { MessageMention } from "@houston-ai/engine-client";
 import { isAgentProvisioning } from "../stores/agent-provisioning";
 import { analytics } from "./analytics";
+import { createMissionNow } from "./create-mission-now";
 import { createMissionWhileWarming } from "./create-mission-warming";
 import { logger } from "./logger";
 import { fallbackMissionTitle, refreshMissionTitle } from "./mission-title";
@@ -83,6 +84,14 @@ export interface CreateMissionOptions {
   title?: string;
   /** Source text used for async AI title generation. Defaults to `text`. */
   titleText?: string;
+  /**
+   * A composer send (PRODUCT-1643): resolve the moment the turn is on screen —
+   * the board row lands in the background through an id-upsert, so nothing
+   * waits on the pod (asleep or not) before the user sees their message.
+   * Setup flows leave this unset: they patch the row right after create and
+   * need it landed first.
+   */
+  optimistic?: boolean;
 }
 
 export interface CreateMissionResult {
@@ -110,6 +119,7 @@ export async function createMission(
   if (isAgentProvisioning(agent.id)) {
     return createMissionWhileWarming(agent, text, opts);
   }
+  if (opts.optimistic) return createMissionNow(agent, text, opts);
   const titleText = opts.titleText ?? text;
   const title = opts.title ?? fallbackMissionTitle(titleText);
   const description = text;

--- a/app/src/lib/warming-send-pin.ts
+++ b/app/src/lib/warming-send-pin.ts
@@ -1,7 +1,38 @@
+// Explicit `.ts` extension: `node --test --experimental-strip-types` loads
+// this module directly (app/tests/warming-send-pin.test.ts).
+import { normalizeLegacyModel } from "./providers.ts";
+
 export interface WarmingPin {
   provider?: string;
   model?: string;
   effort?: string;
+}
+
+/** A mission row's stored pin, as the activity list returns it. */
+export interface RowPin {
+  provider?: string;
+  model?: string;
+}
+
+/**
+ * The pin a parked FOLLOW-UP flushes with (PRODUCT-1643). A follow-up queued
+ * while the pod was asleep carried the composer's best guess — the agent
+ * default whenever the mission's own row had not loaded yet. The row's pin is
+ * what the picker shows once loaded, and nobody could have changed it while
+ * parked (writes block during a warm-up), so it wins whenever it names a
+ * provider. Legacy aliases are normalized like every other row read. The
+ * send's effort survives either way: rows never store one.
+ */
+export function preferRowPin(
+  row: RowPin | undefined,
+  send: WarmingPin,
+): WarmingPin {
+  if (!row?.provider) return send;
+  return {
+    provider: row.provider,
+    model: normalizeLegacyModel(row.model ?? null) ?? undefined,
+    effort: send.effort,
+  };
 }
 
 export async function verifyWarmingSendPin(args: {

--- a/app/src/lib/warming-sends.ts
+++ b/app/src/lib/warming-sends.ts
@@ -31,7 +31,11 @@ import { logger } from "./logger";
 import { refreshMissionTitle } from "./mission-title";
 import { healStaleRosterFromError } from "./roster-heal";
 import { tauriActivity, tauriChat, tauriProvider } from "./tauri";
-import { verifyWarmingSendPin } from "./warming-send-pin";
+import {
+  preferRowPin,
+  type RowPin,
+  verifyWarmingSendPin,
+} from "./warming-send-pin";
 
 /** Prompt builders keyed by send id — in-memory only, lost on reload. */
 const promptBuilders = new Map<string, () => Promise<string> | string>();
@@ -214,14 +218,30 @@ export async function flushWarmingSends(
       (send.sessionKey.startsWith("activity-")
         ? send.sessionKey.slice("activity-".length)
         : undefined);
+    // A parked follow-up (no row of its own) carries the composer's guess at
+    // the mission's pin — the pod answers now, so read the row's stored pin
+    // before verifying it (PRODUCT-1643). A failed read keeps the guess: the
+    // wrapper already reported it, and the message still delivers.
+    let rowPin: RowPin | undefined;
+    if (!send.row) {
+      try {
+        rowPin = (await tauriActivity.list(entry.agentPath)).find(
+          (a) =>
+            (a.session_key ?? `activity-${a.id}`) === send.sessionKey ||
+            a.id === activityId,
+        );
+      } catch (e) {
+        logger.warn(`[warming-sends] mission pin read failed: ${e}`);
+      }
+    }
     const pin = await verifyWarmingSendPin({
       agentId: entry.agentPath,
       activityId,
-      pin: {
+      pin: preferRowPin(rowPin, {
         provider: send.provider,
         model: send.model,
         effort: send.effort,
-      },
+      }),
       probe: async (agentId, provider) => {
         const statuses = await tauriProvider.checkAllStatusesForAgent(agentId, [
           provider,

--- a/app/tests/mission-control-send.test.ts
+++ b/app/tests/mission-control-send.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   type ActivityOverrideSource,
   resolveActivityOverride,
+  resolveFollowUpOverrides,
   resolveMissionControlSendOverrides,
 } from "../src/components/mission-control-send.ts";
 
@@ -145,6 +146,80 @@ describe("resolveMissionControlSendOverrides", () => {
         modelOverride: "claude-opus-4-7",
         modeOverride: "execute",
       },
+    );
+  });
+});
+
+describe("resolveFollowUpOverrides (no pod read before the bubble)", () => {
+  const composer = {
+    providerOverride: "openai",
+    modelOverride: "gpt-5.5",
+    modeOverride: "plan" as const,
+  };
+
+  it("prefers the cached row's own pin when the list is cached", () => {
+    deepStrictEqual(
+      resolveFollowUpOverrides(
+        `activity-${opus47Activity.id}`,
+        [opus47Activity, codexActivity],
+        composer,
+      ),
+      {
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-7",
+        modeOverride: "execute",
+      },
+    );
+  });
+
+  it("falls back to the composer's pick when nothing is cached", () => {
+    // Cold open against an asleep pod: the activity read is held for the
+    // whole wake, and awaiting it froze the composer. The picker shows the
+    // agent default meanwhile, so the wire ships exactly that.
+    deepStrictEqual(
+      resolveFollowUpOverrides("activity-anything", undefined, composer),
+      {
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+        modeOverride: "execute",
+      },
+    );
+  });
+
+  it("falls back to the composer's pick when the row is not in the cache", () => {
+    deepStrictEqual(
+      resolveFollowUpOverrides("activity-missing", [opus47Activity], composer),
+      {
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+        modeOverride: "execute",
+      },
+    );
+  });
+
+  it("falls back to the composer's pick when the cached row has no pin", () => {
+    // A row without a stored pin means "the agent default" — which is what
+    // the picker resolved and shows; the wire must agree with the picker.
+    deepStrictEqual(
+      resolveFollowUpOverrides("activity-x", [{ id: "x" }], composer),
+      {
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+        modeOverride: "execute",
+      },
+    );
+  });
+
+  it("always pins Mission Control follow-ups to Ask First", () => {
+    // The composer's mode is not honored here (Mission Control never was);
+    // the row's pin and the composer's fallback both carry execute.
+    deepStrictEqual(
+      resolveFollowUpOverrides(
+        `activity-${legacyOpusActivity.id}`,
+        [legacyOpusActivity],
+        composer,
+      ).modeOverride,
+      "execute",
     );
   });
 });

--- a/app/tests/warming-send-pin.test.ts
+++ b/app/tests/warming-send-pin.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { verifyWarmingSendPin } from "../src/lib/warming-send-pin.ts";
+import {
+  preferRowPin,
+  verifyWarmingSendPin,
+} from "../src/lib/warming-send-pin.ts";
 
 const pin = { provider: "anthropic", model: "sonnet", effort: "high" };
 
@@ -41,5 +44,33 @@ describe("warming send provider pin", () => {
       clearActivityPin: async () => assert.fail("must not clear"),
     });
     assert.deepEqual(result, pin);
+  });
+});
+
+describe("preferRowPin (a parked follow-up flushes with the mission's own pin)", () => {
+  it("takes the row's provider+model and keeps the send's effort", () => {
+    assert.deepEqual(
+      preferRowPin(
+        { provider: "anthropic", model: "claude-opus-4-7" },
+        { provider: "openai", model: "gpt-5.5", effort: "high" },
+      ),
+      { provider: "anthropic", model: "claude-opus-4-7", effort: "high" },
+    );
+  });
+
+  it("normalizes a legacy alias stored on the row", () => {
+    assert.deepEqual(
+      preferRowPin({ provider: "anthropic", model: "opus" }, pin),
+      { provider: "anthropic", model: "claude-opus-5", effort: "high" },
+    );
+  });
+
+  it("keeps the send's pin when the row has none", () => {
+    assert.deepEqual(preferRowPin({}, pin), pin);
+    assert.deepEqual(preferRowPin(undefined, pin), pin);
+  });
+
+  it("keeps the send's pin when the row read found nothing", () => {
+    assert.deepEqual(preferRowPin(undefined, {}), {});
   });
 });

--- a/packages/web/e2e/asleep-send.spec.ts
+++ b/packages/web/e2e/asleep-send.spec.ts
@@ -1,0 +1,94 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+import { openNewMission } from "./support/mission";
+
+/**
+ * Sending to an agent whose pod is asleep (PRODUCT-1643).
+ *
+ * On a cloud boot, or after an idle pod scales to zero while the app stays
+ * open, EVERY per-agent read is held by the gateway for the whole cold start.
+ * The send paths used to await such reads (the mission's pin lookup, the board
+ * row's read-modify-write) BEFORE the turn stream could push the user's
+ * bubble — so Enter did nothing visible for seconds and the send button read
+ * as dead. The fake host's cold-start hold models the gateway: every
+ * per-agent GET stalls for the armed window, writes and the turn's POST go
+ * through, and the reply's SSE (a GET) lands once the hold lifts — exactly
+ * like a pod waking up.
+ *
+ * The proof in both specs is the timing gap: the bubble must show well inside
+ * the hold, and the reply must still arrive after it.
+ */
+const HOLD_MS = 8_000;
+/** Far under the hold, generous enough for a contended CI runner. */
+const BUBBLE_GRACE_MS = 3_000;
+
+const userRow = (page: Page, text: string): Locator =>
+  page
+    .locator('[data-conversation-message-key^="user-"]')
+    .filter({ hasText: text });
+
+async function holdAgentReads(
+  request: Parameters<Parameters<typeof test>[2]>[0]["request"],
+  ms: number,
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/hold-agent-reads`, {
+    data: { ms },
+  });
+}
+
+test("a follow-up sent to an asleep pod shows the message instantly", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/");
+  // Open an existing mission while the pod answers: the chat panel mounts and
+  // caches the board's activity list, like any chat the user had open.
+  await page.getByText("Plan a trip to Tokyo").click();
+  const composer = page.getByPlaceholder("Send a follow-up...");
+  await expect(composer).toBeVisible();
+
+  // The pod falls asleep under the open chat.
+  await holdAgentReads(request, HOLD_MS);
+
+  await composer.fill("also book the hotel");
+  await composer.press("Enter");
+
+  // The bubble renders off the cached pin — no held read in front of it.
+  await expect(userRow(page, "also book the hotel")).toBeVisible({
+    timeout: BUBBLE_GRACE_MS,
+  });
+  // The composer let go of the text the moment the send was on screen.
+  await expect(composer).toHaveValue("");
+
+  // The reply streams once the "pod" is up again.
+  await expect(page.getByText(/Roger that\. You said:/)).toBeVisible({
+    timeout: HOLD_MS + 15_000,
+  });
+});
+
+test("a new mission sent to an asleep pod shows the message instantly", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/");
+  await openNewMission(page);
+  const composer = page.getByPlaceholder("What should the agent work on?");
+  await expect(composer).toBeVisible();
+
+  // The pod falls asleep before the first message is sent: the board row's
+  // read-modify-write is now held, and must not stand between Enter and the
+  // bubble.
+  await holdAgentReads(request, HOLD_MS);
+
+  await composer.fill("plan the offsite");
+  await composer.press("Enter");
+
+  await expect(userRow(page, "plan the offsite")).toBeVisible({
+    timeout: BUBBLE_GRACE_MS,
+  });
+
+  await expect(page.getByText(/Roger that\. You said:/)).toBeVisible({
+    timeout: HOLD_MS + 15_000,
+  });
+});


### PR DESCRIPTION
Fixes [PRODUCT-1643](https://linear.app/houston-ai/issue/PRODUCT-1643).

## Problem

Open Houston, write to an agent, press Enter: nothing happens for ~5 seconds, then the message appears. Users read it as a dead send button.

The agent's hosted pod is asleep. Every per-agent request is held by the gateway for the whole cold start, and the send paths awaited per-agent reads/writes BEFORE the turn stream could push the user's bubble:

- **Mission Control follow-up**: awaited `tauriActivity.list` (a held read on the cold-start retry ladder) to resolve the mission's model pin, and never parked the send in the warming queue the way the per-agent board does.
- **New mission**: awaited the activity row's read-modify-write before the send unless the agent was already flagged asleep. Also bites when a pod fell asleep while the app stayed open (the asleep check runs once per chat open).

The SDK's optimistic echo itself is synchronous. Only the app-level pre-send awaits blocked it.

## Fix

- `useMissionControl.handleSendMessage` parks in the existing warming queue when the agent is flagged asleep/creating, and otherwise resolves the pin from the **cached** activity list (`resolveFollowUpOverrides`): the row's own pin when cached, else the composer's effective pick, which the chat panel derives from the same row. No pod read in front of the bubble.
- `flushWarmingSends` re-reads a parked follow-up's row pin once the pod answers (`preferRowPin`), so a follow-up queued before the row loaded never silently changes model.
- `createMission({ optimistic: true })` (new `create-mission-now.ts`): composer sends start the turn immediately (the turn stream pushes the bubble) and land the board row in the background via the id-upsert POST. The warming path's "turned ready mid-check" fallback shares it. Setup flows (routine/skill/integration/onboarding) keep the awaited row since they patch it right after.

Once the bubble is on screen, the existing thinking indicator shows the rotating phrases while the pod wakes.

## Tests

- `app/tests/mission-control-send.test.ts`, `app/tests/warming-send-pin.test.ts`: the pin resolution rules.
- `packages/web/e2e/asleep-send.spec.ts`: follow-up and new mission against the fake host's cold-start hold. Both fail on `main` (bubble arrives only after the hold) and pass here; the reply still streams once the hold lifts.
- `cd app && pnpm test` (3899 pass), `pnpm tsgo --noEmit`, `pnpm check`, `pnpm --filter houston-web typecheck`, chromium e2e for chat, board, interaction, onboarding, setup-chat, senders, mentions.

## Not covered

- Sends with attachments still await the attachment save (a held POST on an asleep pod) before the bubble.
- The SDK-native `turns/send` command still awaits `listProviders` when a model pin is passed (mobile only).