### PR TITLE
fix(host): keep the Claude subscription credential where a non-gateway host can read it (PRODUCT-1644)

### DIFF
--- a/packages/host/src/channel/capture-credential.test.ts
+++ b/packages/host/src/channel/capture-credential.test.ts
@@ -428,3 +428,88 @@ test("an azure api_key capture stores the exported endpoint as enterpriseUrl (PR
     enterpriseUrl: "https://acme.openai.azure.com",
   });
 });
+
+/** A runtime whose export answers `exported` and whose status reports `configured`. */
+function stubAnthropicRuntime(exported: unknown, configured: boolean) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      calls.push(url.replace(/^https?:\/\/[^/]+/, ""));
+      if (url.includes("/auth/export")) return Response.json(exported);
+      if (url.includes("/auth/status"))
+        return Response.json({
+          providers: [{ provider: "anthropic", configured }],
+        });
+      if (url.includes("/auth/scrub-refresh"))
+        return Response.json({ ok: true });
+      return new Response("not found", { status: 404 });
+    }),
+  );
+  return calls;
+}
+
+test("anthropic on a host that never serves it: a refresh-bearing entry is left as the runtime's own, unstored and unscrubbed", async () => {
+  const { credentials, puts } = recordingStore();
+  const calls = stubAnthropicRuntime(
+    { provider: "anthropic", access: "AT", refresh: "RT", expires: 123 },
+    true,
+  );
+  const result = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://rt", token: "t" },
+    credentials,
+    workspaceId: "ws",
+    provider: "anthropic",
+    anthropicServedHere: false,
+  });
+  expect(result).toEqual({ ok: true, provider: "anthropic" });
+  expect(puts).toEqual([]);
+  expect(calls.some((c) => c.includes("/auth/scrub-refresh"))).toBe(false);
+});
+
+test("anthropic on a host that never serves it: nothing exportable settles on the runtime's own status", async () => {
+  const { credentials, puts } = recordingStore();
+  stubAnthropicRuntime({}, true);
+  const connected = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://rt", token: "t" },
+    credentials,
+    workspaceId: "ws",
+    provider: "anthropic",
+    anthropicServedHere: false,
+  });
+  expect(connected).toEqual({ ok: true, provider: "anthropic" });
+  expect(puts).toEqual([]);
+
+  stubAnthropicRuntime({}, false);
+  const notConnected = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://rt", token: "t" },
+    credentials,
+    workspaceId: "ws",
+    provider: "anthropic",
+    anthropicServedHere: false,
+  });
+  expect(notConnected).toEqual({
+    ok: false,
+    status: 400,
+    error: "agent is not connected yet",
+  });
+});
+
+test("anthropic behind the gateway keeps the capture chain: stored centrally, then scrubbed", async () => {
+  const { credentials, puts } = recordingStore();
+  const calls = stubAnthropicRuntime(
+    { provider: "anthropic", access: "AT", refresh: "RT", expires: 123 },
+    true,
+  );
+  const result = await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://rt", token: "t" },
+    credentials,
+    workspaceId: "ws",
+    provider: "anthropic",
+    anthropicServedHere: true,
+  });
+  expect(result).toEqual({ ok: true, provider: "anthropic" });
+  expect(puts.map((p) => p.credential.provider)).toEqual(["anthropic"]);
+  expect(calls.some((c) => c.includes("/auth/scrub-refresh"))).toBe(true);
+});

--- a/packages/host/src/channel/capture-credential.ts
+++ b/packages/host/src/channel/capture-credential.ts
@@ -61,6 +61,17 @@ export async function captureRuntimeCredential(args: {
    * user-initiated (re)connect omits it and overwrites.
    */
   ifAbsent?: boolean;
+  /**
+   * Whether this host serves anthropic back to its runtimes (a gateway-fronted
+   * pod). Default true. On a desktop/self-host host (`routes/credential.ts`
+   * answers anthropic with the not-served-here 404) the runtime's SHARED
+   * login dir is anthropic's single holder and rotator, so an anthropic
+   * capture must neither store a row nothing serves nor scrub the runtime —
+   * that scrub left the connect reading connected for one poll and then
+   * disconnected for good (PRODUCT-1644). The runtime's own status settles
+   * such a capture instead.
+   */
+  anthropicServedHere?: boolean;
 }): Promise<CaptureResult> {
   const {
     endpoint,
@@ -71,6 +82,8 @@ export async function captureRuntimeCredential(args: {
     actingAs,
     ifAbsent,
   } = args;
+  const localAnthropic = (id: string | undefined) =>
+    id === "anthropic" && args.anthropicServedHere === false;
   const params = new URLSearchParams();
   if (provider) params.set("provider", provider);
   if (localOriginOnly) params.set("excludeServed", "1");
@@ -149,7 +162,22 @@ export async function captureRuntimeCredential(args: {
     if (provider && (await settledCentrally(credentials, args))) {
       return { ok: true, provider };
     }
+    // Anthropic on a host that never serves it: the credential lives in the
+    // runtime's shared login dir, never in its auth.json, so there is nothing
+    // to export — the runtime's status (its login-dir probe) is the arbiter.
+    if (localAnthropic(provider) && provider) {
+      return (await runtimeReportsConnected(endpoint, provider, actingAs))
+        ? { ok: true, provider }
+        : { ok: false, status: 400, error: "agent is not connected yet" };
+    }
     return { ok: false, status: 400, error: "agent is not connected yet" };
+  }
+  if (localAnthropic(credential.provider)) {
+    // A refresh-bearing anthropic entry on a host that never serves it (an
+    // older runtime's throwaway-dir login): leave it as the single rotator.
+    // Storing it centrally would seed a second refresh-token holder, and the
+    // scrub would strand the runtime with an access token nothing renews.
+    return { ok: true, provider: credential.provider };
   }
   await credentials.put(
     {
@@ -208,6 +236,47 @@ async function settledCentrally(
   } catch (err) {
     console.warn(
       `[capture] settlement probe for ${args.provider} failed:`,
+      err instanceof Error ? err.message : err,
+    );
+    return false;
+  }
+}
+
+/**
+ * Whether the runtime itself reports `provider` connected (`/auth/status`):
+ * the settlement probe for an anthropic capture on a host that never serves
+ * anthropic, where the credential is in the runtime's login dir and not
+ * exportable. A probe failure is logged and read as "not connected".
+ */
+async function runtimeReportsConnected(
+  endpoint: RuntimeEndpoint,
+  provider: string,
+  actingAs: string | undefined,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${endpoint.baseUrl}/auth/status`, {
+      headers: {
+        Authorization: `Bearer ${endpoint.token}`,
+        ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
+      },
+    });
+    if (!res.ok) {
+      console.warn(
+        `[capture] ${provider} status probe answered ${res.status}; reading it as not connected`,
+      );
+      return false;
+    }
+    const status = (await res.json()) as {
+      providers?: Array<{ provider?: string; configured?: boolean }>;
+    };
+    return (
+      status.providers?.some(
+        (p) => p.provider === provider && p.configured === true,
+      ) ?? false
+    );
+  } catch (err) {
+    console.warn(
+      `[capture] ${provider} status probe failed:`,
       err instanceof Error ? err.message : err,
     );
     return false;

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -65,6 +65,13 @@ export class ProxyChannel implements RuntimeChannel {
        * `x-houston-acting-user` never rides this header.
        */
       forwardActingHeader: boolean;
+      /**
+       * Whether this host serves anthropic back to its runtimes (gateway-
+       * fronted). Default true. False on the desktop/self-host host, where an
+       * anthropic capture must leave the runtime's shared login dir as the
+       * single holder (capture-credential.ts, PRODUCT-1644).
+       */
+      anthropicServedHere?: boolean;
       /** Managed pod shared-cache freshness gate, invoked only for turn starts. */
       beforeTurn?: (agent: ChannelCtx["agent"]) => Promise<void>;
       /** Detached standing-runtime SSE capture for durable turnlog ingest. */
@@ -439,6 +446,7 @@ export class ProxyChannel implements RuntimeChannel {
       // The connecting MEMBER's own credential (HOU-976): read from their
       // runtime auth file, stored on their row, scrubbed from their file.
       actingAs: ctx.actingAs,
+      anthropicServedHere: this.opts.anthropicServedHere ?? true,
     });
     // A user-driven device-code connect supersedes any provider revocation of
     // the previous credential — automatic serving may resume immediately.

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -435,6 +435,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     // the gateway minted the header, so relaying it is what lets the runtime's
     // integration calls act as the driving user (C2).
     forwardActingHeader: opts.gatewayFronted ?? false,
+    // Anthropic is served back only behind the gateway (routes/credential.ts);
+    // elsewhere the runtime's shared login dir holds it (PRODUCT-1644).
+    anthropicServedHere: opts.gatewayFronted ?? false,
     beforeTurn: sharedMirror ? () => sharedMirror.beforeTurn() : undefined,
     turnLogCapture: standingFrameCapture,
   });
@@ -463,6 +466,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
             // after a recycle was the one resurrection path that survived
             // (PRODUCT-1318).
             ifAbsent: true,
+            anthropicServedHere: opts.gatewayFronted ?? false,
           });
           return result.ok;
         },

--- a/packages/runtime/src/auth/anthropic-cli-login.test.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.test.ts
@@ -62,6 +62,8 @@ type Harness = {
   stored: { tokens: string[]; oauth: Array<Record<string, unknown>> };
   cleaned: string[];
   keychainDiscarded: string[];
+  /** The CLAUDE_CONFIG_DIR each spawn was pointed at. */
+  spawnDirs: string[];
   login: Promise<void>;
   paste: (value: string) => void;
 };
@@ -72,12 +74,14 @@ function harness(opts?: {
   credentialFile?: string | null;
   keychain?: string | null;
   pasteNever?: boolean;
+  sharedLoginDir?: string;
 }): Harness {
   const child = new FakeChild();
   const authInfos: Harness["authInfos"] = [];
   const stored: Harness["stored"] = { tokens: [], oauth: [] };
   const cleaned: string[] = [];
   const keychainDiscarded: string[] = [];
+  const spawnDirs: string[] = [];
   let paste!: (value: string) => void;
   const pastePromise = new Promise<string>((r) => {
     paste = r;
@@ -91,7 +95,11 @@ function harness(opts?: {
     binary: opts?.binary === undefined ? "/bundle/claude" : opts.binary,
     storeToken: (key) => void stored.tokens.push(key),
     storeOauth: (cred) => void stored.oauth.push({ ...cred }),
-    spawnChild: () => child,
+    spawnChild: (_binary, dir) => {
+      spawnDirs.push(dir);
+      return child;
+    },
+    sharedLoginDir: opts?.sharedLoginDir ?? null,
     mkLoginDir: () => "/tmp/fake-login-dir",
     cleanupDir: (dir) => void cleaned.push(dir),
     readCredentialFile: () =>
@@ -105,6 +113,7 @@ function harness(opts?: {
     stored,
     cleaned,
     keychainDiscarded,
+    spawnDirs,
     paste,
     login: runAnthropicLogin(cb, deps),
   };
@@ -135,6 +144,39 @@ test("CLI login: URL surfaced, code relayed to stdin, minted oauth stored", asyn
   expect(h.cleaned).toEqual(["/tmp/fake-login-dir"]); // the refresh-bearing dir never lingers
   expect(h.keychainDiscarded).toEqual(["/tmp/fake-login-dir"]);
   expect(h.child.killed).toBe(true);
+});
+
+test("CLI login in the shared dir (a host that never serves anthropic): the dir is the holder, nothing stored or discarded", async () => {
+  const h = harness({ sharedLoginDir: "/houston-home/claude-login" });
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  expect(h.spawnDirs).toEqual(["/houston-home/claude-login"]);
+  h.paste("the-verification-code");
+  await tick();
+  h.child.exit(0);
+  await h.login;
+  // The credential stays where the CLI cached it — every agent runtime's
+  // status probe and the Claude SDK read that dir — so auth.json gets no
+  // entry to capture, and neither the dir nor its Keychain item is destroyed.
+  expect(h.stored.oauth).toEqual([]);
+  expect(h.stored.tokens).toEqual([]);
+  expect(h.cleaned).toEqual([]);
+  expect(h.keychainDiscarded).toEqual([]);
+});
+
+test("CLI login in the shared dir: exit 0 with nothing cached still fails loud", async () => {
+  const h = harness({
+    sharedLoginDir: "/houston-home/claude-login",
+    credentialFile: null,
+    keychain: null,
+  });
+  h.child.stdout.write(`visit: ${AUTHORIZE_URL}\n`);
+  await tick();
+  h.paste("the-verification-code");
+  await tick();
+  h.child.exit(0);
+  await expect(h.login).rejects.toThrow(/no credential was stored/);
+  expect(h.cleaned).toEqual([]);
 });
 
 test("CLI login: no credential file but a Keychain item (macOS host) stores oauth", async () => {

--- a/packages/runtime/src/auth/anthropic-cli-login.ts
+++ b/packages/runtime/src/auth/anthropic-cli-login.ts
@@ -44,8 +44,15 @@ import {
  *      standard pi `oauth` auth.json entry, destroying every other copy. The EXISTING
  *      chain takes over: capture exports it, the gateway stores + rotates it
  *      centrally (the family's ONLY rotator), Gate #2 scrubs the local refresh,
- *      serve keeps it warm. On self-host there is no gateway and pi itself
- *      rotates the entry — also a single rotator.
+ *      serve keeps it warm.
+ *
+ * Where the host never serves anthropic back (desktop, self-host — `login.ts`
+ * passes `sharedLoginDir`, PRODUCT-1644) the CLI runs IN the shared login dir
+ * instead: the credential it caches there (Keychain on macOS, the credential
+ * file elsewhere) is what every agent runtime's status probe and the Claude
+ * SDK read, exactly as the desktop's own browser login leaves it. Nothing is
+ * stored in auth.json and nothing is discarded — the capture that follows has
+ * nothing to export, and the host settles it against the runtime's status.
  *
  * A pasted `sk-ant-…` value in the same input still short-circuits to the
  * token flow (kill the child, store an api_key) — the old escape hatch.
@@ -58,6 +65,12 @@ export type AnthropicLoginDeps = MintedCredentialDeps & {
   storeToken: (key: string) => void;
   /** Persist the CLI-minted subscription credential as pi's `oauth` variant. */
   storeOauth: (cred: CliMintedOauth) => void;
+  /**
+   * Run the CLI login IN this dir and leave the credential there (see the
+   * module note): the single holder on a host that never serves anthropic.
+   * Null/absent = the throwaway dir + auth.json + capture chain.
+   */
+  sharedLoginDir?: string | null;
   // Test seams; production uses the real spawn/tmpdir.
   spawnChild?: (binary: string, configDir: string) => LoginChild;
   mkLoginDir?: () => string;
@@ -96,10 +109,13 @@ async function runAnthropicCliLogin(
   deps: AnthropicLoginDeps,
   binary: string,
 ): Promise<void> {
-  const dir = (
-    deps.mkLoginDir ??
-    (() => mkdtempSync(join(tmpdir(), "houston-claude-login-")))
-  )();
+  const shared = deps.sharedLoginDir ?? null;
+  const dir =
+    shared ??
+    (
+      deps.mkLoginDir ??
+      (() => mkdtempSync(join(tmpdir(), "houston-claude-login-")))
+    )();
   const child = (deps.spawnChild ?? spawnCli)(binary, dir);
   try {
     await driveCliLogin(child, cb, deps, dir);
@@ -109,7 +125,8 @@ async function runAnthropicCliLogin(
     } catch {
       // Already exited — nothing to kill.
     }
-    await discardMintedCredential(dir, deps);
+    // The shared dir IS the credential's home; only a throwaway is destroyed.
+    if (!shared) await discardMintedCredential(dir, deps);
   }
 }
 
@@ -182,5 +199,8 @@ async function driveCliLogin(
       `Claude sign-in failed (exit ${code}): ${scrubTokens(tail.join(" | "))}`,
     );
 
-  deps.storeOauth(await readMintedCredential(dir, deps));
+  // Read back either way: a CLI that exited 0 without caching a credential
+  // fails loud here rather than reporting a connect that never happened.
+  const minted = await readMintedCredential(dir, deps);
+  if (!deps.sharedLoginDir) deps.storeOauth(minted);
 }

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from "node:fs";
 import type {
   AuthPrompt,
   ProviderAuthInteraction,
@@ -25,7 +26,9 @@ import {
 import {
   logoutAnthropicCredential,
   refreshAnthropicCredential,
+  resetAnthropicCredentialCache,
 } from "../backends/claude/credential-status";
+import { claudeLoginConfigDir } from "../backends/claude/paths";
 import {
   currentCredentialScope,
   isPersonalScope,
@@ -33,6 +36,11 @@ import {
 import { resolveClaudeCliBinary } from "./anthropic-cli-binary";
 import { runAnthropicLogin } from "./anthropic-cli-login";
 import { preflightCodexCallbackPort } from "./codex-port-preflight";
+import {
+  anthropicServedHere,
+  serveModeOn,
+  syncServedCredentialSafe,
+} from "./serve";
 import { authStorage, modelRuntime, providerConnected } from "./storage";
 
 /**
@@ -417,34 +425,42 @@ export async function startLogin(
   // `auth_code` wire shape and reuse the paste promise: with `instructions` the
   // webapp renders the paste flow, without them the open-URL + paste-code flow
   // — see auth/anthropic-cli-login.ts.
+  const anthropicLogin = async () => {
+    const sharedLoginDir = await anthropicSharedLoginDir();
+    await runAnthropicLogin(
+      {
+        onAuth: ({ url, instructions }) => {
+          state.info = {
+            kind: "auth_code",
+            url,
+            ...(instructions ? { instructions } : {}),
+          };
+          state.status = "awaiting_user";
+          resolveInfo(state.info);
+        },
+        onManualCodeInput: () => pastePromise,
+      },
+      {
+        binary: resolveClaudeCliBinary(),
+        sharedLoginDir,
+        storeToken: (key) =>
+          authStorage.set("anthropic", { type: "api_key", key }),
+        storeOauth: (cred) =>
+          authStorage.set("anthropic", {
+            type: "oauth",
+            access: cred.access,
+            refresh: cred.refresh,
+            expires: cred.expires,
+          }),
+      },
+    );
+    // The shared-dir credential is read by the status probe, whose cached
+    // "disconnected" answer must flip now, not a TTL later.
+    if (sharedLoginDir) resetAnthropicCredentialCache(true);
+  };
   const login: Promise<unknown> =
     provider === "anthropic"
-      ? runAnthropicLogin(
-          {
-            onAuth: ({ url, instructions }) => {
-              state.info = {
-                kind: "auth_code",
-                url,
-                ...(instructions ? { instructions } : {}),
-              };
-              state.status = "awaiting_user";
-              resolveInfo(state.info);
-            },
-            onManualCodeInput: () => pastePromise,
-          },
-          {
-            binary: resolveClaudeCliBinary(),
-            storeToken: (key) =>
-              authStorage.set("anthropic", { type: "api_key", key }),
-            storeOauth: (cred) =>
-              authStorage.set("anthropic", {
-                type: "oauth",
-                access: cred.access,
-                refresh: cred.refresh,
-                expires: cred.expires,
-              }),
-          },
-        )
+      ? anthropicLogin()
       : runProviderOAuthLogin(provider, interaction);
 
   void login
@@ -618,4 +634,31 @@ export async function logout(providerId: string): Promise<void> {
   // turn would re-resolve a base URL with no (real) key behind it); the
   // endpoint write also drops its runtime provider registration.
   if (providerId === OPENAI_COMPATIBLE) clearCustomEndpointConfig();
+}
+
+/**
+ * Where the anthropic CLI login must leave its credential (PRODUCT-1644).
+ *
+ * On a host that never serves anthropic back — the desktop and self-host
+ * hosts answer the serve probe with the not-served-here marker — the SHARED
+ * login dir every agent runtime probes is the single holder, the way the
+ * desktop's own browser login leaves it. The throwaway-dir path would store
+ * the credential in this runtime's auth.json, capture would move it to a
+ * central row nothing serves and scrub the local refresh token, and the
+ * connect would read connected for one poll and then disconnected for good.
+ *
+ * A gateway-fronted pod keeps the throwaway dir: its shared dir is the TEAM's
+ * credential (HOU-976), so a member's login must never land there, and the
+ * capture chain stores it centrally. Outside serve mode (a standalone
+ * runtime) nothing captures, so auth.json keeps holding it as before. An
+ * unanswered probe is asked once here rather than guessed.
+ */
+async function anthropicSharedLoginDir(): Promise<string | null> {
+  if (!serveModeOn()) return null;
+  if (anthropicServedHere() === undefined)
+    await syncServedCredentialSafe("anthropic-login");
+  if (anthropicServedHere() !== false) return null;
+  const dir = claudeLoginConfigDir();
+  mkdirSync(dir, { recursive: true });
+  return dir;
 }

--- a/packages/runtime/src/auth/serve-probe.test.ts
+++ b/packages/runtime/src/auth/serve-probe.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from "vitest";
 import {
+  anthropicServedVerdict,
   describeProbeError,
   normalizeProbeDetail,
   PROBE_CONCURRENCY,
@@ -167,4 +168,46 @@ test("describeProbeError surfaces the nested undici cause code", () => {
   expect(describeProbeError(errnoErr)).toBe("fetch failed (cause: -54)");
   expect(describeProbeError(new Error("plain"))).toBe("plain");
   expect(describeProbeError("not an error")).toBe("not an error");
+});
+
+test("anthropicServedVerdict: the not-served-here marker says this host never serves anthropic", () => {
+  expect(
+    anthropicServedVerdict({
+      id: "anthropic",
+      state: "not-connected",
+      notServedHere: true,
+    }),
+  ).toBe(false);
+});
+
+test("anthropicServedVerdict: a served or plainly not-connected anthropic probe says it does", () => {
+  expect(
+    anthropicServedVerdict({ id: "anthropic", state: "not-connected" }),
+  ).toBe(true);
+  expect(
+    anthropicServedVerdict({
+      id: "anthropic",
+      state: "served",
+      cred: {
+        provider: "anthropic",
+        kind: "oauth",
+        accessToken: "AT",
+        refreshToken: "",
+        expiresAt: 1,
+      } as never,
+    }),
+  ).toBe(true);
+});
+
+test("anthropicServedVerdict: other providers and unanswered probes teach nothing", () => {
+  expect(
+    anthropicServedVerdict({
+      id: "openai-codex",
+      state: "not-connected",
+      notServedHere: true,
+    }),
+  ).toBeUndefined();
+  expect(
+    anthropicServedVerdict({ id: "anthropic", state: "error", detail: "x" }),
+  ).toBeUndefined();
 });

--- a/packages/runtime/src/auth/serve-probe.ts
+++ b/packages/runtime/src/auth/serve-probe.ts
@@ -219,3 +219,15 @@ export async function probeProviders(
   await Promise.all(workers);
   return results;
 }
+
+/**
+ * What an anthropic probe says about THIS deployment: `false` on the marked
+ * not-served-here 404 (desktop, self-host — the host never serves anthropic
+ * back), `true` on any served / plain not-connected verdict (a gateway-fronted
+ * pod), `undefined` when the probe failed to answer (nothing learned). The
+ * anthropic login keys its credential holder on this (login.ts, PRODUCT-1644).
+ */
+export function anthropicServedVerdict(probe: ServeProbe): boolean | undefined {
+  if (probe.id !== "anthropic" || probe.state === "error") return undefined;
+  return !(probe.state === "not-connected" && probe.notServedHere === true);
+}

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -21,7 +21,11 @@ import {
   noteServeProbeOk,
   noteServeSweepOk,
 } from "./serve-log";
-import { probeProviders, type ServeProbe } from "./serve-probe";
+import {
+  anthropicServedVerdict,
+  probeProviders,
+  type ServeProbe,
+} from "./serve-probe";
 import { reportDeadServedApiKey, servedApiKeyIsDead } from "./served-key-guard";
 import { forgetServedScope, recordServedScope } from "./served-scope";
 import { authStorage } from "./storage";
@@ -63,6 +67,25 @@ const servedManifestPathFor = () =>
 /** True when the sandbox is wired to serve a central workspace credential. */
 export function serveModeOn(): boolean {
   return !!config.controlPlaneUrl && !!config.sandboxToken;
+}
+
+/**
+ * Whether this host serves anthropic centrally, as the last answering probe
+ * said (`anthropicServedVerdict`): `false` behind a desktop/self-host host,
+ * `true` on a gateway-fronted pod, `undefined` before any probe answered.
+ * The anthropic login reads it to pick where its credential must live
+ * (login.ts, PRODUCT-1644): where nothing ever serves anthropic back, the
+ * shared login dir is the single holder, never a captured central row.
+ */
+let anthropicServed: boolean | undefined;
+
+export function anthropicServedHere(): boolean | undefined {
+  return anthropicServed;
+}
+
+/** Test seam: forget what the probes taught. */
+export function resetAnthropicServedHereForTest(): void {
+  anthropicServed = undefined;
 }
 
 /**
@@ -207,6 +230,8 @@ async function runServedSync(): Promise<string[]> {
   let manifestDirty = false;
   for (const probe of probes) {
     if (probe.state !== "error") noteServeProbeOk(probe.id);
+    const servedVerdict = anthropicServedVerdict(probe);
+    if (servedVerdict !== undefined) anthropicServed = servedVerdict;
     if (probe.state === "served" && servedApiKeyIsDead(probe.cred)) {
       // A served "API key" that can never authenticate (a legacy OAuth token
       // stored as a google key — HOU-1107) must not reach auth.json: applying


### PR DESCRIPTION
## Summary

Linear: PRODUCT-1644 (found while verifying PRODUCT-1631 from a phone against a local host; the same path applies to self-host).

Connecting Claude (subscription) from the web app against a host that is not fronted by the gateway completed the sign-in, showed the card connected for one status poll, then flipped back to "Connect" for good.

## Root cause

The runtime's CLI login runs `claude auth login` in a throwaway dir and stores the minted credential in its `auth.json`. The client's connect-once capture then PUTs it to the central store and scrubs the runtime's refresh token. Behind the gateway the serve sync hands an access token back every turn, but the desktop/self-host host never serves Anthropic (`routes/credential.ts` answers the marked `x-houston-not-served-here` 404). After the scrub the runtime held nothing usable, the status probe read logged-out, and the only copy sat in a `credentials.json` row nothing serves.

The desktop avoids this because its own browser login lands in the shared login dir every agent runtime probes.

## Fix

- **Runtime.** The serve probe's not-served-here verdict is latched (`anthropicServedHere()` in `auth/serve.ts`, pure verdict in `serve-probe.ts`). On such a host the anthropic login runs *in* the shared login dir (`<HOUSTON_HOME>/claude-login`: Keychain on macOS, the credential file elsewhere), stores nothing in `auth.json` and discards nothing, so every agent runtime's status probe and the Claude SDK read it, exactly as after the desktop's browser login. The status cache is reset on completion so the card flips immediately. Gateway-fronted pods keep the throwaway-dir + capture chain unchanged (a member's login must never land in the pod-shared dir, HOU-976).
- **Host.** `captureRuntimeCredential` takes `anthropicServedHere` (wired from `gatewayFronted` on the proxy channel and the serve healer). On a non-gateway host an anthropic capture neither stores a row nothing serves nor scrubs the runtime (a leftover refresh-bearing entry stays the single rotator), and a nothing-to-export capture settles on the runtime's own `/auth/status`.

## Tests

- `anthropic-cli-login.test.ts`: shared-dir login spawns in that dir, stores nothing, discards nothing; exit 0 with nothing cached still fails loud.
- `serve-probe.test.ts`: the served verdict per probe shape.
- `capture-credential.test.ts`: non-gateway anthropic capture leaves a refresh-bearing entry alone (no PUT, no scrub); nothing-to-export settles on runtime status both ways; gateway-fronted keeps store-then-scrub.
- Full host (1640), runtime (1562) and domain suites pass; Biome, typechecks and `check:boundaries` clean.

## Before

1. Run the local host (`pnpm dev:host`) and the web app against it; connect Claude from the AI hub with the paste code.
2. The card reads connected for a second, then "Connect" again; `GET /setup-runtime/auth/status` shows `anthropic.configured: false` with `login.status: "complete"`, and the runtime log ends in `[serve] applied central credentials: (none)`.

## After

1. Same steps: the card stays connected and `auth/status` reports `configured: true`.
2. The credential is in the shared login dir (macOS: Keychain item `Claude Code-credentials-<sha256(dir)[..8]>`), `auth.json` has no anthropic entry, and the agent created next is connected too.