### PR TITLE
fix(chat): the phone composer toolbar wraps and opening a chat keeps the keyboard down (PRODUCT-1630)

### DIFF
--- a/app/src/components/chat-effort-selector.tsx
+++ b/app/src/components/chat-effort-selector.tsx
@@ -108,7 +108,9 @@ export function ChatEffortSelector({
           renders as a lone short + tall bar. Cycling still uses the model's own
           `levels` above. */}
       <EffortIcon levels={EFFORT_ORDER} active={current} className="size-3.5" />
-      <span>{activeLabel}</span>
+      {/* The gauge alone on a phone: the bars already read the level, and the
+          row has no room for the word. The aria-label keeps the value. */}
+      <span className="hidden md:inline">{activeLabel}</span>
     </button>
   );
 }

--- a/app/src/components/chat-effort-selector.tsx
+++ b/app/src/components/chat-effort-selector.tsx
@@ -101,7 +101,7 @@ export function ChatEffortSelector({
         e.stopPropagation();
         if (nextLevel) onSelect(nextLevel);
       }}
-      className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-ink-muted hover:text-ink hover:bg-hover transition-colors outline-none focus-visible:ring-1 focus-visible:ring-focus"
+      className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-ink-muted whitespace-nowrap hover:text-ink hover:bg-hover transition-colors outline-none focus-visible:ring-1 focus-visible:ring-focus"
     >
       {/* Always render the full effort spectrum (filled to the active level)
           so the gauge looks identical across models — a 2-level model no longer

--- a/app/src/components/chat-mode-options.tsx
+++ b/app/src/components/chat-mode-options.tsx
@@ -1,0 +1,70 @@
+/**
+ * The three turn modes as the mode picker lists them, shared by its desktop
+ * menu and its phone sheet so the two never drift: the order, each mode's
+ * icon, its authored copy, and the one row body (icon, name, description,
+ * check when active).
+ */
+
+import {
+  Check,
+  Handshake,
+  ListTodo,
+  type LucideIcon,
+  Rocket,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { TurnMode } from "../lib/turn-mode";
+
+/** Ask first = execute (gets things done, asks before sensitive actions),
+ *  Planner = plan (read-only, writes a plan), Autopilot = auto (fire-and-forget,
+ *  no blocking tools). Wire values stay `execute`/`plan`/`auto`; only the labels
+ *  change. */
+export const MODE_ICONS: Record<TurnMode, LucideIcon> = {
+  execute: Handshake,
+  plan: ListTodo,
+  auto: Rocket,
+};
+
+// Top→bottom as an autonomy dial: Planner (looks, doesn't touch) → Ask first
+// (acts, asks before sensitive actions) → Autopilot (acts and never stops to ask).
+export const MODE_ORDER: readonly TurnMode[] = ["plan", "execute", "auto"];
+
+export function useModeCopy() {
+  const { t } = useTranslation("chat");
+  const labels: Record<TurnMode, string> = {
+    execute: t("modeSelector.askFirst"),
+    plan: t("modeSelector.planner"),
+    auto: t("modeSelector.autopilot"),
+  };
+  const descriptions: Record<TurnMode, string> = {
+    execute: t("modeSelector.askFirstDescription"),
+    plan: t("modeSelector.plannerDescription"),
+    auto: t("modeSelector.autopilotDescription"),
+  };
+  return { labels, descriptions };
+}
+
+export function ModeOptionBody({
+  mode,
+  active,
+}: {
+  mode: TurnMode;
+  active: boolean;
+}) {
+  const { labels, descriptions } = useModeCopy();
+  const Icon = MODE_ICONS[mode];
+  return (
+    <>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="flex items-center gap-2 text-sm font-medium text-ink">
+          <Icon className="size-4 shrink-0 text-ink" />
+          {labels[mode]}
+        </span>
+        <span className="line-clamp-2 text-xs text-ink-muted">
+          {descriptions[mode]}
+        </span>
+      </div>
+      {active && <Check className="size-4 shrink-0 text-ink" />}
+    </>
+  );
+}

--- a/app/src/components/chat-mode-selector.tsx
+++ b/app/src/components/chat-mode-selector.tsx
@@ -92,7 +92,7 @@ export function ChatModeSelector({
           >
             <ActiveIcon className="size-3.5" />
             <span>{labels[mode]}</span>
-            <ChevronDown className="size-3 opacity-60" />
+            <ChevronDown className="hidden md:block size-3 opacity-60" />
           </button>
         </DropdownMenuTrigger>
         {/* Match the model picker card: rounded-2xl, hairline border, soft

--- a/app/src/components/chat-mode-selector.tsx
+++ b/app/src/components/chat-mode-selector.tsx
@@ -3,14 +3,24 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
+  useIsMobile,
 } from "@houston-ai/core";
 import type { Agent } from "@houston-ai/engine-client";
-import type { LucideIcon } from "lucide-react";
-import { Check, ChevronDown, Handshake, ListTodo, Rocket } from "lucide-react";
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../hooks/use-capabilities";
 import { modelSelectorDecision } from "../lib/model-selector-lock";
 import type { TurnMode } from "../lib/turn-mode";
+import {
+  MODE_ICONS,
+  MODE_ORDER,
+  ModeOptionBody,
+  useModeCopy,
+} from "./chat-mode-options";
 
 interface ChatModeSelectorProps {
   /** Currently-pinned turn mode. */
@@ -27,29 +37,16 @@ interface ChatModeSelectorProps {
   agent?: Pick<Agent, "access"> | null;
 }
 
-/** Ask first = execute (gets things done, asks before sensitive actions),
- *  Planner = plan (read-only, writes a plan), Autopilot = auto (fire-and-forget,
- *  no blocking tools). Wire values stay `execute`/`plan`/`auto`; only the labels
- *  change. */
-const MODE_ICONS: Record<TurnMode, LucideIcon> = {
-  execute: Handshake,
-  plan: ListTodo,
-  auto: Rocket,
-};
-
-// Top→bottom as an autonomy dial: Planner (looks, doesn't touch) → Ask first
-// (acts, asks before sensitive actions) → Autopilot (acts and never stops to ask).
-const MODE_ORDER: readonly TurnMode[] = ["plan", "execute", "auto"];
-
 /**
  * "Mode" picker, rendered beside {@link ChatModelSelector} in the composer.
  * Three modes — Planner (read-only planning), Ask first (execute), and
  * Autopilot (auto, fire-and-forget) — each with an icon in a soft tile, a
- * name, and a one-line description. The trigger is the
- * same h-7 muted pill as the model + effort selectors; the menu matches the
- * model picker's card (rounded-2xl, bordered, shadowed, roomy rows). Hidden only
- * for a member on a pre-Teams multiplayer host (mirrors the other selectors);
- * otherwise always available.
+ * name, and a one-line description. The trigger is the same h-7 muted pill as
+ * the model + effort selectors. On desktop the menu matches the model picker's
+ * card (rounded-2xl, bordered, shadowed, roomy rows); on the phone the same
+ * rows open in a bottom sheet, since an anchored menu has no room above a
+ * composer that sits on the keyboard. Hidden only for a member on a pre-Teams
+ * multiplayer host (mirrors the other selectors); otherwise always available.
  */
 export function ChatModeSelector({
   mode,
@@ -58,20 +55,24 @@ export function ChatModeSelector({
 }: ChatModeSelectorProps) {
   const { t } = useTranslation("chat");
   const { capabilities } = useCapabilities();
+  const isMobile = useIsMobile();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const { labels, descriptions } = useModeCopy();
   if (!modelSelectorDecision(capabilities, agent).show) return null;
 
-  const labels: Record<TurnMode, string> = {
-    execute: t("modeSelector.askFirst"),
-    plan: t("modeSelector.planner"),
-    auto: t("modeSelector.autopilot"),
-  };
-  const descriptions: Record<TurnMode, string> = {
-    execute: t("modeSelector.askFirstDescription"),
-    plan: t("modeSelector.plannerDescription"),
-    auto: t("modeSelector.autopilotDescription"),
-  };
-
   const ActiveIcon = MODE_ICONS[mode];
+  const trigger = (
+    <button
+      type="button"
+      aria-label={t("modeSelector.modeValue", { mode: labels[mode] })}
+      title={descriptions[mode]}
+      className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-ink-muted whitespace-nowrap hover:text-ink hover:bg-hover transition-colors outline-none focus-visible:ring-1 focus-visible:ring-focus"
+    >
+      <ActiveIcon className="size-3.5" />
+      <span>{labels[mode]}</span>
+      <ChevronDown className="hidden md:block size-3 opacity-60" />
+    </button>
+  );
 
   return (
     // Stop pointer events from bubbling — keeps the board detail panel from
@@ -82,51 +83,51 @@ export function ChatModeSelector({
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
     >
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label={t("modeSelector.modeValue", { mode: labels[mode] })}
-            title={descriptions[mode]}
-            className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-ink-muted whitespace-nowrap hover:text-ink hover:bg-hover transition-colors outline-none focus-visible:ring-1 focus-visible:ring-focus"
+      {isMobile ? (
+        <ResponsivePopover open={sheetOpen} onOpenChange={setSheetOpen}>
+          <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
+          <ResponsivePopoverContent title={t("modeSelector.mode")}>
+            <div className="flex flex-col gap-0.5 px-2.5 pb-2">
+              {MODE_ORDER.map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  aria-pressed={m === mode}
+                  onClick={() => {
+                    onSelect(m);
+                    setSheetOpen(false);
+                  }}
+                  className="flex w-full items-center gap-3 rounded-xl px-2.5 py-2.5 text-left transition-colors active:bg-hover"
+                >
+                  <ModeOptionBody mode={m} active={m === mode} />
+                </button>
+              ))}
+            </div>
+          </ResponsivePopoverContent>
+        </ResponsivePopover>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+          {/* Match the model picker card: rounded-2xl, hairline border, soft
+              shadow, roomy 1.5 padding — not the default menu slab. */}
+          <DropdownMenuContent
+            align="start"
+            sideOffset={6}
+            className="w-[300px] rounded-2xl border-line p-1.5 shadow-lg"
+            onCloseAutoFocus={(e) => e.preventDefault()}
           >
-            <ActiveIcon className="size-3.5" />
-            <span>{labels[mode]}</span>
-            <ChevronDown className="hidden md:block size-3 opacity-60" />
-          </button>
-        </DropdownMenuTrigger>
-        {/* Match the model picker card: rounded-2xl, hairline border, soft
-            shadow, roomy 1.5 padding — not the default menu slab. */}
-        <DropdownMenuContent
-          align="start"
-          sideOffset={6}
-          className="w-[300px] rounded-2xl border-line p-1.5 shadow-lg"
-          onCloseAutoFocus={(e) => e.preventDefault()}
-        >
-          {MODE_ORDER.map((m) => {
-            const Icon = MODE_ICONS[m];
-            const active = m === mode;
-            return (
+            {MODE_ORDER.map((m) => (
               <DropdownMenuItem
                 key={m}
                 onSelect={() => onSelect(m)}
                 className="items-center gap-3 rounded-xl px-2.5 py-2.5"
               >
-                <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <span className="flex items-center gap-2 text-sm font-medium text-ink">
-                    <Icon className="size-4 shrink-0 text-ink" />
-                    {labels[m]}
-                  </span>
-                  <span className="line-clamp-2 text-xs text-ink-muted">
-                    {descriptions[m]}
-                  </span>
-                </div>
-                {active && <Check className="size-4 shrink-0 text-ink" />}
+                <ModeOptionBody mode={m} active={m === mode} />
               </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </fieldset>
   );
 }

--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -1,8 +1,8 @@
 import {
   ModelPicker,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
 } from "@houston-ai/core";
 import type { Agent } from "@houston-ai/engine-client";
 import { ChevronDown, Lock } from "lucide-react";
@@ -149,8 +149,8 @@ export function ChatModelSelector({
           <span>{label}</span>
         </div>
       ) : (
-        <Popover open={picker.isOpen} onOpenChange={picker.setOpen}>
-          <PopoverTrigger asChild>
+        <ResponsivePopover open={picker.isOpen} onOpenChange={picker.setOpen}>
+          <ResponsivePopoverTrigger asChild>
             <button
               type="button"
               className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-ink-muted whitespace-nowrap hover:text-ink hover:bg-hover transition-colors outline-none focus-visible:ring-1 focus-visible:ring-focus"
@@ -159,12 +159,14 @@ export function ChatModelSelector({
               <span>{label}</span>
               <ChevronDown className="hidden md:block size-3 opacity-60" />
             </button>
-          </PopoverTrigger>
+          </ResponsivePopoverTrigger>
           {/* `p-0` on the shared popover chrome, the same dropdown surface as
-              FilterCombobox; the picker fills it edge to edge. Auto-focus is
-              prevented both ways: the picker places focus itself (input or
-              cmdk root, per screen), and closing must not yank focus back. */}
-          <PopoverContent
+              FilterCombobox; the picker fills it edge to edge (on the phone, a
+              bottom sheet). Auto-focus is prevented both ways: the picker
+              places focus itself (input or cmdk root, per screen), and closing
+              must not yank focus back. */}
+          <ResponsivePopoverContent
+            title={t("modelSelector.selectModel")}
             align="start"
             className="w-[320px] p-0"
             onOpenAutoFocus={(e) => e.preventDefault()}
@@ -195,8 +197,8 @@ export function ChatModelSelector({
                 ) : undefined
               }
             />
-          </PopoverContent>
-        </Popover>
+          </ResponsivePopoverContent>
+        </ResponsivePopover>
       )}
     </fieldset>
   );

--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -157,7 +157,7 @@ export function ChatModelSelector({
             >
               {glyph}
               <span>{label}</span>
-              <ChevronDown className="size-3 opacity-60" />
+              <ChevronDown className="hidden md:block size-3 opacity-60" />
             </button>
           </PopoverTrigger>
           {/* `p-0` on the shared popover chrome, the same dropdown surface as

--- a/app/src/components/context-indicator.tsx
+++ b/app/src/components/context-indicator.tsx
@@ -4,7 +4,8 @@
  * A small footer control showing how full the model's context window is for
  * the current conversation. The trigger is a ring gauge (a
  * donut whose arc fills with the occupied fraction and turns red near the
- * limit) plus the bare percentage; hovering reveals the detail. The caller
+ * limit) plus the bare percentage; hovering reveals the detail (tapping, on
+ * the phone: a hover card never opens for a touch pointer). The caller
  * resolves `usage` (latest turn) and `contextWindow` (a self-correcting
  * estimate; see `sessionContextUsage` + `effectiveContextWindow` in
  * `lib/context-usage.ts` and `getContextWindowConfig` in `lib/providers.ts`).
@@ -20,7 +21,11 @@ import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Progress,
+  useIsMobile,
 } from "@houston-ai/core";
 import { useTranslation } from "react-i18next";
 import { contextFillPercent } from "../lib/context-usage";
@@ -78,6 +83,7 @@ export function ContextIndicator({
   contextWindow,
 }: ContextIndicatorProps) {
   const { t, i18n } = useTranslation("context");
+  const isMobile = useIsMobile();
 
   // A directly-narrowable `number | null` — TypeScript won't carry a boolean
   // alias's narrowing of `contextWindow` across the JSX branches below, so we
@@ -96,54 +102,72 @@ export function ContextIndicator({
       maximumFractionDigits: 1,
     }).format(n);
 
+  const trigger = (
+    <button
+      type="button"
+      aria-label={t("button.aria")}
+      className={`inline-flex items-center justify-center size-7 rounded-full transition-colors hover:bg-hover ${
+        warn ? "text-danger" : "text-ink-muted hover:text-ink"
+      }`}
+    >
+      <ContextRing percent={percent} />
+    </button>
+  );
+  const cardClassName = "flex w-64 flex-col gap-2 rounded-2xl";
+  const detail = (
+    <>
+      <p className="text-sm font-medium leading-none">{t("card.title")}</p>
+
+      {!usage ? (
+        <p className="text-sm text-ink-muted">{t("card.empty")}</p>
+      ) : windowTokens != null ? (
+        <>
+          <div className="flex items-baseline justify-between gap-3">
+            <span
+              className={`text-2xl font-semibold tabular-nums ${
+                warn ? "text-danger" : ""
+              }`}
+            >
+              {t("card.percent", { percent: percent ?? 0 })}
+            </span>
+            <span className="text-xs text-ink-muted tabular-nums">
+              {t("card.usedOfTotal", {
+                used: fmt(usage.context_tokens),
+                total: fmt(windowTokens),
+              })}
+            </span>
+          </div>
+          <Progress value={percent ?? 0} aria-label={t("card.title")} />
+        </>
+      ) : (
+        <>
+          <span className="text-lg font-semibold tabular-nums">
+            {t("card.tokensUsed", { used: fmt(usage.context_tokens) })}
+          </span>
+          <p className="text-xs text-ink-muted">{t("card.unknownWindow")}</p>
+        </>
+      )}
+    </>
+  );
+
+  // Structural fork, not a layout tweak: a hover card is dead to a touch
+  // pointer, so the phone gets a tap-to-open popover around the same detail.
+  if (isMobile) {
+    return (
+      <Popover>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent align="end" className={cardClassName}>
+          {detail}
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
   return (
     <HoverCard openDelay={150} closeDelay={100}>
-      <HoverCardTrigger asChild>
-        <button
-          type="button"
-          aria-label={t("button.aria")}
-          className={`inline-flex items-center justify-center size-7 rounded-full transition-colors hover:bg-hover ${
-            warn ? "text-danger" : "text-ink-muted hover:text-ink"
-          }`}
-        >
-          <ContextRing percent={percent} />
-        </button>
-      </HoverCardTrigger>
-      <HoverCardContent
-        align="end"
-        className="flex w-64 flex-col gap-2 rounded-2xl"
-      >
-        <p className="text-sm font-medium leading-none">{t("card.title")}</p>
-
-        {!usage ? (
-          <p className="text-sm text-ink-muted">{t("card.empty")}</p>
-        ) : windowTokens != null ? (
-          <>
-            <div className="flex items-baseline justify-between gap-3">
-              <span
-                className={`text-2xl font-semibold tabular-nums ${
-                  warn ? "text-danger" : ""
-                }`}
-              >
-                {t("card.percent", { percent: percent ?? 0 })}
-              </span>
-              <span className="text-xs text-ink-muted tabular-nums">
-                {t("card.usedOfTotal", {
-                  used: fmt(usage.context_tokens),
-                  total: fmt(windowTokens),
-                })}
-              </span>
-            </div>
-            <Progress value={percent ?? 0} aria-label={t("card.title")} />
-          </>
-        ) : (
-          <>
-            <span className="text-lg font-semibold tabular-nums">
-              {t("card.tokensUsed", { used: fmt(usage.context_tokens) })}
-            </span>
-            <p className="text-xs text-ink-muted">{t("card.unknownWindow")}</p>
-          </>
-        )}
+      <HoverCardTrigger asChild>{trigger}</HoverCardTrigger>
+      <HoverCardContent align="end" className={cardClassName}>
+        {detail}
       </HoverCardContent>
     </HoverCard>
   );

--- a/app/src/components/context-indicator.tsx
+++ b/app/src/components/context-indicator.tsx
@@ -4,8 +4,9 @@
  * A small footer control showing how full the model's context window is for
  * the current conversation. The trigger is a ring gauge (a
  * donut whose arc fills with the occupied fraction and turns red near the
- * limit) plus the bare percentage; hovering reveals the detail (tapping, on
- * the phone: a hover card never opens for a touch pointer). The caller
+ * limit) plus the bare percentage; hovering reveals the detail (on the phone
+ * a tap opens it as a bottom sheet: a hover card never opens for a touch
+ * pointer). The caller
  * resolves `usage` (latest turn) and `contextWindow` (a self-correcting
  * estimate; see `sessionContextUsage` + `effectiveContextWindow` in
  * `lib/context-usage.ts` and `getContextWindowConfig` in `lib/providers.ts`).
@@ -21,10 +22,10 @@ import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
   Progress,
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
   useIsMobile,
 } from "@houston-ai/core";
 import { useTranslation } from "react-i18next";
@@ -113,11 +114,8 @@ export function ContextIndicator({
       <ContextRing percent={percent} />
     </button>
   );
-  const cardClassName = "flex w-64 flex-col gap-2 rounded-2xl";
   const detail = (
     <>
-      <p className="text-sm font-medium leading-none">{t("card.title")}</p>
-
       {!usage ? (
         <p className="text-sm text-ink-muted">{t("card.empty")}</p>
       ) : windowTokens != null ? (
@@ -151,22 +149,26 @@ export function ContextIndicator({
   );
 
   // Structural fork, not a layout tweak: a hover card is dead to a touch
-  // pointer, so the phone gets a tap-to-open popover around the same detail.
+  // pointer, so the phone gets a tap-to-open sheet around the same detail.
   if (isMobile) {
     return (
-      <Popover>
-        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-        <PopoverContent align="end" className={cardClassName}>
-          {detail}
-        </PopoverContent>
-      </Popover>
+      <ResponsivePopover>
+        <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
+        <ResponsivePopoverContent title={t("card.title")}>
+          <div className="flex flex-col gap-2 px-4 pb-4">{detail}</div>
+        </ResponsivePopoverContent>
+      </ResponsivePopover>
     );
   }
 
   return (
     <HoverCard openDelay={150} closeDelay={100}>
       <HoverCardTrigger asChild>{trigger}</HoverCardTrigger>
-      <HoverCardContent align="end" className={cardClassName}>
+      <HoverCardContent
+        align="end"
+        className="flex w-64 flex-col gap-2 rounded-2xl"
+      >
+        <p className="text-sm font-medium leading-none">{t("card.title")}</p>
         {detail}
       </HoverCardContent>
     </HoverCard>

--- a/app/src/components/mission-chat/mission-chat-screen.tsx
+++ b/app/src/components/mission-chat/mission-chat-screen.tsx
@@ -1,6 +1,6 @@
 import { AIBoard } from "@houston-ai/board";
 import { ChevronLeft } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useVisualViewportInset } from "../../hooks/use-visual-viewport-inset";
 import type { Agent } from "../../lib/types";
@@ -48,10 +48,12 @@ function MissionChatHost({ agent }: { agent: Agent }) {
   const agents = useAgentStore((s) => s.agents);
   const source = useMissionChatSource(agents, agent, missionId);
   const wiring = useBoardChatWiring(source);
-  const keyboardInset = useVisualViewportInset();
+  const screenRef = useRef<HTMLDivElement>(null);
+  const keyboardInset = useVisualViewportInset(screenRef);
 
   return (
     <div
+      ref={screenRef}
       data-testid="mission-chat-screen"
       className="flex h-full min-h-0 flex-col pb-safe"
       style={keyboardInset > 0 ? { paddingBottom: keyboardInset } : undefined}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -2357,46 +2357,45 @@ export function useAgentChatPanel({
 
   const footer = useMemo<AIBoardProps["footer"]>(() => {
     if (!agent) return undefined;
-    // The pills wrap on a phone (four of them plus the ring overrun a 375px
-    // composer); the context ring stays pinned to the first row's right edge.
-    // Desktop is one row, unchanged.
+    // ONE row at both breakpoints. A phone composer has no room for five
+    // labelled pills, so there the Skills entry lives in the composer's "+"
+    // menu (see `attachMenu`), the effort pill is its gauge icon alone, and
+    // the pickers drop their chevrons. Desktop is unchanged.
     return () => (
       <div
         data-testid="composer-toolbar"
-        className="flex w-full items-start gap-2"
+        className="flex w-full items-center gap-1 md:gap-2"
       >
-        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1 md:gap-2">
-          <button
-            type="button"
-            onClick={() => setPickerOpen(true)}
-            className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full text-xs font-medium text-ink-muted whitespace-nowrap hover:text-ink hover:bg-hover transition-colors"
-          >
-            <Play className="size-3 fill-current" />
-            {t("composerSkill.browse")}
-          </button>
-          <ChatModeSelector
-            mode={turnMode}
-            onSelect={handleModeSelect}
-            agent={agent}
-          />
-          <ChatModelSelector
-            provider={displayModelPin.provider}
-            model={displayModelPin.model}
-            onSelect={selectModel}
-            open={modelPickerOpen}
-            onOpenChange={setModelPickerOpen}
-            agent={agent}
-            allowedModels={allowedModels}
-          />
-          <ChatEffortSelector
-            provider={displayModelPin.provider}
-            model={displayModelPin.model}
-            effort={displayModelPin.effort}
-            onSelect={selectEffort}
-            agent={agent}
-          />
-        </div>
-        <div className="shrink-0">
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="hidden md:inline-flex items-center gap-1 h-7 px-2.5 rounded-full text-xs font-medium text-ink-muted whitespace-nowrap hover:text-ink hover:bg-hover transition-colors"
+        >
+          <Play className="size-3 fill-current" />
+          {t("composerSkill.browse")}
+        </button>
+        <ChatModeSelector
+          mode={turnMode}
+          onSelect={handleModeSelect}
+          agent={agent}
+        />
+        <ChatModelSelector
+          provider={displayModelPin.provider}
+          model={displayModelPin.model}
+          onSelect={selectModel}
+          open={modelPickerOpen}
+          onOpenChange={setModelPickerOpen}
+          agent={agent}
+          allowedModels={allowedModels}
+        />
+        <ChatEffortSelector
+          provider={displayModelPin.provider}
+          model={displayModelPin.model}
+          effort={displayModelPin.effort}
+          onSelect={selectEffort}
+          agent={agent}
+        />
+        <div className="ml-auto">
           <ContextIndicator
             usage={contextUsage}
             contextWindow={contextWindow}
@@ -2420,8 +2419,20 @@ export function useAgentChatPanel({
 
   const attachMenu = useMemo<AIBoardProps["attachMenu"]>(() => {
     if (!agent) return undefined;
-    return ({ openFilePicker, openFolderPicker }) => (
+    return ({ openFilePicker, openFolderPicker, close }) => (
       <div className="flex flex-col gap-0.5">
+        {/* Phone only: the toolbar has no room for the Skills pill there. */}
+        <button
+          type="button"
+          onClick={() => {
+            close();
+            setPickerOpen(true);
+          }}
+          className="flex md:hidden items-center gap-2 px-2 py-1.5 rounded-md text-sm text-ink hover:bg-hover transition-colors"
+        >
+          <Play className="size-4 text-ink-muted" />
+          {t("composerSkill.browse")}
+        </button>
         <button
           type="button"
           onClick={() => {

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -2357,38 +2357,46 @@ export function useAgentChatPanel({
 
   const footer = useMemo<AIBoardProps["footer"]>(() => {
     if (!agent) return undefined;
+    // The pills wrap on a phone (four of them plus the ring overrun a 375px
+    // composer); the context ring stays pinned to the first row's right edge.
+    // Desktop is one row, unchanged.
     return () => (
-      <div className="flex items-center gap-2 w-full">
-        <button
-          type="button"
-          onClick={() => setPickerOpen(true)}
-          className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full text-xs font-medium text-ink-muted hover:text-ink hover:bg-hover transition-colors"
-        >
-          <Play className="size-3 fill-current" />
-          {t("composerSkill.browse")}
-        </button>
-        <ChatModeSelector
-          mode={turnMode}
-          onSelect={handleModeSelect}
-          agent={agent}
-        />
-        <ChatModelSelector
-          provider={displayModelPin.provider}
-          model={displayModelPin.model}
-          onSelect={selectModel}
-          open={modelPickerOpen}
-          onOpenChange={setModelPickerOpen}
-          agent={agent}
-          allowedModels={allowedModels}
-        />
-        <ChatEffortSelector
-          provider={displayModelPin.provider}
-          model={displayModelPin.model}
-          effort={displayModelPin.effort}
-          onSelect={selectEffort}
-          agent={agent}
-        />
-        <div className="ml-auto">
+      <div
+        data-testid="composer-toolbar"
+        className="flex w-full items-start gap-2"
+      >
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1 md:gap-2">
+          <button
+            type="button"
+            onClick={() => setPickerOpen(true)}
+            className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full text-xs font-medium text-ink-muted whitespace-nowrap hover:text-ink hover:bg-hover transition-colors"
+          >
+            <Play className="size-3 fill-current" />
+            {t("composerSkill.browse")}
+          </button>
+          <ChatModeSelector
+            mode={turnMode}
+            onSelect={handleModeSelect}
+            agent={agent}
+          />
+          <ChatModelSelector
+            provider={displayModelPin.provider}
+            model={displayModelPin.model}
+            onSelect={selectModel}
+            open={modelPickerOpen}
+            onOpenChange={setModelPickerOpen}
+            agent={agent}
+            allowedModels={allowedModels}
+          />
+          <ChatEffortSelector
+            provider={displayModelPin.provider}
+            model={displayModelPin.model}
+            effort={displayModelPin.effort}
+            onSelect={selectEffort}
+            agent={agent}
+          />
+        </div>
+        <div className="shrink-0">
           <ContextIndicator
             usage={contextUsage}
             contextWindow={contextWindow}

--- a/app/src/hooks/use-visual-viewport-inset.ts
+++ b/app/src/hooks/use-visual-viewport-inset.ts
@@ -1,36 +1,50 @@
-import { useEffect, useState } from "react";
+import { type RefObject, useEffect, useState } from "react";
 
 /**
- * How many pixels of the layout viewport's bottom the on-screen keyboard (or
- * other browser UI) currently occludes, per the visualViewport API — 0 when
- * nothing is occluded or the API is unavailable. iOS Safari does NOT shrink
- * `dvh` when the keyboard opens, so a full-height chat screen pads its bottom
- * by this to keep the composer above the keys; the message log's
- * stick-to-bottom re-anchors on the resulting resize.
+ * How far the bottom edge of `ref`'s element lies below what the visual
+ * viewport shows, in pixels: the part of a full-height screen the on-screen
+ * keyboard (or other browser UI) occludes. 0 when nothing is occluded or the
+ * API is unavailable.
  *
- * Measured against `pageTop` (document scroll + visual offset), not
- * `offsetTop`: a browser that reveals the focused composer by scrolling the
- * document itself would otherwise leave that scroll as a gap between the
- * composer and the keys.
+ * Browsers disagree about keyboards. iOS Safari (and Android Chrome in its
+ * default `resizes-visual` mode) keeps the layout viewport, so `dvh` does not
+ * shrink and a full-height chat screen must pad its bottom by this to keep
+ * the composer above the keys. Android in `resizes-content` mode shrinks the
+ * layout viewport itself, so the screen already ends at the keyboard and any
+ * extra padding is a blank band above the keys. Measuring the element's own
+ * edge against the visible bottom (both in layout-viewport coordinates) gives
+ * the right answer in either mode without knowing which one is in effect,
+ * and a browser that reveals the focused composer by scrolling is accounted
+ * for the same way. The message log's stick-to-bottom re-anchors on the
+ * resulting resize.
  */
-export function useVisualViewportInset(): number {
+export function useVisualViewportInset(
+  ref: RefObject<HTMLElement | null>,
+): number {
   const [inset, setInset] = useState(0);
 
   useEffect(() => {
     const viewport = window.visualViewport;
     if (!viewport) return;
     const update = () => {
-      const occluded = window.innerHeight - viewport.height - viewport.pageTop;
-      setInset(Math.max(0, Math.round(occluded)));
+      const element = ref.current;
+      if (!element) return;
+      const bottom = element.getBoundingClientRect().bottom;
+      const visibleBottom = viewport.offsetTop + viewport.height;
+      setInset(Math.max(0, Math.round(bottom - visibleBottom)));
     };
     update();
     viewport.addEventListener("resize", update);
     viewport.addEventListener("scroll", update);
+    // The layout viewport can resize after the visual one reports (the
+    // keyboard animates in); the last word must come from whichever fires last.
+    window.addEventListener("resize", update);
     return () => {
       viewport.removeEventListener("resize", update);
       viewport.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
     };
-  }, []);
+  }, [ref]);
 
   return inset;
 }

--- a/app/src/hooks/use-visual-viewport-inset.ts
+++ b/app/src/hooks/use-visual-viewport-inset.ts
@@ -7,6 +7,11 @@ import { useEffect, useState } from "react";
  * `dvh` when the keyboard opens, so a full-height chat screen pads its bottom
  * by this to keep the composer above the keys; the message log's
  * stick-to-bottom re-anchors on the resulting resize.
+ *
+ * Measured against `pageTop` (document scroll + visual offset), not
+ * `offsetTop`: a browser that reveals the focused composer by scrolling the
+ * document itself would otherwise leave that scroll as a gap between the
+ * composer and the keys.
  */
 export function useVisualViewportInset(): number {
   const [inset, setInset] = useState(0);
@@ -15,8 +20,7 @@ export function useVisualViewportInset(): number {
     const viewport = window.visualViewport;
     if (!viewport) return;
     const update = () => {
-      const occluded =
-        window.innerHeight - viewport.height - viewport.offsetTop;
+      const occluded = window.innerHeight - viewport.height - viewport.pageTop;
       setInset(Math.max(0, Math.round(occluded)));
     };
     update();

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,17 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v74 - 2026-09-03
+
+The phone composer fits the phone. Its footer row keeps one line below the
+one breakpoint: the mode and model pills stay named, effort is its gauge
+icon, the context ring stays pinned right, and Skills moves into the attach
+menu. Each of those pickers opens as a bottom sheet instead of a popover
+anchored to a 28px pill (which went edge to edge and landed on the composer),
+and the context ring opens on tap. Nothing but the safe area or the keyboard
+inset sits under the row, and opening a chat no longer focuses the textarea,
+so the keyboard waits for the user's own tap.
+
 ## v73 - 2026-09-02
 
 The phone board loses its second chrome row. Below the one breakpoint every

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 73
+version: 74
 
 components:
   - id: agent-avatar
@@ -298,14 +298,23 @@ components:
     purpose: The signature message-input surface -- text, attachments, send/stop.
     anatomy: [leading-attach, textarea, footer-slot, queued-list, trailing-send-stop]
     states: [ready, submitted, streaming, has-attachments, drag-over, disabled, replaced-by-override]
-    variants: [single-line, multiline-expanded]
+    variants: [single-line, multiline-expanded, phone]
     behavior: >-
       Send is gated on non-empty text/attachments; while streaming the trailing
       button becomes Stop. Queued messages show when sending mid-turn. A host
       surface may pass an override card that renders above the input (default)
       or replaces it outright while present (replaced-by-override) when that
       card is the only intended action, e.g. onboarding's one-button offer.
-    a11y: labeled textarea; send/stop button state-labeled; drop zone announced.
+      The footer slot's pickers (mode, model, effort, context) sit in ONE row
+      at both breakpoints. Below the one breakpoint (phone) the row keeps
+      only its two named pills (mode, model) plus the effort gauge and the
+      context ring; Skills moves into the attach menu; each picker opens as a
+      bottom sheet rather than an anchored popover, and the context ring
+      opens on tap (a hover card never does on touch). The composer stays
+      tight to the keyboard: nothing but the safe area (or the keyboard's own
+      inset) sits below its row, and opening a chat never focuses the
+      textarea on the phone.
+    a11y: labeled textarea; send/stop button state-labeled; drop zone announced; phone pickers are titled dialogs.
     since: 1
 
   - id: mention-autocomplete

--- a/design/inventory/manifests/web.yaml
+++ b/design/inventory/manifests/web.yaml
@@ -77,7 +77,7 @@ components:
 
   composer:
     status: implemented
-    ref: "@houston-ai/chat ChatInput / ai-elements/prompt-input"
+    ref: "@houston-ai/chat ChatInput / ai-elements/prompt-input; phone pickers open through @houston-ai/core ResponsivePopover (bottom sheet below the breakpoint)"
 
   mention-autocomplete:
     status: implemented

--- a/packages/web/e2e/mobile/composer-toolbar.spec.ts
+++ b/packages/web/e2e/mobile/composer-toolbar.spec.ts
@@ -78,3 +78,40 @@ test("the toolbar is one row that fits inside the phone viewport", async ({
   await ring.tap();
   await expect(page.getByText("Context", { exact: true })).toBeVisible();
 });
+
+test("the pickers open as full-width bottom sheets", async ({ page }) => {
+  const chat = await openTokyoChat(page);
+  const toolbar = chat.getByTestId("composer-toolbar");
+  const { width, height } = page.viewportSize() ?? { width: 0, height: 0 };
+
+  // Each picker's sheet spans the phone's width and sits on its bottom edge.
+  const pickers: [RegExp, string][] = [
+    [/^Mode:/, "Mode"],
+    [/^Context usage$/, "Context"],
+  ];
+  for (const [pill, title] of pickers) {
+    await toolbar.getByRole("button", { name: pill }).tap();
+    const sheet = page.getByRole("dialog", { name: title });
+    await expect(sheet).toBeVisible();
+    const box = await sheet.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(Math.round(box.x)).toBe(0);
+      expect(Math.round(box.width)).toBe(width);
+      expect(Math.round(box.y + box.height)).toBe(height);
+    }
+    await page.keyboard.press("Escape");
+    await expect(sheet).toBeHidden();
+  }
+
+  // Picking a mode from the sheet applies it and closes the sheet.
+  await toolbar.getByRole("button", { name: /^Mode:/ }).tap();
+  await page
+    .getByRole("dialog", { name: "Mode" })
+    .getByRole("button", { name: /Planner/ })
+    .tap();
+  await expect(page.getByRole("dialog", { name: "Mode" })).toBeHidden();
+  await expect(
+    toolbar.getByRole("button", { name: /^Mode: Planner/ }),
+  ).toBeVisible();
+});

--- a/packages/web/e2e/mobile/composer-toolbar.spec.ts
+++ b/packages/web/e2e/mobile/composer-toolbar.spec.ts
@@ -1,0 +1,71 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+
+/**
+ * The phone chat's composer chrome: opening a chat leaves the keyboard down,
+ * and the toolbar under the composer (skills, mode, model, effort, context
+ * ring) fits a narrow phone instead of running off the right edge.
+ */
+
+// Narrower than the project's Pixel 7 so the toolbar's row has to wrap.
+test.use({ viewport: { width: 375, height: 667 } });
+
+async function openTokyoChat(page: Page) {
+  await page.goto("/");
+  await page.getByTestId("agents-home-row").tap();
+  await page
+    .getByTestId("agent-missions-screen")
+    .getByText("Plan a trip to Tokyo")
+    .tap();
+  const chat = page.getByTestId("mission-chat-screen");
+  await expect(chat.getByText("Task: Plan a trip to Tokyo")).toBeVisible();
+  return chat;
+}
+
+test("opening a chat leaves the composer unfocused (no keyboard)", async ({
+  page,
+}) => {
+  const chat = await openTokyoChat(page);
+  const composer = chat.getByPlaceholder("Send a follow-up...");
+  await expect(composer).toBeVisible();
+  // The desktop board focuses the composer as a chat opens; on a phone that
+  // raises the keyboard over the log, so the phone must not.
+  await expect(composer).not.toBeFocused();
+  await expect(
+    chat.getByText("Plan a trip to Tokyo", { exact: false }).first(),
+  ).toBeVisible();
+  await expect(composer).not.toBeFocused();
+});
+
+test("every toolbar control fits inside the phone viewport", async ({
+  page,
+}) => {
+  const chat = await openTokyoChat(page);
+  const toolbar = chat.getByTestId("composer-toolbar");
+  await expect(toolbar).toBeVisible();
+  await expect(toolbar.getByRole("button", { name: "Skills" })).toBeVisible();
+  const ring = toolbar.getByRole("button", { name: "Context usage" });
+  await expect(ring).toBeVisible();
+
+  const width = page.viewportSize()?.width ?? 0;
+  const buttons = await toolbar.getByRole("button").all();
+  expect(buttons.length).toBeGreaterThanOrEqual(3);
+  for (const button of buttons) {
+    const box = await button.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) continue;
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(width);
+  }
+  // Nothing forces the document wider than the phone.
+  const overflow = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+
+  // The ring opens its detail on a tap: a hover card never would on touch.
+  await ring.tap();
+  await expect(page.getByText("Context", { exact: true })).toBeVisible();
+});

--- a/packages/web/e2e/mobile/composer-toolbar.spec.ts
+++ b/packages/web/e2e/mobile/composer-toolbar.spec.ts
@@ -50,16 +50,20 @@ test("the toolbar is one row that fits inside the phone viewport", async ({
   const width = page.viewportSize()?.width ?? 0;
   const buttons = await toolbar.getByRole("button").all();
   expect(buttons.length).toBeGreaterThanOrEqual(3);
-  const tops = new Set<number>();
+  const tops: number[] = [];
+  const bottoms: number[] = [];
   for (const button of buttons) {
     const box = await button.boundingBox();
     expect(box).not.toBeNull();
     if (!box) continue;
     expect(box.x).toBeGreaterThanOrEqual(0);
     expect(box.x + box.width).toBeLessThanOrEqual(width);
-    tops.add(Math.round(box.y + box.height / 2));
+    tops.push(box.y);
+    bottoms.push(box.y + box.height);
   }
-  expect(tops.size).toBe(1);
+  // One row: no control starts below the bottom of any other (sub-pixel font
+  // differences across platforms shift centers, never rows).
+  expect(Math.max(...tops)).toBeLessThan(Math.min(...bottoms));
 
   // Skills leaves the phone toolbar for the composer's "+" menu.
   await expect(toolbar.getByRole("button", { name: "Skills" })).toBeHidden();

--- a/packages/web/e2e/mobile/composer-toolbar.spec.ts
+++ b/packages/web/e2e/mobile/composer-toolbar.spec.ts
@@ -37,26 +37,35 @@ test("opening a chat leaves the composer unfocused (no keyboard)", async ({
   await expect(composer).not.toBeFocused();
 });
 
-test("every toolbar control fits inside the phone viewport", async ({
+test("the toolbar is one row that fits inside the phone viewport", async ({
   page,
 }) => {
   const chat = await openTokyoChat(page);
   const toolbar = chat.getByTestId("composer-toolbar");
   await expect(toolbar).toBeVisible();
-  await expect(toolbar.getByRole("button", { name: "Skills" })).toBeVisible();
   const ring = toolbar.getByRole("button", { name: "Context usage" });
   await expect(ring).toBeVisible();
 
+  // Every visible control sits inside the viewport, on the same row.
   const width = page.viewportSize()?.width ?? 0;
   const buttons = await toolbar.getByRole("button").all();
   expect(buttons.length).toBeGreaterThanOrEqual(3);
+  const tops = new Set<number>();
   for (const button of buttons) {
     const box = await button.boundingBox();
     expect(box).not.toBeNull();
     if (!box) continue;
     expect(box.x).toBeGreaterThanOrEqual(0);
     expect(box.x + box.width).toBeLessThanOrEqual(width);
+    tops.add(Math.round(box.y + box.height / 2));
   }
+  expect(tops.size).toBe(1);
+
+  // Skills leaves the phone toolbar for the composer's "+" menu.
+  await expect(toolbar.getByRole("button", { name: "Skills" })).toBeHidden();
+  await chat.getByRole("button", { name: "Attach" }).tap();
+  await expect(page.getByRole("button", { name: "Skills" })).toBeVisible();
+  await page.keyboard.press("Escape");
   // Nothing forces the document wider than the phone.
   const overflow = await page.evaluate(
     () =>

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -12,6 +12,7 @@ import {
   hasConversationMoments,
   resolveConversationMapLabels,
 } from "@houston-ai/chat";
+import { isMobileViewport } from "@houston-ai/core";
 import { SplitView } from "@houston-ai/layout";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -512,7 +513,10 @@ export function AIBoard({
     if (!selectedId) return;
     hydrateSession(selectedId);
     setNewPanelOpen(false);
-    if (!disableComposerAutoFocus) {
+    // Never on the phone: a programmatic focus raises the on-screen keyboard
+    // over the chat the user just opened to read. There the keyboard follows
+    // their own tap on the composer.
+    if (!disableComposerAutoFocus && !isMobileViewport()) {
       setComposerFocusToken((prev) => (prev ?? 0) + 1);
     }
   }, [selectedId, hydrateSession, disableComposerAutoFocus]);

--- a/ui/chat/src/chat-input.tsx
+++ b/ui/chat/src/chat-input.tsx
@@ -140,7 +140,9 @@ export function ChatInput({
   useDictationHotkeys(dictation);
 
   return (
-    <div className="shrink-0 px-4 pb-6 pt-2">
+    // The phone keeps the composer tight to what sits below it (the home
+    // indicator's safe area, or the keyboard); desktop keeps its air.
+    <div className="shrink-0 px-4 pb-2 pt-2 md:pb-6">
       <div
         className={cn(
           "max-w-3xl mx-auto relative transition-opacity",

--- a/ui/core/src/components/responsive-popover.tsx
+++ b/ui/core/src/components/responsive-popover.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+import { useIsMobile } from "../hooks/use-mobile";
+import { cn } from "../utils";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "./sheet";
+
+/**
+ * One picker, two presentations: an anchored popover on desktop and a bottom
+ * sheet below the one breakpoint. A popover pinned to a 28px pill has nowhere
+ * to go on a phone (it goes edge to edge and lands on top of the composer);
+ * the sheet gives the same content the full width, a title, and the home
+ * indicator's safe area. A structural fork, so it reads `useIsMobile()`.
+ *
+ * The trigger and content are the same children either way; `title` is the
+ * sheet's heading (a dialog needs an accessible name) and is not rendered in
+ * the popover form.
+ */
+
+const MobileContext = React.createContext(false);
+
+function ResponsivePopover({
+  open,
+  onOpenChange,
+  children,
+}: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
+}) {
+  const mobile = useIsMobile();
+  const Root = mobile ? Sheet : Popover;
+  return (
+    <MobileContext.Provider value={mobile}>
+      <Root open={open} onOpenChange={onOpenChange}>
+        {children}
+      </Root>
+    </MobileContext.Provider>
+  );
+}
+
+function ResponsivePopoverTrigger(
+  props: React.ComponentProps<typeof PopoverTrigger>,
+) {
+  const mobile = React.useContext(MobileContext);
+  return mobile ? (
+    <SheetTrigger data-slot="responsive-popover-trigger" {...props} />
+  ) : (
+    <PopoverTrigger data-slot="responsive-popover-trigger" {...props} />
+  );
+}
+
+function ResponsivePopoverContent({
+  title,
+  className,
+  sheetClassName,
+  children,
+  onOpenAutoFocus,
+  onCloseAutoFocus,
+  ...popoverProps
+}: React.ComponentProps<typeof PopoverContent> & {
+  /** The sheet's heading; doubles as its accessible name. */
+  title: string;
+  /** Extra classes for the sheet form only (the popover takes `className`). */
+  sheetClassName?: string;
+}) {
+  const mobile = React.useContext(MobileContext);
+  if (mobile) {
+    return (
+      <SheetContent
+        side="bottom"
+        showCloseButton={false}
+        data-slot="responsive-popover-sheet"
+        className={cn(
+          "max-h-[85dvh] gap-0 rounded-t-2xl border-t-0 pb-safe",
+          sheetClassName,
+        )}
+        onOpenAutoFocus={onOpenAutoFocus}
+        onCloseAutoFocus={onCloseAutoFocus}
+      >
+        <SheetHeader className="px-4 pt-4 pb-2">
+          <SheetTitle className="text-sm">{title}</SheetTitle>
+        </SheetHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+      </SheetContent>
+    );
+  }
+  return (
+    <PopoverContent
+      className={className}
+      onOpenAutoFocus={onOpenAutoFocus}
+      onCloseAutoFocus={onCloseAutoFocus}
+      {...popoverProps}
+    >
+      {children}
+    </PopoverContent>
+  );
+}
+
+export {
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
+};

--- a/ui/core/src/hooks/use-mobile.ts
+++ b/ui/core/src/hooks/use-mobile.ts
@@ -8,6 +8,16 @@ import * as React from "react";
    (see ui/core/tests/breakpoint-sync.test.ts). */
 const MOBILE_BREAKPOINT = breakpointPx.mobile;
 
+/**
+ * The same edge, read synchronously. For one-shot decisions made inside an
+ * effect or handler (e.g. "would focusing this input raise a phone keyboard
+ * right now?") where the hook's post-mount state would still read `false` on
+ * the very render that decides.
+ */
+export function isMobileViewport(): boolean {
+  return typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT;
+}
+
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
     undefined,

--- a/ui/core/src/index.ts
+++ b/ui/core/src/index.ts
@@ -41,6 +41,7 @@ export * from "./components/model-picker";
 export * from "./components/popover";
 export * from "./components/progress";
 export * from "./components/resizable";
+export * from "./components/responsive-popover";
 export * from "./components/scroll-area";
 export * from "./components/search-clear-button";
 export * from "./components/select";


### PR DESCRIPTION
## Summary

PRODUCT-1630. Phone-only defects in the mobile web chat.

**Toolbar ran off the right edge.** The row under the composer (Skills, mode, model, effort, context ring) was five labelled pills, wider than a 375px composer (and wider than 412px in Spanish), so the effort pill and the ring were clipped. On the phone the row now fits in one line: the Skills entry lives in the composer's "+" menu, the effort pill is its gauge icon alone (the bars already read the level; the aria-label keeps the word), and the mode/model pickers drop their chevrons. Desktop is unchanged.

**Pickers were desktop popovers.** The model picker was a 320px popover anchored to a 28px pill: at phone width it went edge to edge and landed on top of the composer. New `ResponsivePopover` in `@houston-ai/core` renders the anchored popover on desktop and a titled bottom sheet below the breakpoint. The model picker, the mode picker (desktop keeps its dropdown menu; the rows are shared through `chat-mode-options.tsx`) and the context ring use it. Inventory v74.

**Keyboard popped when opening a chat.** `AIBoard` bumps a composer-focus token on every selection so desktop keyboard users can type immediately. On a phone the pushed mission chat goes through the same board, so every card tap focused the textarea and raised the keyboard over the log. The bump is now skipped below the mobile breakpoint via a synchronous `isMobileViewport()` beside `useIsMobile()` in ui/core.

**Keyboard inset double-counted on Android.** The composer carried desktop air (`pb-6`) under its toolbar, and the inset hook padded the screen by "window height minus visible height", which is the keyboard height on iOS but also on Android after the browser already shrank the layout viewport. The phone padding is now `pb-2` (desktop keeps `pb-6`) and the hook measures the chat screen's own bottom edge against the visible bottom, which is zero once the browser has resized and the occluded height otherwise. It also re-measures on window resize.

**Context ring was dead to touch.** It was a Radix hover card, which never opens for a touch pointer. Below the breakpoint it opens on tap as a bottom sheet.

## Verification

Before the fix (main), on the `mobile` Playwright project at 375px wide:
1. Home, tap the agent row, tap "Plan a trip to Tokyo".
2. The composer textarea is focused as the chat opens.
3. The toolbar's last control's right edge is at ~411px, past the 375px viewport.
4. Tap the model pill: a 320px popover covers the composer.

After the fix:
1. Same steps: the textarea is not focused; nothing raises the keyboard until the user taps the composer.
2. Every toolbar control is inside the viewport on a single row; Skills is reachable from the "+" menu; the document does not scroll horizontally.
3. The mode, model and context pickers open as full-width bottom sheets; picking a mode from the sheet applies it and closes the sheet.

```
pnpm --filter houston-web exec tsx e2e/support/run-locked.ts playwright test --project=mobile e2e/mobile/composer-toolbar.spec.ts e2e/mobile/mission-chat.spec.ts
```

Known remaining gap, out of scope here: on Brave for Android a ~96px band stays between the composer and the keys. By the browser's own numbers (`visualViewport.height`, the toolbar's rect) the composer already touches the keyboard; Brave subtracts the full keyboard from a layout viewport that already excludes its hidden bottom toolbar. `interactive-widget=resizes-content` is ignored there and the VirtualKeyboard API needs a secure origin, so it stays parked.

`pnpm check`, `pnpm typecheck`, `pnpm --filter houston-web typecheck:e2e`, `pnpm check:parity`, and the ui/board + ui/core unit tests pass. CI is green.