### PR TITLE
docs(release-notes): drop the phone section from the 0.6.16 notes (en/es/pt)

### DIFF
--- a/.github/release-notes/0.6.16.es.md
+++ b/.github/release-notes/0.6.16.es.md
@@ -1,9 +1,5 @@
 ## Houston 0.6.16
 
-### Houston en tu teléfono
-
-- **Completa la configuración y trabaja desde tu teléfono**, con un campo de mensaje y controles del tablero que se ajustan a la pantalla y un teclado que no estorba.
-
 ### Esperas más claras, menos errores alarmantes
 
 - **Envía un mensaje a un agente dormido y velo al instante**, con un aviso tranquilo de que está despertando en lugar de un error rojo.

--- a/.github/release-notes/0.6.16.md
+++ b/.github/release-notes/0.6.16.md
@@ -1,9 +1,5 @@
 ## Houston 0.6.16
 
-### Houston on your phone
-
-- **Finish setup and work from your phone**, with a message box and board controls that fit the screen and a keyboard that stays out of the way.
-
 ### Clearer waiting, fewer alarming errors
 
 - **Send a message to a sleeping agent and see it right away**, with a calm waking up notice instead of a red error.

--- a/.github/release-notes/0.6.16.pt.md
+++ b/.github/release-notes/0.6.16.pt.md
@@ -1,9 +1,5 @@
 ## Houston 0.6.16
 
-### Houston no seu celular
-
-- **Conclua a configuração e trabalhe pelo celular**, com campo de mensagem e controles do quadro que cabem na tela e um teclado que não atrapalha.
-
 ### Esperas mais claras, menos erros assustadores
 
 - **Envie uma mensagem para um agente adormecido e veja ela na hora**, com um aviso tranquilo de que ele está acordando no lugar de um erro vermelho.


### PR DESCRIPTION
Removes the "Houston on your phone" section from the 0.6.16 notes in all three languages. The cloud-v0.6.16 draft release body and its `latest-cloud.json` updater asset were already edited in place to match, so no re-cut is needed; this keeps the committed source identical to what ships.