### PR TITLE
fix(integrations): walk every Composio toolkits page so the catalog is not truncated at 1000

### DIFF
--- a/packages/host/src/integrations/composio-catalog.ts
+++ b/packages/host/src/integrations/composio-catalog.ts
@@ -1,0 +1,35 @@
+import type { ComposioHttp } from "./composio-http";
+import type { RawToolkit } from "./composio-wire";
+
+/** Composio caps a toolkits page at 1000 whatever `limit` says. */
+const PAGE_SIZE = "1000";
+
+/** Upper bound on catalog pages walked per fetch (1000 toolkits each). */
+const MAX_CATALOG_PAGES = 10;
+
+/**
+ * The whole toolkits catalog, every page. The catalog outgrew one page (1502
+ * toolkits, 2026-09): reading only the first silently dropped telegram, odoo,
+ * quickbooks… so this walks `next_cursor` until it is null. The seen-cursor
+ * and page-count guards keep a misbehaving upstream from looping forever; a
+ * failing page throws (no partial catalog served as if complete).
+ */
+export async function fetchAllRawToolkits(
+  http: ComposioHttp,
+): Promise<RawToolkit[]> {
+  const items: RawToolkit[] = [];
+  const seen = new Set<string>();
+  let cursor: string | undefined;
+  for (let page = 0; page < MAX_CATALOG_PAGES; page++) {
+    const body = await http.call<{
+      items?: RawToolkit[];
+      next_cursor?: string | null;
+    }>("/api/v3/toolkits", { query: { limit: PAGE_SIZE, cursor } });
+    items.push(...(body?.items ?? []));
+    const next = body?.next_cursor ?? undefined;
+    if (!next || seen.has(next)) break;
+    seen.add(next);
+    cursor = next;
+  }
+  return items;
+}

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -91,6 +91,43 @@ test("listToolkits maps the catalog and sends the platform key", async () => {
   expect(calls[0]?.path).toBe("/api/v3/toolkits?limit=1000");
 });
 
+test("listToolkits walks every catalog page: Composio caps a page at 1000 and the catalog is bigger", async () => {
+  // Prod 2026-09: 1502 toolkits, `limit=1000` still returns 1000 + next_cursor.
+  // Reading page 1 alone silently dropped telegram, odoo, quickbooks, typeform.
+  const { provider, calls } = harness((url) => {
+    if (url.pathname !== "/api/v3/toolkits") return { status: 404 };
+    const cursor = url.searchParams.get("cursor");
+    if (cursor === null) {
+      return { body: { items: [{ slug: "gmail" }], next_cursor: "Mi0xMDAw" } };
+    }
+    if (cursor === "Mi0xMDAw") {
+      return {
+        body: {
+          items: [{ slug: "telegram" }, { slug: "odoo" }],
+          next_cursor: null,
+        },
+      };
+    }
+    return { status: 400 };
+  });
+  const toolkits = await provider.listToolkits();
+  expect(toolkits.map((t) => t.slug)).toEqual(["gmail", "telegram", "odoo"]);
+  expect(calls.map((c) => c.path)).toEqual([
+    "/api/v3/toolkits?limit=1000",
+    "/api/v3/toolkits?limit=1000&cursor=Mi0xMDAw",
+  ]);
+});
+
+test("listToolkits stops on a cursor it has already followed instead of looping forever", async () => {
+  const { provider, calls } = harness((url) => {
+    if (url.pathname !== "/api/v3/toolkits") return { status: 404 };
+    return { body: { items: [{ slug: "gmail" }], next_cursor: "same" } };
+  });
+  const toolkits = await provider.listToolkits();
+  expect(toolkits).toHaveLength(2);
+  expect(calls).toHaveLength(2);
+});
+
 test("listToolkits keeps no_auth toolkits, flagged — ready to use, never connectable", async () => {
   // Composio's catalog includes toolkits with no auth at all (web search,
   // hackernews…). A Connect button on those can only produce the

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -49,6 +49,9 @@ const DEFAULT_BASE_URL = "https://backend.composio.dev";
  *  for search's name resolution so a hot session does not refetch ~1000 apps. */
 const CATALOG_TTL_MS = 60 * 60 * 1000;
 
+/** Upper bound on catalog pages walked per fetch (1000 toolkits each). */
+const MAX_CATALOG_PAGES = 10;
+
 /**
  * Which Composio TOOL VERSION every /tools read and execute requests. The v3
  * endpoints default to the FROZEN base snapshot (`00000000_00`), not the newest
@@ -121,18 +124,31 @@ export class ComposioProvider implements IntegrationProvider {
   }
 
   private async fetchToolkits(): Promise<Toolkit[]> {
-    const body = await this.http.call<{ items?: RawToolkit[] }>(
-      "/api/v3/toolkits",
-      {
-        query: { limit: "1000" },
-      },
-    );
+    // Composio caps a toolkits page at 1000 whatever `limit` says and the
+    // catalog outgrew that (1502 toolkits, 2026-09): reading only the first
+    // page silently dropped telegram, odoo, quickbooks… so the catalog walks
+    // `next_cursor` until it is null. Seen-cursor + page guards keep a
+    // misbehaving upstream from looping forever.
+    const items: RawToolkit[] = [];
+    const seen = new Set<string>();
+    let cursor: string | undefined;
+    for (let page = 0; page < MAX_CATALOG_PAGES; page++) {
+      const body = await this.http.call<{
+        items?: RawToolkit[];
+        next_cursor?: string | null;
+      }>("/api/v3/toolkits", { query: { limit: "1000", cursor } });
+      items.push(...(body?.items ?? []));
+      const next = body?.next_cursor ?? undefined;
+      if (!next || seen.has(next)) break;
+      seen.add(next);
+      cursor = next;
+    }
     // no_auth toolkits (web search, weather…) stay in the catalog but carry
     // the flag: there is no account to connect (creating an auth config 400s
     // upstream — Auth_Config_NoAuthApp, seen in prod), yet their tools work
     // as-is. The UI renders them "ready to use" instead of connectable, and
     // search stamps their matches `connected` (see composio-search.ts).
-    return (body?.items ?? []).map(mapToolkit);
+    return items.map(mapToolkit);
   }
 
   async listToolkits(): Promise<Toolkit[]> {

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -1,4 +1,5 @@
 import { resolveAuthConfig } from "./composio-auth-config";
+import { fetchAllRawToolkits } from "./composio-catalog";
 import { ComposioHttp } from "./composio-http";
 import { extractIdentity, IDENTITY_PROBES } from "./composio-identity";
 import { searchComposio } from "./composio-search";
@@ -10,7 +11,6 @@ import {
   type RawConnection,
   type RawExecute,
   type RawTool,
-  type RawToolkit,
 } from "./composio-wire";
 import type {
   ActingContext,
@@ -48,9 +48,6 @@ const DEFAULT_BASE_URL = "https://backend.composio.dev";
 /** The toolkits catalog is large-ish and changes rarely — cache it per process
  *  for search's name resolution so a hot session does not refetch ~1000 apps. */
 const CATALOG_TTL_MS = 60 * 60 * 1000;
-
-/** Upper bound on catalog pages walked per fetch (1000 toolkits each). */
-const MAX_CATALOG_PAGES = 10;
 
 /**
  * Which Composio TOOL VERSION every /tools read and execute requests. The v3
@@ -124,31 +121,12 @@ export class ComposioProvider implements IntegrationProvider {
   }
 
   private async fetchToolkits(): Promise<Toolkit[]> {
-    // Composio caps a toolkits page at 1000 whatever `limit` says and the
-    // catalog outgrew that (1502 toolkits, 2026-09): reading only the first
-    // page silently dropped telegram, odoo, quickbooks… so the catalog walks
-    // `next_cursor` until it is null. Seen-cursor + page guards keep a
-    // misbehaving upstream from looping forever.
-    const items: RawToolkit[] = [];
-    const seen = new Set<string>();
-    let cursor: string | undefined;
-    for (let page = 0; page < MAX_CATALOG_PAGES; page++) {
-      const body = await this.http.call<{
-        items?: RawToolkit[];
-        next_cursor?: string | null;
-      }>("/api/v3/toolkits", { query: { limit: "1000", cursor } });
-      items.push(...(body?.items ?? []));
-      const next = body?.next_cursor ?? undefined;
-      if (!next || seen.has(next)) break;
-      seen.add(next);
-      cursor = next;
-    }
     // no_auth toolkits (web search, weather…) stay in the catalog but carry
     // the flag: there is no account to connect (creating an auth config 400s
     // upstream — Auth_Config_NoAuthApp, seen in prod), yet their tools work
     // as-is. The UI renders them "ready to use" instead of connectable, and
     // search stamps their matches `connected` (see composio-search.ts).
-    return items.map(mapToolkit);
+    return (await fetchAllRawToolkits(this.http)).map(mapToolkit);
   }
 
   async listToolkits(): Promise<Toolkit[]> {


### PR DESCRIPTION
## Problem

Composio caps a `/api/v3/toolkits` page at 1000 items whatever `limit` says, and the catalog now holds 1502 toolkits. `fetchToolkits` read page 1 only and never followed `next_cursor`, so 502 toolkits (telegram, odoo, quickbooks, typeform, ntfy, …) were missing from the catalog: the Integrations page could not list or find them (its search filters the fetched catalog client-side), and search's app-name resolution missed them too, so the agent fell into custom-integration dead ends for real catalog apps.

## Fix

`fetchToolkits` walks `next_cursor` until it is null, bounded by a page cap and a seen-cursor guard so a misbehaving upstream can never loop. Both the fresh UI catalog and the cached search catalog go through it.

## Tests

- two pages merge in order and the second request carries the opaque cursor
- a repeated cursor ends the walk

Companion gateway fix for cloud: gethouston/cloud#339.

Fixes PRODUCT-1658