### PR TITLE
fix(chat): allowed-models ceiling picks a model the connected provider can run

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -98,7 +98,7 @@ import {
   finalConnectNames,
   finalCredentialNames,
 } from "../lib/interaction-reply";
-import { providerForModel } from "../lib/model-labels";
+import { providerForModel, providerOffersModel } from "../lib/model-labels";
 import {
   isModelAllowed,
   modelSelectorDecision,
@@ -667,6 +667,17 @@ export function useAgentChatPanel({
     agentEffort,
   );
 
+  // What a ceiling pick may run on: the hydrated catalog plus the CONFIRMED
+  // connected accounts, so a ceiling never pins the chat to a provider the user
+  // has not connected (PRODUCT-1657).
+  const ceilingResolver = useMemo(
+    () => ({
+      offers: providerOffersModel,
+      providerFor: providerForModel,
+      connected: authedProviders,
+    }),
+    [authedProviders],
+  );
   const personalDefaultPin = useMemo(
     () =>
       resolvePersonalModelPin(
@@ -678,7 +689,7 @@ export function useAgentChatPanel({
           effort: effectiveEffort,
         },
         null,
-        providerForModel,
+        ceilingResolver,
       ),
     [
       modelChoiceInfo?.choice,
@@ -686,6 +697,7 @@ export function useAgentChatPanel({
       effectiveProvider,
       effectiveModel,
       effectiveEffort,
+      ceilingResolver,
     ],
   );
 
@@ -710,7 +722,7 @@ export function useAgentChatPanel({
                   model: activityModel,
                 }
               : null,
-            providerForModel,
+            ceilingResolver,
           )
         : {
             provider: effectiveProvider,
@@ -726,6 +738,7 @@ export function useAgentChatPanel({
       effectiveProvider,
       effectiveModel,
       effectiveEffort,
+      ceilingResolver,
     ],
   );
   const displayModelPin = useMemo(

--- a/app/src/hooks/use-routine-model-resolution.ts
+++ b/app/src/hooks/use-routine-model-resolution.ts
@@ -23,7 +23,8 @@
 import type { Routine } from "@houston-ai/engine-client";
 import { useMemo } from "react";
 import { resolveAgentModelOverrides } from "../lib/agent-model-overrides";
-import { providerForModel } from "../lib/model-labels";
+import type { CeilingResolver } from "../lib/ceiling-pin";
+import { providerForModel, providerOffersModel } from "../lib/model-labels";
 import {
   modelSelectorDecision,
   resolvePersonalModelPin,
@@ -31,6 +32,19 @@ import {
 import type { Agent } from "../lib/types";
 import { useAgentConfig, useAgentModelChoice } from "./queries";
 import { useCapabilities } from "./use-capabilities";
+
+/**
+ * How a ceiling pick resolves for an UNATTENDED run: the catalog only, no
+ * connection set — exactly the gateway's per-turn clamp, which has no
+ * connection knowledge either. Handing it the connected providers would be the
+ * auth-switch the comment above forbids (and would show a pair the fire path
+ * never runs).
+ */
+const GATEWAY_CEILING_RESOLVER: CeilingResolver = {
+  offers: providerOffersModel,
+  providerFor: providerForModel,
+  connected: [],
+};
 
 export interface RoutineModelResolution {
   /** Resolved provider id; `""` while the agent config has not answered yet. */
@@ -90,7 +104,7 @@ export function useRoutineModelResolution(
       allowedModels,
       fallback,
       null,
-      providerForModel,
+      GATEWAY_CEILING_RESOLVER,
     );
     return {
       provider: pin.provider,

--- a/app/src/lib/ceiling-pin.ts
+++ b/app/src/lib/ceiling-pin.ts
@@ -1,0 +1,59 @@
+import type { ModelPin } from "./model-selector-lock.ts";
+
+/**
+ * What the composer knows about the catalog and the connected accounts when it
+ * has to pick a model out of an agent's allowed-models ceiling on the user's
+ * behalf (no stored choice, shared fallback outside the ceiling).
+ */
+export interface CeilingResolver {
+  /** Whether `provider` offers `model` in the hydrated catalog. */
+  offers: (provider: string, model: string) => boolean;
+  /** Which catalogued provider offers `model`, or `null` when none does. */
+  providerFor: (model: string) => string | null;
+  /** Provider ids the acting user is CONFIRMED connected to, registry order. */
+  connected: readonly string[];
+}
+
+/**
+ * The provider/model the composer pins when the ceiling has to choose.
+ *
+ * A ceiling is the sorted union of EVERY provider's id for each allowed model
+ * (`toggleModel`): "Claude Opus 5" contributes OpenRouter's
+ * `anthropic/claude-opus-5` ahead of Anthropic's `claude-opus-5`. Taking the
+ * first entry blindly therefore pinned a Claude-connected user to OpenRouter —
+ * an account they never connected — and every send answered with a "reconnect
+ * OpenRouter" card they could not act on (PRODUCT-1657). So the pick prefers
+ * what can actually run:
+ *
+ *  1. an entry the fallback's own provider offers (it is already the
+ *     connection-resolved composer provider);
+ *  2. else an entry offered by any connected provider, in registry order;
+ *  3. else the first entry on its catalogued provider — nothing connected can
+ *     run this ceiling, and the resulting card names the provider truthfully.
+ *
+ * Effort always carries over from the fallback: activities and ceilings have no
+ * effort field.
+ */
+export function pickCeilingPin(
+  ceiling: readonly string[],
+  fallback: ModelPin,
+  resolver: CeilingResolver,
+): ModelPin {
+  const own = ceiling.find((model) =>
+    resolver.offers(fallback.provider, model),
+  );
+  if (own !== undefined) return { ...fallback, model: own };
+  for (const provider of resolver.connected) {
+    const model = ceiling.find((candidate) =>
+      resolver.offers(provider, candidate),
+    );
+    if (model !== undefined)
+      return { provider, model, effort: fallback.effort };
+  }
+  const first = ceiling[0];
+  return {
+    provider: resolver.providerFor(first) ?? fallback.provider,
+    model: first,
+    effort: fallback.effort,
+  };
+}

--- a/app/src/lib/model-labels.ts
+++ b/app/src/lib/model-labels.ts
@@ -38,6 +38,11 @@ export function providerForModel(model: string): string | null {
   );
 }
 
+/** Whether the catalogued `provider` offers `model` (hydrated catalog lookup). */
+export function providerOffersModel(provider: string, model: string): boolean {
+  return getModel(provider, model) !== undefined;
+}
+
 /**
  * The RESOLVED pair as one line — "Claude · Opus 5". Shown wherever a surface
  * must name the account AND the model it will run on (the routine screen: a

--- a/app/src/lib/model-selector-lock.ts
+++ b/app/src/lib/model-selector-lock.ts
@@ -22,6 +22,7 @@ import type {
   Capabilities,
 } from "@houston-ai/engine-client";
 import { canEditAgentConfig } from "./agent-access.ts";
+import { type CeilingResolver, pickCeilingPin } from "./ceiling-pin.ts";
 import { decodeModelPickerId } from "./chat-model-picker-ids.ts";
 import { isMultiplayer } from "./org-roles.ts";
 
@@ -109,8 +110,9 @@ export interface ModelPin {
  *     the personal resolution's effort because activities have no effort field;
  *  2. the user's stored `choice` when present;
  *  3. else, when a ceiling exists and the shared `fallback` model is outside it,
- *     the ceiling's first model carried on its catalogued provider (the gateway
- *     forces first-of-ceiling for a member who has not picked yet);
+ *     a ceiling model the user can actually run (`pickCeilingPin`: the
+ *     fallback provider's own id first, then any connected provider's, then
+ *     the first entry on its catalogued provider);
  *  4. else the shared `fallback` (agent / pod default) unchanged.
  */
 export function resolvePersonalModelPin(
@@ -118,7 +120,7 @@ export function resolvePersonalModelPin(
   allowedModels: string[] | null | undefined,
   fallback: ModelPin,
   missionPin: ModelPin | null,
-  resolveProvider: (model: string) => string | null,
+  resolver: CeilingResolver,
 ): ModelPin {
   const personalPin = choice
     ? {
@@ -129,11 +131,7 @@ export function resolvePersonalModelPin(
     : allowedModels != null &&
         allowedModels.length > 0 &&
         !allowedModels.includes(fallback.model)
-      ? {
-          provider: resolveProvider(allowedModels[0]) ?? fallback.provider,
-          model: allowedModels[0],
-          effort: fallback.effort,
-        }
+      ? pickCeilingPin(allowedModels, fallback, resolver)
       : fallback;
   if (missionPin && isModelAllowed(allowedModels, missionPin.model)) {
     return {

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -246,8 +246,22 @@ export const VISIBLE_MODELS: Readonly<Record<string, ReadonlySet<string>>> = {
   ]),
 };
 
+/**
+ * OpenRouter's rolling aliases (`~anthropic/claude-opus-latest`, named
+ * "Anthropic: Claude Opus Latest") duplicate a concrete model under a name that
+ * reads as the lab's own. In the hub / ceiling editor they surfaced as a
+ * separate Anthropic-lab model offered ONLY by OpenRouter, so a Claude user who
+ * allowed "Claude Opus Latest" got a ceiling nothing they connected could run
+ * (PRODUCT-1657). Presentation-only, like `VISIBLE_MODELS`: an existing pin to
+ * one stays runnable on the wire.
+ */
+function isOpenRouterAlias(providerId: string, modelId: string): boolean {
+  return providerId === "openrouter" && modelId.startsWith("~");
+}
+
 /** Whether `modelId` may surface for `providerId` (a Houston display id). */
 export function isModelVisible(providerId: string, modelId: string): boolean {
+  if (isOpenRouterAlias(providerId, modelId)) return false;
   const visible = VISIBLE_MODELS[providerId];
   return !visible || visible.has(modelId);
 }

--- a/app/tests/catalog-pi.test.ts
+++ b/app/tests/catalog-pi.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/lib/ai-hub/catalog-merge.ts";
 import { piCatalogToCandidates } from "../src/lib/ai-hub/catalog-pi.ts";
 import type { RawModel } from "../src/lib/ai-hub/catalog-snapshot.ts";
+import { isModelVisible } from "../src/lib/provider-overrides.ts";
 
 /** Compact CatalogModelEntry builder with sane defaults. */
 function entry(
@@ -231,5 +232,39 @@ describe("snapshot enrichment is gated to pi-existing models", () => {
     strictEqual(m.toolCall, false);
     strictEqual(m.releaseDate, undefined);
     strictEqual(m.offers.length, 1);
+  });
+});
+
+describe("OpenRouter rolling aliases never surface (PRODUCT-1657)", () => {
+  // `~anthropic/claude-opus-latest` ("Anthropic: Claude Opus Latest") is a
+  // duplicate of a concrete model under a name that reads as Anthropic's own.
+  // In the ceiling editor it became a separate Anthropic-lab model offered ONLY
+  // by OpenRouter, so a Claude user who allowed it got a ceiling nothing they
+  // connected could run. Hidden everywhere the visibility gate applies; still
+  // runnable on the wire for an existing pin.
+  const catalog: ProviderCatalog = [
+    provider("openrouter", "apiKey", [
+      entry("anthropic/claude-opus-5", { name: "Claude Opus 5" }),
+      entry("~anthropic/claude-opus-latest", {
+        name: "Anthropic: Claude Opus Latest",
+      }),
+    ]),
+  ];
+  const candidates = piCatalogToCandidates(catalog);
+
+  it("hides the alias and keeps the concrete id", () => {
+    strictEqual(
+      isModelVisible("openrouter", "~anthropic/claude-opus-latest"),
+      false,
+    );
+    strictEqual(isModelVisible("openrouter", "anthropic/claude-opus-5"), true);
+    deepStrictEqual(
+      candidates.map((c) => c.raw.id),
+      ["anthropic/claude-opus-5"],
+    );
+  });
+
+  it("only gates OpenRouter: a tilde id elsewhere is untouched", () => {
+    strictEqual(isModelVisible("groq", "~anything"), true);
   });
 });

--- a/app/tests/ceiling-pin.test.ts
+++ b/app/tests/ceiling-pin.test.ts
@@ -1,0 +1,106 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  type CeilingResolver,
+  pickCeilingPin,
+} from "../src/lib/ceiling-pin.ts";
+
+/**
+ * PRODUCT-1657 — a ceiling is the sorted union of every provider's id for each
+ * allowed model, so its FIRST entry is usually OpenRouter's (`anthropic/…`
+ * sorts before `claude-…`). The pick must land on a provider the user can run,
+ * never on whichever provider happens to own the first entry.
+ */
+const catalog: Record<string, string[]> = {
+  anthropic: ["claude-opus-5", "claude-sonnet-5"],
+  openai: ["gpt-5.5"],
+  openrouter: [
+    "anthropic/claude-opus-5",
+    "openai/gpt-5.5",
+    "~anthropic/claude-opus-latest",
+  ],
+};
+
+const resolver = (connected: string[]): CeilingResolver => ({
+  offers: (provider, model) => catalog[provider]?.includes(model) ?? false,
+  providerFor: (model) =>
+    Object.keys(catalog).find((p) => catalog[p]?.includes(model)) ?? null,
+  connected,
+});
+
+// "Claude Opus 5" as the ceiling editor writes it: OpenRouter's id sorts first.
+const opusCeiling = ["anthropic/claude-opus-5", "claude-opus-5"];
+const fallback = {
+  provider: "anthropic",
+  model: "claude-sonnet-5",
+  effort: "high",
+};
+
+describe("pickCeilingPin", () => {
+  it("prefers the fallback provider's own id over the first entry", () => {
+    deepStrictEqual(
+      pickCeilingPin(opusCeiling, fallback, resolver(["anthropic"])),
+      {
+        provider: "anthropic",
+        model: "claude-opus-5",
+        effort: "high",
+      },
+    );
+  });
+
+  it("falls to a CONNECTED provider's offer when the fallback provider has none", () => {
+    // Only OpenAI is connected and the ceiling is "GPT-5.5" (OpenRouter's id
+    // first): run it on OpenAI, not on the OpenRouter account never connected.
+    deepStrictEqual(
+      pickCeilingPin(
+        ["gpt-5.5", "openai/gpt-5.5"].sort(),
+        fallback,
+        resolver(["openai"]),
+      ),
+      { provider: "openai", model: "gpt-5.5", effort: "high" },
+    );
+  });
+
+  it("walks connected providers in registry order", () => {
+    deepStrictEqual(
+      pickCeilingPin(
+        opusCeiling,
+        { ...fallback, provider: "google" },
+        resolver(["openrouter", "anthropic"]),
+      ),
+      {
+        provider: "openrouter",
+        model: "anthropic/claude-opus-5",
+        effort: "high",
+      },
+    );
+  });
+
+  it("names the owning provider when nothing connected can run the ceiling", () => {
+    // OpenRouter's rolling alias alone: honest "connect OpenRouter", never a
+    // Claude pin that the runtime rejects as "not available".
+    deepStrictEqual(
+      pickCeilingPin(
+        ["~anthropic/claude-opus-latest"],
+        fallback,
+        resolver(["anthropic"]),
+      ),
+      {
+        provider: "openrouter",
+        model: "~anthropic/claude-opus-latest",
+        effort: "high",
+      },
+    );
+  });
+
+  it("keeps the fallback provider for an id no catalog knows", () => {
+    deepStrictEqual(
+      pickCeilingPin(["unknown"], fallback, resolver(["anthropic"])),
+      {
+        provider: "anthropic",
+        model: "unknown",
+        effort: "high",
+      },
+    );
+  });
+});

--- a/app/tests/model-labels.test.ts
+++ b/app/tests/model-labels.test.ts
@@ -4,6 +4,7 @@ import {
   modelDisplayLabel,
   providerForModel,
   providerModelLabel,
+  providerOffersModel,
 } from "../src/lib/model-labels.ts";
 import {
   getModel,
@@ -52,6 +53,18 @@ describe("providerForModel", () => {
 
   it("is null for a model no provider offers", () => {
     strictEqual(providerForModel("not-a-real-model"), null);
+  });
+});
+
+describe("providerOffersModel", () => {
+  it("is true only for the provider that lists the id", () => {
+    strictEqual(providerOffersModel("anthropic", "claude-opus-5"), true);
+    // OpenRouter's id for the same model is not Anthropic's (PRODUCT-1657).
+    strictEqual(
+      providerOffersModel("anthropic", "anthropic/claude-opus-5"),
+      false,
+    );
+    strictEqual(providerOffersModel("nope", "claude-opus-5"), false);
   });
 });
 

--- a/app/tests/model-selector-lock.test.ts
+++ b/app/tests/model-selector-lock.test.ts
@@ -115,6 +115,8 @@ describe("isModelAllowed", () => {
 
 describe("resolvePersonalModelPin", () => {
   const fallback = { provider: "anthropic", model: "claude", effort: "high" };
+  /** A resolver that knows nothing: no catalog, nothing connected. */
+  const blind = { offers: () => false, providerFor: () => null, connected: [] };
 
   it("uses the user's stored choice when present", () => {
     deepStrictEqual(
@@ -123,7 +125,7 @@ describe("resolvePersonalModelPin", () => {
         ["gpt-5.5"],
         fallback,
         null,
-        () => null,
+        blind,
       ),
       { provider: "openai", model: "gpt-5.5", effort: "low" },
     );
@@ -131,11 +133,11 @@ describe("resolvePersonalModelPin", () => {
 
   it("keeps the fallback when there is no ceiling", () => {
     deepStrictEqual(
-      resolvePersonalModelPin(null, null, fallback, null, () => null),
+      resolvePersonalModelPin(null, null, fallback, null, blind),
       fallback,
     );
     deepStrictEqual(
-      resolvePersonalModelPin(undefined, undefined, fallback, null, () => null),
+      resolvePersonalModelPin(undefined, undefined, fallback, null, blind),
       fallback,
     );
   });
@@ -147,7 +149,7 @@ describe("resolvePersonalModelPin", () => {
         ["claude", "gpt-5.5"],
         fallback,
         null,
-        () => null,
+        blind,
       ),
       fallback,
     );
@@ -155,27 +157,44 @@ describe("resolvePersonalModelPin", () => {
 
   it("snaps to the ceiling model's owning provider", () => {
     deepStrictEqual(
+      resolvePersonalModelPin(null, ["gpt-5.5", "gemini"], fallback, null, {
+        ...blind,
+        providerFor: (model) => (model === "gpt-5.5" ? "openai" : null),
+      }),
+      { provider: "openai", model: "gpt-5.5", effort: "high" },
+    );
+  });
+
+  it("snaps to the ceiling id the fallback provider can run, not the first entry (PRODUCT-1657)", () => {
+    // "Claude Opus 5" as the ceiling editor writes it: OpenRouter's id sorts
+    // first. A Claude-connected user stays on Claude.
+    deepStrictEqual(
       resolvePersonalModelPin(
         null,
-        ["gpt-5.5", "gemini"],
+        ["anthropic/claude-opus-5", "claude-opus-5"],
         fallback,
         null,
-        (model) => (model === "gpt-5.5" ? "openai" : null),
+        {
+          offers: (provider, model) =>
+            provider === "anthropic" && model === "claude-opus-5",
+          providerFor: () => "openrouter",
+          connected: ["anthropic"],
+        },
       ),
-      { provider: "openai", model: "gpt-5.5", effort: "high" },
+      { provider: "anthropic", model: "claude-opus-5", effort: "high" },
     );
   });
 
   it("keeps the fallback provider when the snapped model is unknown", () => {
     deepStrictEqual(
-      resolvePersonalModelPin(null, ["unknown"], fallback, null, () => null),
+      resolvePersonalModelPin(null, ["unknown"], fallback, null, blind),
       { provider: "anthropic", model: "unknown", effort: "high" },
     );
   });
 
   it("keeps the fallback for an empty ceiling (no model to snap to)", () => {
     deepStrictEqual(
-      resolvePersonalModelPin(null, [], fallback, null, () => null),
+      resolvePersonalModelPin(null, [], fallback, null, blind),
       fallback,
     );
   });
@@ -187,7 +206,7 @@ describe("resolvePersonalModelPin", () => {
         ["claude", "gpt-5.5"],
         fallback,
         { provider: "anthropic", model: "claude" },
-        () => null,
+        blind,
       ),
       { provider: "anthropic", model: "claude", effort: "low" },
     );
@@ -200,7 +219,7 @@ describe("resolvePersonalModelPin", () => {
         ["gpt-5.5"],
         fallback,
         { provider: "anthropic", model: "claude" },
-        () => null,
+        blind,
       ),
       { provider: "openai", model: "gpt-5.5", effort: "low" },
     );

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -3,6 +3,7 @@ import {
   classifyProviderError,
   extractHttpStatus,
   extractRetryAfterSeconds,
+  ModelNotOfferedError,
 } from "./provider-error";
 
 // Fixtures are verbatim-shaped provider failure strings: the Anthropic SDK
@@ -1515,4 +1516,31 @@ test("Azure missing base URL → unauthenticated / no_credentials (PRODUCT-1532)
     message: "base URL is required",
   });
   expect(other.kind).toBe("unknown");
+});
+
+test("ModelNotOfferedError: a pinned id the provider lacks is a typed model_unavailable (PRODUCT-1657)", () => {
+  const err = new ModelNotOfferedError(
+    "anthropic",
+    "anthropic/claude-opus-5",
+    "claude-sonnet-5",
+  );
+  expect(err.message).toBe(
+    'anthropic model "anthropic/claude-opus-5" is not available',
+  );
+  expect(err.providerError).toEqual({
+    kind: "model_unavailable",
+    provider: "anthropic",
+    model: "anthropic/claude-opus-5",
+    reason: "unknown",
+    suggested_fallback: "claude-sonnet-5",
+    message: 'anthropic model "anthropic/claude-opus-5" is not available',
+  });
+  // No switch target when the default IS the failing model.
+  const same = new ModelNotOfferedError(
+    "anthropic",
+    "claude-sonnet-5",
+    "claude-sonnet-5",
+  );
+  if (same.providerError.kind === "model_unavailable")
+    expect(same.providerError.suggested_fallback).toBeNull();
 });

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -401,6 +401,35 @@ function localServedFallback(message: string): string | null {
 }
 
 /**
+ * A PINNED model id the provider does not offer, thrown by `safeGetModel`
+ * before any request is made. A pin is never auto-corrected (a routine or a
+ * managed-cloud ceiling chose it on purpose), but the failure must still be a
+ * typed `model_unavailable` card with the provider's default as the one-click
+ * switch target: classified from its message alone it degraded to `unknown`
+ * (report-bug card + a Sentry error per turn), which is what a ceiling that
+ * forced OpenRouter's `anthropic/claude-opus-5` onto Anthropic produced for 15
+ * users (PRODUCT-1657). The message keeps its long-standing shape — unattended
+ * readers (a routine's reconcile) parse it off the persisted assistant message.
+ */
+export class ModelNotOfferedError extends Error {
+  readonly providerError: ProviderError;
+
+  constructor(provider: string, model: string, fallback: string | null) {
+    const message = `${provider} model "${model}" is not available`;
+    super(message);
+    this.name = "ModelNotOfferedError";
+    this.providerError = stampCredentialScope({
+      kind: "model_unavailable",
+      provider,
+      model,
+      reason: "unknown",
+      suggested_fallback: fallback && fallback !== model ? fallback : null,
+      message,
+    });
+  }
+}
+
+/**
  * Map a failed model request to a typed `ProviderError`, then stamp WHOSE
  * credential ran the turn (`stampCredentialScope`).
  *

--- a/packages/runtime/src/ai/providers.test.ts
+++ b/packages/runtime/src/ai/providers.test.ts
@@ -11,6 +11,7 @@ import {
   registerCustomProviderIfConfigured,
   setCustomEndpointConfig,
 } from "./openai-compatible";
+import { ModelNotOfferedError } from "./provider-error";
 import {
   isProvider,
   PROVIDERS,
@@ -170,6 +171,25 @@ test("safeGetModel keeps a valid saved id but falls back on a stale one", () => 
   expect(() => safeGetModel("anthropic", "claude-2.1", true)).toThrow(
     'anthropic model "claude-2.1" is not available',
   );
+  // …and the throw is TYPED: the chat renders a switch-model card with the
+  // provider's default as the one-click target, not the report-bug card
+  // (PRODUCT-1657: a managed-cloud ceiling forced OpenRouter's
+  // `anthropic/claude-opus-5` onto Anthropic for 15 users).
+  let thrown: unknown;
+  try {
+    safeGetModel("anthropic", "anthropic/claude-opus-5", true);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeInstanceOf(ModelNotOfferedError);
+  expect((thrown as ModelNotOfferedError).providerError).toEqual({
+    kind: "model_unavailable",
+    provider: "anthropic",
+    model: "anthropic/claude-opus-5",
+    reason: "unknown",
+    suggested_fallback: providerDefaultModel("anthropic"),
+    message: 'anthropic model "anthropic/claude-opus-5" is not available',
+  });
 });
 
 test("resolveModel honors a pinned provider regardless of the active one (never auth-gated)", () => {

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -35,6 +35,7 @@ import {
   piModelIds,
   piProviderIds,
 } from "./pi-catalog";
+import { ModelNotOfferedError } from "./provider-error";
 import { QWEN_PROVIDER_ID, qwenModel } from "./qwen-dashscope";
 import {
   withXiaomiBaseUrl,
@@ -517,7 +518,12 @@ export function safeGetModel(
     // still be validated here: returning undefined would crash the turn
     // downstream with a raw `Cannot read properties of undefined` TypeError.
     const m = lookup(mp);
-    if (!m) throw new Error(`${provider} model "${modelId}" is not available`);
+    if (!m)
+      throw new ModelNotOfferedError(
+        provider,
+        modelId,
+        providerDefaultModel(provider),
+      );
     return m;
   }
   const offered = safeModelIds(provider as ProviderId);

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -12,7 +12,10 @@ import {
   learnCustomContextWindow,
   OPENAI_COMPATIBLE,
 } from "../ai/openai-compatible";
-import { classifyProviderError } from "../ai/provider-error";
+import {
+  classifyProviderError,
+  ModelNotOfferedError,
+} from "../ai/provider-error";
 import { logProviderError } from "../ai/provider-error-log";
 import {
   activeEffort,
@@ -685,6 +688,7 @@ export async function execTurn(
     const attributedModel = turnModel ?? pin?.model ?? null;
     const thrown =
       providerError ??
+      (err instanceof ModelNotOfferedError ? err.providerError : null) ??
       classifyProviderError({
         // The provider the turn RESOLVED onto, never the cached session's last
         // one; else the turn's pin. Empty only when neither exists: "provider

--- a/packages/runtime/src/turn/turn-session-failure.ts
+++ b/packages/runtime/src/turn/turn-session-failure.ts
@@ -4,7 +4,10 @@ import type {
   ToolCallRecord,
   WireFrame,
 } from "@houston/runtime-client";
-import { classifyProviderError } from "../ai/provider-error";
+import {
+  classifyProviderError,
+  ModelNotOfferedError,
+} from "../ai/provider-error";
 import { logProviderError } from "../ai/provider-error-log";
 import { noteAuthFailure, noteQuotaExhausted } from "../auth/credential-health";
 import { reportRevokedServedToken } from "../auth/report-revoked";
@@ -48,7 +51,8 @@ export function handleTurnSessionFailure(input: {
   }
   if (!input.providerError) {
     const thrown =
-      input.error instanceof TurnBackendProviderError
+      input.error instanceof TurnBackendProviderError ||
+      input.error instanceof ModelNotOfferedError
         ? input.error.providerError
         : classifyProviderError({
             provider: input.provider,


### PR DESCRIPTION
Closes PRODUCT-1657. Sentry HOUSTON-APP-56N (15 users).

## Symptom
A cloud user with Claude connected is repeatedly asked to reconnect OpenRouter, which they never connected. The picker shows "Anthropic: Claude Opus Latest" with the OpenRouter glyph. Their turns hit the pod as `provider=anthropic model=anthropic/claude-opus-5` / `~anthropic/claude-opus-latest` and fail with `anthropic model "…" is not available`.

## Root cause
The per-agent allowed-models ceiling stores every provider's offer id for each allowed model, code-point sorted, so its first entry is OpenRouter's (`anthropic/claude-opus-5` sorts before `claude-opus-5`). `resolvePersonalModelPin` carried that first entry onto whatever provider offers it, regardless of what the user has connected, so the chat was pinned to OpenRouter and every send came back as a reconnect card nobody could satisfy. OpenRouter's `~…-latest` rolling aliases made it worse: the hub listed "Claude Opus Latest" as a separate Anthropic-lab model offered only by OpenRouter, so allowing it produced a ceiling nothing the user connected could run.

## Fix
- `app/src/lib/ceiling-pin.ts`: when the ceiling has to choose, prefer the entry the composer's own provider offers, then a connected provider's, then the first entry on its catalogued provider. The routine screen mirrors the gateway resolution (no connection set).
- `isModelVisible` hides OpenRouter `~` aliases from the hub, picker, and ceiling editor (presentation-only; existing pins stay runnable).
- Runtime: a pinned id the provider does not offer throws `ModelNotOfferedError`, a typed `model_unavailable` card with the provider default as the one-click switch target, instead of an `unknown` error and a Sentry error per turn. The message text is unchanged.

The gateway clamp that pairs the forced ceiling entry with the user's provider gets the matching fix in the cloud repo.

## Tests
- `app/tests/ceiling-pin.test.ts` (new), `model-selector-lock`, `model-labels`, `catalog-pi`
- `packages/runtime/src/ai/provider-error.test.ts`, `providers.test.ts`
- Gates: `pnpm check`, `pnpm check:boundaries`, app `tsgo` + `pnpm test`, full `@houston/runtime` suite, `houston-web typecheck`