### PR TITLE
fix(shell): member org-level connect 403 is an expected state (PRODUCT-1663)

### DIFF
--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -14,6 +14,7 @@ import {
   type ApiKeyConnectReason,
   apiKeyConnectReason,
 } from "../../lib/api-key-connect-error";
+import { isOrgAdminRequiredError } from "../../lib/org-admin-required-error";
 import { API_KEY_ENDPOINT_PROVIDERS } from "../../lib/provider-overrides";
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriProvider, tauriSystem } from "../../lib/tauri";
@@ -132,7 +133,12 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
       // every provider-QA failure into an undiagnosable "failed to connect".
       // Sentry capture already happened in the tauri call wrapper.
       const reason = apiKeyConnectReason(err);
-      if (reason) {
+      if (isOrgAdminRequiredError(err)) {
+        // A plain member on the org-level (pre-agent) connect: the gateway
+        // reserves it for owners/admins. Expected state, explained inline —
+        // `setApiKey` silences it so nothing else surfaces.
+        setError(t("apiKey.errorOrgAdminRequired"));
+      } else if (reason) {
         setError(
           t(reasonCopyKey(provider.id, reason), { name: provider.name }),
         );

--- a/app/src/hooks/provider-connections/use-provider-connect-actions.ts
+++ b/app/src/hooks/provider-connections/use-provider-connect-actions.ts
@@ -1,6 +1,7 @@
 import { type Dispatch, type SetStateAction, useCallback } from "react";
 import { genericErrorDescription } from "../../lib/error-report";
 import { isNetworkTransportError } from "../../lib/network-transport-error";
+import { isOrgAdminRequiredError } from "../../lib/org-admin-required-error";
 import type { ProviderInfo } from "../../lib/providers";
 import { tauriProvider } from "../../lib/tauri";
 import type {
@@ -73,8 +74,10 @@ export function useProviderConnectActions({
         // A device-offline transport drop was already surfaced by the
         // engine-call layer as the one deduped connectivity toast (HOU-1085);
         // the authored red toast on top would double-surface an environment
-        // state (HOUSTON-APP-4PQ, PRODUCT-1383).
-        if (!isNetworkTransportError(err)) {
+        // state (HOUSTON-APP-4PQ, PRODUCT-1383). Same for the gateway's
+        // owner/admin refusal of a member's org-level connect: the engine-call
+        // layer already showed the "ask an admin" info toast.
+        if (!isNetworkTransportError(err) && !isOrgAdminRequiredError(err)) {
           addToast({
             title: t("toast.signInFailed", { provider: provider.name }),
             description: genericErrorDescription("provider_sign_in", err),

--- a/app/src/lib/org-admin-required-error.ts
+++ b/app/src/lib/org-admin-required-error.ts
@@ -1,0 +1,5 @@
+// The classifier itself lives in the engine adapter (see the note at the top
+// of that file: the adapter is bundled by the desktop app, which cannot resolve
+// `@houston/app/*`, so app code must never be imported from there). This
+// module keeps the app's import path and the node:test entry point stable.
+export { isOrgAdminRequiredError } from "../../../packages/web/src/engine-adapter/org-admin-required-error.ts";

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -57,6 +57,7 @@ import i18n from "./i18n";
 import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
 import { isNetworkTransportError } from "./network-transport-error";
+import { isOrgAdminRequiredError } from "./org-admin-required-error";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
 import { healStaleRosterFromError } from "./roster-heal";
@@ -244,6 +245,24 @@ async function surfaceError(
     showExpectedStateToast(
       i18n.t("teams:people.lastOwner.title"),
       i18n.t("teams:people.lastOwner.body"),
+    );
+    return;
+  }
+
+  // Expected business state, not a bug: a plain member tried the org-level
+  // (pre-agent, setup-runtime) provider connect, which the gateway reserves for
+  // owners and admins (403 "only an org owner or admin can connect…"). The
+  // member has no agent of their own to connect through, so tell them to ask
+  // an admin — never the red bug pair, and no Sentry (HOUSTON-APP-597 / -55X).
+  // Runs ahead of the `toast: false` gate on purpose: the OAuth launch callers
+  // that own their own failure toast skip it for this class, so this info
+  // toast is the one surface. The api-key dialog silences it instead and
+  // renders the same copy inline.
+  if (isOrgAdminRequiredError(err)) {
+    const { showExpectedStateToast } = await import("./error-toast");
+    showExpectedStateToast(
+      i18n.t("providers:toast.orgAdminRequiredTitle"),
+      i18n.t("providers:toast.orgAdminRequiredBody"),
     );
     return;
   }
@@ -1880,8 +1899,11 @@ export const tauriProvider = {
       // The connect dialog surfaces the failure inline with the engine's typed
       // reason (bad key / restricted key / provider outage) — a red bug toast
       // on top double-surfaces a user-fixable state. Capture stays on so
-      // verification failures keep reaching Sentry.
-      { toast: false },
+      // verification failures keep reaching Sentry. The gateway's owner/admin
+      // refusal of a member's org-level connect is an expected state the
+      // dialog explains inline too, so it is silenced here (no toast, no
+      // Sentry) rather than routed to the surfacing layer's info toast.
+      { toast: false, silence: isOrgAdminRequiredError },
     ),
   /**
    * Connect an OpenAI-compatible (local / BYO model) server: a base URL + model

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -23,7 +23,9 @@
     "signOutFailed": "Couldn't sign out of {{provider}}",
     "signInSucceeded": "Signed in to {{provider}}",
     "cancelFailed": "Couldn't cancel {{provider}} sign-in",
-    "catalogLoadFailed": "Couldn't load your available AI models. The list may be incomplete until this succeeds."
+    "catalogLoadFailed": "Couldn't load your available AI models. The list may be incomplete until this succeeds.",
+    "orgAdminRequiredTitle": "Ask an admin to connect this",
+    "orgAdminRequiredBody": "Only an owner or admin can connect AI for the organization. Ask one of them to set it up, or to add you to an agent so you can connect your own account."
   },
   "providerLogin": {
     "title": "Finish signing in to {{name}}",
@@ -95,7 +97,8 @@
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
     "errorNvidiaAccountGated": "Your key is valid, but NVIDIA isn't serving any chat models to your account right now. Make sure your key is a Personal Key from org.ngc.nvidia.com with \"Public API Endpoints\" under Services Included. If it still fails, ask NVIDIA support to enable model access for your account.",
     "errorBedrockInvalidKey": "Amazon Bedrock didn't accept this key. Make sure you pasted the key value (it starts with \"ABSK\"), not its name from the list (\"BedrockAPIKey-...\"). AWS shows the value only once, so generate a new key if you no longer have it.",
-    "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment."
+    "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment.",
+    "errorOrgAdminRequired": "Only an owner or admin can connect AI for the organization. Ask one of them to set it up, or to add you to an agent so you can connect your own key."
   },
   "copilot": {
     "title": "Connect GitHub Copilot",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -23,7 +23,9 @@
     "signOutFailed": "No se pudo cerrar sesión de {{provider}}",
     "signInSucceeded": "Sesión iniciada en {{provider}}",
     "cancelFailed": "No se pudo cancelar el inicio de sesión de {{provider}}",
-    "catalogLoadFailed": "No se pudieron cargar tus modelos de IA disponibles. La lista puede estar incompleta hasta que esto funcione."
+    "catalogLoadFailed": "No se pudieron cargar tus modelos de IA disponibles. La lista puede estar incompleta hasta que esto funcione.",
+    "orgAdminRequiredTitle": "Pide a un administrador que conecte esto",
+    "orgAdminRequiredBody": "Solo un propietario o administrador puede conectar la IA de la organización. Pídele a uno de ellos que la configure, o que te agregue a un agente para que conectes tu propia cuenta."
   },
   "providerLogin": {
     "title": "Termina de iniciar sesión en {{name}}",
@@ -95,7 +97,8 @@
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
     "errorNvidiaAccountGated": "Tu clave es válida, pero NVIDIA no está sirviendo modelos de chat a tu cuenta en este momento. Asegúrate de que tu clave sea una Personal Key de org.ngc.nvidia.com con \"Public API Endpoints\" en Services Included. Si aun así falla, pide al soporte de NVIDIA que habilite el acceso a modelos para tu cuenta.",
     "errorBedrockInvalidKey": "Amazon Bedrock no aceptó esta clave. Asegúrate de pegar el valor de la clave (empieza con \"ABSK\") y no su nombre de la lista (\"BedrockAPIKey-...\"). AWS muestra el valor una sola vez, así que genera una clave nueva si ya no lo tienes.",
-    "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento."
+    "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento.",
+    "errorOrgAdminRequired": "Solo un propietario o administrador puede conectar la IA de la organización. Pídele a uno de ellos que la configure, o que te agregue a un agente para que conectes tu propia clave."
   },
   "copilot": {
     "title": "Conectar GitHub Copilot",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -23,7 +23,9 @@
     "signOutFailed": "Não foi possível sair de {{provider}}",
     "signInSucceeded": "Conectado a {{provider}}",
     "cancelFailed": "Não foi possível cancelar o login de {{provider}}",
-    "catalogLoadFailed": "Não foi possível carregar seus modelos de IA disponíveis. A lista pode estar incompleta até isso funcionar."
+    "catalogLoadFailed": "Não foi possível carregar seus modelos de IA disponíveis. A lista pode estar incompleta até isso funcionar.",
+    "orgAdminRequiredTitle": "Peça a um administrador para conectar isso",
+    "orgAdminRequiredBody": "Só um proprietário ou administrador pode conectar a IA da organização. Peça a um deles para configurar, ou para adicionar você a um agente para conectar sua própria conta."
   },
   "providerLogin": {
     "title": "Termine de entrar em {{name}}",
@@ -95,7 +97,8 @@
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
     "errorNvidiaAccountGated": "Sua chave é válida, mas a NVIDIA não está servindo modelos de chat para a sua conta neste momento. Confira se sua chave é uma Personal Key de org.ngc.nvidia.com com \"Public API Endpoints\" em Services Included. Se ainda falhar, peça ao suporte da NVIDIA para habilitar o acesso aos modelos na sua conta.",
     "errorBedrockInvalidKey": "A Amazon Bedrock não aceitou esta chave. Confira se você colou o valor da chave (começa com \"ABSK\") e não o nome da lista (\"BedrockAPIKey-...\"). A AWS mostra o valor só uma vez, então gere uma chave nova se você não o tiver mais.",
-    "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes."
+    "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes.",
+    "errorOrgAdminRequired": "Só um proprietário ou administrador pode conectar a IA da organização. Peça a um deles para configurar, ou para adicionar você a um agente para conectar sua própria chave."
   },
   "copilot": {
     "title": "Conectar GitHub Copilot",

--- a/app/tests/error-report-connectivity.test.ts
+++ b/app/tests/error-report-connectivity.test.ts
@@ -117,8 +117,12 @@ describe("provider connect actions do not double-surface connectivity", () => {
       "the hook must import the connectivity classifier",
     );
     const toasts = source.split("addToast({").length - 1;
-    const guards =
-      source.split("if (!isNetworkTransportError(err))").length - 1;
+    // A guard may carry further expected-state classifiers after the
+    // connectivity one (`&& !isOrgAdminRequiredError(err)`), so match the
+    // connectivity check as the leading condition rather than the whole `if`.
+    const guards = (
+      source.match(/if \(\s*!isNetworkTransportError\(err\)/g) ?? []
+    ).length;
     ok(toasts > 0, "expected authored failure toasts in the hook");
     ok(
       guards === toasts,

--- a/app/tests/org-admin-required-error.test.ts
+++ b/app/tests/org-admin-required-error.test.ts
@@ -1,0 +1,106 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isOrgAdminRequiredError } from "../src/lib/org-admin-required-error.ts";
+
+// The surfacing-layer classifier that keeps the gateway's deliberate
+// owner/admin refusal of a plain member's org-level connect out of the red
+// bug-toast + Sentry pipeline. It must match exactly that (403, reason) pair on
+// every client error shape, and must NEVER match other 403s — a false positive
+// here silently drops a real bug report.
+
+const REASON =
+  "only an org owner or admin can connect the organization's AI subscription";
+
+/** The shape `HoustonEngineError` mints (structural stand-in). */
+function engineError(status: number, body: unknown): Error {
+  const reason = (body as { error?: unknown } | null)?.error;
+  const err = new Error(
+    typeof reason === "string"
+      ? `${reason} (engine error ${status})`
+      : `engine error ${status}`,
+  ) as Error & { status: number; body: unknown };
+  err.name = "HoustonEngineError";
+  err.status = status;
+  err.body = body;
+  return err;
+}
+
+/** The shape `@houston/runtime-client`'s `EngineError` mints. */
+function runtimeError(status: number, body: string): Error {
+  const err = new Error(
+    `engine request failed (${status}): ${body}`,
+  ) as Error & {
+    status: number;
+    body: string;
+  };
+  err.name = "EngineError";
+  err.status = status;
+  err.body = body;
+  return err;
+}
+
+/** The shape the SDK's `AgentsHttpError` mints (raw body as the message). */
+function agentsError(status: number, body: string): Error {
+  const err = new Error(body) as Error & { status: number };
+  err.name = "AgentsHttpError";
+  err.status = status;
+  return err;
+}
+
+describe("isOrgAdminRequiredError", () => {
+  it("matches the api-key connect shape (HoustonEngineError)", () => {
+    strictEqual(
+      isOrgAdminRequiredError(engineError(403, { error: REASON })),
+      true,
+    );
+  });
+
+  it("matches the OAuth launch shape (runtime-client EngineError)", () => {
+    strictEqual(
+      isOrgAdminRequiredError(
+        runtimeError(403, JSON.stringify({ error: REASON })),
+      ),
+      true,
+    );
+  });
+
+  it("matches the SDK write shape (AgentsHttpError)", () => {
+    strictEqual(
+      isOrgAdminRequiredError(
+        agentsError(403, JSON.stringify({ error: REASON })),
+      ),
+      true,
+    );
+  });
+
+  it("never matches other 403s", () => {
+    strictEqual(
+      isOrgAdminRequiredError(engineError(403, { error: "needs_upgrade" })),
+      false,
+    );
+    strictEqual(
+      isOrgAdminRequiredError(runtimeError(403, '{"error":"forbidden"}')),
+      false,
+    );
+    strictEqual(isOrgAdminRequiredError(runtimeError(403, "forbidden")), false);
+  });
+
+  it("never matches the reason on another status", () => {
+    strictEqual(
+      isOrgAdminRequiredError(engineError(500, { error: REASON })),
+      false,
+    );
+    strictEqual(
+      isOrgAdminRequiredError(
+        runtimeError(401, JSON.stringify({ error: REASON })),
+      ),
+      false,
+    );
+  });
+
+  it("ignores non-errors and plain errors", () => {
+    strictEqual(isOrgAdminRequiredError(null), false);
+    strictEqual(isOrgAdminRequiredError(REASON), false);
+    strictEqual(isOrgAdminRequiredError(new Error(REASON)), false);
+  });
+});

--- a/packages/web/src/engine-adapter/org-admin-required-error.ts
+++ b/packages/web/src/engine-adapter/org-admin-required-error.ts
@@ -1,0 +1,76 @@
+// The "is this the gateway refusing a plain member the org-level connect?"
+// classifier for the error-surfacing layer. Dependency-free so it is
+// node-testable directly (app/tests/org-admin-required-error.test.ts) and
+// importable from anywhere; it lives in the engine adapter for the same reason
+// `engine-waking-error.ts` does (the adapter is bundled by the desktop app,
+// which cannot resolve `@houston/app/*`). app/src/lib/org-admin-required-error.ts
+// re-exports it for the app's own call sites.
+//
+// Before any agent exists for the caller, every provider connect (OAuth
+// launch, api-key paste, credential capture) routes through the gateway's
+// hidden SETUP runtime, whose POSTs land the credential on the organization's
+// central store. The gateway deliberately reserves that for owners and admins
+// (`cloud/internal/edge/setupruntime/routes.go`): a plain `user` in a shared
+// org is answered `403 {"error": "only an org owner or admin can connect the
+// organization's AI subscription"}` before the pod is even touched. That is
+// an EXPECTED business state — nothing in Houston broke — so the surfacing
+// layer routes it to a plain informational toast, never the red bug pipeline
+// (HOUSTON-APP-597 / HOUSTON-APP-55X captured it as a bug per attempt).
+//
+// The gateway sends the sentence only (no `code`), so this matches on the
+// (403, reason prefix) pair across the client stacks that reach it — the same
+// three shapes `engine-waking-error.ts` documents:
+//  - `HoustonEngineError`: message is `"<reason> (engine error 403)"`.
+//  - `EngineError` (`@houston/runtime-client`, the setup-runtime client the
+//    OAuth launch uses): raw JSON body in `body`.
+//  - `AgentsHttpError`: raw JSON body as the message.
+
+const ORG_ADMIN_REQUIRED_403 = "only an org owner or admin can connect";
+
+function gatewayReason(body: string): string | null {
+  if (!body.startsWith("{")) return null;
+  try {
+    const reason = (JSON.parse(body) as { error?: unknown } | null)?.error;
+    return typeof reason === "string" ? reason : null;
+  } catch {
+    return null;
+  }
+}
+
+function bodyReason(body: unknown): string | null {
+  if (typeof body === "string") return gatewayReason(body);
+  const reason = (body as { error?: unknown } | null)?.error;
+  return typeof reason === "string" ? reason : null;
+}
+
+/**
+ * A gateway "only an owner or admin can connect the organization's AI" 403:
+ * a plain member tried the org-level (pre-agent) connect. Matched structurally
+ * (name + status + reason prefix) so this stays dependency-free.
+ */
+export function isOrgAdminRequiredError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if ((err as { status?: unknown }).status !== 403) return false;
+  if (err.name === "HoustonEngineError") {
+    return (
+      err.message.startsWith(ORG_ADMIN_REQUIRED_403) ||
+      (bodyReason((err as { body?: unknown }).body)?.startsWith(
+        ORG_ADMIN_REQUIRED_403,
+      ) ??
+        false)
+    );
+  }
+  if (err.name === "AgentsHttpError") {
+    return (
+      gatewayReason(err.message)?.startsWith(ORG_ADMIN_REQUIRED_403) ?? false
+    );
+  }
+  if (err.name === "EngineError") {
+    return (
+      bodyReason((err as { body?: unknown }).body)?.startsWith(
+        ORG_ADMIN_REQUIRED_403,
+      ) ?? false
+    );
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

A plain `user` member of a shared org who has no agent of their own routes every provider connect (OAuth launch, API-key paste) through the gateway's pre-agent setup-runtime path. The gateway deliberately reserves that connect for owners and admins and answers `403 {"error":"only an org owner or admin can connect the organization's AI subscription"}` before touching the pod. The client had no classifier for it, so:

- an OAuth launch fell into the red "Couldn't open sign-in" toast plus a Sentry capture per attempt (HOUSTON-APP-55X);
- the API-key dialog showed the raw gateway sentence and captured to Sentry (HOUSTON-APP-597).

Nothing is broken in that state, so it is now an expected business state:

- `isOrgAdminRequiredError` (engine adapter, dependency-free, re-exported at `app/src/lib/org-admin-required-error.ts`) matches the (403, reason) pair on all three client error shapes: `HoustonEngineError`, runtime-client `EngineError`, `AgentsHttpError`.
- `surfaceError` in `lib/tauri.ts` routes it to `showExpectedStateToast` with authored en/es/pt copy ("Ask an admin to connect this"), no Sentry. The provider connect-actions hook skips its own red toast for this class so the info toast is the one surface.
- `setApiKey` silences the class and the API-key dialog renders the same copy inline.

Not in this PR: hiding the connect action up front for non-admin members with no agent. The app has no cheap signal for "this connect will route pre-agent" today; the adapter decides that from its settled agent list.

Linear: PRODUCT-1663

## Before (reproduce the bug)

1. In a shared org, sign in as a member with role `user` who is not assigned to any agent.
2. Open the AI hub and click Connect on an OAuth provider (e.g. Claude), or on an API-key provider and paste any key.
3. Observe: red "Couldn't open sign-in" toast (OAuth) or the raw sentence "This key couldn't be connected: only an org owner or admin can connect..." (API key), and a new Sentry event under `launch_provider_login` / `set_provider_api_key`.

## After (verify the fix)

1. Same steps as above.
2. OAuth: a plain informational toast "Ask an admin to connect this" with the explanation; no red toast, no Sentry event. The frontend log still carries the `[engine:launch_provider_login]` line.
3. API key: the dialog shows the same explanation inline; no toast, no Sentry event.
4. Owners and admins connect exactly as before.

## Checks

- `pnpm check` (Biome) clean
- `cd app && pnpm tsgo --noEmit`, `pnpm check-locales`
- `pnpm --filter houston-web typecheck`
- `cd app && pnpm test`: 3918 pass, 0 fail (new `org-admin-required-error.test.ts` covers all three error shapes plus negative cases)