### PR TITLE
fix(app): silence not-allowed agent reads in the board sweep and event patches

### DIFF
--- a/app/src/components/agent/use-agent-shared-skills.ts
+++ b/app/src/components/agent/use-agent-shared-skills.ts
@@ -2,7 +2,10 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useStaleRosterHeal } from "../../hooks/use-stale-roster-heal";
-import { agentRosterSettled, isAgentGoneError } from "../../lib/agent-gone";
+import {
+  agentRosterSettled,
+  isStaleRosterReadError,
+} from "../../lib/agent-gone";
 import { analytics } from "../../lib/analytics";
 import { logger } from "../../lib/logger";
 import { queryKeys } from "../../lib/query-keys";
@@ -54,20 +57,21 @@ export function useAgentSharedSkills(agentPath: string): {
   // the roster having settled for the current space: a space switch wipes the
   // cache and would refire this query for the PREVIOUS space's agent under the
   // new org — a guaranteed `404 agent not found` (HOUSTON-APP-544). A genuine
-  // 404 (agent deleted/unshared elsewhere) is silenced — an expected stale-
-  // roster state, surfaced by the heal below — never a red bug toast.
+  // 404 (agent deleted elsewhere) or 403 (unassigned elsewhere) is silenced —
+  // an expected stale-roster state, surfaced by the heal below — never a red
+  // bug toast.
   const rosterSettled = useAgentStore(agentRosterSettled);
   const manifest = useQuery({
     queryKey: queryKeys.skillsManifest(agentPath),
     queryFn: () =>
-      tauriSkillsManifest.get(agentPath, { silence: isAgentGoneError }),
+      tauriSkillsManifest.get(agentPath, { silence: isStaleRosterReadError }),
     enabled: advertised && rosterSettled,
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnWindowFocus: false,
   });
-  // Inline surfacing for the silenced 404: reload the roster so the ghost
+  // Inline surfacing for the silenced 404/403: reload the roster so the ghost
   // agent (and this whole surface with it) disappears on its own.
-  useStaleRosterHeal(isAgentGoneError(manifest.error));
+  useStaleRosterHeal(isStaleRosterReadError(manifest.error));
 
   // The gateway advertises `capabilities.sharedSkills` unconditionally, even
   // where no skill store is actually bound — so the store's own answer is the

--- a/app/src/components/skills-view/use-shared-skills.ts
+++ b/app/src/components/skills-view/use-shared-skills.ts
@@ -1,7 +1,10 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useStaleRosterHeal } from "../../hooks/use-stale-roster-heal";
-import { agentRosterSettled, isAgentGoneError } from "../../lib/agent-gone";
+import {
+  agentRosterSettled,
+  isStaleRosterReadError,
+} from "../../lib/agent-gone";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriSharedSkills, tauriSkillsManifest } from "../../lib/tauri";
 import type { Agent, SkillSummary } from "../../lib/types";
@@ -39,7 +42,7 @@ export function useSharedSkills(args: {
   });
 
   // Gated on the roster having settled for the current space, and with the
-  // agent-gone 404 silenced — same contract as the per-agent hook
+  // agent-gone 404 / not-readable 403 silenced — same contract as the per-agent hook
   // (`use-agent-shared-skills`): a space switch or a stale roster must not
   // turn this fan-out into a storm of red "agent not found" toasts
   // (HOUSTON-APP-544). A gone agent's row simply carries no manifest, and the
@@ -52,7 +55,7 @@ export function useSharedSkills(args: {
             queryKey: queryKeys.skillsManifest(agent.folderPath),
             queryFn: () =>
               tauriSkillsManifest.get(agent.folderPath, {
-                silence: isAgentGoneError,
+                silence: isStaleRosterReadError,
               }),
             staleTime: Number.POSITIVE_INFINITY,
             refetchOnWindowFocus: false,
@@ -61,7 +64,7 @@ export function useSharedSkills(args: {
     combine: (results) => ({
       manifests: results.map((r) => r.data?.enabled),
       manifestsLoading: results.some((r) => r.isLoading),
-      agentGone: results.some((r) => isAgentGoneError(r.error)),
+      agentGone: results.some((r) => isStaleRosterReadError(r.error)),
     }),
   });
   useStaleRosterHeal(agentGone);

--- a/app/src/hooks/queries/all-conversations-sweep.ts
+++ b/app/src/hooks/queries/all-conversations-sweep.ts
@@ -10,7 +10,7 @@
 
 import type { FailedAgentRead } from "@houston-ai/engine-client";
 import type { QueryClient } from "@tanstack/react-query";
-import { isAgentGoneError } from "../../lib/agent-gone";
+import { isStaleRosterReadError } from "../../lib/agent-gone";
 import {
   NO_SWEEP_RECOVERY,
   type PartialSweepSurface,
@@ -168,13 +168,14 @@ export async function sweepWithRetry(agentPaths: string[]) {
       const next = planSweepAttempt(attempt, isTransientEngineError(err));
       if (next.surface) {
         // Same silence as the engine layer's (`tauriConversations.listAll`):
-        // a sweep where EVERY agent answered "agent not found" is a stale
-        // roster mid-heal, not a bug — logged, no toast, no report.
+        // a sweep where EVERY agent answered "agent not found" or "not
+        // allowed" is a stale roster mid-heal, not a bug — logged, no toast,
+        // no report.
         await surfaceEngineError(
           "list_all_conversations",
           err,
           { agentCount: agentPaths.length, attempts: attempt + 1 },
-          { silence: isAgentGoneError },
+          { silence: isStaleRosterReadError },
         );
         throw err;
       }

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -75,8 +75,14 @@ export function useAgentInvalidation() {
       // QueryClient + stores. See `agent-invalidation-plan.ts` for the rules
       // (e.g. why ActivityChanged also invalidates the per-agent conversations
       // query the board's face stack is derived from).
+      const roster = useAgentStore.getState().agents;
       const plan = planInvalidation(p, {
         workspaceId: useWorkspaceStore.getState().current?.id,
+        // The aggregate is patched only for agents in THIS viewer's roster:
+        // the hosted stream names every awake agent in the space, and a read
+        // of one the viewer is not assigned to is a 403 every time.
+        isKnownAgent: (agentPath) =>
+          roster.some((a) => a.folderPath === agentPath),
         // Consumed (one-shot) ONLY for the event type it gates, so an
         // unrelated event can never burn a pending OAuth's return marker.
         customOAuthReturn:

--- a/app/src/lib/agent-gone.ts
+++ b/app/src/lib/agent-gone.ts
@@ -30,6 +30,34 @@ export function isAgentGoneError(err: unknown): boolean {
   return (err as { status?: unknown }).status === 404;
 }
 
+/**
+ * An agent-scoped READ answered "this viewer may not use this agent"
+ * (HOUSTON-APP-540 / 5AV / 5AT / 55C). The hosted gateway's proxy gate answers
+ * `403 { error: "not allowed", code: "not_assigned" }` for every agent-scoped
+ * route the caller is not assigned to, and a passive read reaches one in two
+ * expected ways: the roster is stale (unassigned on another device, and the
+ * `AgentsChanged` reload has not landed yet), or the event stream named an
+ * agent outside the viewer's roster (the fan-in is org-wide, not per
+ * assignee). Neither is a Houston bug — the honest surface is the roster
+ * without the agent — so a 403 on a passive read is silenced and heals the
+ * roster exactly like {@link isAgentGoneError}. Same structural `.status`
+ * key: the gateway's 403 body carries its code at the top level, which the
+ * engine-client's `.code` getter (`body.error.code`) never sees.
+ */
+export function isAgentUnreadableError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as { status?: unknown }).status === 403;
+}
+
+/**
+ * The passive-read silence + heal classifier: the agent is gone (404) or not
+ * readable by this viewer (403). Both mean the LOCAL ROSTER is not the
+ * server's — nothing to re-sweep, nothing to report, only a roster to reload.
+ */
+export function isStaleRosterReadError(err: unknown): boolean {
+  return isAgentGoneError(err) || isAgentUnreadableError(err);
+}
+
 /** The agent-store signals the query gate reads. */
 export interface AgentRosterSignals {
   /** True once `loadAgents` has settled at least once (even on failure). */
@@ -86,12 +114,13 @@ export function makeRosterHealer(
 
 /**
  * The engine-call-layer trigger: classify a failed passive read and, when the
- * agent is gone, fire the roster heal for the current workspace — the same
+ * roster is stale about the agent (gone, or not readable by this viewer),
+ * fire the roster heal for the current workspace — the same
  * classify→heal contract `useStaleRosterHeal` gives the query surfaces, for
  * reads whose surfaces don't observe the error (HOUSTON-APP-4W3 family).
  * Factory form so the wiring is unit-testable: `heal` is the ONE shared
  * healer (`lib/roster-heal.ts`) and `currentWorkspaceId` reads the workspace
- * store. Anything but an agent-gone error is a no-op — surfacing stays with
+ * store. Anything but a stale-roster error is a no-op — surfacing stays with
  * the caller.
  */
 export function makeAgentGoneHealTrigger(
@@ -99,26 +128,29 @@ export function makeAgentGoneHealTrigger(
   currentWorkspaceId: () => string | null,
 ): (err: unknown) => void {
   return (err) => {
-    if (!isAgentGoneError(err)) return;
+    if (!isStaleRosterReadError(err)) return;
     void heal(currentWorkspaceId(), true);
   };
 }
 
 /**
- * Split a cross-agent sweep's failed reads into the agents the server no
- * longer knows (roster stale — see {@link isAgentGoneError}) and the real
- * failures. A gone agent's read is not "missions unread": there is nothing to
- * re-sweep or report, only a roster to heal, so the sweep's recovery layer
+ * Split a cross-agent sweep's failed reads into the agents the local roster
+ * is wrong about (gone, or not readable by this viewer — see
+ * {@link isStaleRosterReadError}) and the real failures. A stale-roster read
+ * is not "missions unread": there is nothing to re-sweep or report, only a
+ * roster to heal, so the sweep's recovery layer
  * (`hooks/queries/all-conversations-sweep.ts`) must never see it as a partial
  * failure — that made every stale roster a red toast, a Sentry report, and
- * three doomed re-sweeps (HOUSTON-APP-4WR / 58R / 55E).
+ * three doomed re-sweeps (HOUSTON-APP-4WR / 58R / 55E), and every unassigned
+ * agent a deterministic 403 on every sweep, escalating to
+ * `list_all_conversations_stuck` (HOUSTON-APP-5AV / 5AT).
  */
-export function partitionAgentGoneReads<T extends { reason: unknown }>(
+export function partitionStaleRosterReads<T extends { reason: unknown }>(
   failed: readonly T[],
-): { gone: T[]; failed: T[] } {
-  const gone: T[] = [];
+): { stale: T[]; failed: T[] } {
+  const stale: T[] = [];
   const rest: T[] = [];
   for (const read of failed)
-    (isAgentGoneError(read.reason) ? gone : rest).push(read);
-  return { gone, failed: rest };
+    (isStaleRosterReadError(read.reason) ? stale : rest).push(read);
+  return { stale, failed: rest };
 }

--- a/app/src/lib/agent-invalidation-plan.ts
+++ b/app/src/lib/agent-invalidation-plan.ts
@@ -34,6 +34,17 @@ export interface InvalidationContext {
    * which must never pull the window to the front.
    */
   customOAuthReturn?: boolean;
+  /**
+   * Whether an agent path is in the viewer's CURRENT roster. The hosted
+   * event stream is org-wide (the gateway fans in every awake pod in the
+   * space, not just the viewer's assigned agents), so an agent-scoped event
+   * can name an agent this viewer is not allowed to read — and the aggregate
+   * patch it would trigger is a deterministic `403 not allowed` on every
+   * event that agent emits (HOUSTON-APP-540). An agent outside the roster
+   * has no slice in the aggregate to patch, so the read is skipped, not
+   * attempted. Absent means "every agent is known" (single-user hosts).
+   */
+  isKnownAgent?: (agentPath: string) => boolean;
 }
 
 const empty = (): InvalidationPlan => ({
@@ -188,5 +199,9 @@ export function planInvalidation(
       break;
   }
 
+  if (ctx.isKnownAgent) {
+    const known = ctx.isKnownAgent;
+    plan.patchAllConversations = plan.patchAllConversations.filter(known);
+  }
   return plan;
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -29,7 +29,11 @@ import type {
 } from "@houston-ai/engine-client";
 import { shouldUseClaudeDesktopLogin } from "../components/shell/provider-login-url";
 import { actingUser } from "./acting-user";
-import { isAgentGoneError, partitionAgentGoneReads } from "./agent-gone";
+import {
+  isAgentGoneError,
+  isStaleRosterReadError,
+  partitionStaleRosterReads,
+} from "./agent-gone";
 import { isAgentNameConflictError } from "./agent-name-conflict";
 import {
   blockWriteWhileWarming,
@@ -144,12 +148,12 @@ async function call<T>(
  * writes never route through here.
  */
 function passiveAgentRead<T>(label: string, fn: () => Promise<T>): Promise<T> {
-  return call<T>(label, fn, undefined, { silence: isAgentGoneError }).catch(
-    (err) => {
-      healStaleRosterFromError(err);
-      throw err;
-    },
-  );
+  return call<T>(label, fn, undefined, {
+    silence: isStaleRosterReadError,
+  }).catch((err) => {
+    healStaleRosterFromError(err);
+    throw err;
+  });
 }
 
 /**
@@ -1250,26 +1254,28 @@ export const tauriConversations = {
     //
     // A PASSIVE read like every other roster-driven one (`passiveAgentRead`):
     // an agent the server no longer knows (`404 agent not found` — the local
-    // roster is stale after a space switch or a delete on another device) is
-    // not a failed read of OUR agent. Its 404 is silenced and the roster
-    // heals; in a partial sweep the gone agents leave `failedAgents` (nothing
-    // to re-sweep, nothing to report — HOUSTON-APP-4WR / 58R / 55E), and a
-    // sweep where EVERY agent is gone rejects quietly (the caller's surface
-    // silences it too) so the cache keeps the last real rows for the roster
-    // reload that follows. Every real failure keeps its loud path.
+    // roster is stale after a space switch or a delete on another device) or
+    // one this viewer may not read (`403 not allowed` — unassigned on another
+    // device, HOUSTON-APP-5AV / 5AT) is not a failed read of OUR agent. The
+    // error is silenced and the roster heals; in a partial sweep the stale
+    // agents leave `failedAgents` (nothing to re-sweep, nothing to report —
+    // HOUSTON-APP-4WR / 58R / 55E), and a sweep where EVERY agent is stale
+    // rejects quietly (the caller's surface silences it too) so the cache
+    // keeps the last real rows for the roster reload that follows. Every
+    // real failure keeps its loud path.
     return call<AllConversationsSweep>(
       "list_all_conversations",
       async () => {
         const { conversations, failedAgents } =
           await getEngine().listAllConversations(reachable);
-        const { gone, failed } = partitionAgentGoneReads(failedAgents);
-        if (gone.length > 0) {
+        const { stale, failed } = partitionStaleRosterReads(failedAgents);
+        if (stale.length > 0) {
           logger.warn(
-            `[engine:list_all_conversations] ${gone.length} agent(s) gone from the roster: ${gone
-              .map((g) => g.agentPath)
+            `[engine:list_all_conversations] ${stale.length} agent(s) gone from the roster or not readable by this viewer: ${stale
+              .map((g) => `${g.agentPath} (${String(g.reason)})`)
               .join(", ")}`,
           );
-          healStaleRosterFromError(gone[0].reason);
+          healStaleRosterFromError(stale[0].reason);
         }
         return {
           items: conversations.map(conversationToRaw),
@@ -1277,7 +1283,7 @@ export const tauriConversations = {
         };
       },
       undefined,
-      { silence: isAgentGoneError, ...options },
+      { silence: isStaleRosterReadError, ...options },
     ).catch((err) => {
       healStaleRosterFromError(err);
       throw err;

--- a/app/tests/agent-gone.test.ts
+++ b/app/tests/agent-gone.test.ts
@@ -3,9 +3,11 @@ import { describe, it } from "node:test";
 import {
   agentRosterSettled,
   isAgentGoneError,
+  isAgentUnreadableError,
+  isStaleRosterReadError,
   makeAgentGoneHealTrigger,
   makeRosterHealer,
-  partitionAgentGoneReads,
+  partitionStaleRosterReads,
 } from "../src/lib/agent-gone.ts";
 
 describe("isAgentGoneError", () => {
@@ -36,6 +38,36 @@ describe("isAgentGoneError", () => {
     assert.equal(isAgentGoneError("agent not found"), false);
     assert.equal(isAgentGoneError(new Error("boom")), false);
     assert.equal(isAgentGoneError({ status: "404" }), false);
+  });
+});
+
+describe("isAgentUnreadableError", () => {
+  it("matches the gateway proxy's not-assigned 403", () => {
+    // Structural shape of HoustonEngineError(403, {error, code}) — the
+    // gateway's `code` sits at the top level of the body, not under `error`.
+    const err = Object.assign(new Error("not allowed (engine error 403)"), {
+      status: 403,
+      body: { error: "not allowed", code: "not_assigned" },
+    });
+    assert.equal(isAgentUnreadableError(err), true);
+    assert.equal(isStaleRosterReadError(err), true);
+  });
+
+  it("never matches the agent-gone 404 or any loud status", () => {
+    assert.equal(isAgentUnreadableError({ status: 404 }), false);
+    assert.equal(isAgentUnreadableError({ status: 401 }), false);
+    assert.equal(isAgentUnreadableError({ status: 500 }), false);
+    assert.equal(isAgentUnreadableError({ status: 503 }), false);
+    assert.equal(isAgentUnreadableError(new Error("boom")), false);
+    assert.equal(isAgentUnreadableError(undefined), false);
+  });
+
+  it("isStaleRosterReadError is exactly gone-or-unreadable", () => {
+    assert.equal(isStaleRosterReadError({ status: 404 }), true);
+    assert.equal(isStaleRosterReadError({ status: 403 }), true);
+    assert.equal(isStaleRosterReadError({ status: 401 }), false);
+    assert.equal(isStaleRosterReadError({ status: 502 }), false);
+    assert.equal(isStaleRosterReadError(null), false);
   });
 });
 
@@ -138,6 +170,23 @@ describe("makeAgentGoneHealTrigger", () => {
     assert.deepEqual(calls, [["ws-1", true]]);
   });
 
+  it("fires the heal on a not-readable 403 too — the roster is stale", () => {
+    const calls: Array<[string | null, boolean]> = [];
+    const trigger = makeAgentGoneHealTrigger(
+      async (ws, stale) => {
+        calls.push([ws, stale]);
+        return true;
+      },
+      () => "ws-1",
+    );
+    trigger(
+      Object.assign(new Error("not allowed (engine error 403)"), {
+        status: 403,
+      }),
+    );
+    assert.deepEqual(calls, [["ws-1", true]]);
+  });
+
   it("ignores every other failure — surfacing stays with the caller", () => {
     let calls = 0;
     const trigger = makeAgentGoneHealTrigger(
@@ -167,11 +216,18 @@ describe("makeAgentGoneHealTrigger", () => {
   });
 });
 
-describe("partitionAgentGoneReads", () => {
+describe("partitionStaleRosterReads", () => {
   const gone = (agentPath: string) => ({
     agentPath,
     reason: Object.assign(new Error("agent not found (engine error 404)"), {
       status: 404,
+    }),
+  });
+  const unreadable = (agentPath: string) => ({
+    agentPath,
+    reason: Object.assign(new Error("not allowed (engine error 403)"), {
+      status: 403,
+      body: { error: "not allowed", code: "not_assigned" },
     }),
   });
   const waking = (agentPath: string) => ({
@@ -182,8 +238,37 @@ describe("partitionAgentGoneReads", () => {
   });
 
   it("splits a stale roster's 404s from the real failures", () => {
-    const { gone: g, failed } = partitionAgentGoneReads([
+    const { stale: g, failed } = partitionStaleRosterReads([
       gone("a"),
+      waking("b"),
+      gone("c"),
+    ]);
+    assert.deepEqual(
+      g.map((r) => r.agentPath),
+      ["a", "c"],
+    );
+    assert.deepEqual(
+      failed.map((r) => r.agentPath),
+      ["b"],
+    );
+  });
+
+  it("keeps an unassigned agent's 403 out of the partial-sweep surface", () => {
+    // HOUSTON-APP-5AV / 5AT: one agent the viewer may not read, among 200
+    // siblings that answered. The sweep's failed list holds only the 403 —
+    // it is stale-roster, so `failed` is empty and the recovery layer sees a
+    // COMPLETE sweep: no toast, no Sentry report, no re-sweep escalation.
+    const { stale: g, failed } = partitionStaleRosterReads([unreadable("z")]);
+    assert.deepEqual(
+      g.map((r) => r.agentPath),
+      ["z"],
+    );
+    assert.deepEqual(failed, []);
+  });
+
+  it("a mixed sweep still reports the real failure beside the 403", () => {
+    const { stale: g, failed } = partitionStaleRosterReads([
+      unreadable("a"),
       waking("b"),
       gone("c"),
     ]);
@@ -199,7 +284,7 @@ describe("partitionAgentGoneReads", () => {
 
   it("leaves a sweep with no gone agents untouched", () => {
     const reads = [waking("a"), waking("b")];
-    const { gone: g, failed } = partitionAgentGoneReads(reads);
+    const { stale: g, failed } = partitionStaleRosterReads(reads);
     assert.deepEqual(g, []);
     assert.deepEqual(failed, reads);
   });
@@ -207,12 +292,15 @@ describe("partitionAgentGoneReads", () => {
   it("classifies an all-gone sweep as nothing to re-sweep", () => {
     // The space-switch shape (HOUSTON-APP-4WR): every agent of the previous
     // space's roster answers 404 under the new org.
-    const { gone: g, failed } = partitionAgentGoneReads([gone("a"), gone("b")]);
+    const { stale: g, failed } = partitionStaleRosterReads([
+      gone("a"),
+      gone("b"),
+    ]);
     assert.equal(g.length, 2);
     assert.deepEqual(failed, []);
   });
 
   it("is empty-safe", () => {
-    assert.deepEqual(partitionAgentGoneReads([]), { gone: [], failed: [] });
+    assert.deepEqual(partitionStaleRosterReads([]), { stale: [], failed: [] });
   });
 });

--- a/app/tests/agent-invalidation-plan.test.ts
+++ b/app/tests/agent-invalidation-plan.test.ts
@@ -213,3 +213,55 @@ describe("planInvalidation — EventStreamReconnected catches the aggregate up",
     strictEqual(plan.focusWindow, undefined);
   });
 });
+
+/**
+ * The hosted event stream is org-wide: the gateway fans in every awake pod
+ * in the space, not just the viewer's assigned agents. An event naming an
+ * agent outside the viewer's roster must not trigger the aggregate patch —
+ * that read is a deterministic `403 not allowed` on every event the agent
+ * emits (HOUSTON-APP-540).
+ */
+describe("planInvalidation — events for agents outside the roster", () => {
+  const OTHER = "Houston/SomeoneElsesAgent";
+  const isKnownAgent = (path: string) => path === PATH;
+
+  it("skips the aggregate patch for an unknown agent", () => {
+    const plan = planInvalidation(
+      { type: "ActivityChanged", data: { agent_path: OTHER } },
+      { isKnownAgent },
+    );
+    deepStrictEqual(plan.patchAllConversations, []);
+  });
+
+  it("still patches a known agent", () => {
+    const plan = planInvalidation(
+      { type: "ConversationsChanged", data: { agent_path: PATH } },
+      { isKnownAgent },
+    );
+    deepStrictEqual(plan.patchAllConversations, [PATH]);
+  });
+
+  it("SessionStatus (completed) for an unknown agent patches nothing", () => {
+    const plan = planInvalidation(
+      {
+        type: "SessionStatus",
+        data: {
+          agent_path: OTHER,
+          session_key: "s",
+          status: "completed",
+          error: null,
+        },
+      },
+      { isKnownAgent },
+    );
+    deepStrictEqual(plan.patchAllConversations, []);
+  });
+
+  it("without a roster predicate every agent is known", () => {
+    const plan = planInvalidation(
+      { type: "ActivityChanged", data: { agent_path: OTHER } },
+      {},
+    );
+    deepStrictEqual(plan.patchAllConversations, [OTHER]);
+  });
+});


### PR DESCRIPTION
## Linear

PRODUCT-1661 — Web: board sweep reports "not allowed (403)" for an agent the viewer cannot read, on every refresh. Sentry HOUSTON-APP-540 (plus the sweep variants 5AV / 5AT and the manifest variant 55C).

## Root cause

Two client paths read an agent the viewer is not assigned to, and the gateway proxy refuses each read with `403 { error: "not allowed", code: "not_assigned" }`:

1. **Event-driven patch (the 10 HOUSTON-APP-540 events).** The hosted event stream fans in every awake pod in the space, not only the viewer's assigned agents. Each `ActivityChanged` / `ConversationsChanged` / `SessionStatus` event for such an agent made the app patch that agent's slice of the cross-agent aggregate via `list_conversations`, which 403s. The breadcrumbs show exactly this: `[invalidation] event: ActivityChanged <agent>` immediately followed by `GET /agents/<agent>/activities → 403`. The passive-read layer only silenced the agent-gone 404, so every event that agent emitted became a red toast plus a Sentry report.
2. **The sweep (5AV / 5AT).** An agent unassigned on another device stays in the local roster until the `AgentsChanged` reload lands. Its 403 counted as a real partial-sweep failure: toast, three doomed re-sweeps, then escalation to `list_all_conversations_stuck`.

## Fix

- `app/src/lib/agent-gone.ts`: `isAgentUnreadableError` (403) joins `isAgentGoneError` (404) under `isStaleRosterReadError`. It is now the silence + heal classifier for `passiveAgentRead`, the sweep's `listAll` (partition renamed to `partitionStaleRosterReads`), `sweepWithRetry`, and the two shared-skills manifest hooks. A 403 read is logged, never toasted or reported, and triggers the existing deduped silent roster reload.
- `app/src/lib/agent-invalidation-plan.ts`: `InvalidationContext.isKnownAgent` filters `patchAllConversations` to agents in the viewer's current roster; `use-agent-invalidation.ts` passes the agent store's roster. An event naming an agent outside the roster no longer triggers the read at all. Query invalidations for that agent are unchanged (no-ops against an empty cache).

Gateway follow-up (separate repo, not in this PR): the pod-event fan-in could filter by the viewer's assigned slugs so members never receive events for agents they cannot read.

## Tests

- `app/tests/agent-gone.test.ts`: the 403 classifier, the heal trigger firing on 403, and the sweep partition keeping a not-assigned agent out of the partial-sweep surface while a real failure beside it still reports.
- `app/tests/agent-invalidation-plan.test.ts`: events for an agent outside the roster produce no aggregate patch; known agents still patch; without a roster predicate behavior is unchanged.

`pnpm check` exits 0, `cd app && pnpm tsgo --noEmit` clean, `cd app && pnpm test` 3922 passing.

## Before (reproduce)

1. In a team space, as a plain member assigned to agent A, sign in to `app.gethouston.ai` (or `pnpm dev` with the cloud profile) and open Mission Control.
2. Have an owner run a task on agent B, which the member is not assigned to.
3. The member's console logs `[invalidation] event: ActivityChanged <B>` followed by `GET /agents/<B>/activities → 403`, a red error toast appears, and Sentry receives `list_conversations: not allowed (engine error 403)` on every event B emits.
4. Variant: while the member's app is open, have the owner unassign the member from agent A. The next sweep toasts "missions unread", re-sweeps three times, and files `list_all_conversations_stuck`.

## After (verify)

1. Repeat step 2. The member's console shows the event, no `/agents/<B>/activities` request is made, no toast appears, no Sentry event is filed.
2. Repeat step 4. The console logs `[engine:list_all_conversations] 1 agent(s) gone from the roster or not readable by this viewer: <A> (…403)`, no toast, no report, and agent A drops from the rail after the silent roster reload.
3. Real failures stay loud: a 5xx from an assigned agent's pod still surfaces through the existing partial-sweep path.
