### PR TITLE
fix(providers): sign out and connect a local model in a space with no agents (PRODUCT-1662)

### DIFF
--- a/app/src/lib/no-agent-provider-write-error.ts
+++ b/app/src/lib/no-agent-provider-write-error.ts
@@ -1,0 +1,4 @@
+// The classifier lives in the engine adapter (the adapter is bundled by the
+// desktop app, which cannot resolve `@houston/app/*`, so app code must never be
+// imported from there). This module keeps the app's import path stable.
+export { isNoAgentForProviderWriteError } from "../../../packages/web/src/engine-adapter/no-agent-provider-write-error.ts";

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -57,6 +57,7 @@ import i18n from "./i18n";
 import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
 import { isNetworkTransportError } from "./network-transport-error";
+import { isNoAgentForProviderWriteError } from "./no-agent-provider-write-error";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
 import { healStaleRosterFromError } from "./roster-heal";
@@ -244,6 +245,19 @@ async function surfaceError(
     showExpectedStateToast(
       i18n.t("teams:people.lastOwner.title"),
       i18n.t("teams:people.lastOwner.body"),
+    );
+    return;
+  }
+
+  // Expected business state, not a bug: a provider write that only an agent's
+  // runtime can hold (a local model endpoint) in a space with no agent yet
+  // (PRODUCT-1662). The remedy is the user's: create an agent, then connect.
+  // Plain guidance, never the red bug pair.
+  if (isNoAgentForProviderWriteError(err)) {
+    const { showExpectedStateToast } = await import("./error-toast");
+    showExpectedStateToast(
+      i18n.t("shell:errorToast.noAgentTitle"),
+      i18n.t("shell:errorToast.noAgentDescription"),
     );
     return;
   }

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -424,7 +424,9 @@
     "engineWakingTitle": "Houston, your agent is waking up",
     "engineWakingDescription": "It will be ready in a moment. Try again shortly.",
     "updateStuckTitle": "Houston, updates can't reach you",
-    "updateStuckDescription": "We haven't been able to check for updates. Your network may be blocking them. You can always get the latest version at gethouston.ai."
+    "updateStuckDescription": "We haven't been able to check for updates. Your network may be blocking them. You can always get the latest version at gethouston.ai.",
+    "noAgentTitle": "Houston, you need an agent first",
+    "noAgentDescription": "Create an agent, then connect from its settings. This connection lives on an agent."
   },
   "agentDelete": {
     "title": "Delete agent?",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -424,7 +424,9 @@
     "engineWakingTitle": "Houston, tu agente se está despertando",
     "engineWakingDescription": "Estará listo en un momento. Inténtalo de nuevo en breve.",
     "updateStuckTitle": "Houston, las actualizaciones no te llegan",
-    "updateStuckDescription": "No hemos podido buscar actualizaciones. Puede que tu red las esté bloqueando. Siempre puedes descargar la última versión en gethouston.ai."
+    "updateStuckDescription": "No hemos podido buscar actualizaciones. Puede que tu red las esté bloqueando. Siempre puedes descargar la última versión en gethouston.ai.",
+    "noAgentTitle": "Houston, primero necesitas un agente",
+    "noAgentDescription": "Crea un agente y luego conéctalo desde su configuración. Esta conexión vive en un agente."
   },
   "agentDelete": {
     "title": "¿Eliminar el agente?",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -424,7 +424,9 @@
     "engineWakingTitle": "Houston, seu agente está acordando",
     "engineWakingDescription": "Ele estará pronto em um momento. Tente novamente em breve.",
     "updateStuckTitle": "Houston, as atualizações não estão chegando",
-    "updateStuckDescription": "Não conseguimos verificar atualizações. Sua rede pode estar bloqueando. Você sempre pode baixar a versão mais recente em gethouston.ai."
+    "updateStuckDescription": "Não conseguimos verificar atualizações. Sua rede pode estar bloqueando. Você sempre pode baixar a versão mais recente em gethouston.ai.",
+    "noAgentTitle": "Houston, você precisa de um agente primeiro",
+    "noAgentDescription": "Crie um agente e depois conecte pelas configurações dele. Esta conexão fica em um agente."
   },
   "agentDelete": {
     "title": "Excluir o agente?",

--- a/packages/host/src/routes/setup-runtime-credentials.ts
+++ b/packages/host/src/routes/setup-runtime-credentials.ts
@@ -1,0 +1,139 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { parseClaudeOAuthEnvelope } from "@houston/protocol";
+import { RevokedRefillBlockedError } from "../credentials/revocation-tombstones";
+import {
+  ApiKeyRejectedError,
+  type ChannelCtx,
+  type RuntimeChannel,
+} from "../ports";
+import { json, readJson } from "./http";
+
+/**
+ * The setup runtime's CREDENTIAL routes — the agentless mirrors of the
+ * per-agent `/agents/:id/credential/*` family (see `setup-runtime.ts` for why
+ * a hidden runtime exists at all). Each lands on the caller's PERSONAL
+ * workspace through the synthetic setup agent, so a credential connected or
+ * forgotten here is the one every real agent runtime is served from.
+ *
+ * Handled host-side ahead of the runtime allowlist: none of these reach the
+ * runtime's own routes, and the per-agent handlers they mirror have the same
+ * body validation + error mapping.
+ *
+ * Returns true when the request was handled.
+ */
+export async function handleSetupCredential(
+  channel: RuntimeChannel,
+  ctx: ChannelCtx,
+  method: string,
+  rest: string,
+  url: URL,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  if (method !== "POST") return false;
+
+  // Connect-once capture: store the setup runtime's fresh credential for the
+  // WHOLE personal workspace and scrub its refresh token — identical to the
+  // per-agent `/agents/:id/credential/capture`, minus the agent.
+  if (rest === "credential/capture") {
+    const body = (await readJson(req).catch(() => ({}))) as {
+      provider?: unknown;
+    };
+    const provider =
+      typeof body.provider === "string" ? body.provider : undefined;
+    const result = await channel.captureCredential(ctx, provider);
+    if (result.ok) json(res, 200, { ok: true, provider: result.provider });
+    else
+      json(res, result.status, {
+        error: result.error,
+        ...(result.detail ? { detail: result.detail } : {}),
+      });
+    return true;
+  }
+
+  // Connect-once logout, agentless: a space with NO agent (first-run before
+  // the assistant exists, a failed first create, a deleted last agent) still
+  // holds the central credential the user connected through this runtime, and
+  // this is the only runtime that can forget it (PRODUCT-1662). Mirrors the
+  // per-agent `/agents/:id/credential/forget`; the client clears the setup
+  // runtime's own auth copy through `auth/:provider/logout` alongside.
+  if (rest === "credential/forget") {
+    const { provider } = await readJson(req);
+    if (!provider || typeof provider !== "string") {
+      json(res, 400, { error: "missing 'provider'" });
+      return true;
+    }
+    await channel.forgetCredential(ctx, provider);
+    json(res, 200, { ok: true });
+    return true;
+  }
+
+  // API-key provider connect (no OAuth dance): store centrally + push into the
+  // setup runtime so `auth/status` reads connected immediately.
+  if (rest === "credential/api-key") {
+    const { provider, apiKey, endpoint } = await readJson(req);
+    if (!provider || typeof provider !== "string") {
+      json(res, 400, { error: "missing 'provider'" });
+      return true;
+    }
+    if (!apiKey || typeof apiKey !== "string") {
+      json(res, 400, { error: "missing 'apiKey'" });
+      return true;
+    }
+    try {
+      await channel.saveApiKeyCredential(
+        ctx,
+        provider,
+        apiKey,
+        typeof endpoint === "string" && endpoint.trim()
+          ? endpoint.trim()
+          : undefined,
+      );
+      json(res, 200, { ok: true });
+    } catch (err) {
+      // Mirror the per-agent route: the runtime's typed verification reason
+      // rides the body so the connect dialog can show actionable copy.
+      json(res, 502, {
+        error: err instanceof Error ? err.message : String(err),
+        ...(err instanceof ApiKeyRejectedError && err.reason
+          ? { reason: err.reason }
+          : {}),
+      });
+    }
+    return true;
+  }
+
+  // Claude-subscription connect pre-agent: the desktop's browser login mints
+  // the OAuth credential locally, and with NO agent selected yet (first-run
+  // onboarding, the cloud-migration wizard) it lands here — the setup
+  // runtime's workspace-central store serves every agent created or migrated
+  // after. Mirrors the per-agent `/agents/:id/credential/claude-oauth`: the
+  // envelope is validated (a malformed push is a clean 400, never a false
+  // success) so the desktop can fall back to the paste flow.
+  if (rest === "credential/claude-oauth") {
+    const parsed = parseClaudeOAuthEnvelope(
+      await readJson(req).catch(() => ({})),
+    );
+    if (!parsed.ok) {
+      json(res, 400, { error: parsed.error });
+      return true;
+    }
+    try {
+      await channel.saveClaudeOAuthCredential(ctx, parsed.value, {
+        // Fill-only for a cached-snapshot reconcile (HOU-855) — mirrors the
+        // per-agent claude-oauth route.
+        ifAbsent: url.searchParams.get("if_absent") === "1",
+      });
+      json(res, 200, { ok: true });
+    } catch (err) {
+      // 409, not 502: the fill was refused on purpose (the credential was
+      // just provider-revoked — HOUSTON-APP-530), not lost to a broken hop.
+      json(res, err instanceof RevokedRefillBlockedError ? 409 : 502, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/packages/host/src/routes/setup-runtime.test.ts
+++ b/packages/host/src/routes/setup-runtime.test.ts
@@ -41,6 +41,7 @@ class FakeChannel implements RuntimeChannel {
   captured: { ctx: ChannelCtx; provider?: string }[] = [];
   apiKeys: { ctx: ChannelCtx; provider: string; apiKey: string }[] = [];
   claudeOAuth: { ctx: ChannelCtx; accessToken: string }[] = [];
+  forgotten: { ctx: ChannelCtx; provider: string }[] = [];
   claudeOAuthError: Error | null = null;
   captureResult: CaptureResult = { ok: true, provider: "openai-codex" };
 
@@ -97,7 +98,9 @@ class FakeChannel implements RuntimeChannel {
     if (this.claudeOAuthError) throw this.claudeOAuthError;
     this.claudeOAuth.push({ ctx, accessToken: cred.accessToken });
   }
-  async forgetCredential(): Promise<void> {}
+  async forgetCredential(ctx: ChannelCtx, provider: string): Promise<void> {
+    this.forgotten.push({ ctx, provider });
+  }
 }
 
 async function setup(opts: { withChannel?: boolean } = {}) {
@@ -245,6 +248,54 @@ test("credential/api-key stores through the channel and validates its body", asy
       body: JSON.stringify({ provider: "opencode" }),
     });
     expect(missing.status).toBe(400);
+  } finally {
+    stop();
+  }
+});
+
+test("credential/forget + auth/:provider/logout: a space with no agent signs out through the setup runtime (PRODUCT-1662)", async () => {
+  const { base, ws, channel, stop } = await setup();
+  try {
+    // The central credential is forgotten on the PERSONAL workspace — the same
+    // scope the setup-runtime connect captured it into.
+    const forget = await fetch(`${base}/setup-runtime/credential/forget`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ provider: "anthropic" }),
+    });
+    expect(forget.status).toBe(200);
+    expect(await forget.json()).toEqual({ ok: true });
+    expect(channel.forgotten).toEqual([
+      {
+        ctx: expect.objectContaining({
+          workspace: expect.objectContaining({ id: ws.id }),
+          agent: expect.objectContaining({ workspaceId: ws.id }),
+        }),
+        provider: "anthropic",
+      },
+    ]);
+
+    // …and the runtime's own auth copy is cleared through the allowlisted
+    // logout, so `auth/status` stops reading connected.
+    const logout = await fetch(`${base}/setup-runtime/auth/anthropic/logout`, {
+      method: "POST",
+      headers: auth,
+    });
+    expect(logout.status).toBe(200);
+    expect(channel.dispatched).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        rest: "auth/anthropic/logout",
+      }),
+    ]);
+
+    const missing = await fetch(`${base}/setup-runtime/credential/forget`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({}),
+    });
+    expect(missing.status).toBe(400);
+    expect(channel.forgotten).toHaveLength(1);
   } finally {
     stop();
   }

--- a/packages/host/src/routes/setup-runtime.ts
+++ b/packages/host/src/routes/setup-runtime.ts
@@ -1,13 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { parseClaudeOAuthEnvelope } from "@houston/protocol";
-import { RevokedRefillBlockedError } from "../credentials/revocation-tombstones";
 import type { Agent, UserId, WorkspaceRuntime } from "../domain/types";
-import {
-  ApiKeyRejectedError,
-  type RuntimeChannel,
-  type WorkspaceStore,
-} from "../ports";
-import { json, readJson } from "./http";
+import type { RuntimeChannel, WorkspaceStore } from "../ports";
+import { json } from "./http";
+import { handleSetupCredential } from "./setup-runtime-credentials";
 
 /**
  * User-level provider connection for FIRST-RUN, before any agent exists.
@@ -25,10 +20,14 @@ import { json, readJson } from "./http";
  *    agent runtime from — the agent created right after first-run is already
  *    connected.
  *  - Only the connect surface is exposed (providers, auth status, login,
- *    login/complete, capture, api-key, claude-oauth). Everything else the
- *    runtime serves (chat, files, settings) stays agent-scoped; notably
- *    `auth/export` is NOT reachable here — capture pulls it host-side and
- *    scrubs, so a refresh token never crosses to a client.
+ *    login/complete, cancel, logout, capture, forget, api-key, claude-oauth —
+ *    the credential routes live in `setup-runtime-credentials.ts`). Everything
+ *    else the runtime serves (chat, files, settings) stays agent-scoped;
+ *    notably `auth/export` is NOT reachable here — capture pulls it host-side
+ *    and scrubs, so a refresh token never crosses to a client.
+ *
+ * The hosted gateway mirrors this allowlist verbatim in front of the org's
+ * setup pod: a route added here is dead on cloud until it is allowed there too.
  *
  * Returns true when the request was handled.
  */
@@ -48,8 +47,11 @@ function allowedRest(method: string, rest: string): boolean {
     // login/cancel is part of the connect surface: the reconnect card's every
     // press goes cancel → launch (the runtime keeps one login slot per
     // provider), so blocking cancel 404s the chain and the login never
-    // launches (HOU-676).
-    return /^auth\/[^/]+\/login(\/(complete|cancel))?$/.test(rest);
+    // launches (HOU-676). logout is the sign-out half of the same surface: a
+    // space with no agent signs out here, clearing this runtime's own auth
+    // copy right after `credential/forget` drops the central one
+    // (PRODUCT-1662).
+    return /^auth\/[^/]+\/(login(\/(complete|cancel))?|logout)$/.test(rest);
   }
   return false;
 }
@@ -84,89 +86,7 @@ export async function handleSetupRuntime(
   }
   const ctx = { workspace: ws, agent };
 
-  // Connect-once capture: store the setup runtime's fresh credential for the
-  // WHOLE personal workspace and scrub its refresh token — identical to the
-  // per-agent `/agents/:id/credential/capture`, minus the agent.
-  if (rest === "credential/capture" && method === "POST") {
-    const body = (await readJson(req).catch(() => ({}))) as {
-      provider?: unknown;
-    };
-    const provider =
-      typeof body.provider === "string" ? body.provider : undefined;
-    const result = await channel.captureCredential(ctx, provider);
-    if (result.ok) json(res, 200, { ok: true, provider: result.provider });
-    else
-      json(res, result.status, {
-        error: result.error,
-        ...(result.detail ? { detail: result.detail } : {}),
-      });
-    return true;
-  }
-
-  // API-key provider connect (no OAuth dance): store centrally + push into the
-  // setup runtime so `auth/status` reads connected immediately.
-  if (rest === "credential/api-key" && method === "POST") {
-    const { provider, apiKey, endpoint } = await readJson(req);
-    if (!provider || typeof provider !== "string") {
-      json(res, 400, { error: "missing 'provider'" });
-      return true;
-    }
-    if (!apiKey || typeof apiKey !== "string") {
-      json(res, 400, { error: "missing 'apiKey'" });
-      return true;
-    }
-    try {
-      await channel.saveApiKeyCredential(
-        ctx,
-        provider,
-        apiKey,
-        typeof endpoint === "string" && endpoint.trim()
-          ? endpoint.trim()
-          : undefined,
-      );
-      json(res, 200, { ok: true });
-    } catch (err) {
-      // Mirror the per-agent route: the runtime's typed verification reason
-      // rides the body so the connect dialog can show actionable copy.
-      json(res, 502, {
-        error: err instanceof Error ? err.message : String(err),
-        ...(err instanceof ApiKeyRejectedError && err.reason
-          ? { reason: err.reason }
-          : {}),
-      });
-    }
-    return true;
-  }
-
-  // Claude-subscription connect pre-agent: the desktop's browser login mints
-  // the OAuth credential locally, and with NO agent selected yet (first-run
-  // onboarding, the cloud-migration wizard) it lands here — the setup
-  // runtime's workspace-central store serves every agent created or migrated
-  // after. Mirrors the per-agent `/agents/:id/credential/claude-oauth`: the
-  // envelope is validated (a malformed push is a clean 400, never a false
-  // success) so the desktop can fall back to the paste flow.
-  if (rest === "credential/claude-oauth" && method === "POST") {
-    const parsed = parseClaudeOAuthEnvelope(
-      await readJson(req).catch(() => ({})),
-    );
-    if (!parsed.ok) {
-      json(res, 400, { error: parsed.error });
-      return true;
-    }
-    try {
-      await channel.saveClaudeOAuthCredential(ctx, parsed.value, {
-        // Fill-only for a cached-snapshot reconcile (HOU-855) — mirrors the
-        // per-agent claude-oauth route.
-        ifAbsent: url.searchParams.get("if_absent") === "1",
-      });
-      json(res, 200, { ok: true });
-    } catch (err) {
-      // 409, not 502: the fill was refused on purpose (the credential was
-      // just provider-revoked — HOUSTON-APP-530), not lost to a broken hop.
-      json(res, err instanceof RevokedRefillBlockedError ? 409 : 502, {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+  if (await handleSetupCredential(channel, ctx, method, rest, url, req, res)) {
     return true;
   }
 

--- a/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
+++ b/packages/web/src/engine-adapter/client/provider-credentials-mixin.ts
@@ -7,7 +7,10 @@ import { isHoustonEngineError } from "./errors";
 import type { BaseCtor } from "./mixin";
 import { connectApiKey } from "./provider-api-key";
 import { pushClaudeCredential } from "./provider-claude-push";
-import { requireProviderAgentId } from "./provider-routing";
+import {
+  requireProviderAgentId,
+  requireProviderRouting,
+} from "./provider-routing";
 
 export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
   class ProviderCredentials extends Base {
@@ -28,8 +31,22 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
         // no in-flight turn can re-serve it, then clear the runtime's local copy.
         // SPACE-VALIDATED id (HOU-979): the raw pref can still name the
         // previous space's agent, and forgetting a credential through a foreign
-        // agent's route is a cross-space write.
-        const agentId = requireProviderAgentId(this.ctx);
+        // agent's route is a cross-space write. Refuse only while the list is
+        // still loading; a settled space with NO agent signs out through the
+        // hidden setup runtime, the mirror of how it connected (PRODUCT-1662):
+        // the credential is workspace-central, so no agent is needed to forget
+        // it, and the setup runtime's own auth copy is cleared alongside.
+        requireProviderRouting(this.ctx);
+        const agentId = this.ctx.providerAgentId();
+        if (!agentId) {
+          for (const target of targets) {
+            await controlPlane.forgetSetupCredential(this.ctx.cp, target);
+            await controlPlane
+              .setupRuntimeClientFor(this.ctx.cp)
+              .logout(target);
+          }
+          return;
+        }
         for (const target of targets) {
           await controlPlane.forgetCredential(this.ctx.cp, agentId, target);
           await controlPlane
@@ -76,7 +93,11 @@ export function ProviderCredentialsMixin<TBase extends BaseCtor>(Base: TBase) {
      */
     async setProviderCustomEndpoint(endpoint: CustomEndpoint): Promise<void> {
       if (this.ctx.cp) {
-        // Space-validated, like every other provider write (HOU-979).
+        // Space-validated, like every other provider write (HOU-979). Unlike
+        // the credential writes this one has NO pre-agent path: the endpoint
+        // is per-runtime state and the setup runtime dies with the first
+        // agent's creation, so a zero-agent space is the typed expected
+        // state the app turns into "create an agent first" (PRODUCT-1662).
         const agentId = requireProviderAgentId(this.ctx);
         await controlPlane.setCustomEndpoint(this.ctx.cp, agentId, endpoint);
         await controlPlane

--- a/packages/web/src/engine-adapter/client/provider-routing.ts
+++ b/packages/web/src/engine-adapter/client/provider-routing.ts
@@ -1,3 +1,4 @@
+import { NoAgentForProviderWriteError } from "../no-agent-provider-write-error";
 import type { AdapterContext } from "./context";
 
 /**
@@ -42,14 +43,22 @@ export function requireProviderRouting(ctx: AdapterContext): void {
 }
 
 /**
- * The agent id every provider WRITE must target: the space-validated
+ * The agent id a provider write that ONLY an agent's runtime can hold must
+ * target (the custom OpenAI-compatible endpoint): the space-validated
  * `ctx.providerAgentId()`, never the raw pref. `ctx.requireAgentId()` is
  * deliberately not this — it means "the agent the user has open", for routes
  * (project files, per-agent prefs) where another agent would be the wrong data.
+ *
+ * Two distinct refusals, because they mean different things to the user:
+ * a `pending` list is "still loading, try again" (a moment), while a settled
+ * list with no agent is the typed `NoAgentForProviderWriteError` ("create an
+ * agent first") — an expected state the app surfaces as plain guidance, not a
+ * bug (PRODUCT-1662). Credential writes (connect, sign-out) must NOT use this:
+ * they are workspace-central and route pre-agent through the setup runtime.
  */
 export function requireProviderAgentId(ctx: AdapterContext): string {
   requireProviderRouting(ctx);
   const id = ctx.providerAgentId();
-  if (!id) throw new Error("Open an agent first, then connect its account.");
+  if (!id) throw new NoAgentForProviderWriteError();
   return id;
 }

--- a/packages/web/src/engine-adapter/cp/credentials.ts
+++ b/packages/web/src/engine-adapter/cp/credentials.ts
@@ -171,6 +171,23 @@ export async function captureSetupCredential(
   });
 }
 
+/**
+ * Connect-once logout on the setup runtime — `forgetCredential`, agentless. A
+ * space with NO agent (first-run before the assistant exists, a failed first
+ * create, a deleted last agent) still holds the workspace-central credential
+ * the user connected; the setup runtime is the one runtime that can forget it
+ * (PRODUCT-1662).
+ */
+export async function forgetSetupCredential(
+  cfg: ControlPlaneConfig,
+  provider: string,
+): Promise<void> {
+  await cpFetch(cfg, `/setup-runtime/credential/forget`, {
+    method: "POST",
+    body: JSON.stringify({ provider }),
+  });
+}
+
 /** API-key connect on the setup runtime — `setApiKey`, agentless. */
 export async function setSetupApiKey(
   cfg: ControlPlaneConfig,

--- a/packages/web/src/engine-adapter/no-agent-provider-write-error.ts
+++ b/packages/web/src/engine-adapter/no-agent-provider-write-error.ts
@@ -1,0 +1,28 @@
+/**
+ * A provider WRITE that has to land on a specific agent's runtime, attempted
+ * in a space whose agent list is settled and EMPTY (PRODUCT-1662).
+ *
+ * Provider credentials are workspace-central, so connect and sign-out work
+ * pre-agent through the hidden setup runtime. A custom OpenAI-compatible
+ * endpoint is different: it is NOT a credential but per-runtime state (the
+ * runtime's settings + auth files, or the agent's `custom-endpoint.json`), and
+ * the setup runtime is torn down the moment the org's first real agent is
+ * created, taking anything saved on it along. Saving there would report success
+ * and silently lose the endpoint. So a zero-agent space is an EXPECTED state
+ * for this write, surfaced as actionable copy ("create an agent first"), never
+ * the red bug toast + Sentry pair.
+ *
+ * Lives in the adapter (never `app/`): the desktop bundle cannot resolve
+ * `@houston/app/*`, and `app/src/lib/no-agent-provider-write-error.ts` keeps
+ * the app's import path stable.
+ */
+export class NoAgentForProviderWriteError extends Error {
+  constructor() {
+    super("Create an agent first, then connect its account.");
+    this.name = "NoAgentForProviderWriteError";
+  }
+}
+
+export function isNoAgentForProviderWriteError(e: unknown): boolean {
+  return e instanceof NoAgentForProviderWriteError;
+}

--- a/packages/web/tests/credential-write-urls.test.ts
+++ b/packages/web/tests/credential-write-urls.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from "vitest";
 import {
   captureCredential,
   forgetCredential,
+  forgetSetupCredential,
   pushClaudeOAuthCredential,
   setApiKey,
   setCustomEndpoint,
@@ -59,12 +60,14 @@ test("every credential write sends a bare, query-less URL", async () => {
     baseUrl: "http://localhost:1234/v1",
     model: "local",
   });
+  await forgetSetupCredential(cfg, "anthropic");
   expect(urls).toEqual([
     "http://gw.test/agents/agent-1/credential/capture",
     "http://gw.test/agents/agent-1/credential/claude-oauth",
     "http://gw.test/agents/agent-1/credential/forget",
     "http://gw.test/agents/agent-1/credential/api-key",
     "http://gw.test/agents/agent-1/provider/openai-compatible",
+    "http://gw.test/setup-runtime/credential/forget",
   ]);
   for (const url of urls) {
     expect(url).not.toContain("?");

--- a/packages/web/tests/provider-write-no-agent.test.ts
+++ b/packages/web/tests/provider-write-no-agent.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { isNoAgentForProviderWriteError } from "../src/engine-adapter/no-agent-provider-write-error";
+
+/**
+ * PRODUCT-1662 — provider writes in a space whose agent list is settled and
+ * EMPTY (first-run before the assistant exists, a failed first create, a
+ * deleted last agent).
+ *
+ * `requireProviderAgentId` used to refuse every zero-agent write with "Open an
+ * agent first", the copy written for the STILL-LOADING state — a dead end for
+ * users that also filed as an unexpected error. The rules now:
+ *   1. sign-out routes through the hidden SETUP runtime (the mirror of how the
+ *      credential was connected): forget the central credential, clear the
+ *      setup runtime's own auth copy, and never touch a per-agent route;
+ *   2. a custom endpoint has no pre-agent home (it is per-runtime state and
+ *      the setup runtime dies with the first agent), so it refuses with the
+ *      TYPED expected-state error the app turns into "create an agent first";
+ *   3. the "still loading" refusal stays exactly what it was for `pending`.
+ */
+
+const {
+  cpListAgents,
+  forgetCredential,
+  forgetSetupCredential,
+  setCustomEndpoint,
+  runtimeLogout,
+  setupLogout,
+  agentClaim,
+} = vi.hoisted(() => ({
+  cpListAgents: vi.fn(),
+  forgetCredential: vi.fn(),
+  forgetSetupCredential: vi.fn(),
+  setCustomEndpoint: vi.fn(),
+  runtimeLogout: vi.fn(),
+  setupLogout: vi.fn(),
+  agentClaim: vi.fn(),
+}));
+
+vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/engine-adapter/control-plane")
+    >();
+  return {
+    ...actual,
+    listAgents: cpListAgents,
+    forgetCredential,
+    forgetSetupCredential,
+    setCustomEndpoint,
+    runtimeClientFor: vi.fn(() => ({
+      logout: runtimeLogout,
+      claimActiveProvider: agentClaim,
+    })),
+    setupRuntimeClientFor: vi.fn(() => ({ logout: setupLogout })),
+  };
+});
+
+import { HoustonClient } from "../src/engine-adapter/client";
+
+const PREF = "houston.pref.last_agent_id";
+/** A selection left over from before the last agent was deleted. */
+const STALE_PREF_AGENT = "agent-that-no-longer-exists";
+
+beforeEach(() => {
+  const store = new Map<string, string>([[PREF, STALE_PREF_AGENT]]);
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  for (const fn of [
+    forgetCredential,
+    forgetSetupCredential,
+    setCustomEndpoint,
+    runtimeLogout,
+    setupLogout,
+    agentClaim,
+  ]) {
+    fn.mockReset().mockResolvedValue(undefined);
+  }
+  // The space's list is KNOWN and EMPTY.
+  cpListAgents.mockReset().mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function zeroAgentClient() {
+  const c = new HoustonClient({
+    baseUrl: "http://gateway",
+    token: "t",
+    controlPlane: true,
+  });
+  await c.listAgents("ws");
+  return c;
+}
+
+test("sign-out with no agent routes through the setup runtime, never a per-agent route", async () => {
+  const c = await zeroAgentClient();
+
+  await c.providerLogout("anthropic");
+
+  expect(forgetSetupCredential).toHaveBeenCalledTimes(1);
+  expect(forgetSetupCredential.mock.calls[0]?.[1]).toBe("anthropic");
+  expect(setupLogout).toHaveBeenCalledWith("anthropic");
+  // The stale pref must not turn into `/agents/<dead>/credential/forget`.
+  expect(forgetCredential).not.toHaveBeenCalled();
+  expect(runtimeLogout).not.toHaveBeenCalled();
+});
+
+test("sign-out with no agent clears every sibling gateway, like the per-agent path", async () => {
+  const c = await zeroAgentClient();
+
+  await c.providerLogout("opencode");
+
+  const forgotten = forgetSetupCredential.mock.calls.map((call) => call[1]);
+  expect(forgotten).toEqual(
+    expect.arrayContaining(["opencode", "opencode-go"]),
+  );
+  expect(setupLogout).toHaveBeenCalledTimes(forgotten.length);
+});
+
+test("a custom endpoint with no agent refuses with the typed expected-state error", async () => {
+  const c = await zeroAgentClient();
+
+  const attempt = c.setProviderCustomEndpoint({
+    baseUrl: "https://tunnel.example/v1",
+    model: "local",
+  });
+
+  await expect(attempt).rejects.toSatisfy(isNoAgentForProviderWriteError);
+  expect(setCustomEndpoint).not.toHaveBeenCalled();
+  expect(agentClaim).not.toHaveBeenCalled();
+});
+
+test("the still-loading refusal is unchanged and is NOT the expected-state error", async () => {
+  const c = new HoustonClient({
+    baseUrl: "http://gateway",
+    token: "t",
+    controlPlane: true,
+  });
+
+  await expect(c.providerLogout("anthropic")).rejects.toThrow(/still loading/i);
+  const endpoint = c.setProviderCustomEndpoint({
+    baseUrl: "https://tunnel.example/v1",
+    model: "local",
+  });
+  await expect(endpoint).rejects.toThrow(/still loading/i);
+  await expect(endpoint).rejects.not.toSatisfy(isNoAgentForProviderWriteError);
+  expect(forgetSetupCredential).not.toHaveBeenCalled();
+});
+
+test("with an agent, sign-out and the endpoint still take the per-agent routes", async () => {
+  cpListAgents.mockResolvedValue([{ id: "agent-1" }]);
+  const c = await zeroAgentClient();
+
+  await c.providerLogout("anthropic");
+  expect(forgetCredential.mock.calls[0]?.[1]).toBe("agent-1");
+  expect(forgetSetupCredential).not.toHaveBeenCalled();
+
+  await c.setProviderCustomEndpoint({
+    baseUrl: "https://tunnel.example/v1",
+    model: "local",
+  });
+  expect(setCustomEndpoint.mock.calls[0]?.[1]).toBe("agent-1");
+});


### PR DESCRIPTION
## Root cause

`requireProviderAgentId` (`packages/web/src/engine-adapter/client/provider-routing.ts`) threw "Open an agent first, then connect its account" whenever `ctx.providerAgentId()` was null. That copy was written for the still-loading (`pending`) list, but null also means a settled space with zero agents. Sign-out (`providerLogout`) and the local-model connect (`setProviderCustomEndpoint`) both called it, so a user whose first agent create failed, who deleted their last agent, or who was mid first-run hit a dead end, and every attempt filed as an unexpected error (Sentry HOUSTON-APP-4ZG, HOUSTON-APP-4Y1).

The two writes are not the same case:

- A provider credential is workspace-central, so it can be forgotten without an agent. The setup runtime is the right place, but it exposed no forget or logout route.
- A custom OpenAI-compatible endpoint is per-runtime state (the runtime's settings and auth files, or the agent's `custom-endpoint.json`). The setup runtime is torn down when the first real agent is created, so saving there would report success and silently lose the endpoint.

## Fix

- Host: `POST /setup-runtime/credential/forget` (agentless mirror of the per-agent forget) and `POST /setup-runtime/auth/:provider/logout` allowlisted. The credential handlers move to `setup-runtime-credentials.ts` to keep the route file within the line budget.
- Adapter: `providerLogout` with a settled empty list forgets through the setup runtime and clears its auth copy; the per-agent path is unchanged. `requireProviderAgentId` now throws a typed `NoAgentForProviderWriteError` for the zero-agent case and keeps "still loading" for `pending`.
- App: the typed error surfaces as an expected-state toast ("Houston, you need an agent first") in en/es/pt, with no Sentry report.

On managed cloud the hosted gateway mirrors the setup-runtime allowlist, so the sign-out half needs the matching gateway allowlist change to ship first. The custom-endpoint half and the Sentry noise fix are independent of it.

## Tests

- `packages/web/tests/provider-write-no-agent.test.ts`: sign-out with zero agents routes through the setup runtime and never a per-agent route, sibling gateways are cleared, the custom endpoint refuses with the typed error, `pending` still says "still loading", and the per-agent paths are unchanged with an agent.
- `packages/host/src/routes/setup-runtime.test.ts`: forget lands on the personal workspace, logout dispatches to the setup runtime, missing provider is a 400.
- `packages/web/tests/credential-write-urls.test.ts`: the new URL is pinned query-less.

## Before

1. Sign in to a hosted space, connect a provider during first-run, then delete the only agent (or use a space whose first agent create failed).
2. Open the AI hub and press Sign out on the connected provider: red error toast "Open an agent first, then connect its account", and a Sentry event.
3. Same space, Connect a local model and submit the manual form: same red toast and Sentry event.

## After

1. Same space, press Sign out: the provider card flips to disconnected, no toast, no Sentry event (on managed cloud once the gateway allowlist ships; on a self-hosted or desktop-sidecar host immediately).
2. Same space, connect a local model: an informational toast "Houston, you need an agent first" and no Sentry event.
3. Create an agent, then repeat both: the per-agent paths behave as before.

PRODUCT-1662
