### PR TITLE
fix(web): opt out of browser page translation and survive translator DOM rewrites (PRODUCT-1660)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <!-- viewport-fit=cover lets the document extend under the notch / home
@@ -11,6 +11,16 @@
          The guard script flips it pre-paint; app/src/lib/theme-boot.ts keeps
          it in sync with every later theme change. -->
     <meta name="theme-color" content="#fcfcfc" />
+    <!-- Houston ships its own es/pt UI, so browser page translation (Chrome,
+         Safari, Edge) only corrupts it: the translator wraps every text node
+         in <font> elements, and React's next commit throws NotFoundError from
+         removeChild/insertBefore and loses the whole screen to the crash card.
+         `translate="no"` on <html> is the standard opt-out; the google meta
+         is the older spelling some translators still key on. Chat replies
+         are covered too: a streaming reply re-renders constantly, so it is
+         the surface a translator breaks first. app/src/lib/foreign-dom-guard.ts
+         is the safety net for translators that ignore both. -->
+    <meta name="google" content="notranslate" />
     <title>Houston</title>
     <!-- Pre-JS frame. The app's CSS arrives with the app bundle, so the FIRST
          painted frame is whatever this document says — before any module runs.

--- a/app/src/lib/document-language.ts
+++ b/app/src/lib/document-language.ts
@@ -1,0 +1,19 @@
+import type { i18n as I18n } from "i18next";
+
+/**
+ * Mirror the active locale onto `<html lang>`. index.html ships `lang="en"`
+ * for the pre-JS frame; once i18n resolves the real locale the document has
+ * to say so. Screen readers pick pronunciation from it, and browsers read it
+ * as the page-language hint: a Spanish screen labelled English is exactly
+ * what invites a translation prompt on a page that opts out of translation.
+ * Bind BEFORE `init()` so the initial language lands too, not only later
+ * changes.
+ */
+export function bindDocumentLanguage(i18n: I18n): void {
+  if (typeof document === "undefined") return;
+  const apply = (lng: string | undefined) => {
+    if (lng) document.documentElement.lang = lng;
+  };
+  i18n.on("languageChanged", apply);
+  apply(i18n.language);
+}

--- a/app/src/lib/foreign-dom-guard.ts
+++ b/app/src/lib/foreign-dom-guard.ts
@@ -1,0 +1,90 @@
+/**
+ * Keeps React's commit phase alive when something outside React rewrites the
+ * DOM under it. Browser page translation (Chrome, Safari, Edge, translating
+ * extensions) wraps every text node in `<font><font>…</font></font>`; React
+ * then calls `parent.removeChild(text)` or `parent.insertBefore(node, text)`
+ * on a text node that is no longer a direct child, the browser throws
+ * NotFoundError ("Failed to execute 'removeChild' on 'Node'" on Blink, "The
+ * object can not be found here." on WebKit), and the top-level error boundary
+ * replaces the whole screen with the crash card (HOUSTON-APP-590/55V/5CA).
+ * The document opts out of translation (`<html translate="no">`, both
+ * index.html files); this is the safety net for anything that ignores it.
+ *
+ * Both DOM methods are re-pointed at the WRAPPER: the ancestor of the target
+ * that is a direct child of the parent. Removing the wrapper takes the
+ * translation and the original text with it; inserting before the wrapper
+ * lands the node where React meant it. React only relies on the tree's shape
+ * at the element level, and that shape is preserved. A target that is not
+ * inside the parent at all is treated as already removed, or appended, never
+ * thrown on: a wrong order beats a lost screen. Every rescue is reported
+ * through `onRescue` (silent to the user, never silent to us).
+ *
+ * Dependency-free so the resolution and the patch are node-testable against a
+ * fake prototype (app/tests/foreign-dom-guard.test.ts).
+ */
+
+export interface NodeLike {
+  parentNode: NodeLike | null;
+}
+
+/**
+ * The ancestor of `node` that is a direct child of `parent` (`node` itself
+ * when it already is one); null when `node` is not inside `parent` at all.
+ */
+export function directChildOf<N extends NodeLike>(
+  parent: N,
+  node: N,
+): N | null {
+  let current: N | null = node;
+  while (current && current.parentNode !== parent) {
+    current = current.parentNode as N | null;
+  }
+  return current;
+}
+
+export type ForeignDomOp = "removeChild" | "insertBefore";
+
+export interface ForeignDomRescue {
+  op: ForeignDomOp;
+  /** The node the call was addressed at. */
+  parent: NodeLike;
+  /** The child (removeChild) or reference (insertBefore) React expected to be a direct child. */
+  target: NodeLike;
+  /** The direct child the call was re-pointed at; null when `target` was not inside `parent`. */
+  wrapper: NodeLike | null;
+}
+
+export type DomMethods = Pick<Node, "removeChild" | "insertBefore">;
+
+/**
+ * Patch `proto` (the live `Node.prototype` in a browser) in place. Calls that
+ * address a genuine direct child go straight to the original method, so the
+ * fast path costs one property read.
+ */
+export function installForeignDomGuard(
+  proto: DomMethods,
+  onRescue: (rescue: ForeignDomRescue) => void,
+): void {
+  const { removeChild, insertBefore } = proto;
+  proto.removeChild = function <T extends Node>(this: Node, child: T): T {
+    if (child.parentNode === this) {
+      return removeChild.call(this, child) as T;
+    }
+    const wrapper = directChildOf<NodeLike>(this, child);
+    onRescue({ op: "removeChild", parent: this, target: child, wrapper });
+    if (wrapper) removeChild.call(this, wrapper as Node);
+    return child;
+  };
+  proto.insertBefore = function <T extends Node>(
+    this: Node,
+    node: T,
+    reference: Node | null,
+  ): T {
+    if (reference === null || reference.parentNode === this) {
+      return insertBefore.call(this, node, reference) as T;
+    }
+    const wrapper = directChildOf<NodeLike>(this, reference);
+    onRescue({ op: "insertBefore", parent: this, target: reference, wrapper });
+    return insertBefore.call(this, node, wrapper as Node | null) as T;
+  };
+}

--- a/app/src/lib/foreign-dom-report.ts
+++ b/app/src/lib/foreign-dom-report.ts
@@ -1,0 +1,53 @@
+import { createBurstGate } from "./error-burst";
+import {
+  type ForeignDomRescue,
+  installForeignDomGuard,
+  type NodeLike,
+} from "./foreign-dom-guard";
+import { captureQuietEvent } from "./sentry-quiet";
+
+/**
+ * The reporting half of the foreign-DOM guard: a rescue is invisible to the
+ * user by design (the screen simply keeps working), so it must still reach
+ * us. One line in the frontend log and ONE warning-level Sentry event per
+ * burst, in a single fingerprinted issue: a translated page rescues on every
+ * commit, and counting each would only inflate the issue against the quota.
+ * No node content rides along, only tag names: the text under a rescued
+ * wrapper is whatever the user was reading.
+ */
+const rescueBurst = createBurstGate();
+
+function describeNode(node: NodeLike): string {
+  const dom = node as Partial<Node>;
+  if (typeof dom.nodeName !== "string") return "?";
+  return dom.nodeName.toLowerCase();
+}
+
+function reportForeignDomRescue(rescue: ForeignDomRescue): void {
+  const parent = describeNode(rescue.parent);
+  const target = describeNode(rescue.target);
+  const wrapper = rescue.wrapper ? describeNode(rescue.wrapper) : "none";
+  if (!rescueBurst.isFirst(`${rescue.op}:${parent}:${wrapper}`, Date.now())) {
+    return;
+  }
+  const message = `${rescue.op} re-pointed: ${target} is no longer a direct child of ${parent} (wrapper: ${wrapper})`;
+  console.warn(`[foreign-dom] ${message}`);
+  const error = new Error(message);
+  error.name = "ForeignDomRescue";
+  captureQuietEvent(error, {
+    level: "warning",
+    fingerprint: ["foreign_dom_rescue"],
+    tags: {
+      source: "foreign_dom_guard",
+      dom_op: rescue.op,
+      dom_wrapper: wrapper,
+      document_translate: document.documentElement.translate ? "yes" : "no",
+    },
+    extra: { parent, target, wrapper, lang: document.documentElement.lang },
+  });
+}
+
+/** Install the guard on the live DOM with reporting wired. Call once at boot. */
+export function installForeignDomSafetyNet(): void {
+  installForeignDomGuard(Node.prototype, reportForeignDomRescue);
+}

--- a/app/src/lib/global-error-handlers.ts
+++ b/app/src/lib/global-error-handlers.ts
@@ -10,6 +10,7 @@ import {
   showEngineWakingToast,
   showErrorToast,
 } from "./error-toast";
+import { installForeignDomSafetyNet } from "./foreign-dom-report";
 import { isNetworkTransportError } from "./network-transport-error";
 
 /**
@@ -28,6 +29,10 @@ import { isNetworkTransportError } from "./network-transport-error";
  * out of both the log file and the user's face.
  */
 export function installGlobalErrorHandlers(): void {
+  // The DOM safety net belongs with the error handlers: it is what keeps a
+  // page rewritten by a browser translator (or a translating extension) from
+  // ever reaching the crash boundary below, and both app entries must get it.
+  installForeignDomSafetyNet();
   window.onerror = (_event, _source, _line, _col, error) => {
     const message = error?.message ?? String(_event);
     console.error("[global:error]", message, error);

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -83,6 +83,7 @@ import shellPt from "../locales/pt/shell.json";
 import skillsPt from "../locales/pt/skills.json";
 import storePt from "../locales/pt/store.json";
 import teamsPt from "../locales/pt/teams.json";
+import { bindDocumentLanguage } from "./document-language";
 import {
   activeWorkspaceLocale,
   isSupported,
@@ -220,6 +221,8 @@ const initialLng =
     typeof navigator !== "undefined" ? navigator.language : null,
   ) ??
   "en";
+
+bindDocumentLanguage(i18n);
 
 void i18n
   .use(LanguageDetector)

--- a/app/tests/document-language.test.ts
+++ b/app/tests/document-language.test.ts
@@ -1,0 +1,57 @@
+import { strictEqual } from "node:assert";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { bindDocumentLanguage } from "../src/lib/document-language.ts";
+
+// <html lang> must follow the active locale: index.html ships "en" for the
+// pre-JS frame, and a Spanish screen labelled English invites translation.
+
+interface FakeI18n {
+  language: string | undefined;
+  handlers: Array<(lng: string) => void>;
+  on(event: string, handler: (lng: string) => void): void;
+}
+
+function fakeI18n(language: string | undefined): FakeI18n {
+  return {
+    language,
+    handlers: [],
+    on(event, handler) {
+      if (event === "languageChanged") this.handlers.push(handler);
+    },
+  };
+}
+
+let root: { lang: string };
+beforeEach(() => {
+  root = { lang: "en" };
+  globalThis.document = { documentElement: root } as unknown as Document;
+});
+afterEach(() => {
+  // @ts-expect-error — tear down the fake between tests.
+  globalThis.document = undefined;
+});
+
+const bind = (i18n: FakeI18n) =>
+  bindDocumentLanguage(
+    i18n as unknown as Parameters<typeof bindDocumentLanguage>[0],
+  );
+
+describe("bindDocumentLanguage", () => {
+  it("applies the already-resolved language on bind", () => {
+    bind(fakeI18n("pt"));
+    strictEqual(root.lang, "pt");
+  });
+  it("keeps the document default until the first language resolves", () => {
+    const i18n = fakeI18n(undefined);
+    bind(i18n);
+    strictEqual(root.lang, "en");
+    i18n.handlers[0]?.("es");
+    strictEqual(root.lang, "es");
+  });
+  it("follows later locale changes", () => {
+    const i18n = fakeI18n("en");
+    bind(i18n);
+    i18n.handlers[0]?.("es");
+    strictEqual(root.lang, "es");
+  });
+});

--- a/app/tests/foreign-dom-guard.test.ts
+++ b/app/tests/foreign-dom-guard.test.ts
@@ -1,0 +1,163 @@
+import { deepStrictEqual, strictEqual, throws } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  directChildOf,
+  type ForeignDomRescue,
+  installForeignDomGuard,
+} from "../src/lib/foreign-dom-guard.ts";
+
+// A browser translator wraps text nodes in <font><font> under React's feet;
+// React's next removeChild/insertBefore on the text node must land on the
+// wrapper instead of throwing NotFoundError (HOUSTON-APP-590/55V/5CA).
+
+/** The DOM's own contract, minus everything the guard does not touch. */
+class FakeNode {
+  parentNode: FakeNode | null = null;
+  childNodes: FakeNode[] = [];
+  readonly nodeName: string;
+  constructor(nodeName: string) {
+    this.nodeName = nodeName;
+  }
+  appendChild(child: FakeNode): FakeNode {
+    child.parentNode?.detach(child);
+    child.parentNode = this;
+    this.childNodes.push(child);
+    return child;
+  }
+  detach(child: FakeNode): void {
+    this.childNodes = this.childNodes.filter((c) => c !== child);
+    child.parentNode = null;
+  }
+}
+
+/** Prototype with the strict browser semantics the guard wraps. */
+function strictProto() {
+  return {
+    removeChild(this: FakeNode, child: FakeNode): FakeNode {
+      if (child.parentNode !== this) throw new Error("NotFoundError");
+      this.detach(child);
+      return child;
+    },
+    insertBefore(
+      this: FakeNode,
+      node: FakeNode,
+      reference: FakeNode | null,
+    ): FakeNode {
+      if (reference === null) return this.appendChild(node);
+      if (reference.parentNode !== this) throw new Error("NotFoundError");
+      node.parentNode?.detach(node);
+      node.parentNode = this;
+      this.childNodes.splice(this.childNodes.indexOf(reference), 0, node);
+      return node;
+    },
+  };
+}
+
+type Proto = ReturnType<typeof strictProto>;
+const asDom = (proto: Proto) =>
+  proto as unknown as Parameters<typeof installForeignDomGuard>[0];
+
+/** <p>text</p> after translation: <p><font><font>text</font></font></p>. */
+function translated() {
+  const p = new FakeNode("p");
+  const text = new FakeNode("#text");
+  const outer = new FakeNode("font");
+  const inner = new FakeNode("font");
+  p.appendChild(outer);
+  outer.appendChild(inner);
+  inner.appendChild(text);
+  return { p, text, outer };
+}
+
+describe("directChildOf", () => {
+  it("resolves the wrapper a translator put between parent and text", () => {
+    const { p, text, outer } = translated();
+    strictEqual(directChildOf(p, text), outer);
+  });
+  it("is the node itself when it is already a direct child", () => {
+    const p = new FakeNode("p");
+    const text = p.appendChild(new FakeNode("#text"));
+    strictEqual(directChildOf(p, text), text);
+  });
+  it("is null when the node is not inside the parent at all", () => {
+    const { p, text } = translated();
+    strictEqual(directChildOf(new FakeNode("div"), text), null);
+    const detached = new FakeNode("#text");
+    strictEqual(directChildOf(p, detached), null);
+  });
+});
+
+describe("installForeignDomGuard", () => {
+  it("leaves direct-child calls on the original methods, no rescue", () => {
+    const proto = strictProto();
+    const rescues: ForeignDomRescue[] = [];
+    installForeignDomGuard(asDom(proto), (r) => rescues.push(r));
+    const p = new FakeNode("p");
+    const a = p.appendChild(new FakeNode("#text"));
+    const b = new FakeNode("span");
+    proto.insertBefore.call(p, b, a);
+    deepStrictEqual(p.childNodes, [b, a]);
+    proto.removeChild.call(p, a);
+    deepStrictEqual(p.childNodes, [b]);
+    deepStrictEqual(rescues, []);
+  });
+
+  it("removes the wrapper when React removes a wrapped text node", () => {
+    const proto = strictProto();
+    const rescues: ForeignDomRescue[] = [];
+    installForeignDomGuard(asDom(proto), (r) => rescues.push(r));
+    const { p, text, outer } = translated();
+    strictEqual(proto.removeChild.call(p, text), text);
+    deepStrictEqual(p.childNodes, []);
+    strictEqual(rescues.length, 1);
+    deepStrictEqual(rescues[0], {
+      op: "removeChild",
+      parent: p,
+      target: text,
+      wrapper: outer,
+    });
+  });
+
+  it("inserts before the wrapper when the reference node is wrapped", () => {
+    const proto = strictProto();
+    const rescues: ForeignDomRescue[] = [];
+    installForeignDomGuard(asDom(proto), (r) => rescues.push(r));
+    const { p, text, outer } = translated();
+    const badge = new FakeNode("span");
+    strictEqual(proto.insertBefore.call(p, badge, text), badge);
+    deepStrictEqual(p.childNodes, [badge, outer]);
+    strictEqual(rescues[0]?.op, "insertBefore");
+    strictEqual(rescues[0]?.wrapper, outer);
+  });
+
+  it("treats a node outside the parent as removed, or appends", () => {
+    const proto = strictProto();
+    const rescues: ForeignDomRescue[] = [];
+    installForeignDomGuard(asDom(proto), (r) => rescues.push(r));
+    const p = new FakeNode("p");
+    const kept = p.appendChild(new FakeNode("span"));
+    const gone = new FakeNode("#text");
+    strictEqual(proto.removeChild.call(p, gone), gone);
+    deepStrictEqual(p.childNodes, [kept]);
+    const late = new FakeNode("em");
+    proto.insertBefore.call(p, late, gone);
+    deepStrictEqual(p.childNodes, [kept, late]);
+    deepStrictEqual(
+      rescues.map((r) => [r.op, r.wrapper]),
+      [
+        ["removeChild", null],
+        ["insertBefore", null],
+      ],
+    );
+  });
+
+  it("without the guard the same calls throw (the crash being fixed)", () => {
+    const proto = strictProto();
+    const { p, text } = translated();
+    throws(() => proto.removeChild.call(p, text), /NotFoundError/);
+    throws(
+      () => proto.insertBefore.call(p, new FakeNode("span"), text),
+      /NotFoundError/,
+    );
+  });
+});

--- a/app/tests/index-html-notranslate.test.ts
+++ b/app/tests/index-html-notranslate.test.ts
@@ -1,0 +1,27 @@
+import { match } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Both shells serve the same document, and both must opt out of browser page
+// translation: the translator's <font> wrappers crash React's commit
+// (HOUSTON-APP-590/55V/5CA). A regression here is a whole-screen loss on
+// every translated phone, so the attribute and the meta are pinned.
+
+const shells = {
+  desktop: "../index.html",
+  web: "../../packages/web/index.html",
+};
+
+describe("index.html opts out of browser translation", () => {
+  for (const [shell, relative] of Object.entries(shells)) {
+    it(`${shell} shell`, () => {
+      const html = readFileSync(
+        fileURLToPath(new URL(relative, import.meta.url)),
+        "utf8",
+      );
+      match(html, /<html[^>]*\stranslate="no"[^>]*>/);
+      match(html, /<meta name="google" content="notranslate" \/>/);
+    });
+  }
+});

--- a/packages/web/e2e/page-translation.spec.ts
+++ b/packages/web/e2e/page-translation.spec.ts
@@ -1,0 +1,146 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+import { completeSurvey, resetToFirstRun } from "./support/onboarding";
+
+/**
+ * Browser page translation (Chrome, Safari, translating extensions) rewrites
+ * the DOM under React: every text node ends up inside `<font><font>` wrappers,
+ * and React's next commit throws NotFoundError from removeChild/insertBefore
+ * and loses the whole screen to the crash card (HOUSTON-APP-590/55V/5CA).
+ * Two layers keep that away, and both are pinned here: the document opts out
+ * of translation, and the DOM guard installed at boot re-points React's
+ * calls at the wrapper for a translator that ignores the opt-out.
+ */
+
+/**
+ * What Chrome's translator does to a page: every non-blank text node moves
+ * inside a fresh `<font><font>` pair, and a MutationObserver keeps doing it
+ * to whatever React renders next. Text is left as-is so the specs' own text
+ * assertions still hold; the wrapper is what breaks React's direct-child
+ * assumption, not the words.
+ */
+async function translateLikeChrome(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const wrap = (text: Text) => {
+      const parent = text.parentElement;
+      if (!parent || !text.data.trim()) return;
+      if (parent.tagName === "FONT" || parent.closest("script,style,textarea"))
+        return;
+      const outer = document.createElement("font");
+      const inner = document.createElement("font");
+      outer.appendChild(inner);
+      parent.replaceChild(outer, text);
+      inner.appendChild(text);
+    };
+    const wrapUnder = (node: Node) => {
+      const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+      const texts: Text[] = [];
+      for (let t = walker.nextNode(); t; t = walker.nextNode()) {
+        texts.push(t as Text);
+      }
+      texts.forEach(wrap);
+    };
+    wrapUnder(document.body);
+    new MutationObserver((records) => {
+      for (const record of records) {
+        for (const added of record.addedNodes) {
+          if (added.nodeType === Node.TEXT_NODE) wrap(added as Text);
+          else wrapUnder(added);
+        }
+      }
+    }).observe(document.body, { childList: true, subtree: true });
+  });
+}
+
+test("the document opts out of browser translation", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("html")).toHaveAttribute("translate", "no");
+  await expect(
+    page.locator('meta[name="google"][content="notranslate"]'),
+  ).toHaveCount(1);
+  // The pre-JS frame says "en"; the app corrects it to the active locale.
+  await expect(page.locator("html")).toHaveAttribute("lang", "en");
+});
+
+test("a translated first run survives the survey's saving spinner", async ({
+  page,
+  request,
+}) => {
+  const crashes: string[] = [];
+  const rescues: string[] = [];
+  page.on("console", (msg) => {
+    const text = msg.text();
+    if (text.includes("react_crash") || text.includes("uncaught_error")) {
+      crashes.push(text);
+    }
+    if (text.includes("[foreign-dom]")) rescues.push(text);
+  });
+  // HOUSTON-APP-5CA's exact shape: Chrome on iOS translated the first-run
+  // survey. Each Continue renders a spinner BEFORE its label while the answer
+  // saves, an insertBefore whose reference is the translated text node.
+  await resetToFirstRun(request);
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: "What best describes your work?" }),
+  ).toBeVisible();
+
+  await translateLikeChrome(page);
+  await completeSurvey(page);
+
+  await expect(
+    page.getByRole("heading", { name: "Welcome to Houston!" }),
+  ).toBeVisible();
+  await expect(page.getByText("App crashed")).toHaveCount(0);
+  expect(crashes).toEqual([]);
+  // The guard did the work (the translator's wrappers were hit), and said so.
+  expect(rescues.length).toBeGreaterThan(0);
+});
+
+test("the DOM guard re-points removeChild/insertBefore at the wrapper", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+
+  const outcome = await page.evaluate(() => {
+    const translate = (p: HTMLElement) => {
+      const text = p.firstChild as Text;
+      const outer = document.createElement("font");
+      const inner = document.createElement("font");
+      outer.appendChild(inner);
+      p.replaceChild(outer, text);
+      inner.appendChild(text);
+      return text;
+    };
+    const removed = document.createElement("p");
+    removed.textContent = "hola";
+    const removedText = translate(removed);
+    removed.removeChild(removedText);
+
+    const inserted = document.createElement("p");
+    inserted.textContent = "mundo";
+    translate(inserted);
+    const badge = document.createElement("span");
+    inserted.insertBefore(
+      badge,
+      inserted.querySelector("font")?.firstChild?.firstChild ?? null,
+    );
+
+    const detached = document.createElement("p");
+    const stray = document.createTextNode("gone");
+    detached.removeChild(stray);
+    const late = document.createElement("em");
+    detached.insertBefore(late, stray);
+
+    return {
+      removedChildren: removed.childNodes.length,
+      insertedOrder: Array.from(inserted.childNodes).map((n) => n.nodeName),
+      detachedOrder: Array.from(detached.childNodes).map((n) => n.nodeName),
+    };
+  });
+  expect(outcome).toEqual({
+    removedChildren: 0,
+    insertedOrder: ["SPAN", "FONT"],
+    detachedOrder: ["EM"],
+  });
+});

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <!-- viewport-fit=cover lets the document extend under the notch / home
@@ -11,6 +11,16 @@
          The guard script flips it pre-paint; app/src/lib/theme-boot.ts keeps
          it in sync with every later theme change. -->
     <meta name="theme-color" content="#fcfcfc" />
+    <!-- Houston ships its own es/pt UI, so browser page translation (Chrome,
+         Safari, Edge) only corrupts it: the translator wraps every text node
+         in <font> elements, and React's next commit throws NotFoundError from
+         removeChild/insertBefore and loses the whole screen to the crash card.
+         `translate="no"` on <html> is the standard opt-out; the google meta
+         is the older spelling some translators still key on. Chat replies
+         are covered too: a streaming reply re-renders constantly, so it is
+         the surface a translator breaks first. app/src/lib/foreign-dom-guard.ts
+         is the safety net for translators that ignore both. -->
+    <meta name="google" content="notranslate" />
     <title>Houston</title>
     <!-- Pre-JS frame. The app's CSS arrives with the app bundle, so the FIRST
          painted frame is whatever this document says — before any module runs.


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1660. All web `react_crash` events for `removeChild` / `insertBefore` / "The object can not be found here." share one cause: the browser's page translation (Chrome, Safari, Edge) wraps every text node in `<font><font>` elements. React's next commit then calls `removeChild` or `insertBefore` on a text node that is no longer a direct child, the browser throws `NotFoundError`, and the top-level error boundary replaces the whole screen with the crash card. Every Sentry event carries the `font > font` click breadcrumb, and the "Maximum call stack size exceeded" loop in the same session runs inside Chrome iOS's injected translate script (its frames point at the page URL, not our bundle), so it goes away with translation.

## Changes

- **Opt out of translation.** Both `index.html` documents (desktop shell and web) carry `<html translate="no">` plus `<meta name="google" content="notranslate">`. Houston ships es/pt itself, so translation only ever corrupted the UI, including streaming chat replies.
- **`<html lang>` follows the locale.** `bindDocumentLanguage` mirrors the active i18n language onto the document instead of leaving the shipped `lang="en"` on a Spanish screen.
- **DOM safety net.** `foreign-dom-guard.ts` patches `Node.prototype.removeChild` / `insertBefore` so a call whose target is wrapped is re-pointed at the wrapper (the ancestor that is a direct child); a target outside the parent is treated as removed, or appended. Calls on real direct children take the original fast path. Installed from `installGlobalErrorHandlers`, so both app entries get it. Every rescue is silent to the user but reaches the frontend log and one fingerprinted Sentry warning per burst (`foreign_dom_rescue`).

## Tests

- `app/tests/foreign-dom-guard.test.ts`: resolution and patch semantics against a strict fake prototype, including the pre-fix throw.
- `app/tests/document-language.test.ts`, `app/tests/index-html-notranslate.test.ts`: the lang sync and the opt-out pinned in both shells.
- `packages/web/e2e/page-translation.spec.ts`: the opt-out, the guard's DOM semantics in a real browser, and the first-run survey under a Chrome-style fake translator (a MutationObserver that keeps wrapping text nodes). That survey flow is the exact HOUSTON-APP-5CA shape: Continue renders a spinner before its label while saving, an `insertBefore` whose reference is the translated text node. With the guard disabled the spec fails with the crash card and the `insertBefore` NotFoundError; with it, it passes on Chromium and WebKit.

Ran: `pnpm check`, `cd app && pnpm test` (3925 pass), `cd app && pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck` + `typecheck:e2e`, the new spec on Chromium + WebKit, and a DOM-heavy subset of the existing e2e suite (boot, survey, chat, sidebar DnD, language gate, mobile smoke + onboarding: 32 pass).

## Verify

Before (main): open the web app on a phone, let Chrome translate the page (or in DevTools wrap a text node: `const t=$0.firstChild, f=document.createElement('font'); $0.replaceChild(f,t); f.appendChild(t)`), then trigger a re-render that inserts or removes a sibling of that text (the first-run survey's Continue, or any button that shows a spinner before its label). The screen is replaced by "App crashed" with the NotFoundError.

After: the browser no longer offers to translate (`document.documentElement.translate === false`), and the same DevTools wrapping followed by the re-render keeps the screen working with a `[foreign-dom] insertBefore re-pointed…` warning in the console.