### PR TITLE
fix(sentry): pin quiet-class fingerprints above the server value rules

### DIFF
--- a/app/src/lib/sentry-quiet.ts
+++ b/app/src/lib/sentry-quiet.ts
@@ -11,6 +11,15 @@ import * as Sentry from "@sentry/browser";
  * adds events to that issue and never files a new one. The raw gateway body
  * rides as `extra`, where Sentry's event search can still find it.
  *
+ * The fingerprint only holds if no server-side fingerprinting rule matches
+ * first: a matched rule REPLACES the client fingerprint (the SDK's value
+ * survives only as `_fingerprint_info.client_fingerprint`). The project's
+ * `value:"Load failed*"` / `value:"Failed to fetch*"` rules did exactly that
+ * to every offline capture, re-flipping the old transport-drop issues to
+ * regressed. The project now pins `tags.quiet_class:<class> -> <class>` ABOVE
+ * those rules, so `quiet_class` must stay a tag on every quiet capture and
+ * its value must equal the fingerprint constant.
+ *
  * No-op until `initSentry` ran (dev builds without the send-in-dev opt-in,
  * forks with no DSN), same as every other capture.
  */

--- a/app/tests/sentry-quiet.test.ts
+++ b/app/tests/sentry-quiet.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import * as Sentry from "@sentry/browser";
+import { captureQuietEvent } from "../src/lib/sentry-quiet.ts";
+
+/**
+ * Whole-SDK check that a quiet-class capture leaves the client with its
+ * FIXED fingerprint on the wire. Sentry groups by the event's `fingerprint`
+ * unless a server-side fingerprinting rule matches first, so this pins the
+ * client half of the contract: the outgoing envelope item carries the class
+ * constant, the warning level, the class tag and the raw body as extra.
+ */
+type SentEvent = {
+  fingerprint?: string[];
+  level?: string;
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+  exception?: { values?: { type?: string; value?: string }[] };
+};
+
+const sent: SentEvent[] = [];
+
+before(() => {
+  Sentry.init({
+    dsn: "https://public@o0.ingest.sentry.io/0",
+    defaultIntegrations: false,
+    transport: () => ({
+      send: async (envelope) => {
+        for (const item of envelope[1] as unknown[]) {
+          const [header, payload] = item as [{ type?: string }, SentEvent];
+          if (header.type === "event") sent.push(payload);
+        }
+        return { statusCode: 200 };
+      },
+      flush: async () => true,
+    }),
+  });
+});
+
+after(async () => {
+  await Sentry.close(0);
+});
+
+describe("captureQuietEvent", () => {
+  it("sends the class constant as the event fingerprint", async () => {
+    const error = new Error("Load failed (gateway.gethouston.ai)");
+    error.name = "load_chat_history";
+    captureQuietEvent(error, {
+      level: "warning",
+      fingerprint: ["offline"],
+      tags: { source: "load_chat_history", quiet_class: "offline" },
+      extra: { command: "load_chat_history", body: "dial tcp: i/o timeout" },
+    });
+    assert.equal(await Sentry.flush(1000), true);
+
+    assert.equal(sent.length, 1);
+    const event = sent[0];
+    assert.deepEqual(event.fingerprint, ["offline"]);
+    assert.equal(event.level, "warning");
+    assert.equal(event.tags?.quiet_class, "offline");
+    assert.equal(event.tags?.source, "load_chat_history");
+    assert.equal(event.extra?.body, "dial tcp: i/o timeout");
+    assert.equal(event.exception?.values?.[0]?.type, "load_chat_history");
+    assert.equal(
+      event.exception?.values?.[0]?.value,
+      "Load failed (gateway.gethouston.ai)",
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

PRODUCT-1640 captures waking/offline failures as warnings with a fixed per-class fingerprint (`["offline"]`, `["engine_waking"]`, `["waking_stuck"]`). The SDK does ship it: every 0.6.16 event's raw payload carries `_fingerprint_info.client_fingerprint: ["offline"]`. But the Sentry project's **server-side fingerprinting rules** run first and a matched rule replaces the client fingerprint. Two long-standing rules matched every offline capture:

```
value:"Failed to fetch*" -> renderer-failed-to-fetch
value:"Load failed*"     -> renderer-load-failed
```

So offline warnings hashed into the old resolved transport-drop issues (4PG `load_chat_history: Load failed`, 4PQ `integration_status: Failed to fetch`) and flipped them to regressed on every blip. The waking class was never affected: 5CE **is** the single `engine_waking` issue and 5CG **is** the single `offline` issue (its title is just the latest event); 5CG stayed small only because the value rules stole most of its events.

## Fix

- **Sentry project (applied):** three rules pinned ABOVE the value rules: `tags.quiet_class:"offline" -> offline`, `…"engine_waking" -> engine_waking`, `…"waking_stuck" -> waking_stuck`. Same fingerprint values as the SDK, so the hashes land in the existing class issues. Applies to every 0.6.16 client already in the field; no release needed.
- **Repo:** `captureQuietEvent` documents the constraint (`quiet_class` must stay a tag whose value equals the fingerprint constant). New whole-SDK test `app/tests/sentry-quiet.test.ts` inits `@sentry/browser` with a capturing transport and asserts the outgoing envelope item carries `fingerprint: ["offline"]`, warning level, the class tag and the raw body.

## Before

1. Pull any 0.6.16 warning event from 4PG with `quiet_class:offline` and read its raw JSON (`/projects/houston-cd/houston-app/events/<id>/json/`).
2. `fingerprint` is `["renderer-load-failed"]`, `_fingerprint_info.client_fingerprint` is `["offline"]`, `matched_rule` is `value:"Load failed*"`. Issue 4PG shows as regressed.

## After

1. Synthetic verification already run: a `Load failed (rule check)` warning tagged `quiet_class:offline` (env `development`, release `houston-app@0.0.0-fingerprint-check`) grouped into 5CG with `matched_rule: tags.quiet_class:"offline" -> "offline"`; a 503 tagged `engine_waking` grouped into 5CE.
2. `cd app && pnpm test` passes (3952 tests, incl. the new envelope assertion).
3. 4PG / 4PQ resolved in next release; a new event on them now means a real non-quiet transport drop, not an offline blip.

PRODUCT-1665