### PR TITLE
fix(shell): classify three more waking shapes as quiet (PRODUCT-1666)

### DIFF
--- a/app/src/components/integrations/use-integration-chat-setup.ts
+++ b/app/src/components/integrations/use-integration-chat-setup.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useActivity, useAllConversations } from "../../hooks/queries";
 import { useConnectedProviders } from "../../hooks/use-connected-providers";
 import { readAgentModelOverrides } from "../../lib/agent-model-overrides";
+import { isAgentWarmingError } from "../../lib/agent-warming-guard";
 import { analytics } from "../../lib/analytics";
 import { connectedProviderIds } from "../../lib/connected-providers";
 import { createMission } from "../../lib/create-mission";
@@ -101,6 +102,9 @@ export function useIntegrationChatSetup() {
 
   const toastStartError = useCallback(
     (err: unknown) => {
+      // A write refused while the agent's engine warms up (HOU-693) already
+      // opened the "almost ready" dialog: that is the surface, not a failure.
+      if (isAgentWarmingError(err)) return;
       // The mission never started (createMission rolled the activity back), so
       // a toast is the only surface for the failure.
       addToast({
@@ -199,6 +203,7 @@ export function useIntegrationChatSetup() {
           });
         })
         .catch((err) => {
+          if (isAgentWarmingError(err)) return;
           addToast({
             title: t("custom.setupChat.startError"),
             description: genericErrorDescription(

--- a/app/src/lib/agent-warming-guard.ts
+++ b/app/src/lib/agent-warming-guard.ts
@@ -5,14 +5,18 @@
  * routine, update instructions, install a skill…) would be a held request
  * that dies with infrastructure timeouts or a reload. Instead of letting the
  * button hang for minutes, the guard opens the "your agent is almost ready"
- * dialog and rejects with {@link AgentWarmingError} — which the tauri
- * wrapper's error surface recognizes and does NOT toast or report: the
- * dialog IS the surface.
+ * dialog and rejects with {@link AgentWarmingError} — which the reporting
+ * layer (`error-report.ts`, `error-toast.ts`, the global rejection handler)
+ * recognizes and does NOT toast or report: the dialog IS the surface.
  */
 
 import { useAgentProvisioningStore } from "../stores/agent-provisioning";
 import { useUIStore } from "../stores/ui";
 import { warmingReadsAnswerEmpty } from "./agent-provisioning";
+import {
+  AGENT_WARMING_ERROR_NAME,
+  isAgentWarmingRefusal,
+} from "./agent-warming-refusal";
 import i18n from "./i18n";
 
 export interface WarmingWriteOptions {
@@ -25,12 +29,12 @@ export interface WarmingWriteOptions {
 export class AgentWarmingError extends Error {
   constructor() {
     super(i18n.t("shell:agentProvisioning.blockedBody"));
-    this.name = "AgentWarmingError";
+    this.name = AGENT_WARMING_ERROR_NAME;
   }
 }
 
 export function isAgentWarmingError(e: unknown): boolean {
-  return e instanceof AgentWarmingError;
+  return isAgentWarmingRefusal(e);
 }
 
 /** True when this engine route key belongs to a still-warming agent. */

--- a/app/src/lib/agent-warming-refusal.ts
+++ b/app/src/lib/agent-warming-refusal.ts
@@ -1,0 +1,20 @@
+// The app's OWN "not yet" refusal, told apart structurally so the reporting
+// layer can recognize it without importing the guard (`agent-warming-guard.ts`
+// pulls the provisioning store, which pulls the reporting layer back — a
+// cycle). Dependency-free, node-testable (app/tests/agent-warming-refusal.test.ts).
+//
+// `blockWriteWhileWarming` (HOU-693) opens the "your agent is almost ready"
+// dialog and throws this error to abort a user-initiated write against an
+// engine still warming up. The dialog IS the surface: the global rejection
+// handler already declines it, but a caller's own catch that funnels every
+// failure through `genericErrorDescription` / `showErrorToast` re-surfaced it
+// as a red "couldn't start" toast plus a Sentry error whose message was the
+// dialog's localized copy (HOUSTON-APP-53K). Nothing failed and nothing is to
+// fix, so the reporting layer drops it — logged for the local tail only.
+
+export const AGENT_WARMING_ERROR_NAME = "AgentWarmingError";
+
+/** True for the warming guard's refusal, whichever module minted it. */
+export function isAgentWarmingRefusal(err: unknown): boolean {
+  return err instanceof Error && err.name === AGENT_WARMING_ERROR_NAME;
+}

--- a/app/src/lib/error-report.ts
+++ b/app/src/lib/error-report.ts
@@ -1,3 +1,4 @@
+import { isAgentWarmingRefusal } from "./agent-warming-refusal";
 import { classifyAnalyticsError } from "./analytics";
 import i18n from "./i18n";
 import { classifyQuietError } from "./quiet-error-class";
@@ -35,6 +36,12 @@ export function reportError(
   message: string,
   originalError?: unknown,
 ): void {
+  // The app's own warming-guard refusal: the "almost ready" dialog is already
+  // open and nothing failed, so there is no bug to report (HOUSTON-APP-53K).
+  if (isAgentWarmingRefusal(originalError)) {
+    console.debug(`[report:${command}] write blocked while the agent warms up`);
+    return;
+  }
   const quiet = classifyQuietError(originalError);
   if (quiet) {
     reportQuietError(quiet, command, message, originalError);

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -1,5 +1,6 @@
 import { isSignedOutEngineError } from "@houston-ai/engine-client";
 import { useUIStore } from "../stores/ui";
+import { isAgentWarmingRefusal } from "./agent-warming-refusal";
 import { analytics, classifyAnalyticsError } from "./analytics";
 import { createBurstGate } from "./error-burst";
 import i18n from "./i18n";
@@ -190,6 +191,12 @@ export function showErrorToast(
   // the transport only mints the synthetic body when no session exists at all.
   if (isSignedOutEngineError(originalError)) {
     console.warn(`[toast:${command}] suppressed: signed-out engine call`);
+    return;
+  }
+  // The app's own warming-guard refusal (HOU-693): the "almost ready" dialog
+  // is the surface and nothing failed — no capture either (HOUSTON-APP-53K).
+  if (isAgentWarmingRefusal(originalError)) {
+    console.debug(`[toast:${command}] write blocked while the agent warms up`);
     return;
   }
 

--- a/app/tests/agent-warming-refusal.test.ts
+++ b/app/tests/agent-warming-refusal.test.ts
@@ -1,0 +1,78 @@
+import { ok, strictEqual } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { isAgentWarmingRefusal } from "../src/lib/agent-warming-refusal.ts";
+
+// PRODUCT-1666 (HOUSTON-APP-53K): the warming guard's own refusal (HOU-693) is
+// a deliberate "not yet" with the "almost ready" dialog as its surface. A
+// caller's generic catch funnelled it through `genericErrorDescription`, which
+// showed a red "couldn't start" toast AND captured a Sentry error whose message
+// was the dialog's localized copy. The reporting layer must decline it, the
+// same way the global rejection handler always has.
+
+const read = (rel: string): string =>
+  readFileSync(join(import.meta.dirname, rel), "utf8");
+
+describe("isAgentWarmingRefusal", () => {
+  it("matches the guard's error by name, whichever module minted it", () => {
+    const err = new Error("Almost ready.");
+    err.name = "AgentWarmingError";
+    strictEqual(isAgentWarmingRefusal(err), true);
+  });
+
+  it("never matches anything else", () => {
+    strictEqual(isAgentWarmingRefusal(new Error("Almost ready.")), false);
+    strictEqual(isAgentWarmingRefusal("AgentWarmingError"), false);
+    strictEqual(isAgentWarmingRefusal(null), false);
+  });
+});
+
+describe("the guard mints the name the predicate matches", () => {
+  const source = read("../src/lib/agent-warming-guard.ts");
+
+  it("uses the shared name constant and delegates its own predicate", () => {
+    ok(source.includes("this.name = AGENT_WARMING_ERROR_NAME;"));
+    ok(source.includes("return isAgentWarmingRefusal(e);"));
+  });
+});
+
+// Asserted against the source: both reporting modules pull i18n / analytics,
+// which do not load under this suite's `--experimental-strip-types` runner
+// (same pattern as error-report-connectivity.test.ts).
+describe("the reporting layer declines the warming refusal", () => {
+  it("reportError returns before any Sentry capture", () => {
+    const source = read("../src/lib/error-report.ts");
+    const body = source.slice(source.indexOf("export function reportError("));
+    const guard = body.indexOf("if (isAgentWarmingRefusal(originalError))");
+    ok(guard !== -1, "reportError must gate on the warming refusal");
+    ok(guard < body.indexOf("reportQuietError"));
+    ok(guard < body.indexOf("sentryCapture"));
+  });
+
+  it("showErrorToast returns before any Sentry capture", () => {
+    const source = read("../src/lib/error-toast.ts");
+    const body = source.slice(
+      source.indexOf("export function showErrorToast("),
+    );
+    const guard = body.indexOf("if (isAgentWarmingRefusal(originalError))");
+    ok(guard !== -1, "showErrorToast must gate on the warming refusal");
+    ok(guard < body.indexOf("sentryCapture"));
+  });
+});
+
+describe("the custom-integration chat keeps its red toast for real failures only", () => {
+  const source = read(
+    "../src/components/integrations/use-integration-chat-setup.ts",
+  );
+
+  it("gates every authored failure toast on isAgentWarmingError", () => {
+    ok(source.includes('from "../../lib/agent-warming-guard"'));
+    const toasts = source.split("custom.setupChat.startError").length - 1;
+    const guards = (
+      source.match(/if \(isAgentWarmingError\(err\)\) return;/g) ?? []
+    ).length;
+    ok(toasts > 0, "expected authored failure toasts in the hook");
+    strictEqual(guards, toasts);
+  });
+});

--- a/app/tests/engine-waking-error.test.ts
+++ b/app/tests/engine-waking-error.test.ts
@@ -279,3 +279,125 @@ describe("isEngineWakingError (runtime-client shape)", () => {
     strictEqual(isEngineWakingError(bodyless), false);
   });
 });
+
+// PRODUCT-1666: the HOST's own "not there yet" answer — probe-wake.ts answers
+// the read-only probe routes `503 {"error":"the agent's runtime is still
+// starting, try again shortly"}` while the runtime boots. Same waking state as
+// the gateway's "engine unavailable", a different reason string; it escaped
+// into the red toast + Sentry pipeline on every shape (HOUSTON-APP-54Q).
+const STILL_STARTING =
+  "the agent's runtime is still starting, try again shortly";
+
+describe("isEngineWakingError (runtime still starting)", () => {
+  it("matches on the runtime-client shape, where it was observed", () => {
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(503, `{"error":"${STILL_STARTING}"}`),
+      ),
+      true,
+    );
+  });
+
+  it("matches on the legacy and SDK shapes too", () => {
+    strictEqual(isEngineWakingError(engineError(503, STILL_STARTING)), true);
+    strictEqual(
+      isEngineWakingError(
+        agentsHttpError(503, `{"error":"${STILL_STARTING}"}`),
+      ),
+      true,
+    );
+  });
+
+  it("is a 503 reason only, matched exactly", () => {
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(502, `{"error":"${STILL_STARTING}"}`),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(
+        runtimeEngineError(503, '{"error":"the agent\'s runtime is starting"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(engineError(503, "the agent's runtime")),
+      false,
+    );
+  });
+});
+
+/** The shape the SDK activity-write path throws (`ActivitiesHttpError`): the
+ *  same raw-body-as-message contract as `AgentsHttpError`. */
+function activitiesHttpError(status: number, body: string): Error {
+  const err = new Error(body) as Error & { status: number };
+  err.name = "ActivitiesHttpError";
+  err.status = status;
+  return err;
+}
+
+// HOUSTON-APP-51X: a mission created against a pod mid-roll answered the
+// proxy-failed 502 through the SDK activities module, which carries the body
+// exactly like the agents module but was not in the classifier's name list.
+describe("isEngineWakingError (SDK activity-write shape)", () => {
+  it("matches the proxy-failed 502 body", () => {
+    strictEqual(
+      isEngineWakingError(
+        activitiesHttpError(
+          502,
+          '{"detail":"Post http://agent-x:4318/agents/A/activities: dial tcp: lookup agent-x: no such host","error":"engine proxy failed"}',
+        ),
+      ),
+      true,
+    );
+  });
+
+  it("matches the wake 503 bodies", () => {
+    strictEqual(
+      isEngineWakingError(
+        activitiesHttpError(
+          503,
+          '{"detail":"agent is waking","error":"engine unavailable"}',
+        ),
+      ),
+      true,
+    );
+    strictEqual(
+      isEngineWakingError(
+        activitiesHttpError(503, `{"error":"${STILL_STARTING}"}`),
+      ),
+      true,
+    );
+  });
+
+  it("never matches other reasons, statuses or non-JSON bodies", () => {
+    strictEqual(
+      isEngineWakingError(
+        activitiesHttpError(404, '{"error":"agent not found"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(
+        activitiesHttpError(500, '{"error":"engine unavailable"}'),
+      ),
+      false,
+    );
+    strictEqual(
+      isEngineWakingError(
+        activitiesHttpError(503, "activities request failed: 503"),
+      ),
+      false,
+    );
+  });
+
+  it("rejects an unknown error name carrying a waking body", () => {
+    const err = new Error('{"error":"engine unavailable"}') as Error & {
+      status: number;
+    };
+    err.name = "MissionsHttpError";
+    err.status = 503;
+    strictEqual(isEngineWakingError(err), false);
+  });
+});

--- a/app/tests/quiet-error-class.test.ts
+++ b/app/tests/quiet-error-class.test.ts
@@ -42,6 +42,33 @@ describe("classifyQuietError", () => {
     );
     strictEqual(classifyQuietError(new TypeError("x is not a function")), null);
   });
+
+  // PRODUCT-1666: the three shapes that escaped the waking class.
+  it("names the waking class for the still-starting 503 and the activities shape", () => {
+    strictEqual(
+      classifyQuietError(
+        named(
+          "EngineError",
+          'engine request failed (503): {"error":"the agent\'s runtime is still starting, try again shortly"}',
+          {
+            status: 503,
+            body: '{"error":"the agent\'s runtime is still starting, try again shortly"}',
+          },
+        ),
+      ),
+      "engine_waking",
+    );
+    strictEqual(
+      classifyQuietError(
+        named(
+          "ActivitiesHttpError",
+          `{"detail":"Post ...: ${dial}","error":"engine proxy failed"}`,
+          { status: 502 },
+        ),
+      ),
+      "engine_waking",
+    );
+  });
 });
 
 describe("quietErrorDetails", () => {

--- a/packages/web/src/engine-adapter/cp/transient-retry.ts
+++ b/packages/web/src/engine-adapter/cp/transient-retry.ts
@@ -63,6 +63,15 @@ const TRANSIENT_STATUSES = new Set([502, 503, 504]);
 const ENGINE_UNAVAILABLE = "engine unavailable";
 const AGENT_IS_WAKING = "agent is waking";
 const ENGINE_PROXY_FAILED = "engine proxy failed";
+/**
+ * The HOST's own word, not the gateway's (`packages/host/src/channel/
+ * probe-wake.ts`): the read-only probe routes (`/providers`, `/providers/usage`,
+ * `/auth/status`) race the agent runtime's boot against a short deadline and
+ * answer this + `Retry-After: 2` instead of holding the socket for the whole
+ * cold boot. The boot keeps running; a retry meets a live runtime.
+ */
+const RUNTIME_STILL_STARTING =
+  "the agent's runtime is still starting, try again shortly";
 export const SHARED_SKILLS_UNCONFIGURED = "shared skills not configured";
 
 /** Why a read got no answer — the typed form of the gateway's 5xx body. */
@@ -117,6 +126,11 @@ export function classifyUnavailableBody(body: unknown): UnavailableReason {
     return "engine-waking";
   }
   if (b?.error === ENGINE_PROXY_FAILED) return "pod-unreachable";
+  // An explicit "ask me again" from a runtime mid-boot. Under the handoff
+  // budget (~2s) every cold boot slower than that surfaced the probe's 503 as
+  // a failure of the provider picker (HOUSTON-APP-54Q); it earns the wake
+  // budget, which is sized for exactly this boot.
+  if (b?.error === RUNTIME_STILL_STARTING) return "engine-waking";
   return "handoff";
 }
 

--- a/packages/web/src/engine-adapter/engine-waking-error.ts
+++ b/packages/web/src/engine-adapter/engine-waking-error.ts
@@ -35,16 +35,29 @@
 // first; this classifier decides how the ones that outlive that budget
 // surface.
 //
-// Three client stacks reach the gateway, minting different error shapes (same
+// A third "not there yet" answer comes from the HOST itself, not the gateway:
+// `503 {"error":"the agent's runtime is still starting, try again shortly"}`
+// (`packages/host/src/channel/probe-wake.ts`). The read-only probe routes
+// (`/providers`, `/providers/usage`, `/auth/status`) race the agent runtime's
+// boot against a short deadline and answer this plus `Retry-After: 2` rather
+// than hold the socket for the whole cold boot. The boot keeps running; the
+// retry meets a live runtime. Same waking state, a different reason string,
+// and it escaped into the red toast + Sentry pipeline because only the two
+// gateway reasons were matched (HOUSTON-APP-54Q).
+//
+// Four client stacks reach the host, minting different error shapes (same
 // split as `agent-name-conflict.ts`, plus the runtime client):
 //
 //  - `HoustonEngineError` (legacy adapter): message is
 //    `"<reason> (engine error <status>)"`, reason verbatim — prefix-matched.
-//  - `AgentsHttpError` (the SDK agent-write path: rename/create/delete):
-//    message is the gateway's RAW JSON body, so the reason is parsed out of
-//    it. Renaming an asleep agent answered the same wake 503 but escaped this
-//    classifier into the red toast + Sentry pipeline because only the legacy
-//    shape was matched (HOUSTON-APP-536).
+//  - `AgentsHttpError` (the SDK agent-write path: rename/create/delete) and
+//    `ActivitiesHttpError` (the SDK activity-write path: mission create /
+//    delete): the message is the gateway's RAW JSON body, so the reason is
+//    parsed out of it. Renaming an asleep agent answered the same wake 503 but
+//    escaped this classifier into the red toast + Sentry pipeline because only
+//    the legacy shape was matched (HOUSTON-APP-536); a mission created against
+//    a pod mid-roll did the same through the activities module, which carries
+//    the body identically but wasn't in the name list (HOUSTON-APP-51X).
 //  - `EngineError` (`@houston/runtime-client` — the per-agent runtime and the
 //    pre-agent setup-runtime clients): carries the raw response text in
 //    `body`, so the reason is parsed the same way. First-run provider login
@@ -65,10 +78,19 @@
 // from the dispatch path, where a wedged pod is a bug we want reported.
 
 const ENGINE_UNAVAILABLE_503 = "engine unavailable";
+const RUNTIME_STILL_STARTING_503 =
+  "the agent's runtime is still starting, try again shortly";
 const ENGINE_PROXY_FAILED_502 = "engine proxy failed";
 const AGENT_POD_UNUSABLE_502 = "agent pod unusable";
 
-/** The gateway `error` reason out of a raw response body (an `AgentsHttpError`
+/** The SDK's per-module HTTP errors. Each carries the raw response body as its
+ *  message, so they share one branch; a new SDK module's error joins here. */
+const SDK_HTTP_ERROR_NAMES = new Set([
+  "AgentsHttpError",
+  "ActivitiesHttpError",
+]);
+
+/** The gateway `error` reason out of a raw response body (an SDK http error's
  *  message or an `EngineError` `body`); null when it isn't gateway JSON
  *  (an HTML error page, the synthetic `agents request failed: <status>`). */
 function gatewayReason(body: string): string | null {
@@ -81,37 +103,44 @@ function gatewayReason(body: string): string | null {
   }
 }
 
+/** The (status, reason) pairs every shape reads as "not there yet". */
+function isWakingAnswer(
+  status: unknown,
+  matches: (reason: string) => boolean,
+): boolean {
+  if (status === 503) {
+    return (
+      matches(ENGINE_UNAVAILABLE_503) || matches(RUNTIME_STILL_STARTING_503)
+    );
+  }
+  return status === 502 && matches(ENGINE_PROXY_FAILED_502);
+}
+
 /**
- * A gateway "the agent's pod is not there right now" answer: the pod is
- * warming up, restarting, or otherwise not accepting connections, and the same
- * request succeeds once it does. Matched structurally (name + status + reason)
- * so this stays dependency-free.
+ * A "the agent's pod is not there right now" answer: the pod or its runtime
+ * is warming up, restarting, or otherwise not accepting connections, and the
+ * same request succeeds once it does. Matched structurally (name + status +
+ * reason) so this stays dependency-free.
  */
 export function isEngineWakingError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const status = (err as { status?: unknown }).status;
   if (err.name === "HoustonEngineError") {
-    return (
-      (status === 503 && err.message.startsWith(ENGINE_UNAVAILABLE_503)) ||
-      (status === 502 && err.message.startsWith(ENGINE_PROXY_FAILED_502))
-    );
+    return isWakingAnswer(status, (reason) => err.message.startsWith(reason));
   }
-  if (err.name === "AgentsHttpError") {
+  if (SDK_HTTP_ERROR_NAMES.has(err.name)) {
     const reason = gatewayReason(err.message);
+    if (reason === null) return false;
     return (
-      (status === 503 && reason === ENGINE_UNAVAILABLE_503) ||
-      (status === 502 &&
-        (reason === ENGINE_PROXY_FAILED_502 ||
-          reason === AGENT_POD_UNUSABLE_502))
+      isWakingAnswer(status, (r) => reason === r) ||
+      (status === 502 && reason === AGENT_POD_UNUSABLE_502)
     );
   }
   if (err.name === "EngineError") {
     const body = (err as { body?: unknown }).body;
     const reason = typeof body === "string" ? gatewayReason(body) : null;
-    return (
-      (status === 503 && reason === ENGINE_UNAVAILABLE_503) ||
-      (status === 502 && reason === ENGINE_PROXY_FAILED_502)
-    );
+    if (reason === null) return false;
+    return isWakingAnswer(status, (r) => reason === r);
   }
   return false;
 }

--- a/packages/web/tests/transient-retry-fetch.test.ts
+++ b/packages/web/tests/transient-retry-fetch.test.ts
@@ -167,6 +167,23 @@ test("the gateway's 5xx vocabulary maps to typed reasons", () => {
   expect(retryDelaysFor("feature-absent")).toEqual([]);
 });
 
+// ── HOUSTON-APP-54Q: the host's runtime-still-starting 503 ──────────────────
+
+test("the host's probe-route 'runtime is still starting' 503 earns the wake budget", () => {
+  // probe-wake.ts answers the read-only probes this way + Retry-After: 2 when
+  // the runtime boot outlasts its 1.5s race; under the handoff budget every
+  // slower cold boot surfaced the probe as a failure.
+  expect(
+    classifyUnavailableBody({
+      error: "the agent's runtime is still starting, try again shortly",
+    }),
+  ).toBe("engine-waking");
+  // The reason is exact: a neighbouring 503 keeps the short patience.
+  expect(
+    classifyUnavailableBody({ error: "the agent's runtime is starting" }),
+  ).toBe("handoff");
+});
+
 // ── PRODUCT-1403: the pod-unreachable 502 ───────────────────────────────────
 
 test("the proxy's engine-proxy-failed 502 is a pod-unreachable read, with the wake budget", () => {


### PR DESCRIPTION
## Summary

PRODUCT-1666. Three "the agent isn't there yet" states escaped the waking classifier and reached the user as a red toast and Sentry as a bug (HOUSTON-APP-54Q, -51X, -53K):

1. **`503 "the agent's runtime is still starting, try again shortly"`** — the host's own probe-route answer (`packages/host/src/channel/probe-wake.ts`), a different reason string for the same waking state. Root cause is two-fold: the read-retry ladder (`transient-retry.ts`) classified it as a generic handoff with ~2s of patience, so every cold boot slower than that surfaced the probe; and the classifier then didn't recognise the reason on any shape.
2. **`ActivitiesHttpError`** (SDK activity-write path) carries the raw gateway body as its message exactly like `AgentsHttpError`, but wasn't in the classifier's name list, so a mission created against a pod mid-roll surfaced `engine proxy failed` as a bug.
3. **`AgentWarmingError`** — the app's own warming-guard refusal, whose "almost ready" dialog is the surface. The custom-integration chat's catch funnelled it through `genericErrorDescription`, which toasted a red "couldn't start" and captured a Sentry error whose message was the dialog's localized copy.

## Fix

- `engine-waking-error.ts`: one `(status, reason)` matcher shared by every shape; adds the still-starting reason on 503 and `ActivitiesHttpError` to the SDK body branch.
- `transient-retry.ts`: the still-starting reason earns the wake budget (15s), which is what the probe's `Retry-After: 2` asks for.
- New dependency-free `agent-warming-refusal.ts` (the guard module pulls the provisioning store, which pulls the reporting layer back); `reportError` and `showErrorToast` decline the refusal, and the integration-chat hook skips its authored toast for it.

## Verification

Before (on `main`): `cd app && pnpm test` with the new cases in `tests/engine-waking-error.test.ts`, `tests/quiet-error-class.test.ts`, `tests/agent-warming-refusal.test.ts`, and `packages/web/tests/transient-retry-fetch.test.ts` fails on each of the three shapes. In the app: open a cloud agent whose pod is asleep and open the provider picker within ~3s of the runtime boot starting, or start a custom-integration chat on a just-created agent: red toast + Sentry error.

After: all of the above pass; `pnpm check`, `cd app && pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck` exit 0. The same actions show the deduped "waking up" notice (or only the "almost ready" dialog), and Sentry gets at most one low-noise `engine_waking` warning.
