### PR TITLE
fix(chat): quiet a same-bearer 401 replay instead of a raw expired-token toast (PRODUCT-1664)

### DIFF
--- a/app/src/lib/gateway-fetch.ts
+++ b/app/src/lib/gateway-fetch.ts
@@ -116,6 +116,13 @@ export async function gatewayFetch(
   const res = await send(bearer);
   if (res.status !== 401) return res;
   const fresh = await refreshGatewayBearer(() => deps.refresh());
+  // A refresh that hands back the SAME bearer the gateway just rejected is not
+  // a real mint (securetoken returns the still-cached idToken when refreshed
+  // twice inside one token's lifetime): replaying it earns the identical 401.
+  // Treat it as signed-out (null) so callers stay quiet instead of surfacing a
+  // raw expired-token error, matching the canonical `cp/fetch` twin
+  // (PRODUCT-1664). A genuinely new bearer the gateway rejects still replays.
+  if (fresh === bearer) return res;
   return fresh ? await send(fresh) : res;
 }
 

--- a/app/tests/gateway-fetch.test.ts
+++ b/app/tests/gateway-fetch.test.ts
@@ -122,6 +122,28 @@ describe("gatewayFetch", () => {
     strictEqual(sent.length, 1);
   });
 
+  it("does not replay when the refresh returns the same rejected bearer", async () => {
+    // securetoken hands back the still-cached idToken when refreshed twice
+    // inside one token's lifetime, so the "fresh" bearer equals the one the
+    // gateway just rejected — replaying it only earns the identical 401
+    // (PRODUCT-1664). Surface the original 401 without a doomed second send.
+    const sent: Sent[] = [];
+    let refreshes = 0;
+    const res = await gatewayFetch(
+      deps([new Response(null, { status: 401 })], sent, {
+        token: () => "stale",
+        refresh: async () => {
+          refreshes++;
+          return "stale";
+        },
+      }),
+      "/v1/me",
+    );
+    strictEqual(refreshes, 1);
+    strictEqual(res?.status, 401);
+    strictEqual(sent.length, 1);
+  });
+
   it("sends nothing at all when there is no session", async () => {
     const sent: Sent[] = [];
     strictEqual(

--- a/packages/web/src/engine-adapter/cp/fetch.ts
+++ b/packages/web/src/engine-adapter/cp/fetch.ts
@@ -146,6 +146,20 @@ export function gatewayAuthFetch(
         ? signedOutResponse()
         : res;
     }
+    // The refresher handed back the SAME bearer the gateway just rejected: no
+    // real mint happened (securetoken returns the still-cached idToken when it
+    // is asked to refresh twice inside one token's lifetime — no network POST,
+    // no breadcrumb), so replaying would only earn the identical 401. On a
+    // wake-from-sleep burst several parallel queries share one such refresh and
+    // each would surface a raw "invalid or expired token" toast + Sentry report
+    // (HOUSTON-APP-4YD/53R/58P, PRODUCT-1664). Treat it as the same quiet
+    // signed-out lifecycle state as the null branch — a genuinely NEW fresh
+    // bearer the gateway rejects still replays below and stays loud.
+    if (fresh === bearer) {
+      return inControlPlaneMode() && hasSessionRefresher()
+        ? signedOutResponse()
+        : res;
+    }
     return send(fresh);
   };
 }

--- a/packages/web/tests/gateway-reauth.test.ts
+++ b/packages/web/tests/gateway-reauth.test.ts
@@ -28,6 +28,7 @@ afterEach(() => {
 function setEngineWindow(opts: {
   token: string;
   refresh?: () => Promise<string | null>;
+  controlPlane?: boolean;
 }): void {
   Object.defineProperty(globalThis, "window", {
     configurable: true,
@@ -37,8 +38,16 @@ function setEngineWindow(opts: {
         token: opts.token,
       },
       __HOUSTON_SESSION_REFRESH__: opts.refresh,
+      __HOUSTON_CP__: opts.controlPlane === true,
     },
   });
+}
+
+/** The `error` field of a JSON Response body, or null. `signedOutResponse`
+ *  mints `{ error: "signed_out" }`, which the toast layer suppresses. */
+async function errorFieldOf(res: Response): Promise<string | null> {
+  const body = (await res.clone().json()) as { error?: string };
+  return body.error ?? null;
 }
 
 function json(status: number, body: unknown = {}): Response {
@@ -96,6 +105,39 @@ test("a 401 whose refresh fails (real sign-out) surfaces as-is", async () => {
 
   expect(res.status).toBe(401);
   expect(calls).toHaveLength(1);
+});
+
+test("a refresh that returns the SAME rejected bearer stays quiet, never replays", async () => {
+  // On a wake-from-sleep burst, securetoken hands back the still-cached idToken
+  // when refreshed twice inside one token's lifetime — no network mint (no
+  // breadcrumb) — so the "fresh" bearer equals the one the gateway just
+  // rejected. Replaying it earns the identical 401 and a raw expired-token
+  // toast storm (HOUSTON-APP-4YD/53R/58P, PRODUCT-1664). Treat it as the quiet
+  // synthetic signed-out state instead, and never send the doomed replay.
+  const refresh = vi.fn(async () => "stale");
+  setEngineWindow({ token: "stale", refresh, controlPlane: true });
+  const calls = stubFetch(json(401));
+
+  const res = await gatewayAuthFetch(CFG.token)("https://gateway.example/x");
+
+  expect(res.status).toBe(401);
+  expect(await errorFieldOf(res)).toBe("signed_out");
+  expect(refresh).toHaveBeenCalledTimes(1);
+  expect(calls).toHaveLength(1); // only the original attempt — no replay
+});
+
+test("a genuinely NEW fresh bearer the gateway still rejects stays LOUD", async () => {
+  // The narrow same-bearer carve-out must not swallow a real bug: a token the
+  // refresher actually minted anew, rejected on replay, is surfaced raw.
+  const refresh = vi.fn(async () => "fresh");
+  setEngineWindow({ token: "stale", refresh, controlPlane: true });
+  const calls = stubFetch(json(401), json(401));
+
+  const res = await gatewayAuthFetch(CFG.token)("https://gateway.example/x");
+
+  expect(res.status).toBe(401);
+  expect(await errorFieldOf(res)).toBe(null); // the gateway's raw 401, not signed_out
+  expect(calls.map(bearerOf)).toEqual(["Bearer stale", "Bearer fresh"]);
 });
 
 test("concurrent 401s share one refresh (single-flight)", async () => {


### PR DESCRIPTION
## Root cause

The hosted `401 → refresh → replay` seam surfaced a loud **"invalid or expired token (401)"** toast + Sentry report whenever the session refresher handed back the **same bearer** the gateway had just rejected.

Google's `securetoken` refresh endpoint returns the still-cached `idToken` when it is asked to refresh twice inside one token's ~1h lifetime — no network mint happens (so **no `securetoken` breadcrumb**, matching every recent event), and the replay carries the identical, already-rejected token. On a wake-from-sleep burst several parallel queries share one such refresh via the single-flight latch, so a single expired bearer fanned out into a storm of raw 401 toasts across `list_workspaces`, `integration_status`, `list_all_conversations_partial`, providers, etc.

Confirmed against gateway logs for the 0.6.14 events (e.g. 2026-09-03 18:40:30): ~24 parallel `invalid or expired token` 401s for one user in the same second, while a sibling call's later replay returned 200 — the early single-flight group replayed a cached, rejected bearer and toasted.

This reopened **HOUSTON-APP-4YD / 53R / 58P** on 0.6.13 and 0.6.14 after PR #1426 only closed the refresher-returns-**null** flavor.

## Fix

After the single refresh, if the returned bearer **equals** the one the gateway just rejected, treat it as the same quiet signed-out lifecycle state as the null branch and **skip the doomed replay** — no raw 401, no Sentry report. A genuinely **new** fresh bearer the gateway still rejects stays loud, because that is a real bug that must surface.

Applied to both parity twins:
- `packages/web/src/engine-adapter/cp/fetch.ts` (`gatewayAuthFetch`) — quiet synthetic signed-out 401.
- `app/src/lib/gateway-fetch.ts` (`gatewayFetch`) — surfaces the original 401 without a second send, matching its own terminal semantics.

## Tests

- `packages/web/tests/gateway-reauth.test.ts`: same rejected bearer → quiet `signed_out`, exactly one network attempt; new fresh bearer still rejected → stays loud with a replay.
- `app/tests/gateway-fetch.test.ts`: same rejected bearer → no replay, original 401 returned.

## Verify

**Before** — with an expired desktop session on 0.6.13/0.6.14, wake the app from sleep so many cached queries fire at once. A red "invalid or expired token" toast storm appears and Sentry logs 4YD/53R/58P, with zero `securetoken` POSTs in the breadcrumbs.

**After** — the same wake resolves silently: the first query's refresh returns the cached bearer, the transport recognizes it as the signed-out state and stays quiet, and the proactive refresh timer / next query recovers. No toast, no Sentry report. `pnpm --filter houston-web test` and `cd app && pnpm test` both green.

Closes PRODUCT-1664.