### PR TITLE
fix(host): view-docs boot warm survives a synchronised roll (PRODUCT-1621)

### DIFF
--- a/packages/host/src/docs/view-warm.test.ts
+++ b/packages/host/src/docs/view-warm.test.ts
@@ -42,6 +42,110 @@ test("boot warm outlasts a runtime that takes 70s to become healthy", async () =
   vi.useRealTimers();
 });
 
+function stillStarting(): Response {
+  return new Response('{"error":"still starting"}', {
+    status: 503,
+    headers: { "Retry-After": "2" },
+  });
+}
+
+// A fleet-synchronised roll can blow the launcher's 60s boot budget outright;
+// the warm's next probe re-spawns, so the runtime is only up after a SECOND
+// full boot. The warm must cover that, not give up between the two.
+test("boot warm outlasts a failed first boot plus a second one (150s)", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  await store.createAgent({ workspaceId: workspace.id, name: "Only" });
+  const start = Date.now();
+  const statuses: number[] = [];
+  const fetchImpl = vi.fn(async () => {
+    const response =
+      Date.now() - start < 150_000
+        ? stillStarting()
+        : new Response("{}", { status: 200 });
+    statuses.push(response.status);
+    return response;
+  }) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  warmViewDocs({ port: 4318, token: "t", store, fetchImpl });
+  await vi.advanceTimersByTimeAsync(400_000);
+  expect(statuses).toContain(200);
+  expect(errorSpy).not.toHaveBeenCalled();
+  expect(warnSpy).not.toHaveBeenCalled();
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// A runtime STILL not up after the whole window is the launcher's failure and
+// already a Sentry error there; the warm stands down as a breadcrumb instead
+// of filing a second error per pod per roll (HOUSTON-APP-5AP).
+test("a runtime still starting after the whole window stands down quietly", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  await store.createAgent({ workspaceId: workspace.id, name: "Only" });
+  const fetchImpl = vi.fn(async () =>
+    stillStarting(),
+  ) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  warmViewDocs({ port: 4318, token: "t", store, fetchImpl });
+  await vi.advanceTimersByTimeAsync(1_000_000);
+  expect(errorSpy).not.toHaveBeenCalled();
+  // One stand-down per view route, each after its own window.
+  expect(warnSpy).toHaveBeenCalledTimes(4);
+  expect(warnSpy.mock.calls[0]?.[0]).toMatch(/still starting/);
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// A runtime that IS up but answers the view with an error is a broken view,
+// never a boot: that stays loud.
+test("a view that keeps answering 500 after the window still reports", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  await store.createAgent({ workspaceId: workspace.id, name: "Only" });
+  const fetchImpl = vi.fn(
+    async () => new Response("{}", { status: 500 }),
+  ) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  warmViewDocs({ port: 4318, token: "t", store, fetchImpl });
+  await vi.advanceTimersByTimeAsync(1_000_000);
+  expect(warnSpy).not.toHaveBeenCalled();
+  expect(errorSpy).toHaveBeenCalledTimes(4);
+  expect(errorSpy.mock.calls[0]?.[0]).toMatch(/gave up \(last status 500\)/);
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// A plain 503 (no Retry-After) is not the probe contract's "not now" — e.g. a
+// route with no channel wired — and stays loud like any other failure.
+test("a bare 503 without Retry-After still reports", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  await store.createAgent({ workspaceId: workspace.id, name: "Only" });
+  const fetchImpl = vi.fn(
+    async () => new Response("{}", { status: 503 }),
+  ) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  warmViewDocs({ port: 4318, token: "t", store, fetchImpl });
+  await vi.advanceTimersByTimeAsync(1_000_000);
+  expect(warnSpy).not.toHaveBeenCalled();
+  expect(errorSpy).toHaveBeenCalledTimes(4);
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  vi.useRealTimers();
+});
+
 test("a SkillsChanged event re-fetches /skills for that agent (debounced)", async () => {
   vi.useFakeTimers();
   const store = new MemoryWorkspaceStore();

--- a/packages/host/src/docs/view-warm.ts
+++ b/packages/host/src/docs/view-warm.ts
@@ -4,13 +4,14 @@ import type { WorkspaceStore } from "../ports";
 import { listAgentIds } from "./project-family";
 import { VIEW_RESTS } from "./view-capture";
 
-// The ladder must OUTLAST the launcher's 60s boot-health budget
+// The warm must OUTLAST the launcher's 60s boot-health budget
 // (launcher/process.ts BOOT_HEALTH_BUDGET_MS): `/providers` probes answer 503
-// while the runtime boots, and on a freshly woken pod the boot competes with
-// store hydration for a capped CPU (observed >35s). 9 attempts × 10s spacing
-// ≈ 85s of coverage — a give-up now means a runtime that blew its own boot
-// budget, not a slow-but-healthy wake (HOUSTON-APP-5AP).
-const ATTEMPTS = 9;
+// while the runtime boots. Under a fleet-synchronised roll a CPU-starved pod
+// can blow that budget outright (hydration alone was seen at >100s), and the
+// warm's next probe re-spawns the runtime — so the window covers a FAILED
+// first boot plus a full second one, not just one slow-but-healthy wake
+// (HOUSTON-APP-5AP).
+const WARM_BUDGET_MS = 180_000;
 const RETRY_DELAY_MS = 10_000;
 const REFRESH_DEBOUNCE_MS = 500;
 
@@ -20,33 +21,51 @@ interface SelfFetch {
   fetchImpl?: typeof fetch;
 }
 
-/** GET one of our own view routes so the server's capture re-publishes it. */
+interface ViewAnswer {
+  /** Last HTTP status, or -1 for a network-level failure. */
+  status: number;
+  /**
+   * The last answer was the probe contract's "not here, not now" (503 +
+   * Retry-After, channel/probe-wake.ts): the runtime is still starting or the
+   * host is mid-shutdown. Nothing about the view itself failed.
+   */
+  notNow: boolean;
+}
+
+/**
+ * GET one of our own view routes so the server's capture re-publishes it.
+ * Retries every RETRY_DELAY_MS until a 200 or until `budgetMs` elapses; a zero
+ * budget is a single attempt.
+ */
 async function fetchView(
   self: SelfFetch,
   agentId: string,
   rest: string,
-  attempts: number,
-): Promise<number> {
+  budgetMs: number,
+): Promise<ViewAnswer> {
   const fetchImpl = self.fetchImpl ?? fetch;
   const url = `http://127.0.0.1:${self.port}/agents/${encodeURIComponent(agentId)}/${rest}`;
-  let lastStatus = 0;
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    if (attempt > 0) {
-      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-    }
+  const deadline = Date.now() + budgetMs;
+  const answer: ViewAnswer = { status: 0, notNow: false };
+  for (;;) {
     try {
       const response = await fetchImpl(url, {
         headers: { Authorization: `Bearer ${self.token}` },
         signal: AbortSignal.timeout(30_000),
       });
-      lastStatus = response.status;
+      answer.status = response.status;
+      answer.notNow =
+        response.status === 503 && response.headers.has("Retry-After");
       await response.body?.cancel();
       if (response.ok) break;
     } catch {
-      lastStatus = -1; // network-level; retry
+      answer.status = -1; // network-level; retry
+      answer.notNow = false;
     }
+    if (Date.now() + RETRY_DELAY_MS > deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
   }
-  return lastStatus;
+  return answer;
 }
 
 async function singleAgentId(store: WorkspaceStore): Promise<string | null> {
@@ -70,12 +89,28 @@ export function warmViewDocs(
     const only = await singleAgentId(opts.store);
     if (only === null) return;
     for (const rest of Object.keys(VIEW_RESTS)) {
-      const status = await fetchView(opts, only, rest, ATTEMPTS);
-      if (status !== 200) {
-        console.error(
-          `[view-docs] boot warm for ${rest} gave up (last status ${status})`,
+      const { status, notNow } = await fetchView(
+        opts,
+        only,
+        rest,
+        WARM_BUDGET_MS,
+      );
+      if (status === 200) continue;
+      // A runtime still not up after the whole window is the launcher's
+      // failure, and it is already loud there (the eager spawn's "never became
+      // healthy" error). The warm is best-effort on top: the previously
+      // published doc keeps serving asleep readers and the next live read
+      // re-publishes, so a give-up here is a breadcrumb, not a second error
+      // per pod per roll.
+      if (notNow) {
+        console.warn(
+          `[view-docs] boot warm for ${rest} stood down: runtime still starting after ${WARM_BUDGET_MS / 1000}s`,
         );
+        continue;
       }
+      console.error(
+        `[view-docs] boot warm for ${rest} gave up (last status ${status})`,
+      );
     }
   })().catch((error: unknown) => {
     console.error("[view-docs] boot warm failed", error);
@@ -110,7 +145,7 @@ export function refreshViewsOnEvents(
             ? event.agentPath
             : await singleAgentId(opts.store);
         if (agentId === null) return;
-        const status = await fetchView(opts, agentId, rest, 1);
+        const { status } = await fetchView(opts, agentId, rest, 0);
         if (status !== 200) {
           // An agent delete/rename unlinks `.agents/skills/**`, and the FS
           // watcher classifies each unlink as SkillsChanged for the now-gone


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1621 (Sentry HOUSTON-APP-5AP, boot-warm flavor).

**Root cause.** A fleet-synchronised roll CPU-starves engine pods. On the latest event's pod, store hydration took 106s and the eager runtime spawn then blew the launcher's 60s boot-health budget (that failure is its own Sentry issue, HOUSTON-APP-5AZ, 68s earlier on the same pod). The warm's next `/providers` probe re-spawned the runtime, but the old 9x10s ladder (~85s) expired while that second boot was still in flight, so the warm logged `gave up (last status 503)` as an error, one per pod per roll. The single `(last status 500)` event is the same boot failure landing inside the probe's 1.5s race window.

**Fix** (`packages/host/src/docs/view-warm.ts`):
- The boot warm runs on a 180s window (covers a failed first boot plus a full second one), 10s spacing, instead of a fixed 9-attempt ladder.
- A give-up whose last answer was the probe contract's "not now" (503 + `Retry-After`, `channel/probe-wake.ts`) stands down at **warn** level (a Sentry breadcrumb, not an event): the runtime not being up is the launcher's failure and already loud there, the previously published doc keeps serving asleep readers, and the next live read re-publishes. Any other non-200 (500, bare 503 without `Retry-After`, 404, network) still reports as an error.
- Event-driven refreshes keep their single attempt.

## Before

1. Simulate a pod whose runtime needs more than 85s to boot: the warm's fetch answers `503` + `Retry-After: 2` for 150s, then `200` (the new test "boot warm outlasts a failed first boot plus a second one" does exactly this).
2. On `main` the warm gives up at ~85s and `console.error("[view-docs] boot warm for providers gave up (last status 503)")` fires, which the host console capture turns into a HOUSTON-APP-5AP event.

## After

1. Same scenario: the warm keeps probing, reaches the 200 at 150s and publishes the doc. No error, no warning.
2. Runtime never up: after 180s per runtime-backed view the warm logs a `console.warn` stand-down (breadcrumb only). HOUSTON-APP-5AZ still carries the launcher's boot failure.
3. Runtime up but the view answers 500 / bare 503: still `console.error`, unchanged.

```
pnpm --filter @houston/host exec vitest run src/docs/view-warm.test.ts   # 9 passed
pnpm --filter @houston/host typecheck
pnpm check
```

## Follow-up after merge (Sentry)

Resolve HOUSTON-APP-5AP with an in-next-release condition once this is the newest engine build, so events from pre-fix engines cannot flip it to regressed and the Linear sync stops re-filing it.
