### PR TITLE
fix(shell): never forward a stale CLAUDE_CODE_GIT_BASH_PATH to the Claude CLI

### DIFF
--- a/app/src-tauri/src/claude_login/mod.rs
+++ b/app/src-tauri/src/claude_login/mod.rs
@@ -24,13 +24,16 @@
 //! Two Tauri events carry the flow to the webview:
 //!   * `claude-login://url`  — payload is the authorize URL `String` (emitted at
 //!     most once, when the CLI prints its `visit:` line).
-//!   * `claude-login://done` — payload
-//!     `{ success: bool, error: string | null, helperUnavailable?: bool }`.
+//!   * `claude-login://done` — payload `{ success: bool, error: string | null,
+//!     helperUnavailable?: bool, shellUnavailable?: bool }`.
 //!     A `null` error on `success: false` is a benign CANCEL (the frontend
 //!     treats it as a silent dismissal, not a failure to toast).
 //!     `helperUnavailable: true` means the helper binary cannot run on this
 //!     machine at all (pre-AVX2 CPU, signal death) — the frontend degrades a
 //!     remote-engine login to the runtime's paste flow instead of toasting.
+//!     `shellUnavailable: true` means the CLI started but refused its Windows
+//!     shell gate (no runnable Git Bash / PowerShell; [`shell_gate`]) — same
+//!     degrade path, and a co-located engine gets install-Git copy.
 //!
 //! Cancel + child kill run through `ClaudeLoginState`; the background task that
 //! owns the child polls a shared cancel flag and tears the child down when set.
@@ -38,6 +41,7 @@
 //! Split across submodules to stay under the 200-line file limit:
 //!   * [`resolve`] — binary/config-dir resolution, command building, URL parse.
 //!   * [`runner`] — the spawn/stream/wait state machine (`run_login_child`).
+//!   * [`shell_gate`] — classify the CLI's Windows shell-gate refusal.
 //!   * [`credential`] — extract the cached credential to PUSH to a remote pod.
 
 // `pub(crate)` so `generate_handler!` in `lib.rs` can name the command at its
@@ -50,6 +54,7 @@ pub(crate) mod credential;
 pub(crate) mod discard;
 mod resolve;
 mod runner;
+mod shell_gate;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/app/src-tauri/src/claude_login/resolve.rs
+++ b/app/src-tauri/src/claude_login/resolve.rs
@@ -69,9 +69,7 @@ pub(super) fn build_login_command(bin: &Path, config_dir: &Path) -> Command {
         .kill_on_drop(true);
     // The CLI's Windows startup gate needs a resolvable shell (Git Bash or
     // PowerShell); repair the child env so it can't miss (HOUSTON-APP-4YP).
-    for (key, value) in crate::shell_env::claude_shell_env() {
-        cmd.env(key, value);
-    }
+    crate::shell_env::apply_claude_shell_env(cmd.as_std_mut());
     // Spawn from the user's home dir, NOT the inherited cwd: the CLI's shell
     // probe discards which() hits inside its own cwd, so an inherited
     // `C:\Windows\System32` (autostart / deep-link launches) silently filters

--- a/app/src-tauri/src/claude_login/runner.rs
+++ b/app/src-tauri/src/claude_login/runner.rs
@@ -17,6 +17,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdout};
 
 use super::resolve::{build_login_command, extract_visit_url};
+use super::shell_gate::is_shell_gate_failure;
 use super::{EVENT_DONE, EVENT_URL};
 
 /// Give up on the login if the CLI never returns (user closed the consent tab,
@@ -111,25 +112,36 @@ where
                 .code()
                 .map(|c| c.to_string())
                 .unwrap_or_else(|| signal_label(&status));
+            // The CLI ran but refused its Windows shell gate: the machine
+            // lacks a runnable Git Bash / PowerShell (HOUSTON-APP-4ZP). Same
+            // degrade path as an unrunnable helper; the frontend shows
+            // install-Git copy instead of the raw CLI text.
+            let shell_unavailable = is_shell_gate_failure(&tail);
             let mut error = format!("Claude sign-in failed (exit {code})");
             if !tail.trim().is_empty() {
                 error.push_str(": ");
                 error.push_str(tail.trim());
             }
-            if helper_unavailable {
+            if helper_unavailable || shell_unavailable {
                 // WARN, not error: a signal death means this machine cannot run
-                // the helper (SIGILL on pre-AVX2, OOM kill, hardened kernel) and
-                // the frontend already degrades to the paste flow. A Sentry
-                // event per attempt from the same broken machines is noise
-                // (HOUSTON-APP-543 kept regressing on it); the breadcrumb +
-                // backend.log line keeps the diagnosis trail.
+                // the helper (SIGILL on pre-AVX2, OOM kill, hardened kernel),
+                // a shell-gate refusal means it lacks a prerequisite, and the
+                // frontend already degrades both. A Sentry event per attempt
+                // from the same machines is noise (HOUSTON-APP-543 and -4ZP
+                // kept regressing on it); the breadcrumb + backend.log line
+                // keeps the diagnosis trail.
                 tracing::warn!("[claude-login] {error}");
             } else {
                 tracing::error!("[claude-login] {error}");
             }
             emit(
                 EVENT_DONE,
-                json!({ "success": false, "error": error, "helperUnavailable": helper_unavailable }),
+                json!({
+                    "success": false,
+                    "error": error,
+                    "helperUnavailable": helper_unavailable,
+                    "shellUnavailable": shell_unavailable,
+                }),
             );
         }
         Ok(LoginOutcome::Exited(Err(e))) => {
@@ -412,6 +424,38 @@ mod tests {
         );
         // A plain non-zero exit (e.g. a declined authorization) is NOT a
         // helper-can't-run condition — it must never reroute to the paste flow.
+        assert_eq!(done.1["helperUnavailable"], json!(false));
+        assert_eq!(done.1["shellUnavailable"], json!(false));
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_login_flags_the_cli_shell_gate_as_shell_unavailable() {
+        // The CLI's Windows shell-gate refusal (HOUSTON-APP-4ZP) is a missing
+        // prerequisite, not a login failure: the payload must carry the flag
+        // so the frontend shows install-Git copy (or the paste flow on a
+        // remote engine) instead of the raw CLI text, while the helper itself
+        // stays "runnable".
+        let dir = unique_tmp_dir("shell-gate");
+        let script = write_fake_claude(
+            &dir,
+            "claude",
+            "#!/bin/sh\n\
+             echo 'Claude Code was unable to find CLAUDE_CODE_GIT_BASH_PATH path \"C:\\x\\bash.exe\"' 1>&2\n\
+             exit 1\n",
+        );
+        let config_dir = dir.join("config");
+
+        let (events, emit) = collect();
+        run_login(&script, &config_dir, Arc::new(AtomicBool::new(false)), emit).await;
+
+        let got = events.lock().expect("events lock");
+        let done = got.last().expect("done event");
+        assert_eq!(done.0, EVENT_DONE);
+        assert_eq!(done.1["success"], json!(false));
+        assert_eq!(done.1["shellUnavailable"], json!(true));
         assert_eq!(done.1["helperUnavailable"], json!(false));
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/app/src-tauri/src/claude_login/shell_gate.rs
+++ b/app/src-tauri/src/claude_login/shell_gate.rs
@@ -1,0 +1,60 @@
+//! Recognize the Claude Code CLI's Windows shell gate in a failed login's
+//! stderr. The CLI refuses to start on Windows without a runnable shell (Git
+//! Bash or PowerShell) and exits 1 with an install-Git message; when it does,
+//! nothing in Houston broke — the machine is missing a prerequisite — so the
+//! result is reported as an expected setup state (warn + a flagged `done`
+//! payload the frontend turns into authored copy), never a raw CLI toast or a
+//! Sentry error per retry (HOUSTON-APP-4ZP kept regressing on exactly that).
+
+/// Phrases the CLI prints (any version shipped so far) when its Windows shell
+/// probe fails. Matched case-insensitively on the stderr tail.
+const SHELL_GATE_MARKERS: [&str; 4] = [
+    // An override the CLI could not run (CLI ≤ 2.1.25x wording).
+    "unable to find claude_code_git_bash_path",
+    // Neither Git Bash nor PowerShell resolved.
+    "requires either git for windows",
+    // Git Bash missing while the PowerShell tool is disabled by env/settings.
+    "requires a shell tool",
+    "git bash was not found",
+];
+
+/// True when `stderr` carries the CLI's Windows shell-gate refusal.
+pub(super) fn is_shell_gate_failure(stderr: &str) -> bool {
+    let lowered = stderr.to_ascii_lowercase();
+    SHELL_GATE_MARKERS.iter().any(|m| lowered.contains(m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_a_rejected_override() {
+        // Verbatim from HOUSTON-APP-4ZP.
+        assert!(is_shell_gate_failure(
+            "Claude Code was unable to find CLAUDE_CODE_GIT_BASH_PATH path \
+             \"C:\\Users\\u\\AppData\\Local\\Microsoft\\WindowsApps\\bash.exe\""
+        ));
+    }
+
+    #[test]
+    fn recognizes_the_no_shell_install_prompts() {
+        assert!(is_shell_gate_failure(
+            "Claude Code on Windows requires either Git for Windows (for bash) or PowerShell. \
+             Install one of:\n  - Git for Windows: https://git-scm.com/downloads/win"
+        ));
+        assert!(is_shell_gate_failure(
+            "Claude Code on Windows requires a shell tool. Git Bash was not found and the \
+             PowerShell tool is disabled (CLAUDE_CODE_USE_POWERSHELL_TOOL=0)."
+        ));
+    }
+
+    #[test]
+    fn ignores_other_login_failures() {
+        // A declined authorization or a network error is a real login
+        // failure and must keep its verbatim surface.
+        assert!(!is_shell_gate_failure("authentication was declined"));
+        assert!(!is_shell_gate_failure("fetch failed: ENOTFOUND claude.ai"));
+        assert!(!is_shell_gate_failure(""));
+    }
+}

--- a/app/src-tauri/src/engine_supervisor.rs
+++ b/app/src-tauri/src/engine_supervisor.rs
@@ -190,9 +190,7 @@ impl EngineSubprocess {
         // on Windows that CLI refuses to start without a resolvable shell.
         // Repair the env BEFORE the caller-provided pairs so an explicit
         // override still wins (see `shell_env`).
-        for (key, value) in crate::shell_env::claude_shell_env() {
-            cmd.env(key, value);
-        }
+        crate::shell_env::apply_claude_shell_env(&mut cmd);
         for (k, v) in env {
             cmd.env(k, v);
         }

--- a/app/src-tauri/src/git_bash.rs
+++ b/app/src-tauri/src/git_bash.rs
@@ -1,0 +1,145 @@
+//! Validation of an inherited `CLAUDE_CODE_GIT_BASH_PATH` override.
+//!
+//! The Claude Code CLI honors that env var verbatim and refuses to start when
+//! it does not name a usable bash (HOUSTON-APP-4ZP: `unable to find
+//! CLAUDE_CODE_GIT_BASH_PATH path ".../WindowsApps/bash.exe"`). A value the
+//! app inherits from the user's environment can be stale in ways a plain
+//! "does the file exist" probe cannot see:
+//!
+//! * `%LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe` is the Windows
+//!   app-execution alias for WSL — a reparse-point stub that `is_file()`
+//!   accepts, but it is not Git Bash and the CLI rejects it.
+//! * `%SystemRoot%\System32\bash.exe` (and its `Sysnative` twin) is the
+//!   classic WSL launcher, equally wrong.
+//! * Any other reparse point (app alias, dangling junction) may resolve for
+//!   us and fail for the CLI's own probe.
+//!
+//! Path-shape logic is pure so it is unit-tested on every host; the
+//! filesystem probe is Windows-only.
+
+use std::path::Path;
+
+/// Path components (case-insensitive) under which a `bash.exe` is a WSL
+/// launcher rather than Git for Windows.
+const WSL_BASH_DIRS: [&str; 3] = ["windowsapps", "system32", "sysnative"];
+
+/// True when `path` names a WSL `bash.exe` (a Windows app-execution alias or
+/// the System32 launcher). Pure string logic over the path shape; both `\`
+/// and `/` separators are accepted, comparison is case-insensitive.
+pub fn is_wsl_bash_alias(path: &str) -> bool {
+    let lowered = path.to_ascii_lowercase().replace('/', "\\");
+    let mut parts = lowered.rsplit('\\').filter(|p| !p.is_empty());
+    let Some(file) = parts.next() else {
+        return false;
+    };
+    if file != "bash.exe" {
+        return false;
+    }
+    parts.any(|dir| WSL_BASH_DIRS.contains(&dir))
+}
+
+/// True when an inherited `CLAUDE_CODE_GIT_BASH_PATH` value is a bash the CLI
+/// can actually run: not a WSL alias location, and a REAL file rather than a
+/// reparse-point stub. Anything else is stale and must not reach the child.
+pub fn is_usable_git_bash_override(value: &str) -> bool {
+    if is_wsl_bash_alias(value) {
+        return false;
+    }
+    is_regular_file(Path::new(value))
+}
+
+/// A plain file, judged WITHOUT following reparse points: `Path::is_file`
+/// follows app-execution aliases (Rust's stat falls back to the unresolved
+/// attributes for non-symlink reparse tags), so it says "file" for exactly
+/// the WSL stub the CLI cannot run.
+fn is_regular_file(path: &Path) -> bool {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return false;
+        }
+    }
+    meta.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windowsapps_alias_is_wsl() {
+        // The exact shape from HOUSTON-APP-4ZP.
+        assert!(is_wsl_bash_alias(
+            "C:\\Users\\u\\AppData\\Local\\Microsoft\\WindowsApps\\bash.exe"
+        ));
+        // Case and separator variants.
+        assert!(is_wsl_bash_alias(
+            "c:/users/u/appdata/local/microsoft/WINDOWSAPPS/BASH.EXE"
+        ));
+    }
+
+    #[test]
+    fn system32_launchers_are_wsl() {
+        assert!(is_wsl_bash_alias("C:\\Windows\\System32\\bash.exe"));
+        assert!(is_wsl_bash_alias("C:\\Windows\\Sysnative\\bash.exe"));
+    }
+
+    #[test]
+    fn git_for_windows_layouts_are_not_wsl() {
+        assert!(!is_wsl_bash_alias("C:\\Program Files\\Git\\bin\\bash.exe"));
+        assert!(!is_wsl_bash_alias("C:\\Program Files\\Git\\usr\\bin\\bash.exe"));
+        assert!(!is_wsl_bash_alias(
+            "C:\\Users\\u\\AppData\\Local\\Programs\\Git\\bin\\bash.exe"
+        ));
+        // A portable MSYS2 bash is a real bash the CLI can run.
+        assert!(!is_wsl_bash_alias("D:\\tools\\msys64\\usr\\bin\\bash.exe"));
+    }
+
+    #[test]
+    fn non_bash_files_are_never_aliases() {
+        assert!(!is_wsl_bash_alias("C:\\Windows\\System32\\cmd.exe"));
+        assert!(!is_wsl_bash_alias(""));
+        assert!(!is_wsl_bash_alias("bash.exe"));
+    }
+
+    #[test]
+    fn override_probe_rejects_aliases_and_missing_files() {
+        assert!(!is_usable_git_bash_override(
+            "C:\\Users\\u\\AppData\\Local\\Microsoft\\WindowsApps\\bash.exe"
+        ));
+        assert!(!is_usable_git_bash_override("/nonexistent/houston/bash.exe"));
+    }
+
+    #[test]
+    fn override_probe_accepts_a_real_file_and_rejects_a_symlink() {
+        let dir = std::env::temp_dir().join(format!(
+            "houston-git-bash-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir temp");
+        let real = dir.join("bash.exe");
+        std::fs::write(&real, b"#!/bin/sh\n").expect("write fake bash");
+        assert!(is_usable_git_bash_override(real.to_str().expect("utf8 path")));
+        // A directory is not a bash binary.
+        assert!(!is_usable_git_bash_override(dir.to_str().expect("utf8 path")));
+        #[cfg(unix)]
+        {
+            // A symlink resolves for `is_file` but is judged on its own
+            // (unfollowed) metadata here — the same posture that rejects a
+            // Windows reparse-point stub.
+            let link = dir.join("link-bash.exe");
+            std::os::unix::fs::symlink(&real, &link).expect("symlink");
+            assert!(!is_usable_git_bash_override(link.to_str().expect("utf8 path")));
+        }
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2,6 +2,10 @@ mod appimage_env;
 mod auth;
 mod bug_report;
 mod child_guard;
+// Only the Windows shell repair consumes it; the pure path logic stays
+// compiled (and tested) on every host.
+#[cfg_attr(not(windows), allow(dead_code))]
+mod git_bash;
 mod claude_login;
 mod codex_oauth_loopback;
 mod commands;

--- a/app/src-tauri/src/shell_env.rs
+++ b/app/src-tauri/src/shell_env.rs
@@ -12,7 +12,12 @@
 //!
 //! 1. If a Git for Windows `bash.exe` exists at a standard install location,
 //!    point `CLAUDE_CODE_GIT_BASH_PATH` at it (the CLI's documented escape
-//!    hatch; an inherited value that resolves is left alone).
+//!    hatch; an inherited value that names a usable bash is left alone). An
+//!    inherited value that does NOT — the WSL app-execution alias under
+//!    `WindowsApps`, a reparse-point stub, a missing file — is REMOVED from
+//!    the child when no standard install replaces it: forwarding it makes the
+//!    CLI refuse to start outright (HOUSTON-APP-4ZP), whereas without the var
+//!    the CLI's own probe still finds PowerShell (see `git_bash`).
 //! 2. Append the built-in PowerShell dir (and `System32`, which `where`-style
 //!    lookups need) to the child's PATH when missing, so the CLI's
 //!    `powershell` fallback can never miss.
@@ -42,9 +47,20 @@ pub fn claude_spawn_cwd() -> Option<PathBuf> {
     home.is_dir().then_some(home)
 }
 
-/// Env pairs to merge into a child that will execute the Claude Code CLI.
-/// Empty on non-Windows and on Windows machines that need no repair.
-pub fn claude_shell_env() -> Vec<(String, OsString)> {
+/// One env repair for a child that will execute the Claude Code CLI. Only
+/// the Windows module constructs these (hence allowed-unused elsewhere).
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(windows), allow(dead_code))]
+pub enum EnvRepair {
+    /// Set (or override) `key` to `value`.
+    Set(&'static str, OsString),
+    /// Strip an inherited `key` the child must not see.
+    Unset(&'static str),
+}
+
+/// Env repairs for a child that will execute the Claude Code CLI. Empty on
+/// non-Windows and on Windows machines that need no repair.
+pub fn claude_shell_env() -> Vec<EnvRepair> {
     #[cfg(not(windows))]
     {
         Vec::new()
@@ -52,6 +68,21 @@ pub fn claude_shell_env() -> Vec<(String, OsString)> {
     #[cfg(windows)]
     {
         windows::claude_shell_env()
+    }
+}
+
+/// Apply [`claude_shell_env`] to a command. Callers that layer their own env
+/// pairs on top apply this FIRST so an explicit value still wins.
+pub fn apply_claude_shell_env(cmd: &mut std::process::Command) {
+    for repair in claude_shell_env() {
+        match repair {
+            EnvRepair::Set(key, value) => {
+                cmd.env(key, value);
+            }
+            EnvRepair::Unset(key) => {
+                cmd.env_remove(key);
+            }
+        }
     }
 }
 
@@ -87,36 +118,48 @@ fn append_missing_dirs(path: &str, dirs: &[String]) -> Option<String> {
 
 #[cfg(windows)]
 mod windows {
-    use super::append_missing_dirs;
+    use super::{append_missing_dirs, EnvRepair};
+    use crate::git_bash::is_usable_git_bash_override;
     use std::ffi::OsString;
     use std::path::PathBuf;
 
     /// The CLI's documented override for a bash that is not on PATH.
     const GIT_BASH_ENV: &str = "CLAUDE_CODE_GIT_BASH_PATH";
 
-    pub(super) fn claude_shell_env() -> Vec<(String, OsString)> {
+    pub(super) fn claude_shell_env() -> Vec<EnvRepair> {
         let mut env = Vec::new();
-        if let Some(bash) = resolve_git_bash() {
-            env.push((GIT_BASH_ENV.to_string(), bash.into_os_string()));
-        }
+        env.extend(git_bash_repair());
         if let Some(path) = hardened_path() {
-            env.push(("PATH".to_string(), OsString::from(path)));
+            env.push(EnvRepair::Set("PATH", OsString::from(path)));
         }
         env
     }
 
-    /// Find a Git for Windows `bash.exe`. An inherited `GIT_BASH_ENV` that
-    /// points at a real file wins (respect the user's override — the child
-    /// inherits it, nothing to add). A stale override, or none, falls through
-    /// to the standard machine- and user-scope install locations. No PATH
-    /// scan: `C:\Windows\System32\bash.exe` is WSL, not Git Bash, and would
-    /// wedge the CLI.
-    fn resolve_git_bash() -> Option<PathBuf> {
-        if let Ok(existing) = std::env::var(GIT_BASH_ENV) {
-            if PathBuf::from(&existing).is_file() {
-                return None;
-            }
+    /// The `GIT_BASH_ENV` repair. An inherited value naming a usable bash wins
+    /// (respect the user's override — the child inherits it, nothing to do).
+    /// Otherwise a Git for Windows `bash.exe` at a standard machine- or
+    /// user-scope install location is set; and when none exists, a STALE
+    /// inherited value is stripped rather than forwarded — the CLI exits 1 on
+    /// an override it cannot run, but auto-detects PowerShell without one
+    /// (HOUSTON-APP-4ZP: the WSL alias under `WindowsApps`). No PATH scan:
+    /// `System32\bash.exe` is WSL, not Git Bash, and would wedge the CLI.
+    fn git_bash_repair() -> Option<EnvRepair> {
+        let inherited = std::env::var(GIT_BASH_ENV).ok();
+        if inherited.as_deref().is_some_and(is_usable_git_bash_override) {
+            return None;
         }
+        match standard_git_bash() {
+            Some(bash) => Some(EnvRepair::Set(GIT_BASH_ENV, bash.into_os_string())),
+            None => inherited.map(|stale| {
+                tracing::warn!(
+                    "[shell-env] ignoring inherited {GIT_BASH_ENV}={stale:?}: not a runnable Git Bash"
+                );
+                EnvRepair::Unset(GIT_BASH_ENV)
+            }),
+        }
+    }
+
+    fn standard_git_bash() -> Option<PathBuf> {
         let roots = [
             std::env::var("ProgramFiles").ok(),
             std::env::var("ProgramFiles(x86)").ok(),
@@ -198,6 +241,9 @@ mod tests {
     #[test]
     fn claude_shell_env_is_inert_off_windows() {
         assert!(claude_shell_env().is_empty());
+        let mut cmd = std::process::Command::new("true");
+        apply_claude_shell_env(&mut cmd);
+        assert_eq!(cmd.get_envs().count(), 0);
     }
 
     #[test]

--- a/app/src/lib/claude-login-failure.ts
+++ b/app/src/lib/claude-login-failure.ts
@@ -10,8 +10,12 @@
  *     browser login can only reproduce it, so a remote engine degrades to the
  *     runtime's paste flow (which needs no local helper) and a co-located one
  *     gets a translated explanation.
- *   * anything else — a real login failure (declined, timed out, shell gate);
- *     toast the reason verbatim.
+ *   * `shellUnavailable: true` — the helper ran but the Claude CLI refused
+ *     its Windows shell gate (no runnable Git Bash / PowerShell;
+ *     HOUSTON-APP-4ZP). A missing prerequisite, not a login failure: same
+ *     paste-flow degrade on a remote engine, install-Git copy co-located.
+ *   * anything else — a real login failure (declined, timed out); toast the
+ *     reason verbatim.
  */
 
 /** Payload of the native `claude-login://done` event. */
@@ -20,6 +24,8 @@ export interface ClaudeLoginDone {
   error: string | null;
   /** The helper binary cannot run on this machine at all. */
   helperUnavailable?: boolean;
+  /** The CLI refused its Windows shell gate: no runnable Git Bash / PowerShell. */
+  shellUnavailable?: boolean;
 }
 
 export type ClaudeLoginFailureRoute =
@@ -29,6 +35,8 @@ export type ClaudeLoginFailureRoute =
   | { kind: "paste-fallback"; reason: string }
   /** Co-located engine + unrunnable helper: translated explanation. */
   | { kind: "helper-unsupported" }
+  /** Co-located engine + CLI shell gate: install Git for Windows copy. */
+  | { kind: "shell-unavailable" }
   /** A real login failure: surface the helper's reason. */
   | { kind: "error"; error: string };
 
@@ -40,6 +48,11 @@ export function classifyClaudeLoginFailure(
     return remoteEngine
       ? { kind: "paste-fallback", reason: done.error ?? "helper unavailable" }
       : { kind: "helper-unsupported" };
+  }
+  if (done.shellUnavailable) {
+    return remoteEngine
+      ? { kind: "paste-fallback", reason: done.error ?? "shell unavailable" }
+      : { kind: "shell-unavailable" };
   }
   if (done.error === null) return { kind: "silent" };
   return { kind: "error", error: done.error };

--- a/app/src/lib/claude-login.ts
+++ b/app/src/lib/claude-login.ts
@@ -189,6 +189,13 @@ export async function beginClaudeBrowserLogin(
                 i18n.t("providers:claudeLogin.helperUnsupported"),
               );
               break;
+            case "shell-unavailable":
+              announce(
+                frontendProviderId,
+                false,
+                i18n.t("providers:claudeLogin.shellUnavailable"),
+              );
+              break;
             default:
               announce(frontendProviderId, false, error);
           }

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -143,7 +143,8 @@
     "handoffFailed": "Signed in to Claude, but Houston hit a problem on our side while finishing the connection. Please try again in a moment, or report a bug if it keeps happening.",
     "autoFailedTitle": "Couldn't finish connecting automatically",
     "autoFailedBody": "Paste an Anthropic API key to finish connecting.",
-    "helperUnsupported": "This computer's processor is too old to run the Claude sign-in helper, so a Claude subscription can't be connected on this machine."
+    "helperUnsupported": "This computer's processor is too old to run the Claude sign-in helper, so a Claude subscription can't be connected on this machine.",
+    "shellUnavailable": "Claude sign-in needs Git for Windows on this computer. Install it from git-scm.com, then try connecting again."
   },
   "localModel": {
     "title": "Connect a local model",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -143,7 +143,8 @@
     "handoffFailed": "Iniciaste sesión en Claude, pero Houston tuvo un problema de nuestro lado al terminar la conexión. Inténtalo de nuevo en un momento o reporta un error si sigue pasando.",
     "autoFailedTitle": "No se pudo completar la conexión automáticamente",
     "autoFailedBody": "Pega una clave de API de Anthropic para terminar de conectar.",
-    "helperUnsupported": "El procesador de este computador es demasiado antiguo para ejecutar el asistente de inicio de sesión de Claude, así que no se puede conectar una suscripción de Claude en esta máquina."
+    "helperUnsupported": "El procesador de este computador es demasiado antiguo para ejecutar el asistente de inicio de sesión de Claude, así que no se puede conectar una suscripción de Claude en esta máquina.",
+    "shellUnavailable": "El inicio de sesión de Claude necesita Git para Windows en este computador. Instálalo desde git-scm.com y vuelve a intentar conectarte."
   },
   "localModel": {
     "title": "Conecta un modelo local",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -143,7 +143,8 @@
     "handoffFailed": "Você entrou no Claude, mas o Houston teve um problema do nosso lado ao concluir a conexão. Tente novamente em instantes ou reporte um erro se continuar acontecendo.",
     "autoFailedTitle": "Não foi possível concluir a conexão automaticamente",
     "autoFailedBody": "Cole uma chave de API da Anthropic para terminar de conectar.",
-    "helperUnsupported": "O processador deste computador é muito antigo para executar o assistente de login do Claude, então não é possível conectar uma assinatura do Claude nesta máquina."
+    "helperUnsupported": "O processador deste computador é muito antigo para executar o assistente de login do Claude, então não é possível conectar uma assinatura do Claude nesta máquina.",
+    "shellUnavailable": "O login do Claude precisa do Git para Windows neste computador. Instale-o em git-scm.com e tente conectar novamente."
   },
   "localModel": {
     "title": "Conecte um modelo local",

--- a/app/tests/claude-login-failure.test.ts
+++ b/app/tests/claude-login-failure.test.ts
@@ -33,6 +33,54 @@ describe("classifyClaudeLoginFailure", () => {
     );
   });
 
+  it("routes the CLI shell gate on a remote engine to the paste flow", () => {
+    // HOUSTON-APP-4ZP: the CLI refused to start for want of Git Bash /
+    // PowerShell. The runtime's paste flow needs no local shell either.
+    deepStrictEqual(
+      classifyClaudeLoginFailure(
+        {
+          success: false,
+          error:
+            "Claude sign-in failed (exit 1): unable to find CLAUDE_CODE_GIT_BASH_PATH",
+          shellUnavailable: true,
+        },
+        true,
+      ),
+      {
+        kind: "paste-fallback",
+        reason:
+          "Claude sign-in failed (exit 1): unable to find CLAUDE_CODE_GIT_BASH_PATH",
+      },
+    );
+  });
+
+  it("explains the CLI shell gate on a co-located engine with install copy", () => {
+    deepStrictEqual(
+      classifyClaudeLoginFailure(
+        { success: false, error: "shell gate", shellUnavailable: true },
+        false,
+      ),
+      { kind: "shell-unavailable" },
+    );
+  });
+
+  it("lets an unrunnable helper outrank the shell gate", () => {
+    // Both flags set is contradictory (the CLI never ran); the helper verdict
+    // is the more fundamental one and keeps its surface.
+    deepStrictEqual(
+      classifyClaudeLoginFailure(
+        {
+          success: false,
+          error: "helper died",
+          helperUnavailable: true,
+          shellUnavailable: true,
+        },
+        false,
+      ),
+      { kind: "helper-unsupported" },
+    );
+  });
+
   it("keeps a cancel silent", () => {
     deepStrictEqual(
       classifyClaudeLoginFailure({ success: false, error: null }, true),


### PR DESCRIPTION
Fixes PRODUCT-1667 (Sentry HOUSTON-APP-4ZP: 7 events, one Windows 11 machine on 0.6.14, user cannot connect a Claude subscription).

## Root cause

`shell_env.rs` honored any inherited `CLAUDE_CODE_GIT_BASH_PATH` whose path passed `Path::is_file()`. The WSL app-execution alias `%LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe` is a reparse-point stub: Rust's stat falls back to the unresolved attributes for non-symlink reparse tags, so it reads as a file, but it is not Git Bash. The child inherited the value, and the Claude CLI refused to start with `unable to find CLAUDE_CODE_GIT_BASH_PATH path "...WindowsApps\bash.exe"`. The existing code already excluded `System32\bash.exe` for the same reason; the WindowsApps alias is the second WSL location. Even when the resolver fell through, it only ever ADDED env, so the stale inherited value still reached the child.

## Fix

- **`git_bash.rs` (new)**: an inherited override is usable only if it is not under a WSL alias directory (`WindowsApps`, `System32`, `Sysnative`) and is a regular file judged via `symlink_metadata` with the reparse-point attribute rejected. Path-shape logic is pure and unit-tested on every host.
- **`shell_env.rs`**: the repair is now a list of `Set` / `Unset` actions applied through one `apply_claude_shell_env` helper used by both spawners (login helper and engine sidecar). A stale override is stripped from the child when no standard Git for Windows install replaces it, so the CLI falls back to its own PowerShell probe, which the existing PATH + cwd hardening keeps resolvable.
- **`claude_login/shell_gate.rs` (new)**: a non-zero exit whose stderr carries the CLI's Windows shell-gate refusal (any wording shipped so far) sets `shellUnavailable: true` on the `done` payload and logs at warn instead of error (expected setup state, no Sentry event per retry).
- **Frontend**: `classifyClaudeLoginFailure` routes `shellUnavailable` like an unrunnable helper: paste flow on a remote engine, authored "Claude sign-in needs Git for Windows on this computer" copy co-located (en / es / pt). Raw CLI text no longer reaches a toast for this case.

## Verification

Gates run locally: `cargo test` for `git_bash`, `shell_env`, `claude_login` (51 tests), `cargo clippy` (no new warnings), `cargo check --target x86_64-pc-windows-gnu` (compiles), `pnpm check`, `tsgo --noEmit`, `check-locales`, `cd app && pnpm test` (3953 pass).

**Before the fix (reproduces the bug)**, on Windows 11 with WSL's alias enabled (Settings > Apps > Advanced app settings > App execution aliases > bash):
1. `setx CLAUDE_CODE_GIT_BASH_PATH "%LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe"`, then start Houston fresh (the app must inherit the var).
2. Settings > AI Hub > Claude > Connect.
3. The sign-in fails immediately with a red toast quoting `Claude sign-in failed (exit 1): Claude Code was unable to find CLAUDE_CODE_GIT_BASH_PATH path "...WindowsApps\bash.exe"`, and `backend.log` carries the same line at error level.

**After the fix**, same setup:
1. Repeat steps 1 and 2.
2. `backend.log` shows `[shell-env] ignoring inherited CLAUDE_CODE_GIT_BASH_PATH=...: not a runnable Git Bash`; with Git for Windows installed the override is replaced by `C:\Program Files\Git\bin\bash.exe`, without it the var is stripped and the CLI uses PowerShell.
3. The browser sign-in proceeds and Claude shows as connected.
4. Negative check: with `CLAUDE_CODE_USE_POWERSHELL_TOOL=0` set and no Git for Windows, Connect now shows "Claude sign-in needs Git for Windows on this computer. Install it from git-scm.com, then try connecting again." and the log line is a warning, not an error.
