### PR TITLE
fix(providers): surface the cloud egress 400 inline on local-model manual connect (PRODUCT-1242)

### DIFF
--- a/app/src/components/shell/local-model-manual-form.tsx
+++ b/app/src/components/shell/local-model-manual-form.tsx
@@ -2,6 +2,10 @@ import { Button } from "@houston-ai/core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useReasoningToggle } from "../../hooks/use-reasoning-toggle";
+import {
+  classifyCloudEgressRejection,
+  cloudEgressBodyKey,
+} from "../../lib/cloud-egress-blocked-error";
 import { genericErrorDescription } from "../../lib/error-report";
 import { connectManualEndpoint } from "../../lib/local-model-connect";
 import { ReasoningToggle } from "./local-model-dialog-parts";
@@ -76,7 +80,15 @@ export function LocalModelManualForm({
       onConnected?.(trimmedModel);
       onClose();
     } catch (err) {
-      setError(genericErrorDescription("local_model_manual_connect", err));
+      // The cloud host's deliberate "can't reach that address" 400 is an
+      // expected state with a user-side remedy: show the rule it broke, not
+      // the generic copy (which also filed a Sentry issue per attempt).
+      const egress = classifyCloudEgressRejection(err);
+      setError(
+        egress
+          ? t(cloudEgressBodyKey(egress))
+          : genericErrorDescription("local_model_manual_connect", err),
+      );
       setSubmitting(false);
     }
   };

--- a/app/src/lib/cloud-egress-blocked-error.ts
+++ b/app/src/lib/cloud-egress-blocked-error.ts
@@ -1,0 +1,88 @@
+// The "is this the managed cloud host refusing an unreachable local-model
+// address?" classifier for the error-surfacing layer. Dependency-free so it is
+// node-testable directly (app/tests/cloud-egress-blocked-error.test.ts).
+//
+// A cloud agent pod egresses ONLY to public TCP 443, so the host rejects a
+// custom OpenAI-compatible base URL that targets plain http, a custom port, or
+// a private/loopback host at save time with a deliberate 400
+// (`packages/host/src/custom-endpoint-validation.ts`). That is an EXPECTED
+// state the user can act on, not a Houston bug: the manual-connect form renders
+// rule-specific translated guidance inline, every other caller gets a plain
+// info toast, and nothing reaches Sentry. Before this classifier the 400 went
+// through the generic "something went wrong" path AND filed a Sentry issue per
+// attempt (HOUSTON-APP-56A).
+//
+// The host sends a typed `code` alongside the English `error` sentence. An
+// older host sends only the sentence, which always opens with the same
+// throughline; that still classifies (as `unspecified`) so the state is never
+// reported as a bug, just with less specific copy.
+
+/** Which egress rule the address broke; `unspecified` = code-less older host. */
+export type CloudEgressRejection =
+  | "not_https"
+  | "custom_port"
+  | "private_host"
+  | "unspecified";
+
+const CODE_TO_REJECTION: Record<string, CloudEgressRejection> = {
+  endpoint_not_https: "not_https",
+  endpoint_custom_port: "custom_port",
+  endpoint_private_host: "private_host",
+};
+
+/** The one throughline every host rejection reason opens with. */
+const CLOUD_ONLY_PREFIX =
+  "Cloud agents can only reach public HTTPS endpoints on port 443.";
+
+type ErrorBody = { error?: unknown; code?: unknown };
+
+function parsedBody(body: unknown): ErrorBody | null {
+  if (typeof body === "string") {
+    if (!body.startsWith("{")) return null;
+    try {
+      return JSON.parse(body) as ErrorBody;
+    } catch {
+      return null;
+    }
+  }
+  return body && typeof body === "object" ? (body as ErrorBody) : null;
+}
+
+/**
+ * The egress rule a `set_provider_custom_endpoint` 400 names, or null for any
+ * other error. Matched structurally (status + body code, then the reason
+ * throughline) so it stays dependency-free across the client error shapes.
+ */
+export function classifyCloudEgressRejection(
+  err: unknown,
+): CloudEgressRejection | null {
+  if (!(err instanceof Error)) return null;
+  if ((err as { status?: unknown }).status !== 400) return null;
+  const body = parsedBody((err as { body?: unknown }).body);
+  const code = typeof body?.code === "string" ? body.code : undefined;
+  const byCode = code === undefined ? undefined : CODE_TO_REJECTION[code];
+  if (byCode) return byCode;
+  const reason = typeof body?.error === "string" ? body.error : err.message;
+  return reason.startsWith(CLOUD_ONLY_PREFIX) ? "unspecified" : null;
+}
+
+/** True when `err` is the cloud egress rejection (any rule). */
+export function isCloudEgressBlockedError(err: unknown): boolean {
+  return classifyCloudEgressRejection(err) !== null;
+}
+
+/** The `providers` namespace key holding the guidance for a rejection. */
+export function cloudEgressBodyKey(
+  rejection: CloudEgressRejection,
+): `openaiCompatible.cloudOnly.${"notHttps" | "customPort" | "privateHost" | "unspecified"}` {
+  switch (rejection) {
+    case "not_https":
+      return "openaiCompatible.cloudOnly.notHttps";
+    case "custom_port":
+      return "openaiCompatible.cloudOnly.customPort";
+    case "private_host":
+      return "openaiCompatible.cloudOnly.privateHost";
+    case "unspecified":
+      return "openaiCompatible.cloudOnly.unspecified";
+  }
+}

--- a/app/src/lib/local-model-connect.ts
+++ b/app/src/lib/local-model-connect.ts
@@ -202,12 +202,13 @@ export async function reconnectLocalModel(signal?: AbortSignal): Promise<void> {
 /**
  * The advanced/manual path (and the web fallback where no native bridge exists):
  * register a base URL + model directly, with no tunnel. Mirrors the old manual
- * OpenAI-compatible dialog.
+ * OpenAI-compatible dialog. The form renders every failure inline next to the
+ * address field, so the engine wrapper's toast is off for this call.
  */
 export async function connectManualEndpoint(
   endpoint: CustomEndpoint,
 ): Promise<void> {
-  await tauriProvider.setCustomEndpoint(endpoint);
+  await tauriProvider.setCustomEndpoint(endpoint, "inline");
 }
 
 /**

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -46,6 +46,11 @@ import {
   beginClaudeBrowserLogin,
   cancelClaudeBrowserLogin,
 } from "./claude-login";
+import {
+  classifyCloudEgressRejection,
+  cloudEgressBodyKey,
+  isCloudEgressBlockedError,
+} from "./cloud-egress-blocked-error";
 import { cancelCodexLoopback } from "./codex-loopback";
 import { COMPOSIO_ALREADY_CONNECTED_KIND } from "./composio-already-connected";
 import { getEngine, isRemoteEngine } from "./engine";
@@ -121,6 +126,13 @@ export interface EngineCallOptions {
    */
   surface?: boolean;
 }
+
+/**
+ * Who surfaces a `setCustomEndpoint` failure: the wrapper's toast (the guided
+ * connect, whose dialog only shows a calm retry state) or the caller inline
+ * (the manual form, which renders the reason next to the fields).
+ */
+export type CustomEndpointSurface = "toast" | "inline";
 
 /** Wrap an engine call and surface errors as toasts unless caller handles them inline. */
 async function call<T>(
@@ -282,6 +294,23 @@ async function surfaceError(
     showExpectedStateToast(
       i18n.t("providers:toast.orgAdminRequiredTitle"),
       i18n.t("providers:toast.orgAdminRequiredBody"),
+    );
+    return;
+  }
+
+  // Expected business state, not a bug: the managed cloud host refusing a
+  // local-model address its pods can never reach (plain http, a custom port,
+  // localhost / a private network). The remedy is the user's (a public https
+  // address or a tunnel), so surface the rule as plain guidance, never the red
+  // bug pair, and never Sentry (HOUSTON-APP-56A filed one issue per attempt).
+  // The manual-connect form silences this class and renders the same copy
+  // inline; this toast covers every other caller (the guided connect).
+  const egress = classifyCloudEgressRejection(err);
+  if (egress) {
+    const { showExpectedStateToast } = await import("./error-toast");
+    showExpectedStateToast(
+      i18n.t("providers:openaiCompatible.cloudOnly.title"),
+      i18n.t(`providers:${cloudEgressBodyKey(egress)}`),
     );
     return;
   }
@@ -1936,9 +1965,21 @@ export const tauriProvider = {
    * gated by the host's `openaiCompatible` capability — the connect UI shows it
    * only then (see `getVisibleProviders`).
    */
-  setCustomEndpoint: (endpoint: CustomEndpoint) =>
-    call<void>("set_provider_custom_endpoint", () =>
-      getEngine().setProviderCustomEndpoint(endpoint),
+  setCustomEndpoint: (
+    endpoint: CustomEndpoint,
+    surface: CustomEndpointSurface = "toast",
+  ) =>
+    call<void>(
+      "set_provider_custom_endpoint",
+      () => getEngine().setProviderCustomEndpoint(endpoint),
+      undefined,
+      // The manual-connect form owns its failure surface: it renders the
+      // failure inline (generic copy for a real bug, which the wrapper still
+      // captures; rule-specific guidance for the cloud egress rejection, which
+      // is silenced here so the inline copy is the ONE surface, no Sentry).
+      surface === "inline"
+        ? { toast: false, silence: isCloudEgressBlockedError }
+        : undefined,
     ),
   /**
    * Mint a relay credential for the guided "connect a local model" flow: the

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -139,7 +139,14 @@
     "modelRequired": "Enter a model name first.",
     "save": "Connect",
     "saving": "Connecting...",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "cloudOnly": {
+      "title": "The cloud can't reach that address",
+      "notHttps": "Cloud agents can only reach public https:// addresses. Enter an https:// address, or put your server behind a tunnel like cloudflared or ngrok.",
+      "customPort": "Cloud agents can only reach addresses on the standard https port. Remove the port from the address.",
+      "privateHost": "Cloud agents can't reach your computer or your local network directly. Use a public https:// address, or put your server behind a tunnel like cloudflared, ngrok or Tailscale Funnel.",
+      "unspecified": "Cloud agents can only reach public https:// addresses. Use a public https:// address, or put your server behind a tunnel like cloudflared or ngrok."
+    }
   },
   "claudeLogin": {
     "timeout": "Claude sign-in timed out. Please try connecting again.",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -139,7 +139,14 @@
     "modelRequired": "Primero ingresa un nombre de modelo.",
     "save": "Conectar",
     "saving": "Conectando...",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "cloudOnly": {
+      "title": "La nube no puede acceder a esa dirección",
+      "notHttps": "Los agentes en la nube solo pueden acceder a direcciones https:// públicas. Ingresa una dirección https:// o expón tu servidor con un túnel como cloudflared o ngrok.",
+      "customPort": "Los agentes en la nube solo pueden acceder a direcciones en el puerto https estándar. Quita el puerto de la dirección.",
+      "privateHost": "Los agentes en la nube no pueden acceder directamente a tu computador ni a tu red local. Usa una dirección https:// pública o expón tu servidor con un túnel como cloudflared, ngrok o Tailscale Funnel.",
+      "unspecified": "Los agentes en la nube solo pueden acceder a direcciones https:// públicas. Usa una dirección https:// pública o expón tu servidor con un túnel como cloudflared o ngrok."
+    }
   },
   "claudeLogin": {
     "timeout": "El inicio de sesión de Claude expiró. Intenta conectarte de nuevo.",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -139,7 +139,14 @@
     "modelRequired": "Primeiro informe um nome de modelo.",
     "save": "Conectar",
     "saving": "Conectando...",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "cloudOnly": {
+      "title": "A nuvem não consegue acessar esse endereço",
+      "notHttps": "Agentes na nuvem só conseguem acessar endereços https:// públicos. Informe um endereço https:// ou exponha o seu servidor com um túnel como cloudflared ou ngrok.",
+      "customPort": "Agentes na nuvem só conseguem acessar endereços na porta https padrão. Remova a porta do endereço.",
+      "privateHost": "Agentes na nuvem não conseguem acessar diretamente o seu computador nem a sua rede local. Use um endereço https:// público ou exponha o seu servidor com um túnel como cloudflared, ngrok ou Tailscale Funnel.",
+      "unspecified": "Agentes na nuvem só conseguem acessar endereços https:// públicos. Use um endereço https:// público ou exponha o seu servidor com um túnel como cloudflared ou ngrok."
+    }
   },
   "claudeLogin": {
     "timeout": "O login do Claude expirou. Tente conectar novamente.",

--- a/app/tests/cloud-egress-blocked-error.test.ts
+++ b/app/tests/cloud-egress-blocked-error.test.ts
@@ -1,0 +1,129 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  classifyCloudEgressRejection,
+  cloudEgressBodyKey,
+  isCloudEgressBlockedError,
+} from "../src/lib/cloud-egress-blocked-error.ts";
+
+// The surfacing-layer classifier that keeps the managed cloud host's
+// deliberate "can't reach that address" 400 out of the red bug-toast + Sentry
+// pipeline and lets the manual-connect form render rule-specific copy. It must
+// key on the host's typed `code`, fall back to the reason throughline for a
+// code-less older host, and NEVER match other 400s: a false positive here
+// silently drops a real bug report.
+
+const CLOUD_ONLY =
+  "Cloud agents can only reach public HTTPS endpoints on port 443.";
+
+/** The shape the engine adapter's `HoustonEngineError` mints. */
+function engineError(status: number, body: unknown): Error {
+  const reason = (body as { error?: unknown } | null)?.error;
+  const err = new Error(
+    typeof reason === "string"
+      ? `${reason} (engine error ${status})`
+      : `engine error ${status}`,
+  ) as Error & { status: number; body: unknown };
+  err.name = "HoustonEngineError";
+  err.status = status;
+  err.body = body;
+  return err;
+}
+
+describe("classifyCloudEgressRejection", () => {
+  it("maps each typed host code to its rule", () => {
+    for (const [code, rule] of [
+      ["endpoint_private_host", "private_host"],
+      ["endpoint_not_https", "not_https"],
+      ["endpoint_custom_port", "custom_port"],
+    ] as const) {
+      strictEqual(
+        classifyCloudEgressRejection(
+          engineError(400, { error: `${CLOUD_ONLY} …`, code }),
+        ),
+        rule,
+      );
+    }
+  });
+
+  it("classifies a code-less older host by the reason throughline", () => {
+    strictEqual(
+      classifyCloudEgressRejection(
+        engineError(400, {
+          error: `${CLOUD_ONLY} Use an https:// address (a tunnel or a directly hosted server).`,
+        }),
+      ),
+      "unspecified",
+    );
+  });
+
+  it("reads a raw JSON string body (runtime-client EngineError shape)", () => {
+    const err = new Error("engine request failed (400)") as Error & {
+      status: number;
+      body: string;
+    };
+    err.name = "EngineError";
+    err.status = 400;
+    err.body = JSON.stringify({
+      error: CLOUD_ONLY,
+      code: "endpoint_custom_port",
+    });
+    strictEqual(classifyCloudEgressRejection(err), "custom_port");
+  });
+
+  it("ignores an unknown code but keeps the throughline fallback", () => {
+    strictEqual(
+      classifyCloudEgressRejection(
+        engineError(400, { error: `${CLOUD_ONLY} x`, code: "something_else" }),
+      ),
+      "unspecified",
+    );
+  });
+
+  it("never matches other 400s, other statuses, or non-errors", () => {
+    strictEqual(
+      classifyCloudEgressRejection(
+        engineError(400, { error: "baseUrl is not a valid URL" }),
+      ),
+      null,
+    );
+    strictEqual(
+      classifyCloudEgressRejection(
+        engineError(400, { error: "missing 'model'" }),
+      ),
+      null,
+    );
+    strictEqual(
+      classifyCloudEgressRejection(
+        engineError(502, {
+          error: `${CLOUD_ONLY} x`,
+          code: "endpoint_not_https",
+        }),
+      ),
+      null,
+    );
+    strictEqual(classifyCloudEgressRejection(engineError(400, null)), null);
+    strictEqual(classifyCloudEgressRejection(new Error(CLOUD_ONLY)), null);
+    strictEqual(classifyCloudEgressRejection("nope"), null);
+    strictEqual(isCloudEgressBlockedError(engineError(400, null)), false);
+  });
+
+  it("pairs every rule with a providers copy key", () => {
+    strictEqual(
+      cloudEgressBodyKey("private_host"),
+      "openaiCompatible.cloudOnly.privateHost",
+    );
+    strictEqual(
+      cloudEgressBodyKey("not_https"),
+      "openaiCompatible.cloudOnly.notHttps",
+    );
+    strictEqual(
+      cloudEgressBodyKey("custom_port"),
+      "openaiCompatible.cloudOnly.customPort",
+    );
+    strictEqual(
+      cloudEgressBodyKey("unspecified"),
+      "openaiCompatible.cloudOnly.unspecified",
+    );
+  });
+});

--- a/packages/host/src/custom-endpoint-validation.test.ts
+++ b/packages/host/src/custom-endpoint-validation.test.ts
@@ -26,7 +26,10 @@ describe("checkPublicHttpsEndpoint — rejects unreachable endpoints", () => {
   test("plain http is rejected (not https)", () => {
     const r = check("http://api.example.com/v1");
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.reason).toMatch(/https/i);
+    if (!r.ok) {
+      expect(r.reason).toMatch(/https/i);
+      expect(r.code).toBe("endpoint_not_https");
+    }
   });
 
   test.each([
@@ -36,7 +39,10 @@ describe("checkPublicHttpsEndpoint — rejects unreachable endpoints", () => {
   ])("a non-443 port is rejected (%s)", (url) => {
     const r = check(url);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.reason).toMatch(/port/i);
+    if (!r.ok) {
+      expect(r.reason).toMatch(/port/i);
+      expect(r.code).toBe("endpoint_custom_port");
+    }
   });
 
   test.each([
@@ -46,7 +52,17 @@ describe("checkPublicHttpsEndpoint — rejects unreachable endpoints", () => {
     "https://printer.local/v1",
     "https://ollama.local/v1",
   ])("a local hostname is rejected (%s)", (url) => {
-    expect(check(url).ok).toBe(false);
+    const r = check(url);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("endpoint_private_host");
+  });
+
+  test("a localhost URL that also breaks scheme and port reports the host", () => {
+    // `http://localhost:11434` (the Ollama default) fails all three rules; the
+    // host is the one the user must act on, so its code wins.
+    const r = check("http://localhost:11434/v1");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("endpoint_private_host");
   });
 
   test.each([

--- a/packages/host/src/custom-endpoint-validation.ts
+++ b/packages/host/src/custom-endpoint-validation.ts
@@ -11,7 +11,19 @@
  * exactly what they target).
  */
 
-export type EndpointCheck = { ok: true } | { ok: false; reason: string };
+/**
+ * Which egress rule a base URL broke. Sent as the 400's `code` so the client
+ * can render translated, rule-specific guidance instead of the English
+ * `reason` (and classify the rejection as an expected state, not a bug).
+ */
+export type CloudEgressRejectionCode =
+  | "endpoint_not_https"
+  | "endpoint_custom_port"
+  | "endpoint_private_host";
+
+export type EndpointCheck =
+  | { ok: true }
+  | { ok: false; code: CloudEgressRejectionCode; reason: string };
 
 /** The one throughline every rejection reason opens with. */
 const CLOUD_ONLY =
@@ -23,9 +35,20 @@ const CLOUD_ONLY =
  * public-:443-HTTPS-only constraints. Call ONLY on the managed cloud profile.
  */
 export function checkPublicHttpsEndpoint(url: URL): EndpointCheck {
+  // A private host is checked FIRST: `http://localhost:11434` breaks all three
+  // rules, and "the cloud can't reach your computer" is the one the user has
+  // to act on. Reporting the scheme would send them to https://localhost.
+  if (isBlockedHostname(url.hostname)) {
+    return {
+      ok: false,
+      code: "endpoint_private_host",
+      reason: `${CLOUD_ONLY} "${url.hostname}" is a private, loopback, or link-local address the cloud can't reach; host your server on a public domain instead.`,
+    };
+  }
   if (url.protocol !== "https:") {
     return {
       ok: false,
+      code: "endpoint_not_https",
       reason: `${CLOUD_ONLY} Use an https:// address (a tunnel or a directly hosted server).`,
     };
   }
@@ -34,13 +57,8 @@ export function checkPublicHttpsEndpoint(url: URL): EndpointCheck {
   if (url.port !== "") {
     return {
       ok: false,
+      code: "endpoint_custom_port",
       reason: `${CLOUD_ONLY} Remove the custom port ":${url.port}" from the address.`,
-    };
-  }
-  if (isBlockedHostname(url.hostname)) {
-    return {
-      ok: false,
-      reason: `${CLOUD_ONLY} "${url.hostname}" is a private, loopback, or link-local address the cloud can't reach; host your server on a public domain instead.`,
     };
   }
   return { ok: true };

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -663,7 +663,9 @@ export async function handleAgents(
     if (deps.gatewayFronted && !deps.loopbackEgress) {
       const check = checkPublicHttpsEndpoint(parsedUrl);
       if (!check.ok) {
-        json(res, 400, { error: check.reason });
+        // `code` lets the client translate the rule and treat this as an
+        // expected state; `error` keeps the English sentence for logs.
+        json(res, 400, { error: check.reason, code: check.code });
         return true;
       }
     }

--- a/packages/host/src/routes/openai-compatible.test.ts
+++ b/packages/host/src/routes/openai-compatible.test.ts
@@ -336,21 +336,29 @@ test("managed cloud rejects localhost with an actionable 400, never forwarded", 
     model: "llama3.1",
   });
   expect(res.status).toBe(400);
-  const { error } = (await res.json()) as { error: string };
+  const { error, code } = (await res.json()) as {
+    error: string;
+    code: string;
+  };
   expect(error).toMatch(/public HTTPS endpoints on port 443/);
+  // The typed code is what the client keys its translated copy on; without
+  // it the manual-connect form falls back to generic "something went wrong".
+  // localhost breaks every rule; the private host is the one worth reporting.
+  expect(code).toBe("endpoint_private_host");
   expect(channel.saved).toHaveLength(0);
 });
 
 test.each([
-  ["plain http", "http://api.example.com/v1"],
-  ["a non-443 port", "https://api.example.com:8443/v1"],
-  ["a private IPv4", "https://192.168.1.10/v1"],
-  ["the metadata IP", "https://169.254.169.254/v1"],
-  ["an IPv6 loopback", "https://[::1]/v1"],
-])("managed cloud rejects %s (400, never forwarded)", async (_label, baseUrl) => {
+  ["plain http", "http://api.example.com/v1", "endpoint_not_https"],
+  ["a non-443 port", "https://api.example.com:8443/v1", "endpoint_custom_port"],
+  ["a private IPv4", "https://192.168.1.10/v1", "endpoint_private_host"],
+  ["the metadata IP", "https://169.254.169.254/v1", "endpoint_private_host"],
+  ["an IPv6 loopback", "https://[::1]/v1", "endpoint_private_host"],
+])("managed cloud rejects %s (400 with a typed code, never forwarded)", async (_label, baseUrl, expectedCode) => {
   const { base, agentId, channel } = await setup(MANAGED_CLOUD_CAPS, true);
   const res = await connect(base, agentId, { baseUrl, model: "m" });
   expect(res.status).toBe(400);
+  expect(((await res.json()) as { code: string }).code).toBe(expectedCode);
   expect(channel.saved).toHaveLength(0);
 });
 


### PR DESCRIPTION
## Summary

PRODUCT-1242

A managed-cloud user who opens "Enter details manually" and types `http://localhost:11434/` gets the host's deliberate, actionable 400 ("Cloud agents can only reach public HTTPS endpoints on port 443 ..."). The manual-connect form ran that through `genericErrorDescription`, so the user saw only "Something unexpected went wrong. Try again." and retried a deterministic rejection, while every attempt filed a Sentry issue (HOUSTON-APP-56A) for behavior working as intended.

## Root cause

`local-model-manual-form.tsx` treated every failure as an unexpected error. The host's egress validation (`custom-endpoint-validation.ts`) only sent an English sentence with no typed code, so the client had nothing to key translated copy on, and nothing in the surfacing layer classified the class as an expected state.

## Fix

- **host**: the egress 400 now carries a typed `code` (`endpoint_private_host` / `endpoint_not_https` / `endpoint_custom_port`) alongside the English `error`. The private-host rule is checked first: `http://localhost:11434` breaks all three rules, and "the cloud can't reach your computer" is the one the user must act on (reporting the scheme sent them to `https://localhost`).
- **app**: a dependency-free classifier (`app/src/lib/cloud-egress-blocked-error.ts`) recognises the class by code, falling back to the reason throughline for a code-less older host. The manual form renders rule-specific guidance inline (en/es/pt, with a tunnel hint) with the wrapper toast off and the class silenced, so the inline copy is the one surface and nothing reaches Sentry. Every other `setCustomEndpoint` caller (the guided connect) gets a plain info toast through the surfacing layer's expected-state gate. Real bugs on the manual path keep the generic copy and Sentry capture.

## Before (reproduction)

1. Sign in to a managed-cloud workspace in the desktop app (the dev launcher accepts localhost by design, so this needs a cloud deployment).
2. Agent settings > connect a local model > "Enter details manually".
3. Server address `http://localhost:11434/v1`, model `gemma4:12b`, Connect.
4. Observe the generic "Something unexpected went wrong. Try again." line under the form, a red toast, and a new `set_provider_custom_endpoint` event on HOUSTON-APP-56A in Sentry.

## After (verification)

1. Same steps 1 to 3 on a build with this change (host and app).
2. The form shows "Cloud agents can't reach your computer or your local network directly. Use a public https:// address, or put your server behind a tunnel like cloudflared, ngrok or Tailscale Funnel." (translated on es/pt). No red toast, no Sentry event; the frontend log still has the `[engine:set_provider_custom_endpoint]` line.
3. `http://api.example.com/v1` shows the https rule; `https://api.example.com:8443/v1` shows the port rule.
4. A public `https://` address on 443 still connects.

Automated: `pnpm --filter @houston/host test` (route + validation tests assert the typed codes and the localhost ordering), `cd app && pnpm test` (`tests/cloud-egress-blocked-error.test.ts`), `pnpm check`, `cd app && pnpm tsgo --noEmit && pnpm check-locales`, `pnpm --filter houston-web typecheck`, `pnpm check:boundaries`.
