### PR TITLE
fix(runtime): retry Gemini MALFORMED_* stops inside the turn before the Retry card (PRODUCT-1078)

### DIFF
--- a/packages/runtime/src/backends/pi/malformed-retry.test.ts
+++ b/packages/runtime/src/backends/pi/malformed-retry.test.ts
@@ -1,0 +1,174 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type AssistantMessage,
+  fauxAssistantMessage,
+  fauxProvider,
+  isRetryableAssistantError,
+} from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import type { WireEvent } from "@houston/runtime-client";
+import { expect, test, vi } from "vitest";
+import { HoustonAuthStore } from "../../auth/credential-store";
+import { PiSession } from "./session";
+
+/**
+ * Gemini ends a turn with finishReason MALFORMED_RESPONSE / MALFORMED_FUNCTION_CALL
+ * when the MODEL's own generation broke (a garbled response, an unparseable tool
+ * call). pi-ai flattens both to `Provider stopped with: <REASON>`, no status, no
+ * body. Google's guidance is to retry the same request, and pi already owns a
+ * retry loop for transient provider failures — but its retryable pattern did
+ * not know these tokens, so every such turn died on the first attempt and the
+ * user got the Retry card for a failure that a retry would have healed.
+ *
+ * The pi-ai pnpm patch (patches/@earendil-works__pi-ai) adds the two tokens
+ * to that pattern. These tests are the patch guard: they drive a REAL pi
+ * AgentSession over the scripted faux provider through Houston's PiSession
+ * seam, so a pi bump that drops the hunk fails here, not in production.
+ */
+
+const MALFORMED_RESPONSE = "Provider stopped with: MALFORMED_RESPONSE";
+
+function malformed(reason = "MALFORMED_RESPONSE"): AssistantMessage {
+  return fauxAssistantMessage("", {
+    stopReason: "error",
+    errorMessage: `Provider stopped with: ${reason}`,
+  });
+}
+
+/**
+ * A real pi AgentSession over the faux provider (scripted responses, no
+ * network), built the way chat.ts builds one and wrapped in PiSession. Retry
+ * backoff is zeroed so the exhausted-retries case runs in milliseconds; the
+ * retry COUNT stays pi's default so the test pins the real policy.
+ */
+async function fauxSession(responses: AssistantMessage[]) {
+  const cwd = mkdtempSync(join(tmpdir(), "houston-malformed-retry-"));
+  const faux = fauxProvider({
+    provider: "faux",
+    api: "faux",
+    models: [
+      { id: "faux-1", name: "Faux 1", contextWindow: 200000, maxTokens: 8192 },
+    ],
+  });
+  faux.setResponses(responses);
+  // Seed the credential through the store, never setRuntimeApiKey (its awaited
+  // refresh() hangs in pi 0.82+).
+  const authStorage = new HoustonAuthStore(join(cwd, "auth.json"));
+  authStorage.set("faux", { type: "api_key", key: "faux-key" });
+  const modelRuntime = await ModelRuntime.create({
+    credentials: authStorage,
+    modelsPath: join(cwd, "models.json"),
+  });
+  modelRuntime.registerNativeProvider(faux.provider);
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir: cwd,
+    modelRuntime,
+    model: faux.getModel() as never,
+    sessionManager: SessionManager.inMemory(),
+    settingsManager: SettingsManager.inMemory({ retry: { baseDelayMs: 0 } }),
+    tools: [],
+    customTools: [],
+  });
+  const wrapped = new PiSession(session);
+  const events: WireEvent[] = [];
+  wrapped.subscribe((e) => events.push(e));
+  return { faux, session: wrapped, events };
+}
+
+const providerErrors = (events: WireEvent[]) =>
+  events.filter(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+
+test("pi-ai's retryable predicate covers Gemini's MALFORMED stops but not its policy stops", () => {
+  for (const reason of ["MALFORMED_RESPONSE", "MALFORMED_FUNCTION_CALL"]) {
+    expect(isRetryableAssistantError(malformed(reason))).toBe(true);
+  }
+  // Older pi phrasing of the same finish reason.
+  expect(
+    isRetryableAssistantError(
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "Unhandled stop reason: MALFORMED_RESPONSE",
+      }),
+    ),
+  ).toBe(true);
+  // Refusals share the prefix; a retry cannot fix them and must not be spent.
+  for (const reason of ["SAFETY", "RECITATION", "BLOCKLIST"]) {
+    expect(isRetryableAssistantError(malformed(reason))).toBe(false);
+  }
+});
+
+test("a MALFORMED_RESPONSE stop is retried inside the same prompt and the healed turn reaches the chat clean", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const { faux, session, events } = await fauxSession([
+      malformed(),
+      fauxAssistantMessage("Recovered answer", { stopReason: "stop" }),
+    ]);
+    await session.prompt("hello");
+    // Two provider requests: the broken generation and its retry.
+    expect(faux.state.callCount).toBe(2);
+    // The held error was dropped by the clean turn: no card, just the answer.
+    expect(providerErrors(events)).toEqual([]);
+    expect(
+      events
+        .filter(
+          (e): e is Extract<WireEvent, { type: "text" }> => e.type === "text",
+        )
+        .map((e) => e.data)
+        .join(""),
+    ).toBe("Recovered answer");
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test("MALFORMED_RESPONSE on every attempt exhausts pi's retry budget and surfaces ONE provider_internal card", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    // pi's default budget is 3 retries: the first attempt plus three more.
+    const { faux, session, events } = await fauxSession([
+      malformed(),
+      malformed(),
+      malformed(),
+      malformed(),
+    ]);
+    await session.prompt("hello");
+    expect(faux.state.callCount).toBe(4);
+    const errors = providerErrors(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.data).toMatchObject({
+      kind: "provider_internal",
+      message: MALFORMED_RESPONSE,
+    });
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test("a SAFETY stop is not retried: one request, the refusal surfaces as-is", async () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const { faux, session, events } = await fauxSession([
+      malformed("SAFETY"),
+      fauxAssistantMessage("never reached", { stopReason: "stop" }),
+    ]);
+    await session.prompt("hello");
+    expect(faux.state.callCount).toBe(1);
+    const errors = providerErrors(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.data.kind).toBe("unknown");
+  } finally {
+    error.mockRestore();
+  }
+});

--- a/patches/@earendil-works__pi-ai@0.84.4.patch
+++ b/patches/@earendil-works__pi-ai@0.84.4.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/api/google-shared.js b/dist/api/google-shared.js
-index dcf5c60f53a8579894d6f2d18f2c565a84ea8a89..058015f04d048841ecbd19cba8b6ac6e887eb10f 100644
+index 4214c050965c3bdb3564b623d54130d2f8608b1f..de52e98530b1800a655123ea14d8c81012995c40 100644
 --- a/dist/api/google-shared.js
 +++ b/dist/api/google-shared.js
-@@ -337,8 +337,10 @@ export function mapStopReason(reason) {
+@@ -353,8 +353,10 @@ export function mapStopReason(reason) {
          case FinishReason.NO_IMAGE:
              return "error";
          default: {
@@ -15,3 +15,22 @@ index dcf5c60f53a8579894d6f2d18f2c565a84ea8a89..058015f04d048841ecbd19cba8b6ac6e
          }
      }
  }
+diff --git a/dist/utils/retry.js b/dist/utils/retry.js
+index 65c7c9efd7667445b711fcd43549062ee3eb5ecf..6b13cf5e8d02a41d40fc589fb62e818a26442f15 100644
+--- a/dist/utils/retry.js
++++ b/dist/utils/retry.js
+@@ -74,6 +74,14 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+     "please retry your request",
+     // gRPC based providers (e.g. NVIDIA NIM)
+     "ResourceExhausted",
++    // Gemini finish reasons for a generation the MODEL itself broke (an
++    // unparseable tool call, a garbled response). Surfaced as `Provider stopped
++    // with: <REASON>` with no HTTP status; transient and server-side, Google's
++    // own guidance is to retry the same request. Matched on the reason tokens
++    // only: policy stops (SAFETY, RECITATION, BLOCKLIST) share the prefix and
++    // are refusals a retry cannot fix.
++    "MALFORMED_FUNCTION_CALL",
++    "MALFORMED_RESPONSE",
+ ]);
+ class RetrySleepAbortError extends Error {
+     constructor() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   '@earendil-works/pi-ai@0.84.4':
-    hash: 646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38
+    hash: fb3ba6696891cb9456673829b564258e061bde2c5551d32b46380884df8589fe
     path: patches/@earendil-works__pi-ai@0.84.4.patch
   '@executor-js/sdk@1.5.37':
     hash: 7061d4455cc286a23ca4c3683819032231059648ed7fef31e7a1f0297e1f3597
@@ -440,7 +440,7 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.84.4
-        version: 0.84.4(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        version: 0.84.4(patch_hash=fb3ba6696891cb9456673829b564258e061bde2c5551d32b46380884df8589fe)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.4
         version: 0.84.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -526,7 +526,7 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.84.4
-        version: 0.84.4(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        version: 0.84.4(patch_hash=fb3ba6696891cb9456673829b564258e061bde2c5551d32b46380884df8589fe)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.4
         version: 0.84.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -8448,7 +8448,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.84.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.4(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.4(patch_hash=fb3ba6696891cb9456673829b564258e061bde2c5551d32b46380884df8589fe)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-telemetry': 0.84.4
       diff: 8.0.4
       ignore: 7.0.5
@@ -8462,7 +8462,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.4(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.4(patch_hash=fb3ba6696891cb9456673829b564258e061bde2c5551d32b46380884df8589fe)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -8489,7 +8489,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.84.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.84.4(patch_hash=646b7c9cdfab689a7d3cb69da6c19c02b36e00c4240b0e930a0199e2f73b8b38)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.4(patch_hash=fb3ba6696891cb9456673829b564258e061bde2c5551d32b46380884df8589fe)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-client': 0.84.4
       '@earendil-works/pi-protocol': 0.84.4
       '@earendil-works/pi-tui': 0.84.4


### PR DESCRIPTION
## Summary

PRODUCT-1078: a Gemini turn that ends with finishReason `MALFORMED_RESPONSE` or `MALFORMED_FUNCTION_CALL` now retries inside the same prompt instead of failing on the first attempt.

**Root cause.** pi-ai flattens these finish reasons to `Provider stopped with: <REASON>` with no HTTP status. pi already owns an auto-retry loop for transient provider failures (3 attempts, exponential backoff, the same loop that heals 429/5xx), but its `RETRYABLE_PROVIDER_ERROR_PATTERN` did not carry the MALFORMED tokens, so the loop never fired. #1440 (PRODUCT-1601) already mapped the failure to `provider_internal` (Retry card, warning log, no Sentry error) and the Sentry issue has been quiet since that engine build shipped; this PR closes the retry half of the ticket.

**Fix.** The existing pi-ai pnpm patch gains a second hunk (`dist/utils/retry.js`) adding `MALFORMED_FUNCTION_CALL` and `MALFORMED_RESPONSE` to the retryable pattern. Matched on the reason tokens, not the shared `Provider stopped with:` prefix, so policy stops (SAFETY, RECITATION, BLOCKLIST) stay non-retryable and surface immediately. A prompt that still fails after the budget reaches the chat exactly as before: one `provider_internal` card at `agent_settled` (the wire translator's HOU-1057 hold/flush already handles the retry sequence).

Retry count follows pi's transient-failure policy (3, with 2s/4s/8s backoff) rather than a bespoke "once": it is the same budget every other transient stop gets, and a bespoke counter would mean a second retry mechanism layered on pi's.

No new `ProviderError` kind: the remedy for a malformed generation is the same as for any provider-side hiccup (retry), so the Retry card copy is honest and a new kind would add protocol + card + three locales for the same message.

**Test.** `packages/runtime/src/backends/pi/malformed-retry.test.ts` drives a REAL pi `AgentSession` over pi-ai's scripted faux provider through Houston's `PiSession` seam (retry backoff zeroed): MALFORMED then success = two requests and no error frame; MALFORMED four times = four requests and one `provider_internal` frame; SAFETY = one request, no retry. It also pins `isRetryableAssistantError` directly. Verified as a patch guard: with the hunk removed from the installed pi-ai, three of the four tests fail.

**Note for #1494 (pi 0.85.0 bump).** That PR renames the patch file; this hunk needs carrying into `patches/@earendil-works__pi-ai@0.85.0.patch` when the two merge (the guard test will fail loudly if it is dropped).

## Verification

**Before (reproduce the bug):**
1. On `main`, from `packages/runtime`, run `pnpm vitest run src/backends/pi/malformed-retry.test.ts` after copying the test file in: the retry tests fail with `expected 1 to be 2` (one request, no retry).
2. Live: a Gemini chat whose turn ends in `MALFORMED_RESPONSE` shows the Retry card immediately; the engine log line reads `[provider_error] provider=google ... kind=provider_internal :: Provider stopped with: MALFORMED_RESPONSE` after a single request.

**After:**
1. `pnpm --filter @houston/runtime test` is green (181 files, 1569 tests), including the new guard test.
2. Live: the same turn logs pi's `auto_retry_start` and answers normally on the retry; the Retry card only appears if all four attempts end malformed.

Checks run: `pnpm check`, `pnpm --filter @houston/runtime typecheck`, `pnpm --filter @houston/runtime test`, `pnpm --filter @houston/host test`.
