### PR TITLE
fix(host): answer 503 on a serve-miss heal while the host drains (PRODUCT-1672)

### DIFF
--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -456,6 +456,11 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     beforeTurn: sharedMirror ? () => sharedMirror.beforeTurn() : undefined,
     turnLogCapture: standingFrameCapture,
   });
+  // Raised at the top of stop(): a heal reads the runtime's live credential
+  // and the drain is about to kill that runtime, so the serve route answers
+  // 503 + Retry-After for the rest of the drain instead of erroring per
+  // provider (PRODUCT-1672).
+  let draining = false;
   const credentialHealer = opts.credentials
     ? new CredentialServeHealer(
         async ({ workspaceId, agentId, provider, actingAs }) => {
@@ -485,6 +490,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           });
           return result.ok;
         },
+        undefined,
+        undefined,
+        () => draining,
       )
     : undefined;
 
@@ -1013,6 +1021,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     stop() {
       if (stopPromise) return stopPromise;
       stopPromise = (async () => {
+        draining = true;
         scheduler.stop();
         watcher.stop();
         standingFrameCapture?.stop();

--- a/packages/host/src/routes/credential-healer.test.ts
+++ b/packages/host/src/routes/credential-healer.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { RevocationTombstones } from "../credentials/revocation-tombstones";
+import { LauncherClosedError } from "../ports";
 import {
   type CredentialHeal,
   CredentialServeHealer,
@@ -145,4 +146,85 @@ test("no acting identity keeps the single shared slot (desktop, self-host)", asy
   expect(await healer.attempt(args)).toBe(false);
 
   expect(seen).toEqual([undefined]);
+});
+
+test("a launcher refusal mid-shutdown rethrows its closed shape without a Sentry error (PRODUCT-1672)", async () => {
+  // ensureAwake throws LauncherClosedError once stop() latched the launcher.
+  // That is the drain, not a fault: the route must answer the waking shape,
+  // and nothing may reach console.error (every console.error is a Sentry
+  // event on a managed pod).
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const healer = new CredentialServeHealer(async () => {
+    throw new LauncherClosedError();
+  });
+  await expect(
+    healer.attempt({ workspaceId: "ws", agentId: "ws/agent", provider: "xai" }),
+  ).rejects.toBeInstanceOf(LauncherClosedError);
+  expect(errors).not.toHaveBeenCalled();
+  errors.mockRestore();
+});
+
+test("a heal that dies once the host is draining is the drain, not a fault", async () => {
+  // The runtime was killed under the export fetch: undici's bare "fetch
+  // failed". With the host draining that is the same shutdown.
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  let draining = false;
+  const healer = new CredentialServeHealer(
+    async () => {
+      draining = true;
+      throw new TypeError("fetch failed");
+    },
+    undefined,
+    undefined,
+    () => draining,
+  );
+  await expect(
+    healer.attempt({ workspaceId: "ws", agentId: "ws/agent", provider: "xai" }),
+  ).rejects.toBeInstanceOf(LauncherClosedError);
+  expect(errors).not.toHaveBeenCalled();
+  errors.mockRestore();
+});
+
+test("a draining host refuses the heal before it starts and spends no cooldown", async () => {
+  const { seen, heal } = recorder();
+  let now = 1_700_000_000_000;
+  let draining = true;
+  const healer = new CredentialServeHealer(
+    heal,
+    () => now,
+    undefined,
+    () => draining,
+  );
+  const args = { workspaceId: "ws", agentId: "ws/agent", provider: "xai" };
+  await expect(healer.attempt(args)).rejects.toBeInstanceOf(
+    LauncherClosedError,
+  );
+  expect(seen).toEqual([]);
+  // The refusal must not have burned the cooldown: a host that stops draining
+  // (tests, a cancelled shutdown) heals on the very next miss.
+  draining = false;
+  now += 1_000;
+  expect(await healer.attempt(args)).toBe(true);
+  expect(seen).toEqual([undefined]);
+});
+
+test("a heal that fails on a live host stays a loud error and names the cause", async () => {
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const healer = new CredentialServeHealer(async () => {
+    throw new TypeError("fetch failed", {
+      cause: Object.assign(new Error("connect ECONNREFUSED"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+  });
+  expect(
+    await healer.attempt({
+      workspaceId: "ws",
+      agentId: "ws/agent",
+      provider: "xai",
+    }),
+  ).toBe(false);
+  expect(errors).toHaveBeenCalledTimes(1);
+  expect(errors.mock.calls[0]?.[1]).toBe("fetch failed (cause: ECONNREFUSED)");
+  errors.mockRestore();
 });

--- a/packages/host/src/routes/credential-healer.ts
+++ b/packages/host/src/routes/credential-healer.ts
@@ -3,6 +3,7 @@ import {
   sharedRevocationTombstones,
 } from "../credentials/revocation-tombstones";
 import { credentialScopeKey } from "../credentials/scope-key";
+import { LauncherClosedError } from "../ports";
 
 const HEAL_COOLDOWN_MS = 5 * 60_000;
 
@@ -15,10 +16,37 @@ export type CredentialHeal = (args: {
 }) => Promise<boolean>;
 
 /**
+ * undici hides the reason for a network failure (ECONNREFUSED, EAI_AGAIN, …)
+ * behind a bare `TypeError: fetch failed`; the log line names it so a heal
+ * that fails on a LIVE host says what actually broke.
+ */
+function describeHealError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const cause = error.cause;
+  const code =
+    cause && typeof cause === "object" && "code" in cause
+      ? String((cause as { code: unknown }).code)
+      : cause instanceof Error
+        ? cause.message
+        : undefined;
+  return code ? `${error.message} (cause: ${code})` : error.message;
+}
+
+/**
  * Coalesces serve-miss recovery and limits each provider to one attempt/5m.
  *
  * Per (workspace, SCOPE, provider): one member's miss must not hand its result
  * to another member's serve, nor spend the cooldown that member needs (HOU-976).
+ *
+ * Rejects with `LauncherClosedError` while the host drains: a heal reads the
+ * runtime's live credential, and a draining host has latched its launcher and
+ * is killing that very runtime. The runtime's own serve sync is what arrives
+ * here mid-drain (it probes every provider at once), so without this every
+ * roll logged one Sentry error per provider per pod, fleet-wide, for a state
+ * that is nothing but the shutdown (PRODUCT-1672). The rejection rides to the
+ * server's catch, which answers 503 + Retry-After — the runtime's probe reads
+ * that as transient and keeps its copy, instead of a marked 404 it would act
+ * on as a verdict.
  */
 export class CredentialServeHealer {
   private readonly inFlight = new Map<string, Promise<boolean>>();
@@ -28,6 +56,8 @@ export class CredentialServeHealer {
     private readonly heal: CredentialHeal,
     private readonly now: () => number = Date.now,
     private readonly revocations: RevocationTombstones = sharedRevocationTombstones,
+    /** Whether the host has begun stopping (local/host.ts `stop()`). */
+    private readonly draining: () => boolean = () => false,
   ) {}
 
   attempt(args: Parameters<CredentialHeal>[0]): Promise<boolean> {
@@ -43,6 +73,9 @@ export class CredentialServeHealer {
     ) {
       return Promise.resolve(false);
     }
+    // Refused before it starts: no attempt log, no cooldown spent — the
+    // replacement host (or the next app start) heals with a clean slate.
+    if (this.draining()) return Promise.reject(new LauncherClosedError());
     const key = `${args.workspaceId}:${credentialScopeKey({ actingAs: args.actingAs })}:${args.provider}`;
     const existing = this.inFlight.get(key);
     if (existing) return existing;
@@ -61,9 +94,20 @@ export class CredentialServeHealer {
         return healed;
       })
       .catch((error) => {
+        // The launcher refused (already latched) or the runtime died under the
+        // export fetch once the drain began: the same shutdown either way, and
+        // never a fault worth a Sentry error.
+        if (error instanceof LauncherClosedError || this.draining()) {
+          console.info(
+            `[sandbox/credential] heal aborted provider=${args.provider} agent=${args.agentId}: the host is shutting down`,
+          );
+          throw error instanceof LauncherClosedError
+            ? error
+            : new LauncherClosedError();
+        }
         console.error(
           `[sandbox/credential] heal failed provider=${args.provider} agent=${args.agentId}:`,
-          error instanceof Error ? error.message : String(error),
+          describeHealError(error),
         );
         return false;
       })

--- a/packages/host/src/server.test.ts
+++ b/packages/host/src/server.test.ts
@@ -13,6 +13,7 @@ import type {
   RuntimeLauncher,
   TokenVerifier,
 } from "./ports";
+import { CredentialServeHealer } from "./routes/credential-healer";
 import {
   type ControlPlaneDeps,
   createControlPlaneServer,
@@ -744,4 +745,32 @@ test("the credential endpoint rejects a bad sandbox token (401) and an unconnect
       })
     ).status,
   ).toBe(404);
+});
+
+test("a serve miss while the host drains answers 503 + Retry-After, never a marked 404 (PRODUCT-1672)", async () => {
+  // A roll kills the runtimes while their serve sync is in flight: the healer
+  // refuses (its runtime is gone) and the route must answer the waking shape
+  // the client retries against the replacement pod — not the store's
+  // authoritative "not connected", and not a 500.
+  const credentialHealer = new CredentialServeHealer(
+    async () => true,
+    undefined,
+    undefined,
+    () => true,
+  );
+  const { base: b, close } = await startServer({
+    ...baseDeps(),
+    credentialHealer,
+  });
+  try {
+    const aliceWs = await store.getOrCreatePersonalWorkspace("alice");
+    const r = await fetch(`${b}/sandbox/credential?provider=xai`, {
+      headers: { Authorization: `Bearer sbx:${aliceWs.id}` },
+    });
+    expect(r.status).toBe(503);
+    expect(r.headers.get("retry-after")).toBe("2");
+    expect(r.headers.get("x-houston-not-connected")).toBeNull();
+  } finally {
+    await close();
+  }
 });


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-5AD (PRODUCT-1672): `[sandbox/credential] heal failed provider=<id> agent=<agent>: …` is a bucket keyed by the healer's error log. Tallying its events: every one is a managed-cloud host pod, and the failures land fleet-wide at the same second (e.g. four distinct pods all at 13:58:02Z on 2026-09-04, ~65s after boot), with two flavors of the same cause:

- `the host is shutting down; retry shortly`: `ensureAwake` refused because `stop()` had already latched the launcher (`LauncherClosedError`).
- `fetch failed`: the runtime was killed under the healer's `/auth/export` fetch.

Root cause: on shutdown, `host.stop()` latches the launcher and kills the runtimes while the HTTP listener stays open for the final sync. The runtime's serve sync (which probes every provider, 8 at a time) is in flight, every central miss goes through `CredentialServeHealer`, and each one lands in the healer's `catch`, which logged at `console.error`. On a managed pod every `console.error` is a Sentry event, so each roll produced one error per not-connected provider per pod. The route then answered a marked 404 ("workspace not connected") for a state that was never a verdict about the store.

## Fix

- `CredentialServeHealer` takes a `draining` signal. While draining it refuses before starting (no attempt log, no cooldown spent), and a heal that fails with `LauncherClosedError`, or with anything else once the drain began, rethrows `LauncherClosedError` after an info-level line. `server.ts` already maps that shape to `503 + Retry-After: 2`, the same answer the wake probe gives mid-shutdown, so the runtime's probe reads it as transient and keeps its copy.
- `local/host.ts` raises the flag as the first line of `stop()` and passes it to the healer.
- A heal that fails on a live host stays a loud `console.error`, now with undici's nested cause code (`fetch failed (cause: ECONNREFUSED)`) so the remaining real events say what broke.

## Tests

- `credential-healer.test.ts`: launcher refusal rethrows without `console.error`; a generic failure once draining is the drain; a draining host refuses before starting and spends no cooldown; a live-host failure stays loud and names the cause.
- `server.test.ts`: a serve miss while draining answers 503 + `Retry-After: 2` with no `x-houston-not-connected` marker.

`pnpm check`, `pnpm --filter @houston/host test` (183 files), `pnpm check:boundaries`, and the repo typecheck all pass.

## Verify

Before (main): run the host with a not-connected provider, send it SIGTERM while a runtime's serve sync is in flight (a pod roll does this on every deploy), and watch stderr: one `[sandbox/credential] heal failed … : the host is shutting down; retry shortly` or `… : fetch failed` line at error level per provider, each a Sentry event.

After: the same drain logs `[sandbox/credential] heal aborted … : the host is shutting down` at info level, `GET /sandbox/credential?provider=<id>` answers `503` with `Retry-After: 2`, and no `console.error` fires. Unit-level: `pnpm --filter @houston/host exec vitest run src/routes/credential-healer.test.ts src/server.test.ts`. Once deployed, HOUSTON-APP-5AD should stop receiving events on rolls; the only remaining events would carry a `(cause: …)` code and mean a runtime died on a live host.