### PR TITLE
feat(shell): add a "Copy an agent" option to the create dialog (PRODUCT-1678)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -43,6 +43,7 @@
     "@tiptap/starter-kit": "3.29.1",
     "ajv": "8.20.0",
     "canvas-confetti": "1.9.4",
+    "fflate": "0.8.3",
     "framer-motion": "12.42.2",
     "i18next": "26.3.4",
     "i18next-browser-languagedetector": "8.2.1",

--- a/app/src/components/agent-actions/use-copy-agent.ts
+++ b/app/src/components/agent-actions/use-copy-agent.ts
@@ -1,3 +1,4 @@
+import type { PortableExportSelection } from "@houston-ai/engine-client";
 import { useTranslation } from "react-i18next";
 import { isAgentNameConflictError } from "../../lib/agent-name-conflict";
 import { finishAgentSetup } from "../../lib/agent-setup";
@@ -24,6 +25,10 @@ import { fullPortableSelection } from "./copy-agent-model";
  * package installs as an ordinary create-with-seeds, and the one move action
  * files the copy in the chosen team.
  *
+ * `selection` narrows what the package carries (the create dialog's "Copy an
+ * agent" wizard lets the user leave items behind); absent, the copy is
+ * faithful. `color` defaults to the source's.
+ *
  * Resolves `true` when the copy exists (the dialog closes on it); failures
  * toast here and resolve `false` so the dialog stays open for a retry.
  */
@@ -31,6 +36,10 @@ export function useCopyAgent(): (args: {
   agent: Agent;
   name: string;
   team: TeamView | null;
+  color?: string;
+  selection?: PortableExportSelection;
+  /** Which door the copy came through, for analytics. */
+  via?: "settings" | "create_dialog";
 }) => Promise<boolean> {
   const { t } = useTranslation("agents");
   const addToast = useUIStore((s) => s.addToast);
@@ -38,12 +47,14 @@ export function useCopyAgent(): (args: {
   const workspaceName = useWorkspaceStore((s) => s.current?.name);
   const moveAgent = useMoveAgentTeam();
 
-  return async ({ agent, name, team }) => {
+  return async ({ agent, name, team, color, selection, via = "settings" }) => {
     try {
       const engine = getEngine();
-      const preview = await engine.portablePreview(agent.folderPath);
+      const packaged =
+        selection ??
+        fullPortableSelection(await engine.portablePreview(agent.folderPath));
       const bytes = await engine.portablePackage(agent.folderPath, {
-        selection: fullPortableSelection(preview),
+        selection: packaged,
         meta: {
           agentId: agent.configId ?? agent.id,
           agentName: agent.name,
@@ -55,7 +66,7 @@ export function useCopyAgent(): (args: {
         packageId: uploaded.packageId,
         workspaceName: workspaceName ?? "",
         agentName: name.trim(),
-        agentColor: agent.color,
+        agentColor: color ?? agent.color,
         selection: fullPortableSelection(uploaded.preview),
       });
       // Reveal now (the optimistic create/import contract, HOU-710), and file
@@ -63,7 +74,7 @@ export function useCopyAgent(): (args: {
       // destination from the live teams model.
       adoptAgent(toAgent(installed.agent));
       if (team) moveAgent(installed.agent.id, team);
-      analytics.track("agent_copied", { agent_slug: agent.id });
+      analytics.track("agent_copied", { agent_slug: agent.id, source: via });
       addToast({
         variant: "success",
         title: t("copyAgent.toasts.createdTitle"),

--- a/app/src/components/agent-actions/use-copy-agent.ts
+++ b/app/src/components/agent-actions/use-copy-agent.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { isAgentNameConflictError } from "../../lib/agent-name-conflict";
 import { finishAgentSetup } from "../../lib/agent-setup";
 import { analytics } from "../../lib/analytics";
+import { copyAgentChats } from "../../lib/copy-agent-chats";
 import { getEngine } from "../../lib/engine";
 import { genericErrorDescription } from "../../lib/error-report";
 import { showExpectedStateToast } from "../../lib/error-toast";
@@ -27,7 +28,10 @@ import { fullPortableSelection } from "./copy-agent-model";
  *
  * `selection` narrows what the package carries (the create dialog's "Copy an
  * agent" wizard lets the user leave items behind); absent, the copy is
- * faithful. `color` defaults to the source's.
+ * faithful. `color` defaults to the source's. `copyChats` moves the source's
+ * tasks and conversations over afterwards through the agent-scoped migration
+ * routes, in the background: on the hosted profile the copy's pod is still
+ * cold-starting, and holding the dialog for that would freeze it.
  *
  * Resolves `true` when the copy exists (the dialog closes on it); failures
  * toast here and resolve `false` so the dialog stays open for a retry.
@@ -38,6 +42,7 @@ export function useCopyAgent(): (args: {
   team: TeamView | null;
   color?: string;
   selection?: PortableExportSelection;
+  copyChats?: boolean;
   /** Which door the copy came through, for analytics. */
   via?: "settings" | "create_dialog";
 }) => Promise<boolean> {
@@ -47,7 +52,15 @@ export function useCopyAgent(): (args: {
   const workspaceName = useWorkspaceStore((s) => s.current?.name);
   const moveAgent = useMoveAgentTeam();
 
-  return async ({ agent, name, team, color, selection, via = "settings" }) => {
+  return async ({
+    agent,
+    name,
+    team,
+    color,
+    selection,
+    copyChats = false,
+    via = "settings",
+  }) => {
     try {
       const engine = getEngine();
       const packaged =
@@ -83,6 +96,31 @@ export function useCopyAgent(): (args: {
         }),
       });
       openAgentBoard(installed.agent.id);
+      if (copyChats) {
+        void (async () => {
+          try {
+            const outcome = await copyAgentChats(
+              engine,
+              agent.folderPath,
+              installed.agentPath,
+            );
+            addToast({
+              variant: "success",
+              title: t("copyAgent.toasts.chatsCopiedTitle"),
+              description: t("copyAgent.toasts.chatsCopiedDescription", {
+                count: outcome.conversations,
+                name: installed.agentName,
+              }),
+            });
+          } catch (err) {
+            addToast({
+              variant: "error",
+              title: t("copyAgent.errors.chatsFailed"),
+              description: genericErrorDescription("agent_copy_chats", err),
+            });
+          }
+        })();
+      }
       // The model pin dispatches to the copy's engine — on the hosted profile a
       // pod still cold-starting — so it finishes in the background like the
       // other create doors (HOU-649); the wrappers toast their own failures.

--- a/app/src/components/agent-actions/use-copy-agent.ts
+++ b/app/src/components/agent-actions/use-copy-agent.ts
@@ -84,9 +84,11 @@ export function useCopyAgent(): (args: {
       });
       // Reveal now (the optimistic create/import contract, HOU-710), and file
       // the copy in its team BEFORE navigating — openAgentBoard resolves its
-      // destination from the live teams model.
+      // destination from the live teams model, so the move must have settled
+      // (on a server host the roster only learns it after the round trip;
+      // navigating earlier lands on the default team's board).
       adoptAgent(toAgent(installed.agent));
-      if (team) moveAgent(installed.agent.id, team);
+      if (team) await moveAgent(installed.agent.id, team);
       analytics.track("agent_copied", { agent_slug: agent.id, source: via });
       addToast({
         variant: "success",

--- a/app/src/components/agent-actions/use-copy-agent.ts
+++ b/app/src/components/agent-actions/use-copy-agent.ts
@@ -2,9 +2,11 @@ import type { PortableExportSelection } from "@houston-ai/engine-client";
 import { useTranslation } from "react-i18next";
 import { isAgentNameConflictError } from "../../lib/agent-name-conflict";
 import { finishAgentSetup } from "../../lib/agent-setup";
+import { isAgentWarmingError } from "../../lib/agent-warming-guard";
 import { analytics } from "../../lib/analytics";
-import { copyAgentChats } from "../../lib/copy-agent-chats";
+import { chatCopyComplete, copyAgentChats } from "../../lib/copy-agent-chats";
 import { getEngine } from "../../lib/engine";
+import { isEngineWakingError } from "../../lib/engine-waking-error";
 import { genericErrorDescription } from "../../lib/error-report";
 import { showExpectedStateToast } from "../../lib/error-toast";
 import { logger } from "../../lib/logger";
@@ -101,11 +103,30 @@ export function useCopyAgent(): (args: {
       if (copyChats) {
         void (async () => {
           try {
+            // The copy's engine may still be waking (a cold pod on the hosted
+            // profile): a waking refusal on the import is waited out, not
+            // reported.
             const outcome = await copyAgentChats(
               engine,
               agent.folderPath,
               installed.agentPath,
+              undefined,
+              (err) => isEngineWakingError(err) || isAgentWarmingError(err),
             );
+            // A rejected file or a board the copy already had (a task was
+            // created in it before the chats arrived) is a partial copy, and
+            // says so; only a complete one gets the success toast.
+            if (!chatCopyComplete(outcome)) {
+              logger.error(
+                `[copy-agent] chats partial: board=${outcome.boardWritten} rejected=${JSON.stringify(outcome.rejected)}`,
+              );
+              addToast({
+                variant: "error",
+                title: t("copyAgent.errors.chatsFailed"),
+                description: t("copyAgent.errors.chatsPartial"),
+              });
+              return;
+            }
             addToast({
               variant: "success",
               title: t("copyAgent.toasts.chatsCopiedTitle"),

--- a/app/src/components/agent-settings/agent-settings-manage.tsx
+++ b/app/src/components/agent-settings/agent-settings-manage.tsx
@@ -161,7 +161,7 @@ export function AgentSettingsManage({ agent }: { agent: Agent }) {
           if (!open) setPendingTeam(null);
         }}
         onConfirm={() => {
-          if (pendingTeam) moveAgent(agent.id, pendingTeam);
+          if (pendingTeam) void moveAgent(agent.id, pendingTeam);
           setPendingTeam(null);
         }}
       />

--- a/app/src/components/copy-agent/copy-agent-wizard-model.ts
+++ b/app/src/components/copy-agent/copy-agent-wizard-model.ts
@@ -1,0 +1,60 @@
+import type {
+  PortableExportSelection,
+  PortableInventoryPreview,
+} from "@houston-ai/engine-client";
+import type { WizardSelection } from "../../lib/portable-share";
+
+/**
+ * The pure rules behind the create dialog's "Copy an agent" path. Unit-tested
+ * in `app/tests/copy-agent-wizard-model.test.ts`.
+ */
+
+export type CopyWizardStep =
+  | "source"
+  | "instructions"
+  | "routines"
+  | "skills"
+  | "name";
+
+/**
+ * The screens the wizard walks, for a chosen source. Content screens exist
+ * only when the source has something to show on them: a bare agent goes
+ * straight from the source list to naming, and no screen ever renders empty.
+ * The instructions screen carries the job description AND the learnings, the
+ * two things a non-technical user reads as "what the agent knows".
+ */
+export function copyWizardSteps(
+  preview: PortableInventoryPreview | null,
+): CopyWizardStep[] {
+  if (!preview) return ["source"];
+  const steps: CopyWizardStep[] = ["source"];
+  if (preview.claudeMd !== null || preview.learnings.length > 0) {
+    steps.push("instructions");
+  }
+  if (preview.routines.length > 0) steps.push("routines");
+  if (preview.skills.length > 0) steps.push("skills");
+  steps.push("name");
+  return steps;
+}
+
+/** Everything on: the copy starts faithful and the user opts things OUT. */
+export function fullCopySelection(
+  preview: PortableInventoryPreview,
+): WizardSelection {
+  return {
+    claudeMd: preview.claudeMd !== null,
+    skillSlugs: new Set(preview.skills.map((skill) => skill.slug)),
+    routineIds: new Set(preview.routines.map((routine) => routine.id)),
+    learningIds: new Set(preview.learnings.map((learning) => learning.id)),
+  };
+}
+
+/** The toggle Sets as the wire selection the portable package is built from. */
+export function toCopySelection(sel: WizardSelection): PortableExportSelection {
+  return {
+    includeClaudeMd: sel.claudeMd,
+    includeSkillSlugs: Array.from(sel.skillSlugs),
+    includeRoutineIds: Array.from(sel.routineIds),
+    includeLearningIds: Array.from(sel.learningIds),
+  };
+}

--- a/app/src/components/copy-agent/copy-agent-wizard-model.ts
+++ b/app/src/components/copy-agent/copy-agent-wizard-model.ts
@@ -17,20 +17,17 @@ export type CopyWizardStep =
   | "name";
 
 /**
- * The screens the wizard walks, for a chosen source. Content screens exist
- * only when the source has something to show on them: a bare agent goes
- * straight from the source list to naming, and no screen ever renders empty.
- * The instructions screen carries the job description AND the learnings, the
- * two things a non-technical user reads as "what the agent knows".
+ * The screens the wizard walks, for a chosen source. The "what should the
+ * copy know" screen always shows: it carries the job description, the
+ * learnings and the chats switch, and the chats choice exists for every
+ * source. The routines and skills screens exist only when the source has
+ * some, so no screen ever renders an empty list.
  */
 export function copyWizardSteps(
   preview: PortableInventoryPreview | null,
 ): CopyWizardStep[] {
   if (!preview) return ["source"];
-  const steps: CopyWizardStep[] = ["source"];
-  if (preview.claudeMd !== null || preview.learnings.length > 0) {
-    steps.push("instructions");
-  }
+  const steps: CopyWizardStep[] = ["source", "instructions"];
   if (preview.routines.length > 0) steps.push("routines");
   if (preview.skills.length > 0) steps.push("skills");
   steps.push("name");

--- a/app/src/components/copy-agent/copy-agent-wizard.tsx
+++ b/app/src/components/copy-agent/copy-agent-wizard.tsx
@@ -84,12 +84,18 @@ export function CopyAgentWizard(props: {
           />
         )}
         {stepProps && w.step === "instructions" && (
-          <InstructionsStep {...stepProps} />
+          <InstructionsStep
+            {...stepProps}
+            copyChats={w.copyChats}
+            onCopyChatsChange={w.setCopyChats}
+          />
         )}
         {stepProps && w.step === "routines" && <RoutinesStep {...stepProps} />}
         {stepProps && w.step === "skills" && <SkillsStep {...stepProps} />}
       </div>
-      <footer className="flex shrink-0 items-center justify-between px-5 py-4 pb-safe md:px-8">
+      {/* Design padding stacked on the safe-area inset: `pb-safe` alone
+          would REPLACE the bottom padding with an inset that is 0 on desktop. */}
+      <footer className="flex shrink-0 items-center justify-between px-5 pt-4 pb-[calc(env(safe-area-inset-bottom)+theme(spacing.4))] md:px-8 md:pb-[calc(env(safe-area-inset-bottom)+theme(spacing.6))]">
         <button
           type="button"
           onClick={w.back}

--- a/app/src/components/copy-agent/copy-agent-wizard.tsx
+++ b/app/src/components/copy-agent/copy-agent-wizard.tsx
@@ -1,0 +1,108 @@
+import { Button, DialogTitle } from "@houston-ai/core";
+import type { FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { ProgressDots } from "../portable/wizard-parts";
+import { NamingStep } from "../shell/naming-step";
+import {
+  InstructionsStep,
+  RoutinesStep,
+  SkillsStep,
+} from "./copy-content-steps";
+import { SourceAgentStep } from "./source-agent-step";
+import { useCopyAgentWizard } from "./use-copy-agent-wizard";
+
+/**
+ * The create dialog's third door: a new agent modeled on one you already have.
+ * Source list, then one screen per kind of content the source carries (job
+ * description + learnings, routines, skills), each item ON by default, then the
+ * same naming screen as "Create new". The copy itself is the portable pipeline
+ * `useCopyAgent` runs for the Settings "Copy agent" row, fed the wizard's
+ * selection instead of everything.
+ */
+export function CopyAgentWizard(props: {
+  /** The team the "+" was pressed in; `null` files the copy in the default. */
+  targetTeamId: string | null;
+  /** Leave the wizard for the dialog's first screen. */
+  onBack: () => void;
+  /** The copy exists: the dialog closes. */
+  onDone: () => void;
+}) {
+  const { t } = useTranslation("agents");
+  const w = useCopyAgentWizard(props);
+
+  if (w.step === "name" && w.source) {
+    const submit = (e: FormEvent) => {
+      e.preventDefault();
+      void w.submit();
+    };
+    return (
+      <NamingStep
+        selectedAgent={undefined}
+        heading={t("copyAgent.wizard.name.heading", { name: w.source.name })}
+        name={w.name}
+        color={w.color}
+        error={w.nameIssueMessage}
+        existingPath={null}
+        creating={w.creating}
+        nameInvalid={w.nameIssue !== null}
+        onNameChange={w.setName}
+        onColorChange={w.setColor}
+        onExistingPathChange={() => undefined}
+        onBack={w.back}
+        onSubmit={submit}
+      />
+    );
+  }
+
+  const stepProps =
+    w.source && w.preview && w.selection
+      ? {
+          sourceName: w.source.name,
+          preview: w.preview,
+          selection: w.selection,
+          setSelection: w.setSelection,
+        }
+      : null;
+
+  return (
+    <>
+      <DialogTitle className="sr-only">
+        {t("copyAgent.wizard.eyebrow")}
+      </DialogTitle>
+      <header className="flex shrink-0 items-center gap-4 px-5 pt-6 pb-2 md:px-8">
+        <p className="text-xs text-ink-muted">
+          {t("copyAgent.wizard.eyebrow")}
+        </p>
+        <ProgressDots index={w.stepIndex} total={w.steps.length} />
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-2 pb-6 md:px-8">
+        {w.step === "source" && (
+          <SourceAgentStep
+            agents={w.sources}
+            loadingId={w.loadingId}
+            onPick={(agent) => void w.pick(agent)}
+          />
+        )}
+        {stepProps && w.step === "instructions" && (
+          <InstructionsStep {...stepProps} />
+        )}
+        {stepProps && w.step === "routines" && <RoutinesStep {...stepProps} />}
+        {stepProps && w.step === "skills" && <SkillsStep {...stepProps} />}
+      </div>
+      <footer className="flex shrink-0 items-center justify-between px-5 py-4 pb-safe md:px-8">
+        <button
+          type="button"
+          onClick={w.back}
+          className="text-sm text-ink-muted hover:text-ink"
+        >
+          {t("copyAgent.wizard.actions.back")}
+        </button>
+        {w.step !== "source" && (
+          <Button className="rounded-full" onClick={w.next}>
+            {t("copyAgent.wizard.actions.next")}
+          </Button>
+        )}
+      </footer>
+    </>
+  );
+}

--- a/app/src/components/copy-agent/copy-agent-wizard.tsx
+++ b/app/src/components/copy-agent/copy-agent-wizard.tsx
@@ -87,6 +87,7 @@ export function CopyAgentWizard(props: {
           <InstructionsStep
             {...stepProps}
             copyChats={w.copyChats}
+            chatCount={w.chatCount}
             onCopyChatsChange={w.setCopyChats}
           />
         )}

--- a/app/src/components/copy-agent/copy-content-steps.tsx
+++ b/app/src/components/copy-agent/copy-content-steps.tsx
@@ -21,15 +21,22 @@ function usePickLabels() {
 }
 
 /**
- * "What should the copy know?": the job description as one switch, then the
- * learnings one by one. Both default ON; the user opts things out.
+ * "What should the copy know?": the job description as one switch, the
+ * learnings one by one (both ON to start), and the chats as one switch that
+ * starts OFF: a conversation can hold personal details, so bringing them is a
+ * deliberate choice.
  */
 export function InstructionsStep({
   sourceName,
   preview,
   selection,
   setSelection,
-}: ContentStepProps) {
+  copyChats,
+  onCopyChatsChange,
+}: ContentStepProps & {
+  copyChats: boolean;
+  onCopyChatsChange: (next: boolean) => void;
+}) {
   const { t } = useTranslation("agents");
   const labels = usePickLabels();
   return (
@@ -80,6 +87,20 @@ export function InstructionsStep({
           compact
         />
       )}
+
+      <section>
+        <h2 className="mb-1 text-sm font-medium">
+          {t("copyAgent.wizard.instructions.chatsLabel")}
+        </h2>
+        <p className="mb-2 text-xs text-ink-muted">
+          {t("copyAgent.wizard.instructions.chatsBody", { name: sourceName })}
+        </p>
+        <PickSwitchRow
+          checked={copyChats}
+          onChange={() => onCopyChatsChange(!copyChats)}
+          title={t("copyAgent.wizard.instructions.chatsRow")}
+        />
+      </section>
     </div>
   );
 }

--- a/app/src/components/copy-agent/copy-content-steps.tsx
+++ b/app/src/components/copy-agent/copy-content-steps.tsx
@@ -1,8 +1,8 @@
 import type { PortableInventoryPreview } from "@houston-ai/engine-client";
 import { useTranslation } from "react-i18next";
 import type { WizardSelection } from "../../lib/portable-share";
-import { PickListStep, PickSwitchRow } from "../portable/pick-list-step";
-import { humanize } from "../portable/wizard-parts";
+import { PickListStep } from "../portable/pick-list-step";
+import { humanize, SwitchRow } from "../portable/wizard-parts";
 
 interface ContentStepProps {
   sourceName: string;
@@ -44,7 +44,7 @@ export function InstructionsStep({
   return (
     <div className="space-y-10">
       <header>
-        <h1 className="text-[28px] font-normal leading-tight text-balance">
+        <h1 className="text-2xl font-normal leading-tight text-balance">
           {t("copyAgent.wizard.instructions.title")}
         </h1>
         <p className="mt-3 text-base text-ink-muted">
@@ -57,7 +57,7 @@ export function InstructionsStep({
           {t("copyAgent.wizard.instructions.instructionsLabel")}
         </h2>
         {preview.claudeMd ? (
-          <PickSwitchRow
+          <SwitchRow
             checked={selection.claudeMd}
             onChange={() =>
               setSelection({ ...selection, claudeMd: !selection.claudeMd })
@@ -95,7 +95,7 @@ export function InstructionsStep({
           {t("copyAgent.wizard.instructions.chatsLabel")}
         </h2>
         {chatCount > 0 ? (
-          <PickSwitchRow
+          <SwitchRow
             checked={copyChats}
             onChange={() => onCopyChatsChange(!copyChats)}
             title={t("copyAgent.wizard.instructions.chatsRow")}
@@ -121,6 +121,7 @@ export function RoutinesStep({
   setSelection,
 }: ContentStepProps) {
   const { t } = useTranslation("agents");
+  const labels = usePickLabels();
   return (
     <PickListStep
       title={t("copyAgent.wizard.routines.title")}
@@ -133,7 +134,7 @@ export function RoutinesStep({
         title: routine.name,
         subtitle: routine.promptExcerpt,
       })}
-      labels={usePickLabels()}
+      labels={labels}
     />
   );
 }
@@ -145,6 +146,7 @@ export function SkillsStep({
   setSelection,
 }: ContentStepProps) {
   const { t } = useTranslation("agents");
+  const labels = usePickLabels();
   return (
     <PickListStep
       title={t("copyAgent.wizard.skills.title")}
@@ -157,7 +159,7 @@ export function SkillsStep({
         title: humanize(skill.slug),
         subtitle: skill.description,
       })}
-      labels={usePickLabels()}
+      labels={labels}
     />
   );
 }

--- a/app/src/components/copy-agent/copy-content-steps.tsx
+++ b/app/src/components/copy-agent/copy-content-steps.tsx
@@ -32,9 +32,11 @@ export function InstructionsStep({
   selection,
   setSelection,
   copyChats,
+  chatCount,
   onCopyChatsChange,
 }: ContentStepProps & {
   copyChats: boolean;
+  chatCount: number;
   onCopyChatsChange: (next: boolean) => void;
 }) {
   const { t } = useTranslation("agents");
@@ -89,17 +91,24 @@ export function InstructionsStep({
       )}
 
       <section>
-        <h2 className="mb-1 text-sm font-medium">
+        <h2 className="mb-3 text-sm font-medium">
           {t("copyAgent.wizard.instructions.chatsLabel")}
         </h2>
-        <p className="mb-2 text-xs text-ink-muted">
-          {t("copyAgent.wizard.instructions.chatsBody", { name: sourceName })}
-        </p>
-        <PickSwitchRow
-          checked={copyChats}
-          onChange={() => onCopyChatsChange(!copyChats)}
-          title={t("copyAgent.wizard.instructions.chatsRow")}
-        />
+        {chatCount > 0 ? (
+          <PickSwitchRow
+            checked={copyChats}
+            onChange={() => onCopyChatsChange(!copyChats)}
+            title={t("copyAgent.wizard.instructions.chatsRow")}
+            subtitle={t("copyAgent.wizard.instructions.chatsCount", {
+              count: chatCount,
+              name: sourceName,
+            })}
+          />
+        ) : (
+          <p className="text-sm text-ink-muted">
+            {t("copyAgent.wizard.instructions.noChats", { name: sourceName })}
+          </p>
+        )}
       </section>
     </div>
   );

--- a/app/src/components/copy-agent/copy-content-steps.tsx
+++ b/app/src/components/copy-agent/copy-content-steps.tsx
@@ -1,0 +1,133 @@
+import type { PortableInventoryPreview } from "@houston-ai/engine-client";
+import { useTranslation } from "react-i18next";
+import type { WizardSelection } from "../../lib/portable-share";
+import { PickListStep, PickSwitchRow } from "../portable/pick-list-step";
+import { humanize } from "../portable/wizard-parts";
+
+interface ContentStepProps {
+  sourceName: string;
+  preview: PortableInventoryPreview;
+  selection: WizardSelection;
+  setSelection: (next: WizardSelection) => void;
+}
+
+function usePickLabels() {
+  const { t } = useTranslation("agents");
+  return {
+    selectAll: t("copyAgent.wizard.actions.selectAll"),
+    clearAll: t("copyAgent.wizard.actions.clearAll"),
+    flagged: "",
+  };
+}
+
+/**
+ * "What should the copy know?": the job description as one switch, then the
+ * learnings one by one. Both default ON; the user opts things out.
+ */
+export function InstructionsStep({
+  sourceName,
+  preview,
+  selection,
+  setSelection,
+}: ContentStepProps) {
+  const { t } = useTranslation("agents");
+  const labels = usePickLabels();
+  return (
+    <div className="space-y-10">
+      <header>
+        <h1 className="text-[28px] font-normal leading-tight text-balance">
+          {t("copyAgent.wizard.instructions.title")}
+        </h1>
+        <p className="mt-3 text-base text-ink-muted">
+          {t("copyAgent.wizard.instructions.body")}
+        </p>
+      </header>
+
+      <section>
+        <h2 className="mb-3 text-sm font-medium">
+          {t("copyAgent.wizard.instructions.instructionsLabel")}
+        </h2>
+        {preview.claudeMd ? (
+          <PickSwitchRow
+            checked={selection.claudeMd}
+            onChange={() =>
+              setSelection({ ...selection, claudeMd: !selection.claudeMd })
+            }
+            title={t("copyAgent.wizard.instructions.instructionsRow")}
+            subtitle={preview.claudeMd.excerpt}
+          />
+        ) : (
+          <p className="text-sm text-ink-muted">
+            {t("copyAgent.wizard.instructions.noInstructions", {
+              name: sourceName,
+            })}
+          </p>
+        )}
+      </section>
+
+      {preview.learnings.length > 0 && (
+        <PickListStep
+          title={t("copyAgent.wizard.instructions.learningsLabel")}
+          body={t("copyAgent.wizard.instructions.learningsBody")}
+          items={preview.learnings}
+          selected={selection.learningIds}
+          setSelected={(next) =>
+            setSelection({ ...selection, learningIds: next })
+          }
+          getId={(learning) => learning.id}
+          renderRow={(learning) => ({ title: learning.text })}
+          labels={labels}
+          compact
+        />
+      )}
+    </div>
+  );
+}
+
+export function RoutinesStep({
+  sourceName,
+  preview,
+  selection,
+  setSelection,
+}: ContentStepProps) {
+  const { t } = useTranslation("agents");
+  return (
+    <PickListStep
+      title={t("copyAgent.wizard.routines.title")}
+      body={t("copyAgent.wizard.routines.body", { name: sourceName })}
+      items={preview.routines}
+      selected={selection.routineIds}
+      setSelected={(next) => setSelection({ ...selection, routineIds: next })}
+      getId={(routine) => routine.id}
+      renderRow={(routine) => ({
+        title: routine.name,
+        subtitle: routine.promptExcerpt,
+      })}
+      labels={usePickLabels()}
+    />
+  );
+}
+
+export function SkillsStep({
+  sourceName,
+  preview,
+  selection,
+  setSelection,
+}: ContentStepProps) {
+  const { t } = useTranslation("agents");
+  return (
+    <PickListStep
+      title={t("copyAgent.wizard.skills.title")}
+      body={t("copyAgent.wizard.skills.body", { name: sourceName })}
+      items={preview.skills}
+      selected={selection.skillSlugs}
+      setSelected={(next) => setSelection({ ...selection, skillSlugs: next })}
+      getId={(skill) => skill.slug}
+      renderRow={(skill) => ({
+        title: humanize(skill.slug),
+        subtitle: skill.description,
+      })}
+      labels={usePickLabels()}
+    />
+  );
+}

--- a/app/src/components/copy-agent/source-agent-step.tsx
+++ b/app/src/components/copy-agent/source-agent-step.tsx
@@ -28,7 +28,7 @@ export function SourceAgentStep({
   return (
     <div className="space-y-8">
       <header>
-        <h1 className="text-[28px] font-normal leading-tight text-balance">
+        <h1 className="text-2xl font-normal leading-tight text-balance">
           {t("copyAgent.wizard.source.title")}
         </h1>
         <p className="mt-3 text-base text-ink-muted">

--- a/app/src/components/copy-agent/source-agent-step.tsx
+++ b/app/src/components/copy-agent/source-agent-step.tsx
@@ -1,0 +1,83 @@
+import {
+  cn,
+  HoustonAvatar,
+  resolveAgentColor,
+  Spinner,
+} from "@houston-ai/core";
+import { ChevronRight } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { Agent } from "../../lib/types";
+
+/**
+ * First screen of "Copy an agent": which of your agents is the model. One row
+ * per agent, the helmet in its own color so the list reads like the rail.
+ * Picking a row reads that agent's shareable content; the row shows a spinner
+ * while it loads and the wizard moves on by itself when it arrives.
+ */
+export function SourceAgentStep({
+  agents,
+  loadingId,
+  onPick,
+}: {
+  agents: readonly Agent[];
+  /** The agent whose content is being read, if any. Locks the list. */
+  loadingId: string | null;
+  onPick: (agent: Agent) => void;
+}) {
+  const { t } = useTranslation("agents");
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="text-[28px] font-normal leading-tight text-balance">
+          {t("copyAgent.wizard.source.title")}
+        </h1>
+        <p className="mt-3 text-base text-ink-muted">
+          {t("copyAgent.wizard.source.body")}
+        </p>
+      </header>
+      {agents.length === 0 ? (
+        <p className="text-sm text-ink-muted">
+          {t("copyAgent.wizard.source.empty")}
+        </p>
+      ) : (
+        <ul className="space-y-1" data-testid="copy-agent-sources">
+          {agents.map((agent) => {
+            const loading = loadingId === agent.id;
+            return (
+              <li key={agent.id}>
+                <button
+                  type="button"
+                  disabled={loadingId !== null}
+                  aria-busy={loading || undefined}
+                  onClick={() => onPick(agent)}
+                  className={cn(
+                    "flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors duration-200",
+                    "hover:bg-hover focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-focus/50",
+                    "disabled:pointer-events-none",
+                    loadingId !== null && !loading && "opacity-50",
+                  )}
+                >
+                  <HoustonAvatar
+                    color={resolveAgentColor(agent.color)}
+                    diameter={36}
+                  />
+                  <span className="min-w-0 flex-1 truncate text-sm text-ink">
+                    {agent.name}
+                  </span>
+                  {loading ? (
+                    <Spinner className="size-4 shrink-0 text-ink-muted" />
+                  ) : (
+                    <ChevronRight
+                      className="size-4 shrink-0 text-ink-muted"
+                      aria-hidden="true"
+                    />
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/copy-agent/use-copy-agent-wizard.ts
+++ b/app/src/components/copy-agent/use-copy-agent-wizard.ts
@@ -46,6 +46,9 @@ export function useCopyAgentWizard(args: {
   const [name, setName] = useState("");
   const [color, setColor] = useState<string | undefined>(undefined);
   const [creating, setCreating] = useState(false);
+  // Chats are opt-IN: a conversation can hold personal details the new agent
+  // has no business knowing, so unlike every other item they start off.
+  const [copyChats, setCopyChats] = useState(false);
 
   // Only agents whose content the caller may read: a "user"-access agent's
   // portable preview is refused by the gateway, so it never appears here.
@@ -70,6 +73,7 @@ export function useCopyAgentWizard(args: {
       setSource(agent);
       setPreview(next);
       setSelection(fullCopySelection(next));
+      setCopyChats(false);
       setName(
         suggestCopyName(
           agent.name,
@@ -105,6 +109,7 @@ export function useCopyAgentWizard(args: {
       team,
       color,
       selection: toCopySelection(selection),
+      copyChats,
       via: "create_dialog",
     });
     setCreating(false);
@@ -118,6 +123,8 @@ export function useCopyAgentWizard(args: {
     preview,
     selection,
     setSelection,
+    copyChats,
+    setCopyChats,
     steps,
     stepIndex,
     step,

--- a/app/src/components/copy-agent/use-copy-agent-wizard.ts
+++ b/app/src/components/copy-agent/use-copy-agent-wizard.ts
@@ -1,0 +1,136 @@
+import type { PortableInventoryPreview } from "@houston-ai/engine-client";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import { useTeams } from "../../hooks/use-teams";
+import { isAgentManager } from "../../lib/agent-access";
+import { AGENT_NAME_MAX_LENGTH, agentNameIssue } from "../../lib/agent-name";
+import { getEngine } from "../../lib/engine";
+import { genericErrorDescription } from "../../lib/error-report";
+import type { WizardSelection } from "../../lib/portable-share";
+import type { Agent } from "../../lib/types";
+import { useAgentStore } from "../../stores/agents";
+import { useUIStore } from "../../stores/ui";
+import { suggestCopyName } from "../agent-actions/copy-agent-model";
+import { useCopyAgent } from "../agent-actions/use-copy-agent";
+import {
+  type CopyWizardStep,
+  copyWizardSteps,
+  fullCopySelection,
+  toCopySelection,
+} from "./copy-agent-wizard-model";
+
+/**
+ * The copy wizard's state: which source, what it carries, what stays switched
+ * on, and the name and color the copy is born with. `pick` reads the source's
+ * shareable content and advances; `submit` runs the same portable copy the
+ * Settings "Copy agent" row runs, fed this selection.
+ */
+export function useCopyAgentWizard(args: {
+  targetTeamId: string | null;
+  onBack: () => void;
+  onDone: () => void;
+}) {
+  const { t } = useTranslation("agents");
+  const agents = useAgentStore((s) => s.agents);
+  const { capabilities } = useCapabilities();
+  const teams = useTeams();
+  const addToast = useUIStore((s) => s.addToast);
+  const copyAgent = useCopyAgent();
+
+  const [source, setSource] = useState<Agent | null>(null);
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PortableInventoryPreview | null>(null);
+  const [selection, setSelection] = useState<WizardSelection | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<string | undefined>(undefined);
+  const [creating, setCreating] = useState(false);
+
+  // Only agents whose content the caller may read: a "user"-access agent's
+  // portable preview is refused by the gateway, so it never appears here.
+  const sources = agents.filter((agent) => isAgentManager(capabilities, agent));
+  const steps = copyWizardSteps(preview);
+  const step: CopyWizardStep = steps[stepIndex] ?? "source";
+  const existingNames = agents.map((agent) => agent.name);
+  const nameIssue = agentNameIssue(name, existingNames);
+  const nameIssueMessage =
+    nameIssue === "taken"
+      ? t("copyAgent.nameTaken", { name: name.trim() })
+      : nameIssue === "tooLong"
+        ? t("nameErrors.tooLong", { max: AGENT_NAME_MAX_LENGTH })
+        : nameIssue === "invalidChars"
+          ? t("nameErrors.invalidChars")
+          : null;
+
+  const pick = async (agent: Agent) => {
+    setLoadingId(agent.id);
+    try {
+      const next = await getEngine().portablePreview(agent.folderPath);
+      setSource(agent);
+      setPreview(next);
+      setSelection(fullCopySelection(next));
+      setName(
+        suggestCopyName(
+          agent.name,
+          existingNames,
+          t("copyAgent.copySuffix"),
+          AGENT_NAME_MAX_LENGTH,
+        ),
+      );
+      setColor(agent.color);
+      setStepIndex(1);
+    } catch (err) {
+      addToast({
+        variant: "error",
+        title: t("copyAgent.errors.failed"),
+        description: genericErrorDescription("agent_copy_preview", err),
+      });
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  const back = () =>
+    stepIndex > 0 ? setStepIndex(stepIndex - 1) : args.onBack();
+  const next = () => setStepIndex(stepIndex + 1);
+
+  const submit = async () => {
+    if (creating || !source || !selection || !name.trim() || nameIssue) return;
+    setCreating(true);
+    const team = teams.find((entry) => entry.id === args.targetTeamId) ?? null;
+    const ok = await copyAgent({
+      agent: source,
+      name,
+      team,
+      color,
+      selection: toCopySelection(selection),
+      via: "create_dialog",
+    });
+    setCreating(false);
+    if (ok) args.onDone();
+  };
+
+  return {
+    sources,
+    source,
+    loadingId,
+    preview,
+    selection,
+    setSelection,
+    steps,
+    stepIndex,
+    step,
+    name,
+    setName,
+    color,
+    setColor,
+    creating,
+    nameIssue,
+    nameIssueMessage,
+    pick,
+    back,
+    next,
+    submit,
+  };
+}

--- a/app/src/components/copy-agent/use-copy-agent-wizard.ts
+++ b/app/src/components/copy-agent/use-copy-agent-wizard.ts
@@ -49,6 +49,7 @@ export function useCopyAgentWizard(args: {
   // Chats are opt-IN: a conversation can hold personal details the new agent
   // has no business knowing, so unlike every other item they start off.
   const [copyChats, setCopyChats] = useState(false);
+  const [chatCount, setChatCount] = useState(0);
 
   // Only agents whose content the caller may read: a "user"-access agent's
   // portable preview is refused by the gateway, so it never appears here.
@@ -69,11 +70,17 @@ export function useCopyAgentWizard(args: {
   const pick = async (agent: Agent) => {
     setLoadingId(agent.id);
     try {
-      const next = await getEngine().portablePreview(agent.folderPath);
+      // The chats count rides along so the know screen can say how many
+      // conversations the switch would bring (and hide it when there are none).
+      const [next, conversations] = await Promise.all([
+        getEngine().portablePreview(agent.folderPath),
+        getEngine().listConversations(agent.folderPath),
+      ]);
       setSource(agent);
       setPreview(next);
       setSelection(fullCopySelection(next));
       setCopyChats(false);
+      setChatCount(conversations.length);
       setName(
         suggestCopyName(
           agent.name,
@@ -125,6 +132,7 @@ export function useCopyAgentWizard(args: {
     setSelection,
     copyChats,
     setCopyChats,
+    chatCount,
     steps,
     stepIndex,
     step,

--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -26,7 +26,6 @@ import {
   HoustonAvatar,
   Input,
   resolveAgentColor,
-  Switch,
 } from "@houston-ai/core";
 import type {
   PortableScanResponse,
@@ -54,6 +53,7 @@ import { useWorkspaceStore } from "../../stores/workspaces";
 import { ChatModelSelector } from "../chat-model-selector";
 import { STORE_VIEW_ID } from "../store-view";
 import { InstallFromLinkPanel } from "./install-from-link";
+import { PickListStep } from "./pick-list-step";
 
 type StepId = "upload" | "name" | "skills" | "routines" | "learnings";
 
@@ -232,6 +232,12 @@ export function ImportAgentWizard() {
     [scan],
   );
 
+  const pickLabels = {
+    selectAll: t("import.actions.selectAll"),
+    clearAll: t("import.actions.clearAll"),
+    flagged: t("import.flagged"),
+  };
+
   const handleInstall = async () => {
     if (!uploaded || !currentWorkspace) return;
     if (!name.trim()) {
@@ -396,6 +402,7 @@ export function ImportAgentWizard() {
                   subtitle: humanize(s.slug),
                   flagged: findingsForId("skill", s.slug).length > 0,
                 })}
+                labels={pickLabels}
               />
             </Frame>
           )}
@@ -415,6 +422,7 @@ export function ImportAgentWizard() {
                   subtitle: r.promptExcerpt,
                   flagged: findingsForId("routine", r.id).length > 0,
                 })}
+                labels={pickLabels}
               />
             </Frame>
           )}
@@ -433,6 +441,7 @@ export function ImportAgentWizard() {
                   title: l.text,
                   flagged: findingsForId("learning", l.id).length > 0,
                 })}
+                labels={pickLabels}
               />
             </Frame>
           )}
@@ -672,83 +681,6 @@ function NameStep({
   );
 }
 
-interface PickListStepProps<T> {
-  title: string;
-  body: string;
-  items: T[];
-  selected: Set<string>;
-  setSelected: (s: Set<string>) => void;
-  getId: (item: T) => string;
-  renderRow: (item: T) => {
-    title: string;
-    subtitle?: string;
-    trailing?: React.ReactNode;
-    flagged?: boolean;
-  };
-}
-
-function PickListStep<T>({
-  title,
-  body,
-  items,
-  selected,
-  setSelected,
-  getId,
-  renderRow,
-}: PickListStepProps<T>) {
-  const { t } = useTranslation("portable");
-  const toggle = (id: string) => {
-    const next = new Set(selected);
-    next.has(id) ? next.delete(id) : next.add(id);
-    setSelected(next);
-  };
-
-  return (
-    <div className="space-y-10">
-      <header>
-        <h1 className="text-[28px] font-normal leading-tight">{title}</h1>
-        <p className="mt-3 text-base text-ink-muted">{body}</p>
-      </header>
-
-      <div>
-        <div className="flex justify-end gap-4 mb-2 text-xs text-ink-muted">
-          <button
-            type="button"
-            onClick={() => setSelected(new Set(items.map(getId)))}
-            className="hover:text-ink"
-          >
-            {t("import.actions.selectAll")}
-          </button>
-          <button
-            type="button"
-            onClick={() => setSelected(new Set())}
-            className="hover:text-ink"
-          >
-            {t("import.actions.clearAll")}
-          </button>
-        </div>
-        <div className="space-y-1">
-          {items.map((item) => {
-            const id = getId(item);
-            const row = renderRow(item);
-            return (
-              <SwitchRow
-                key={id}
-                checked={selected.has(id)}
-                onChange={() => toggle(id)}
-                title={row.title}
-                subtitle={row.subtitle}
-                trailing={row.trailing}
-                flaggedNote={row.flagged ? t("import.flagged") : null}
-              />
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 // ─── Building blocks ──────────────────────────────────────────────────
 
 function Frame({ children }: { children: React.ReactNode }) {
@@ -798,44 +730,6 @@ function ChoiceCard({
       <p className="text-sm font-medium text-ink">{title}</p>
       <p className="mt-1 text-xs text-ink-muted">{body}</p>
     </button>
-  );
-}
-
-function SwitchRow({
-  checked,
-  onChange,
-  title,
-  subtitle,
-  trailing,
-  flaggedNote,
-}: {
-  checked: boolean;
-  onChange: () => void;
-  title: string;
-  subtitle?: string;
-  trailing?: React.ReactNode;
-  flaggedNote?: string | null;
-}) {
-  return (
-    <div className="flex items-start gap-4 px-1 py-3">
-      <div className="min-w-0 flex-1">
-        <p className="text-sm text-ink">{title}</p>
-        {subtitle && (
-          <p className="text-xs text-ink-muted line-clamp-2 mt-0.5">
-            {subtitle}
-          </p>
-        )}
-        {flaggedNote && (
-          <p className="text-xs text-ink-muted mt-1">{flaggedNote}</p>
-        )}
-      </div>
-      {trailing && <div className="shrink-0 mt-0.5">{trailing}</div>}
-      <Switch
-        checked={checked}
-        onCheckedChange={onChange}
-        className="mt-0.5 shrink-0"
-      />
-    </div>
   );
 }
 

--- a/app/src/components/portable/pick-list-step.tsx
+++ b/app/src/components/portable/pick-list-step.tsx
@@ -1,0 +1,144 @@
+import { Switch } from "@houston-ai/core";
+import type { ReactNode } from "react";
+
+/**
+ * One "keep or leave behind" screen: a title, a sentence, select-all / clear,
+ * and a switch per item. Shared by the import wizard ("From a friend") and the
+ * create dialog's "Copy an agent" path, so both read as the same product.
+ */
+
+export interface PickListLabels {
+  selectAll: string;
+  clearAll: string;
+  /** Shown under a row the threat scan flagged. */
+  flagged: string;
+}
+
+export interface PickListStepProps<T> {
+  title: string;
+  body: string;
+  items: T[];
+  selected: Set<string>;
+  setSelected: (s: Set<string>) => void;
+  getId: (item: T) => string;
+  renderRow: (item: T) => {
+    title: string;
+    subtitle?: string;
+    trailing?: ReactNode;
+    flagged?: boolean;
+  };
+  labels: PickListLabels;
+  /** Render as a section inside another screen (smaller heading), not a screen. */
+  compact?: boolean;
+}
+
+export function PickListStep<T>({
+  title,
+  body,
+  items,
+  selected,
+  setSelected,
+  getId,
+  renderRow,
+  labels,
+  compact,
+}: PickListStepProps<T>) {
+  const toggle = (id: string) => {
+    const next = new Set(selected);
+    next.has(id) ? next.delete(id) : next.add(id);
+    setSelected(next);
+  };
+
+  return (
+    <div className={compact ? "space-y-3" : "space-y-10"}>
+      {compact ? (
+        <header>
+          <h2 className="text-sm font-medium">{title}</h2>
+          <p className="mt-1 text-xs text-ink-muted">{body}</p>
+        </header>
+      ) : (
+        <header>
+          <h1 className="text-[28px] font-normal leading-tight text-balance">
+            {title}
+          </h1>
+          <p className="mt-3 text-base text-ink-muted">{body}</p>
+        </header>
+      )}
+
+      <div>
+        <div className="mb-2 flex justify-end gap-4 text-xs text-ink-muted">
+          <button
+            type="button"
+            onClick={() => setSelected(new Set(items.map(getId)))}
+            className="hover:text-ink"
+          >
+            {labels.selectAll}
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelected(new Set())}
+            className="hover:text-ink"
+          >
+            {labels.clearAll}
+          </button>
+        </div>
+        <div className="space-y-1">
+          {items.map((item) => {
+            const id = getId(item);
+            const row = renderRow(item);
+            return (
+              <PickSwitchRow
+                key={id}
+                checked={selected.has(id)}
+                onChange={() => toggle(id)}
+                title={row.title}
+                subtitle={row.subtitle}
+                trailing={row.trailing}
+                flaggedNote={row.flagged ? labels.flagged : null}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PickSwitchRow({
+  checked,
+  onChange,
+  title,
+  subtitle,
+  trailing,
+  flaggedNote,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  title: string;
+  subtitle?: string;
+  trailing?: ReactNode;
+  flaggedNote?: string | null;
+}) {
+  return (
+    <div className="flex items-start gap-4 px-1 py-3">
+      <div className="min-w-0 flex-1">
+        <p className="text-sm text-ink">{title}</p>
+        {subtitle && (
+          <p className="mt-0.5 line-clamp-2 text-xs text-ink-muted">
+            {subtitle}
+          </p>
+        )}
+        {flaggedNote && (
+          <p className="mt-1 text-xs text-ink-muted">{flaggedNote}</p>
+        )}
+      </div>
+      {trailing && <div className="mt-0.5 shrink-0">{trailing}</div>}
+      <Switch
+        checked={checked}
+        onCheckedChange={onChange}
+        aria-label={title}
+        className="mt-0.5 shrink-0"
+      />
+    </div>
+  );
+}

--- a/app/src/components/portable/pick-list-step.tsx
+++ b/app/src/components/portable/pick-list-step.tsx
@@ -1,5 +1,5 @@
-import { Switch } from "@houston-ai/core";
 import type { ReactNode } from "react";
+import { SwitchRow } from "./wizard-parts";
 
 /**
  * One "keep or leave behind" screen: a title, a sentence, select-all / clear,
@@ -58,7 +58,7 @@ export function PickListStep<T>({
         </header>
       ) : (
         <header>
-          <h1 className="text-[28px] font-normal leading-tight text-balance">
+          <h1 className="text-2xl font-normal leading-tight text-balance">
             {title}
           </h1>
           <p className="mt-3 text-base text-ink-muted">{body}</p>
@@ -87,7 +87,7 @@ export function PickListStep<T>({
             const id = getId(item);
             const row = renderRow(item);
             return (
-              <PickSwitchRow
+              <SwitchRow
                 key={id}
                 checked={selected.has(id)}
                 onChange={() => toggle(id)}
@@ -100,45 +100,6 @@ export function PickListStep<T>({
           })}
         </div>
       </div>
-    </div>
-  );
-}
-
-export function PickSwitchRow({
-  checked,
-  onChange,
-  title,
-  subtitle,
-  trailing,
-  flaggedNote,
-}: {
-  checked: boolean;
-  onChange: () => void;
-  title: string;
-  subtitle?: string;
-  trailing?: ReactNode;
-  flaggedNote?: string | null;
-}) {
-  return (
-    <div className="flex items-start gap-4 px-1 py-3">
-      <div className="min-w-0 flex-1">
-        <p className="text-sm text-ink">{title}</p>
-        {subtitle && (
-          <p className="mt-0.5 line-clamp-2 text-xs text-ink-muted">
-            {subtitle}
-          </p>
-        )}
-        {flaggedNote && (
-          <p className="mt-1 text-xs text-ink-muted">{flaggedNote}</p>
-        )}
-      </div>
-      {trailing && <div className="mt-0.5 shrink-0">{trailing}</div>}
-      <Switch
-        checked={checked}
-        onCheckedChange={onChange}
-        aria-label={title}
-        className="mt-0.5 shrink-0"
-      />
     </div>
   );
 }

--- a/app/src/components/portable/wizard-parts.tsx
+++ b/app/src/components/portable/wizard-parts.tsx
@@ -77,12 +77,15 @@ export function SwitchRow({
   title,
   subtitle,
   trailing,
+  flaggedNote,
 }: {
   checked: boolean;
   onChange: () => void;
   title: string;
   subtitle?: string;
   trailing?: React.ReactNode;
+  /** Shown under a row the threat scan flagged. */
+  flaggedNote?: string | null;
 }) {
   return (
     <div className="flex items-start gap-4 px-1 py-3">
@@ -93,11 +96,15 @@ export function SwitchRow({
             {subtitle}
           </p>
         )}
+        {flaggedNote && (
+          <p className="mt-1 text-xs text-muted-foreground">{flaggedNote}</p>
+        )}
       </div>
       {trailing && <div className="shrink-0 mt-0.5">{trailing}</div>}
       <Switch
         checked={checked}
         onCheckedChange={onChange}
+        aria-label={title}
         className="mt-0.5 shrink-0"
       />
     </div>

--- a/app/src/components/shell/agent-color-palette.tsx
+++ b/app/src/components/shell/agent-color-palette.tsx
@@ -1,0 +1,40 @@
+import { AGENT_COLORS, cn, colorValue } from "@houston-ai/core";
+import { Check } from "lucide-react";
+
+/**
+ * The agent color swatches of the naming step: two rows of five on a phone
+ * (ten swatches outgrow the card in one row), the single row at md+.
+ */
+export function AgentColorPalette({
+  color,
+  onColorChange,
+}: {
+  color: string | undefined;
+  onColorChange: (value: string) => void;
+}) {
+  return (
+    <div className="mb-6 grid grid-cols-5 gap-2 md:flex md:items-center">
+      {AGENT_COLORS.map((c) => {
+        const swatch = colorValue(c);
+        const isSelected =
+          color === c.id || color === c.light || color === c.dark;
+        return (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => onColorChange(c.id)}
+            className={cn(
+              "h-7 w-7 rounded-full flex items-center justify-center transition-all duration-150",
+              isSelected
+                ? "ring-2 ring-offset-2 ring-ink/30"
+                : "hover:scale-110",
+            )}
+            style={{ backgroundColor: swatch }}
+          >
+            {isSelected && <Check className="h-3.5 w-3.5 text-white" />}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/components/shell/agent-picker-step.tsx
+++ b/app/src/components/shell/agent-picker-step.tsx
@@ -1,4 +1,4 @@
-import { Plus, Store } from "lucide-react";
+import { Copy, Plus, Store } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useUIStore } from "../../stores/ui";
 import { STORE_VIEW_ID } from "../store-view";
@@ -8,27 +8,39 @@ import { CreateChoiceTile } from "./create-choice-tile";
 interface AgentPickerStepProps {
   /** Starts the from-scratch path (naming step) with the blank config. */
   onCreateBlank: () => void;
+  /** Starts the copy path; absent when there is no agent to copy from. */
+  onCopyExisting?: () => void;
 }
 
 /**
- * Step 1 of the create-agent dialog: exactly two ways to get an agent, drawn
- * as the same square choice tiles the sidebar's create chooser uses — this
- * screen is the direct continuation of that one. Installing a ready-made agent
- * happens on the Agent Store page (free listings, its own install pipeline),
- * so that tile closes the dialog and navigates there instead of embedding a
- * catalog grid in the modal (PRODUCT-1171).
+ * Step 1 of the create-agent dialog: the ways to get an agent, drawn as the
+ * same choice tiles the sidebar's create chooser uses — this screen is the
+ * direct continuation of that one. Installing a ready-made agent happens on
+ * the Agent Store page (free listings, its own install pipeline), so that tile
+ * closes the dialog and navigates there instead of embedding a catalog grid
+ * in the modal (PRODUCT-1171). "Copy an agent" models the new one on an
+ * existing agent, item by item, and only exists once there is one to copy.
  */
-export function AgentPickerStep({ onCreateBlank }: AgentPickerStepProps) {
+export function AgentPickerStep({
+  onCreateBlank,
+  onCopyExisting,
+}: AgentPickerStepProps) {
   const { t } = useTranslation("shell");
   const setCreateOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
   const setViewMode = useUIStore((s) => s.setViewMode);
   // The in-app onboarding teaches ONE path: while it runs, "Create new" is
-  // the only live tile — the store detour would drop the user out of the
-  // dialog mid-lesson.
+  // the only live tile — the store detour or the copy wizard would drop the
+  // user out of the lesson.
   const tutorialActive = useUIStore((s) => s.inAppOnboardingActive);
 
   return (
-    <div className="grid grid-cols-2 gap-3 px-6 pb-6 pt-1">
+    <div
+      className={
+        onCopyExisting
+          ? "grid grid-cols-1 gap-3 px-6 pb-6 pt-1 md:grid-cols-3"
+          : "grid grid-cols-1 gap-3 px-6 pb-6 pt-1 md:grid-cols-2"
+      }
+    >
       <CreateChoiceTile
         icon={Store}
         title={t("newAgent.storeCard")}
@@ -44,6 +56,14 @@ export function AgentPickerStep({ onCreateBlank }: AgentPickerStepProps) {
         onClick={onCreateBlank}
         dataAttrs={tutorialAnchor("createAgentBlankTile")}
       />
+      {onCopyExisting && (
+        <CreateChoiceTile
+          icon={Copy}
+          title={t("newAgent.copyCard")}
+          disabled={tutorialActive}
+          onClick={onCopyExisting}
+        />
+      )}
     </div>
   );
 }

--- a/app/src/components/shell/create-choice-tile.tsx
+++ b/app/src/components/shell/create-choice-tile.tsx
@@ -20,6 +20,10 @@ export type ChoiceTileIcon = ComponentType<{ className?: string }>;
  * On hover the tile wakes as ONE object: the fill steps up and the icon
  * sharpens from muted to ink together. Never the icon alone — a part of a
  * control changing without the whole reads as two controls.
+ *
+ * On a phone the square becomes a full-width row (icon, then label): three
+ * squares do not fit a 343px dialog, and a stacked list of rows is what a
+ * phone action sheet already looks like. At md+ the square is unchanged.
  */
 export function CreateChoiceTile({
   icon: Icon,
@@ -42,10 +46,10 @@ export function CreateChoiceTile({
       {...dataAttrs}
       onClick={onClick}
       disabled={disabled}
-      className="ht-hairline group flex aspect-square flex-col items-center justify-center gap-3 rounded-xl bg-chip-solid px-4 text-center text-ink outline-none transition-[background-color,transform] duration-200 hover:bg-chip-solid-hover active:scale-[0.97] focus-visible:ring-[3px] focus-visible:ring-focus/50 disabled:pointer-events-none disabled:opacity-40"
+      className="ht-hairline group flex min-h-14 items-center gap-3 rounded-xl bg-chip-solid px-4 py-3 text-left text-ink outline-none transition-[background-color,transform] duration-200 hover:bg-chip-solid-hover active:scale-[0.97] focus-visible:ring-[3px] focus-visible:ring-focus/50 disabled:pointer-events-none disabled:opacity-40 md:aspect-square md:min-h-0 md:flex-col md:justify-center md:py-0 md:text-center"
     >
       <Icon
-        className="size-6 text-ink-muted transition-colors duration-200 group-hover:text-ink"
+        className="size-5 shrink-0 text-ink-muted transition-colors duration-200 group-hover:text-ink md:size-6"
         aria-hidden="true"
       />
       <span className="text-sm font-medium">{title}</span>

--- a/app/src/components/shell/create-dialog-surface.ts
+++ b/app/src/components/shell/create-dialog-surface.ts
@@ -1,0 +1,21 @@
+/** 1 = the chooser, 2 = name a blank agent, "copy" = model it on an existing one. */
+export type CreateAgentStep = 1 | 2 | "copy";
+
+/**
+ * The dialog's surface per step. Step 1 is a row of square choice tiles at the
+ * same tile geometry as the sidebar's create chooser (a third tile widens the
+ * surface by one tile), so the two screens read as one flow; the wizards take
+ * a tall, fixed-height sheet whose body scrolls.
+ */
+export function createDialogSurface(
+  step: CreateAgentStep,
+  canCopy: boolean,
+): string {
+  if (step === 1) {
+    return canCopy
+      ? "sm:max-w-lg p-0 gap-0 overflow-hidden"
+      : "sm:max-w-sm p-0 gap-0 overflow-hidden";
+  }
+  const width = step === "copy" ? "sm:max-w-[680px]" : "sm:max-w-[900px]";
+  return `${width} h-[85dvh] flex flex-col p-0 gap-0 overflow-hidden`;
+}

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -10,6 +10,7 @@ import { useMoveAgentToTeam } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useProviderStatuses } from "../../hooks/use-provider-statuses";
 import { useSidebarLayout } from "../../hooks/use-sidebar-layout";
+import { isAgentManager } from "../../lib/agent-access";
 import { AGENT_NAME_MAX_LENGTH, agentNameIssue } from "../../lib/agent-name";
 import { isAgentNameConflictError } from "../../lib/agent-name-conflict";
 import { finishAgentSetup } from "../../lib/agent-setup";
@@ -115,8 +116,11 @@ export function CreateAgentDialog() {
   };
 
   const selectedDef = agentDefs.find((d) => d.config.id === "blank");
-  // Nothing to copy from until the workspace has an agent.
-  const canCopy = existingAgents.length > 0;
+  // Nothing to copy from until the workspace has an agent whose content the
+  // caller may read: the wizard lists only those, so the tile must agree.
+  const canCopy = existingAgents.some((agent) =>
+    isAgentManager(capabilities, agent),
+  );
 
   const handleCreateAgent = async () => {
     const trimmed = name.trim();

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -24,10 +24,11 @@ import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
+import { CopyAgentWizard } from "../copy-agent/copy-agent-wizard";
 import { AgentPickerStep } from "./agent-picker-step";
+import type { CreateAgentStep as Step } from "./create-dialog-surface";
+import { createDialogSurface } from "./create-dialog-surface";
 import { NamingStep } from "./naming-step";
-
-type Step = 1 | 2;
 
 export function CreateAgentDialog() {
   const { t } = useTranslation(["shell", "agents"]);
@@ -114,6 +115,8 @@ export function CreateAgentDialog() {
   };
 
   const selectedDef = agentDefs.find((d) => d.config.id === "blank");
+  // Nothing to copy from until the workspace has an agent.
+  const canCopy = existingAgents.length > 0;
 
   const handleCreateAgent = async () => {
     const trimmed = name.trim();
@@ -211,23 +214,23 @@ export function CreateAgentDialog() {
         if (!o) handleClose();
       }}
     >
-      <DialogContent
-        className={
-          // Step 1 is two square choice tiles; the same surface width as the
-          // sidebar's create chooser gives both screens identical tile
-          // geometry, so they read as one flow.
-          step === 1
-            ? "sm:max-w-sm p-0 gap-0 overflow-hidden"
-            : "sm:max-w-[900px] h-[85dvh] flex flex-col p-0 gap-0 overflow-hidden"
-        }
-      >
+      <DialogContent className={createDialogSurface(step, canCopy)}>
         {step === 1 ? (
           <>
             <DialogHeader className="shrink-0 px-6 pt-6 pb-4">
               <DialogTitle>{t("newAgent.dialogTitle")}</DialogTitle>
             </DialogHeader>
-            <AgentPickerStep onCreateBlank={() => setStep(2)} />
+            <AgentPickerStep
+              onCreateBlank={() => setStep(2)}
+              onCopyExisting={canCopy ? () => setStep("copy") : undefined}
+            />
           </>
+        ) : step === "copy" ? (
+          <CopyAgentWizard
+            targetTeamId={targetTeamId}
+            onBack={() => setStep(1)}
+            onDone={handleClose}
+          />
         ) : (
           <NamingStep
             selectedAgent={selectedDef}

--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -1,24 +1,25 @@
 import {
   AGENT_COLORS,
   Button,
-  cn,
-  colorValue,
   DialogTitle,
   HoustonAvatar,
   Input,
   resolveAgentColor,
   Spinner,
 } from "@houston-ai/core";
-import { ArrowLeft, Check, FolderOpen } from "lucide-react";
+import { ArrowLeft, FolderOpen } from "lucide-react";
 import type { FormEvent } from "react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { localizeCatalogCopy } from "../../agents/catalog-labels";
 import type { AgentDefinition } from "../../lib/types";
 import { tutorialAnchor } from "../tutorial";
+import { AgentColorPalette } from "./agent-color-palette";
 
 interface NamingStepProps {
   selectedAgent: AgentDefinition | undefined;
+  /** Replaces the catalog name above the avatar (the copy path names its source). */
+  heading?: string;
   name: string;
   color: string | undefined;
   error: string | null;
@@ -38,6 +39,7 @@ interface NamingStepProps {
 
 export function NamingStep({
   selectedAgent,
+  heading,
   name,
   color,
   error,
@@ -54,9 +56,11 @@ export function NamingStep({
   const { t } = useTranslation(["shell", "agents"]);
   // Default to white on mount if none selected
   const resolvedColor = resolveAgentColor(color);
-  const selectedName = selectedAgent
-    ? localizeCatalogCopy(selectedAgent.config, t).name
-    : t("naming.newAgentFallback");
+  const selectedName =
+    heading ??
+    (selectedAgent
+      ? localizeCatalogCopy(selectedAgent.config, t).name
+      : t("naming.newAgentFallback"));
 
   useEffect(() => {
     if (!color) {
@@ -96,31 +100,7 @@ export function NamingStep({
           {...tutorialAnchor("createAgentNaming")}
           className="flex w-full flex-col items-center"
         >
-          {/* Color palette: two rows of five on a phone (ten swatches outgrow
-            the card in one row), the single row at md+. */}
-          <div className="mb-6 grid grid-cols-5 gap-2 md:flex md:items-center">
-            {AGENT_COLORS.map((c) => {
-              const swatch = colorValue(c);
-              const isSelected =
-                color === c.id || color === c.light || color === c.dark;
-              return (
-                <button
-                  key={c.id}
-                  type="button"
-                  onClick={() => onColorChange(c.id)}
-                  className={cn(
-                    "h-7 w-7 rounded-full flex items-center justify-center transition-all duration-150",
-                    isSelected
-                      ? "ring-2 ring-offset-2 ring-ink/30"
-                      : "hover:scale-110",
-                  )}
-                  style={{ backgroundColor: swatch }}
-                >
-                  {isSelected && <Check className="h-3.5 w-3.5 text-white" />}
-                </button>
-              );
-            })}
-          </div>
+          <AgentColorPalette color={color} onColorChange={onColorChange} />
 
           <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
             <Input

--- a/app/src/components/shell/sidebar-create-dialog.tsx
+++ b/app/src/components/shell/sidebar-create-dialog.tsx
@@ -124,7 +124,7 @@ export function SidebarCreateDialog({
         <DialogHeader>
           <DialogTitle>{labels.title}</DialogTitle>
         </DialogHeader>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
           {direct.map(({ label, icon, run }) => (
             <CreateChoiceTile
               key={label}

--- a/app/src/components/team-view/use-move-agent-team.ts
+++ b/app/src/components/team-view/use-move-agent-team.ts
@@ -46,8 +46,14 @@ export function useMoveAgentTeam(): (
       sidebar.moveItem(agentId, localMoveDest(team));
       return Promise.resolve();
     }
-    return new Promise((resolve) => {
-      move.mutate({ agentId, teamId: team.id }, { onSettled: () => resolve() });
-    });
+    // `mutateAsync`, not a per-call `onSettled`: TanStack drops per-call
+    // callbacks once the observer unmounts, so a dialog closed mid-request
+    // would leave the caller awaiting forever. The refusal is already reported
+    // and rolled back by the mutation's own onError, so settling quietly here
+    // hides nothing.
+    return move.mutateAsync({ agentId, teamId: team.id }).then(
+      () => undefined,
+      () => undefined,
+    );
   };
 }

--- a/app/src/components/team-view/use-move-agent-team.ts
+++ b/app/src/components/team-view/use-move-agent-team.ts
@@ -24,8 +24,17 @@ import { localMoveDest } from "./move-agent-model";
  * position: the agent is appended, which is what an overlay row that does not
  * name it already means (merge rule 3). The stale id left in the old team's row
  * is ignored on read and pruned by rule 7 on the next write.
+ *
+ * Resolves once the move has SETTLED, success or refusal: a caller that
+ * navigates to the agent's new home next (the copy flows) must not resolve
+ * that home before the roster knows it, or it lands on the default team. The
+ * mutation reports its own refusal (toast + rollback), so a settled promise
+ * never rejects and a fire-and-forget caller has nothing to catch.
  */
-export function useMoveAgentTeam(): (agentId: string, team: TeamView) => void {
+export function useMoveAgentTeam(): (
+  agentId: string,
+  team: TeamView,
+) => Promise<void> {
   const { capabilities } = useCapabilities();
   const serverBacked = hasAgentTeams(capabilities);
   const currentWorkspace = useWorkspaceStore((s) => s.current);
@@ -35,8 +44,10 @@ export function useMoveAgentTeam(): (agentId: string, team: TeamView) => void {
   return (agentId, team) => {
     if (!serverBacked) {
       sidebar.moveItem(agentId, localMoveDest(team));
-      return;
+      return Promise.resolve();
     }
-    move.mutate({ agentId, teamId: team.id });
+    return new Promise((resolve) => {
+      move.mutate({ agentId, teamId: team.id }, { onSettled: () => resolve() });
+    });
   };
 }

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -122,8 +122,8 @@ export type AnalyticsEventName =
   | "agent_shared"
   | "agent_published"
   | "agent_imported"
-  // A workspace-internal duplicate created from the agent's Settings section
-  // (`agent_slug` is the SOURCE agent).
+  // A workspace-internal duplicate (`agent_slug` is the SOURCE agent);
+  // `source` names the door: the agent's Settings row or the create dialog.
   | "agent_copied"
   // Fired when an agent's self-setup mission auto-starts after it is
   // created/imported. Carries `source` (created vs imported).

--- a/app/src/lib/copy-agent-chats.ts
+++ b/app/src/lib/copy-agent-chats.ts
@@ -1,0 +1,90 @@
+import type {
+  ConversationEntry,
+  MigrationImportResult,
+} from "@houston-ai/engine-client";
+
+/**
+ * "Copy an agent" with chats: move the source's tasks and their conversations
+ * into the copy through the agent-scoped migration routes (the same pair the
+ * desktop→cloud migration uses), which exist on every host and are proxied by
+ * the cloud gateway. Pure planning here, unit-tested in
+ * `app/tests/copy-agent-chats.test.ts`; the runner takes the engine as an
+ * argument so a test can hand it a fake.
+ */
+
+/** The board file every task row lives in. */
+export const ACTIVITY_PATH = ".houston/activity/activity.json";
+const TRANSCRIPTS_DIR = ".houston/runtime/conversations";
+
+/** Conversations per export/import round trip. Transcripts are small JSON
+ *  and compress well; this keeps a chatty agent far under the import cap. */
+export const CHAT_COPY_BATCH = 25;
+
+/** The transcript file of one conversation, as the runtime names it. */
+export function transcriptPath(sessionKey: string): string {
+  return `${TRANSCRIPTS_DIR}/${encodeURIComponent(sessionKey)}.json`;
+}
+
+/**
+ * Everything the chats copy carries: the board file, then one transcript per
+ * conversation. Duplicated session keys collapse; a missing transcript on the
+ * source is simply skipped by the export route.
+ */
+export function chatCopyPaths(
+  conversations: readonly Pick<ConversationEntry, "session_key">[],
+): string[] {
+  const keys = new Set(conversations.map((c) => c.session_key));
+  return [ACTIVITY_PATH, ...[...keys].map(transcriptPath)];
+}
+
+export function batchPaths(paths: readonly string[], size: number): string[][] {
+  const out: string[][] = [];
+  for (let i = 0; i < paths.length; i += size) {
+    out.push(paths.slice(i, i + size));
+  }
+  return out;
+}
+
+export interface ChatCopyEngine {
+  listConversations(agentPath: string): Promise<ConversationEntry[]>;
+  migrationExport(agentPath: string, paths: string[]): Promise<ArrayBuffer>;
+  migrationImport(
+    agentPath: string,
+    bytes: ArrayBuffer,
+    opts?: { overwrite?: boolean },
+  ): Promise<MigrationImportResult>;
+}
+
+export interface ChatCopyOutcome {
+  conversations: number;
+  written: number;
+  rejected: MigrationImportResult["rejected"];
+}
+
+/**
+ * Copy every conversation of `source` into `target`, batch by batch. The
+ * target is brand new, so nothing is overwritten and a batch that lands
+ * twice is a no-op (the import route skips existing files).
+ */
+export async function copyAgentChats(
+  engine: ChatCopyEngine,
+  source: string,
+  target: string,
+): Promise<ChatCopyOutcome> {
+  const conversations = await engine.listConversations(source);
+  const outcome: ChatCopyOutcome = {
+    conversations: conversations.length,
+    written: 0,
+    rejected: [],
+  };
+  for (const batch of batchPaths(
+    chatCopyPaths(conversations),
+    CHAT_COPY_BATCH,
+  )) {
+    const zip = await engine.migrationExport(source, batch);
+    const result = await engine.migrationImport(target, zip);
+    outcome.written += result.written;
+    outcome.rejected.push(...result.rejected);
+  }
+  return outcome;
+}

--- a/app/src/lib/copy-agent-chats.ts
+++ b/app/src/lib/copy-agent-chats.ts
@@ -1,5 +1,6 @@
 import type {
   ConversationEntry,
+  MigrationImportOptions,
   MigrationImportResult,
 } from "@houston-ai/engine-client";
 import {
@@ -64,7 +65,7 @@ export interface ChatCopyEngine {
   migrationImport(
     agentPath: string,
     bytes: ArrayBuffer,
-    opts?: { overwrite?: boolean },
+    opts?: MigrationImportOptions,
   ): Promise<MigrationImportResult>;
 }
 
@@ -142,8 +143,12 @@ export async function copyAgentChats(
     const overwrite =
       batch[0] === ACTIVITY_PATH &&
       (await engine.listConversations(target)).length === 0;
+    // No pi session is rebuilt from the transcripts: each one carries the
+    // replay marker (`copy-chat-remap.ts`), so the copy's FIRST turn in a chat
+    // replays its history into whichever backend runs it, every provider alike.
     const result = await withWakingRetry(
-      () => engine.migrationImport(target, bytes, { overwrite }),
+      () =>
+        engine.migrationImport(target, bytes, { overwrite, sessions: false }),
       shouldRetry,
       retry,
     );

--- a/app/src/lib/copy-agent-chats.ts
+++ b/app/src/lib/copy-agent-chats.ts
@@ -2,6 +2,14 @@ import type {
   ConversationEntry,
   MigrationImportResult,
 } from "@houston-ai/engine-client";
+import {
+  ACTIVITY_PATH,
+  planChatIdMap,
+  remapChatArchive,
+  transcriptPath,
+} from "./copy-chat-remap.ts";
+
+export { ACTIVITY_PATH, transcriptPath };
 
 /**
  * "Copy an agent" with chats: move the source's tasks and their conversations
@@ -12,18 +20,9 @@ import type {
  * argument so a test can hand it a fake.
  */
 
-/** The board file every task row lives in. */
-export const ACTIVITY_PATH = ".houston/activity/activity.json";
-const TRANSCRIPTS_DIR = ".houston/runtime/conversations";
-
 /** Conversations per export/import round trip. Transcripts are small JSON
  *  and compress well; this keeps a chatty agent far under the import cap. */
 export const CHAT_COPY_BATCH = 25;
-
-/** The transcript file of one conversation, as the runtime names it. */
-export function transcriptPath(sessionKey: string): string {
-  return `${TRANSCRIPTS_DIR}/${encodeURIComponent(sessionKey)}.json`;
-}
 
 /**
  * Everything the chats copy carries: the board file, then one transcript per
@@ -62,14 +61,18 @@ export interface ChatCopyOutcome {
 }
 
 /**
- * Copy every conversation of `source` into `target`, batch by batch. The
- * target is brand new, so nothing is overwritten and a batch that lands
- * twice is a no-op (the import route skips existing files).
+ * Copy every conversation of `source` into `target`, batch by batch. Each
+ * archive is rewritten with fresh task and conversation ids before it lands
+ * (see `copy-chat-remap.ts`); the map is planned once so a transcript in a
+ * later batch matches the board row that went in the first. The target is
+ * brand new, so nothing is overwritten and a batch that lands twice is a
+ * no-op (the import route skips existing files).
  */
 export async function copyAgentChats(
   engine: ChatCopyEngine,
   source: string,
   target: string,
+  mint: () => string = () => crypto.randomUUID(),
 ): Promise<ChatCopyOutcome> {
   const conversations = await engine.listConversations(source);
   const outcome: ChatCopyOutcome = {
@@ -77,12 +80,20 @@ export async function copyAgentChats(
     written: 0,
     rejected: [],
   };
+  const map = planChatIdMap(conversations, mint);
   for (const batch of batchPaths(
     chatCopyPaths(conversations),
     CHAT_COPY_BATCH,
   )) {
     const zip = await engine.migrationExport(source, batch);
-    const result = await engine.migrationImport(target, zip);
+    const remapped = remapChatArchive(new Uint8Array(zip), map, mint);
+    const result = await engine.migrationImport(
+      target,
+      remapped.buffer.slice(
+        remapped.byteOffset,
+        remapped.byteOffset + remapped.byteLength,
+      ) as ArrayBuffer,
+    );
     outcome.written += result.written;
     outcome.rejected.push(...result.rejected);
   }

--- a/app/src/lib/copy-agent-chats.ts
+++ b/app/src/lib/copy-agent-chats.ts
@@ -20,20 +20,34 @@ export { ACTIVITY_PATH, transcriptPath };
  * argument so a test can hand it a fake.
  */
 
-/** Conversations per export/import round trip. Transcripts are small JSON
- *  and compress well; this keeps a chatty agent far under the import cap. */
-export const CHAT_COPY_BATCH = 25;
+/** Transcripts per export/import round trip. Transcripts are JSON text and
+ *  compress well; ten of them stay far under the host's import body cap even
+ *  for very long chats. */
+export const CHAT_COPY_BATCH = 10;
 
 /**
- * Everything the chats copy carries: the board file, then one transcript per
- * conversation. Duplicated session keys collapse; a missing transcript on the
- * source is simply skipped by the export route.
+ * The transcripts the chats copy carries, one per conversation. Duplicated
+ * session keys collapse; a missing transcript on the source is simply skipped
+ * by the export route.
  */
 export function chatCopyPaths(
   conversations: readonly Pick<ConversationEntry, "session_key">[],
 ): string[] {
   const keys = new Set(conversations.map((c) => c.session_key));
-  return [ACTIVITY_PATH, ...[...keys].map(transcriptPath)];
+  return [...keys].map(transcriptPath);
+}
+
+/**
+ * The requests, in order: the transcripts in batches, then the board file on
+ * its own, LAST. The board is what makes the copied tasks visible, so it
+ * must not land before their transcripts: an opened task whose transcript was
+ * still in flight would start a new one, and the import skips existing files.
+ */
+export function chatCopyBatches(
+  conversations: readonly Pick<ConversationEntry, "session_key">[],
+  size: number = CHAT_COPY_BATCH,
+): string[][] {
+  return [...batchPaths(chatCopyPaths(conversations), size), [ACTIVITY_PATH]];
 }
 
 export function batchPaths(paths: readonly string[], size: number): string[][] {
@@ -54,48 +68,88 @@ export interface ChatCopyEngine {
   ): Promise<MigrationImportResult>;
 }
 
+/**
+ * Re-run one leg while the copy's engine is still waking. Both legs are
+ * idempotent (the export reads; the import skips files it already has), so a
+ * replay is safe. `shouldRetry` names the refusals worth waiting out.
+ */
+export async function withWakingRetry<T>(
+  run: () => Promise<T>,
+  shouldRetry: (err: unknown) => boolean,
+  opts: { attempts: number; delayMs: number },
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await run();
+    } catch (err) {
+      if (attempt >= opts.attempts || !shouldRetry(err)) throw err;
+      await new Promise((resolve) => setTimeout(resolve, opts.delayMs));
+    }
+  }
+}
+
 export interface ChatCopyOutcome {
+  /** Conversations the source listed. */
   conversations: number;
-  written: number;
+  /** Transcripts the target actually wrote. */
+  transcriptsWritten: number;
+  /** Whether the board file landed. False when the target already had one
+   *  (a task was created in the copy before the chats arrived). */
+  boardWritten: boolean;
   rejected: MigrationImportResult["rejected"];
 }
 
+/** Every task and transcript landed: the only outcome worth calling done. */
+export function chatCopyComplete(outcome: ChatCopyOutcome): boolean {
+  return outcome.boardWritten && outcome.rejected.length === 0;
+}
+
 /**
- * Copy every conversation of `source` into `target`, batch by batch. Each
- * archive is rewritten with fresh task and conversation ids before it lands
- * (see `copy-chat-remap.ts`); the map is planned once so a transcript in a
- * later batch matches the board row that went in the first. The target is
- * brand new, so nothing is overwritten and a batch that lands twice is a
- * no-op (the import route skips existing files).
+ * Copy every conversation of `source` into `target`: the transcripts in
+ * batches, then the board. Each archive is rewritten with fresh task and
+ * conversation ids before it lands (see `copy-chat-remap.ts`); the map is
+ * planned once so the board's rows match the transcripts that went before.
+ * Nothing is overwritten: the import route skips a file the target already
+ * has, which the outcome reports rather than hides.
  */
 export async function copyAgentChats(
   engine: ChatCopyEngine,
   source: string,
   target: string,
   mint: () => string = () => crypto.randomUUID(),
+  /** Refusals to wait out (the copy's engine still waking); none by default. */
+  shouldRetry: (err: unknown) => boolean = () => false,
 ): Promise<ChatCopyOutcome> {
+  const retry = { attempts: 12, delayMs: 10_000 };
   const conversations = await engine.listConversations(source);
   const outcome: ChatCopyOutcome = {
     conversations: conversations.length,
-    written: 0,
+    transcriptsWritten: 0,
+    boardWritten: false,
     rejected: [],
   };
   const map = planChatIdMap(conversations, mint);
-  for (const batch of batchPaths(
-    chatCopyPaths(conversations),
-    CHAT_COPY_BATCH,
-  )) {
+  for (const batch of chatCopyBatches(conversations)) {
     const zip = await engine.migrationExport(source, batch);
     const remapped = remapChatArchive(new Uint8Array(zip), map, mint);
-    const result = await engine.migrationImport(
-      target,
-      remapped.buffer.slice(
-        remapped.byteOffset,
-        remapped.byteOffset + remapped.byteLength,
-      ) as ArrayBuffer,
+    const bytes = remapped.buffer.slice(
+      remapped.byteOffset,
+      remapped.byteOffset + remapped.byteLength,
+    ) as ArrayBuffer;
+    // The board replaces an EMPTY board on the target (a host may create one
+    // at agent birth), never one that already holds a task the user made
+    // while the chats were in flight: that lands as a skip, reported below.
+    const overwrite =
+      batch[0] === ACTIVITY_PATH &&
+      (await engine.listConversations(target)).length === 0;
+    const result = await withWakingRetry(
+      () => engine.migrationImport(target, bytes, { overwrite }),
+      shouldRetry,
+      retry,
     );
-    outcome.written += result.written;
     outcome.rejected.push(...result.rejected);
+    if (batch[0] === ACTIVITY_PATH) outcome.boardWritten = result.written > 0;
+    else outcome.transcriptsWritten += result.written;
   }
   return outcome;
 }

--- a/app/src/lib/copy-chat-remap.ts
+++ b/app/src/lib/copy-chat-remap.ts
@@ -1,0 +1,115 @@
+import type { ConversationEntry } from "@houston-ai/engine-client";
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+
+/**
+ * Copied chats get NEW ids. A task's id and its conversation key are global
+ * in the app (the cross-agent sweep, the chat panel, notifications all look a
+ * conversation up by key alone), so a verbatim copy would make the copy's
+ * chats resolve to the SOURCE agent: the panel would show the source's
+ * transcript while sends went to the copy. Pure; unit-tested in
+ * `app/tests/copy-chat-remap.test.ts`.
+ */
+
+export interface ChatIdMap {
+  /** Source task id → the copy's task id. */
+  activity: Map<string, string>;
+  /** Source conversation key → the copy's conversation key. */
+  session: Map<string, string>;
+}
+
+/** The board file every task row lives in. */
+export const ACTIVITY_PATH = ".houston/activity/activity.json";
+const TRANSCRIPT_PREFIX = ".houston/runtime/conversations/";
+
+/** The transcript file of one conversation, as the runtime names it. */
+export function transcriptPath(sessionKey: string): string {
+  return `${TRANSCRIPT_PREFIX}${encodeURIComponent(sessionKey)}.json`;
+}
+
+/** One fresh id per source conversation, decided once so every batch agrees. */
+export function planChatIdMap(
+  conversations: readonly Pick<ConversationEntry, "id" | "session_key">[],
+  mint: () => string,
+): ChatIdMap {
+  const map: ChatIdMap = { activity: new Map(), session: new Map() };
+  for (const c of conversations) {
+    if (map.activity.has(c.id)) continue;
+    const next = mint();
+    map.activity.set(c.id, next);
+    map.session.set(c.session_key, `activity-${next}`);
+  }
+  return map;
+}
+
+interface ActivityRow {
+  id: string;
+  session_key?: string;
+  origin_session_key?: string;
+  [key: string]: unknown;
+}
+
+function remapActivities(text: string, map: ChatIdMap, mint: () => string) {
+  const rows = JSON.parse(text) as ActivityRow[];
+  if (!Array.isArray(rows)) return text;
+  const out = rows.map((row) => {
+    // A task the conversation list did not name still gets a fresh id: its
+    // transcript was not exported, but the id must not collide either.
+    let id = map.activity.get(row.id);
+    if (!id) {
+      id = mint();
+      map.activity.set(row.id, id);
+      map.session.set(
+        row.session_key ?? `activity-${row.id}`,
+        `activity-${id}`,
+      );
+    }
+    const next: ActivityRow = { ...row, id };
+    if (row.session_key !== undefined) {
+      next.session_key = map.session.get(row.session_key) ?? `activity-${id}`;
+    }
+    if (row.origin_session_key !== undefined) {
+      const origin = map.session.get(row.origin_session_key);
+      if (origin) next.origin_session_key = origin;
+    }
+    return next;
+  });
+  return JSON.stringify(out, null, 2);
+}
+
+function remapTranscript(rel: string, text: string, map: ChatIdMap) {
+  const key = decodeURIComponent(
+    rel.slice(TRANSCRIPT_PREFIX.length, -".json".length),
+  );
+  const next = map.session.get(key);
+  if (!next) return { rel, text };
+  const doc = JSON.parse(text) as { id?: string };
+  return {
+    rel: transcriptPath(next),
+    text: JSON.stringify({ ...doc, id: next }),
+  };
+}
+
+/**
+ * Rewrite one exported chats archive: the board file's task ids and keys,
+ * and each transcript's file name and inner id. Entries the map does not
+ * know pass through untouched.
+ */
+export function remapChatArchive(
+  zip: Uint8Array,
+  map: ChatIdMap,
+  mint: () => string,
+): Uint8Array {
+  const entries = unzipSync(zip);
+  const out: Record<string, Uint8Array> = {};
+  for (const [rel, bytes] of Object.entries(entries)) {
+    if (rel === ACTIVITY_PATH) {
+      out[rel] = strToU8(remapActivities(strFromU8(bytes), map, mint));
+    } else if (rel.startsWith(TRANSCRIPT_PREFIX) && rel.endsWith(".json")) {
+      const next = remapTranscript(rel, strFromU8(bytes), map);
+      out[next.rel] = strToU8(next.text);
+    } else {
+      out[rel] = bytes;
+    }
+  }
+  return zipSync(out);
+}

--- a/app/src/lib/copy-chat-remap.ts
+++ b/app/src/lib/copy-chat-remap.ts
@@ -101,16 +101,21 @@ function remapActivities(text: string, map: ChatIdMap, mint: () => string) {
   return JSON.stringify(out, null, 2);
 }
 
+/**
+ * A copied transcript wears the runtime's one-shot replay marker: the copy has
+ * no backend session for it, so its first turn must carry the history in as
+ * a replay preamble (HOU-951), whichever backend the copy runs on. The key
+ * follows the map when it has one, else stays (a routine chat).
+ */
 function remapTranscript(rel: string, text: string, map: ChatIdMap) {
   const key = decodeURIComponent(
     rel.slice(TRANSCRIPT_PREFIX.length, -".json".length),
   );
-  const next = map.session.get(key);
-  if (!next) return { rel, text };
+  const next = map.session.get(key) ?? key;
   const doc = JSON.parse(text) as { id?: string };
   return {
     rel: transcriptPath(next),
-    text: JSON.stringify({ ...doc, id: next }),
+    text: JSON.stringify({ ...doc, id: next, needsSessionReplay: true }),
   };
 }
 

--- a/app/src/lib/copy-chat-remap.ts
+++ b/app/src/lib/copy-chat-remap.ts
@@ -26,6 +26,16 @@ export function transcriptPath(sessionKey: string): string {
   return `${TRANSCRIPT_PREFIX}${encodeURIComponent(sessionKey)}.json`;
 }
 
+/**
+ * The copy's key for a source key. Only the `activity-<id>` family follows
+ * the task's new id; any other family (`routine-<rid>`, setup chats) names
+ * something the copy carries under the SAME id, so the key must stay for the
+ * link to hold.
+ */
+function nextSessionKey(key: string, nextId: string): string {
+  return key.startsWith("activity-") ? `activity-${nextId}` : key;
+}
+
 /** One fresh id per source conversation, decided once so every batch agrees. */
 export function planChatIdMap(
   conversations: readonly Pick<ConversationEntry, "id" | "session_key">[],
@@ -36,15 +46,19 @@ export function planChatIdMap(
     if (map.activity.has(c.id)) continue;
     const next = mint();
     map.activity.set(c.id, next);
-    map.session.set(c.session_key, `activity-${next}`);
+    map.session.set(c.session_key, nextSessionKey(c.session_key, next));
   }
   return map;
 }
 
 interface ActivityRow {
   id: string;
+  status?: string;
   session_key?: string;
   origin_session_key?: string;
+  claude_session_id?: unknown;
+  routine_run_id?: unknown;
+  worktree_path?: unknown;
   [key: string]: unknown;
 }
 
@@ -58,14 +72,25 @@ function remapActivities(text: string, map: ChatIdMap, mint: () => string) {
     if (!id) {
       id = mint();
       map.activity.set(row.id, id);
-      map.session.set(
-        row.session_key ?? `activity-${row.id}`,
-        `activity-${id}`,
-      );
+      const key = row.session_key ?? `activity-${row.id}`;
+      map.session.set(key, nextSessionKey(key, id));
     }
-    const next: ActivityRow = { ...row, id };
+    // Transient state stays behind: no turn is running in the copy, and a
+    // routine run or native session id names something only the source has.
+    const {
+      claude_session_id: _native,
+      routine_run_id: _run,
+      worktree_path: _tree,
+      ...kept
+    } = row;
+    const next: ActivityRow = {
+      ...kept,
+      id,
+      ...(row.status === "running" ? { status: "needs_you" } : {}),
+    };
     if (row.session_key !== undefined) {
-      next.session_key = map.session.get(row.session_key) ?? `activity-${id}`;
+      next.session_key =
+        map.session.get(row.session_key) ?? nextSessionKey(row.session_key, id);
     }
     if (row.origin_session_key !== undefined) {
       const origin = map.session.get(row.origin_session_key);

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -240,8 +240,10 @@
         "learningsLabel": "Learnings",
         "learningsBody": "Notes the agent picked up while working. Personal ones can stay behind.",
         "chatsLabel": "Chats",
-        "chatsRow": "Tasks and their conversations",
-        "chatsBody": "Every task on the board and the chat behind it, as they are today in {{name}}. Off to start, since chats can hold personal details."
+        "chatsRow": "Conversations",
+        "chatsCount_one": "{{count}} conversation {{name}} has had so far",
+        "chatsCount_other": "{{count}} conversations {{name}} has had so far",
+        "noChats": "{{name}} has no conversations yet."
       },
       "routines": {
         "title": "Which routines should come along?",

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -219,6 +219,40 @@
     },
     "errors": {
       "failed": "We couldn't copy the agent"
+    },
+    "wizard": {
+      "eyebrow": "Copy an agent",
+      "source": {
+        "title": "Which agent should we copy?",
+        "body": "The new agent starts out like the one you pick. On the next screens you choose what it keeps. Conversations and files stay with the original.",
+        "empty": "You have no agents to copy yet."
+      },
+      "instructions": {
+        "title": "What should the copy know?",
+        "body": "Everything is on to start. Turn off anything the new agent should not carry over.",
+        "instructionsLabel": "Job description",
+        "instructionsRow": "Job description and rules",
+        "noInstructions": "{{name}} has no job description yet.",
+        "learningsLabel": "Learnings",
+        "learningsBody": "Notes the agent picked up while working. Personal ones can stay behind."
+      },
+      "routines": {
+        "title": "Which routines should come along?",
+        "body": "Routines run on their own schedule. Each one you keep is copied as it is in {{name}}, and you can change it later."
+      },
+      "skills": {
+        "title": "Which skills should come along?",
+        "body": "Skills are the things {{name}} knows how to do. Keep the ones the copy needs."
+      },
+      "name": {
+        "heading": "Based on {{name}}"
+      },
+      "actions": {
+        "back": "Back",
+        "next": "Continue",
+        "selectAll": "Select all",
+        "clearAll": "Clear"
+      }
     }
   },
   "rowMenu": {

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -222,18 +222,19 @@
     },
     "errors": {
       "failed": "We couldn't copy the agent",
-      "chatsFailed": "We couldn't copy the chats"
+      "chatsFailed": "We couldn't copy the chats",
+      "chatsPartial": "Some chats did not make it. Copy the agent again to retry."
     },
     "wizard": {
       "eyebrow": "Copy an agent",
       "source": {
         "title": "Which agent should we copy?",
-        "body": "The new agent starts out like the one you pick. On the next screens you choose what it keeps. Conversations and files stay with the original.",
+        "body": "The new agent starts out like the one you pick. On the next screens you choose what it keeps. Files stay with the original.",
         "empty": "You have no agents to copy yet."
       },
       "instructions": {
         "title": "What should the copy know?",
-        "body": "Everything is on to start. Turn off anything the new agent should not carry over.",
+        "body": "Everything is on to start, except the conversations. Turn off anything the new agent should not carry over.",
         "instructionsLabel": "Job description",
         "instructionsRow": "Job description and rules",
         "noInstructions": "{{name}} has no job description yet.",

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -215,10 +215,14 @@
     "copySuffix": "copy",
     "toasts": {
       "createdTitle": "Copy created",
-      "createdDescription": "{{name}} is ready."
+      "createdDescription": "{{name}} is ready.",
+      "chatsCopiedTitle": "Chats copied",
+      "chatsCopiedDescription_one": "{{count}} conversation now lives with {{name}} too.",
+      "chatsCopiedDescription_other": "{{count}} conversations now live with {{name}} too."
     },
     "errors": {
-      "failed": "We couldn't copy the agent"
+      "failed": "We couldn't copy the agent",
+      "chatsFailed": "We couldn't copy the chats"
     },
     "wizard": {
       "eyebrow": "Copy an agent",
@@ -234,7 +238,10 @@
         "instructionsRow": "Job description and rules",
         "noInstructions": "{{name}} has no job description yet.",
         "learningsLabel": "Learnings",
-        "learningsBody": "Notes the agent picked up while working. Personal ones can stay behind."
+        "learningsBody": "Notes the agent picked up while working. Personal ones can stay behind.",
+        "chatsLabel": "Chats",
+        "chatsRow": "Tasks and their conversations",
+        "chatsBody": "Every task on the board and the chat behind it, as they are today in {{name}}. Off to start, since chats can hold personal details."
       },
       "routines": {
         "title": "Which routines should come along?",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -525,7 +525,8 @@
   "newAgent": {
     "dialogTitle": "New agent",
     "storeCard": "From the store",
-    "createCard": "Create new"
+    "createCard": "Create new",
+    "copyCard": "Copy an agent"
   },
   "engineGate": {
     "starting": "Loading your agents…",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -215,10 +215,14 @@
     "copySuffix": "copia",
     "toasts": {
       "createdTitle": "Copia creada",
-      "createdDescription": "{{name}} está listo."
+      "createdDescription": "{{name}} está listo.",
+      "chatsCopiedTitle": "Chats copiados",
+      "chatsCopiedDescription_one": "{{count}} conversación ahora también vive con {{name}}.",
+      "chatsCopiedDescription_other": "{{count}} conversaciones ahora también viven con {{name}}."
     },
     "errors": {
-      "failed": "No pudimos copiar el agente"
+      "failed": "No pudimos copiar el agente",
+      "chatsFailed": "No pudimos copiar los chats"
     },
     "wizard": {
       "eyebrow": "Copiar un agente",
@@ -234,7 +238,10 @@
         "instructionsRow": "Descripción del puesto y reglas",
         "noInstructions": "{{name}} todavía no tiene descripción del puesto.",
         "learningsLabel": "Aprendizajes",
-        "learningsBody": "Notas que el agente fue tomando mientras trabajaba. Las personales pueden quedarse fuera."
+        "learningsBody": "Notas que el agente fue tomando mientras trabajaba. Las personales pueden quedarse fuera.",
+        "chatsLabel": "Chats",
+        "chatsRow": "Tareas y sus conversaciones",
+        "chatsBody": "Cada tarea del tablero y el chat que hay detrás, tal como están hoy en {{name}}. Empieza desactivado, porque los chats pueden tener datos personales."
       },
       "routines": {
         "title": "¿Qué rutinas se llevan?",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -222,18 +222,19 @@
     },
     "errors": {
       "failed": "No pudimos copiar el agente",
-      "chatsFailed": "No pudimos copiar los chats"
+      "chatsFailed": "No pudimos copiar los chats",
+      "chatsPartial": "Algunos chats no llegaron. Vuelve a copiar el agente para reintentar."
     },
     "wizard": {
       "eyebrow": "Copiar un agente",
       "source": {
         "title": "¿Qué agente copiamos?",
-        "body": "El nuevo agente empieza igual que el que elijas. En las siguientes pantallas decides qué conserva. Las conversaciones y los archivos se quedan con el original.",
+        "body": "El nuevo agente empieza igual que el que elijas. En las siguientes pantallas decides qué conserva. Los archivos se quedan con el original.",
         "empty": "Todavía no tienes agentes para copiar."
       },
       "instructions": {
         "title": "¿Qué debe saber la copia?",
-        "body": "Todo empieza activado. Desactiva lo que el nuevo agente no deba llevarse.",
+        "body": "Todo empieza activado, salvo las conversaciones. Desactiva lo que el nuevo agente no deba llevarse.",
         "instructionsLabel": "Descripción del puesto",
         "instructionsRow": "Descripción del puesto y reglas",
         "noInstructions": "{{name}} todavía no tiene descripción del puesto.",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -240,8 +240,10 @@
         "learningsLabel": "Aprendizajes",
         "learningsBody": "Notas que el agente fue tomando mientras trabajaba. Las personales pueden quedarse fuera.",
         "chatsLabel": "Chats",
-        "chatsRow": "Tareas y sus conversaciones",
-        "chatsBody": "Cada tarea del tablero y el chat que hay detrás, tal como están hoy en {{name}}. Empieza desactivado, porque los chats pueden tener datos personales."
+        "chatsRow": "Conversaciones",
+        "chatsCount_one": "{{count}} conversación que {{name}} ha tenido hasta ahora",
+        "chatsCount_other": "{{count}} conversaciones que {{name}} ha tenido hasta ahora",
+        "noChats": "{{name}} todavía no tiene conversaciones."
       },
       "routines": {
         "title": "¿Qué rutinas se llevan?",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -219,6 +219,40 @@
     },
     "errors": {
       "failed": "No pudimos copiar el agente"
+    },
+    "wizard": {
+      "eyebrow": "Copiar un agente",
+      "source": {
+        "title": "¿Qué agente copiamos?",
+        "body": "El nuevo agente empieza igual que el que elijas. En las siguientes pantallas decides qué conserva. Las conversaciones y los archivos se quedan con el original.",
+        "empty": "Todavía no tienes agentes para copiar."
+      },
+      "instructions": {
+        "title": "¿Qué debe saber la copia?",
+        "body": "Todo empieza activado. Desactiva lo que el nuevo agente no deba llevarse.",
+        "instructionsLabel": "Descripción del puesto",
+        "instructionsRow": "Descripción del puesto y reglas",
+        "noInstructions": "{{name}} todavía no tiene descripción del puesto.",
+        "learningsLabel": "Aprendizajes",
+        "learningsBody": "Notas que el agente fue tomando mientras trabajaba. Las personales pueden quedarse fuera."
+      },
+      "routines": {
+        "title": "¿Qué rutinas se llevan?",
+        "body": "Las rutinas se ejecutan con su propio horario. Cada una que conserves se copia tal como está en {{name}}, y puedes cambiarla después."
+      },
+      "skills": {
+        "title": "¿Qué skills se llevan?",
+        "body": "Las skills son lo que {{name}} sabe hacer. Conserva las que la copia necesite."
+      },
+      "name": {
+        "heading": "Basado en {{name}}"
+      },
+      "actions": {
+        "back": "Atrás",
+        "next": "Continuar",
+        "selectAll": "Seleccionar todo",
+        "clearAll": "Quitar todo"
+      }
     }
   },
   "rowMenu": {

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -525,7 +525,8 @@
   "newAgent": {
     "dialogTitle": "Nuevo agente",
     "storeCard": "Desde la tienda",
-    "createCard": "Crear nuevo"
+    "createCard": "Crear nuevo",
+    "copyCard": "Copiar un agente"
   },
   "engineGate": {
     "starting": "Cargando tus agentes…",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -219,6 +219,40 @@
     },
     "errors": {
       "failed": "Não foi possível copiar o agente"
+    },
+    "wizard": {
+      "eyebrow": "Copiar um agente",
+      "source": {
+        "title": "Qual agente devemos copiar?",
+        "body": "O novo agente começa igual ao que você escolher. Nas próximas telas você decide o que ele mantém. As conversas e os arquivos ficam com o original.",
+        "empty": "Você ainda não tem agentes para copiar."
+      },
+      "instructions": {
+        "title": "O que a cópia deve saber?",
+        "body": "Tudo começa ativado. Desative o que o novo agente não deve levar.",
+        "instructionsLabel": "Descrição do cargo",
+        "instructionsRow": "Descrição do cargo e regras",
+        "noInstructions": "{{name}} ainda não tem descrição do cargo.",
+        "learningsLabel": "Aprendizados",
+        "learningsBody": "Anotações que o agente fez enquanto trabalhava. As pessoais podem ficar de fora."
+      },
+      "routines": {
+        "title": "Quais rotinas vão junto?",
+        "body": "As rotinas rodam no próprio horário. Cada uma que você mantiver é copiada como está em {{name}}, e você pode mudar depois."
+      },
+      "skills": {
+        "title": "Quais skills vão junto?",
+        "body": "Skills são o que {{name}} sabe fazer. Mantenha as que a cópia precisa."
+      },
+      "name": {
+        "heading": "Baseado em {{name}}"
+      },
+      "actions": {
+        "back": "Voltar",
+        "next": "Continuar",
+        "selectAll": "Selecionar tudo",
+        "clearAll": "Limpar"
+      }
     }
   },
   "rowMenu": {

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -222,18 +222,19 @@
     },
     "errors": {
       "failed": "Não foi possível copiar o agente",
-      "chatsFailed": "Não foi possível copiar os chats"
+      "chatsFailed": "Não foi possível copiar os chats",
+      "chatsPartial": "Alguns chats não chegaram. Copie o agente de novo para tentar outra vez."
     },
     "wizard": {
       "eyebrow": "Copiar um agente",
       "source": {
         "title": "Qual agente devemos copiar?",
-        "body": "O novo agente começa igual ao que você escolher. Nas próximas telas você decide o que ele mantém. As conversas e os arquivos ficam com o original.",
+        "body": "O novo agente começa igual ao que você escolher. Nas próximas telas você decide o que ele mantém. Os arquivos ficam com o original.",
         "empty": "Você ainda não tem agentes para copiar."
       },
       "instructions": {
         "title": "O que a cópia deve saber?",
-        "body": "Tudo começa ativado. Desative o que o novo agente não deve levar.",
+        "body": "Tudo começa ativado, menos as conversas. Desative o que o novo agente não deve levar.",
         "instructionsLabel": "Descrição do cargo",
         "instructionsRow": "Descrição do cargo e regras",
         "noInstructions": "{{name}} ainda não tem descrição do cargo.",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -215,10 +215,14 @@
     "copySuffix": "cópia",
     "toasts": {
       "createdTitle": "Cópia criada",
-      "createdDescription": "{{name}} está pronto."
+      "createdDescription": "{{name}} está pronto.",
+      "chatsCopiedTitle": "Chats copiados",
+      "chatsCopiedDescription_one": "{{count}} conversa agora também vive com {{name}}.",
+      "chatsCopiedDescription_other": "{{count}} conversas agora também vivem com {{name}}."
     },
     "errors": {
-      "failed": "Não foi possível copiar o agente"
+      "failed": "Não foi possível copiar o agente",
+      "chatsFailed": "Não foi possível copiar os chats"
     },
     "wizard": {
       "eyebrow": "Copiar um agente",
@@ -234,7 +238,10 @@
         "instructionsRow": "Descrição do cargo e regras",
         "noInstructions": "{{name}} ainda não tem descrição do cargo.",
         "learningsLabel": "Aprendizados",
-        "learningsBody": "Anotações que o agente fez enquanto trabalhava. As pessoais podem ficar de fora."
+        "learningsBody": "Anotações que o agente fez enquanto trabalhava. As pessoais podem ficar de fora.",
+        "chatsLabel": "Chats",
+        "chatsRow": "Tarefas e suas conversas",
+        "chatsBody": "Cada tarefa do quadro e o chat por trás dela, como estão hoje em {{name}}. Começa desativado, porque chats podem ter dados pessoais."
       },
       "routines": {
         "title": "Quais rotinas vão junto?",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -240,8 +240,10 @@
         "learningsLabel": "Aprendizados",
         "learningsBody": "Anotações que o agente fez enquanto trabalhava. As pessoais podem ficar de fora.",
         "chatsLabel": "Chats",
-        "chatsRow": "Tarefas e suas conversas",
-        "chatsBody": "Cada tarefa do quadro e o chat por trás dela, como estão hoje em {{name}}. Começa desativado, porque chats podem ter dados pessoais."
+        "chatsRow": "Conversas",
+        "chatsCount_one": "{{count}} conversa que {{name}} teve até agora",
+        "chatsCount_other": "{{count}} conversas que {{name}} teve até agora",
+        "noChats": "{{name}} ainda não tem conversas."
       },
       "routines": {
         "title": "Quais rotinas vão junto?",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -525,7 +525,8 @@
   "newAgent": {
     "dialogTitle": "Novo agente",
     "storeCard": "Da loja",
-    "createCard": "Criar novo"
+    "createCard": "Criar novo",
+    "copyCard": "Copiar um agente"
   },
   "engineGate": {
     "starting": "Carregando seus agentes…",

--- a/app/tests/copy-agent-chats.test.ts
+++ b/app/tests/copy-agent-chats.test.ts
@@ -1,9 +1,10 @@
-import { deepStrictEqual, strictEqual } from "node:assert";
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import type {
   ConversationEntry,
   MigrationImportResult,
 } from "@houston-ai/engine-client";
+import { strToU8, unzipSync, zipSync } from "fflate";
 import {
   ACTIVITY_PATH,
   batchPaths,
@@ -51,32 +52,58 @@ describe("batchPaths", () => {
 });
 
 describe("copyAgentChats", () => {
-  it("exports every batch from the source and imports it into the target", async () => {
+  it("exports every batch, re-ids it, and imports it into the target", async () => {
     const calls: string[] = [];
+    const imported: string[][] = [];
     const engine: ChatCopyEngine = {
       async listConversations(agentPath) {
         calls.push(`list:${agentPath}`);
         return Array.from(
           { length: 30 },
-          (_, i) => ({ session_key: `c${i}` }) as ConversationEntry,
+          (_, i) =>
+            ({
+              id: `t${i}`,
+              session_key: `activity-t${i}`,
+            }) as ConversationEntry,
         );
       },
       async migrationExport(agentPath, paths) {
         calls.push(`export:${agentPath}:${paths.length}`);
-        return new ArrayBuffer(paths.length);
+        // The archive a host would build for these paths: one entry each.
+        const files: Record<string, Uint8Array> = {};
+        for (const rel of paths) {
+          files[rel] = strToU8(
+            rel.endsWith("activity.json")
+              ? JSON.stringify([{ id: "t0", title: "T0", status: "done" }])
+              : JSON.stringify({ id: rel.slice(rel.lastIndexOf("/") + 1, -5) }),
+          );
+        }
+        const zip = zipSync(files);
+        return zip.buffer.slice(
+          zip.byteOffset,
+          zip.byteOffset + zip.byteLength,
+        ) as ArrayBuffer;
       },
       async migrationImport(agentPath, bytes) {
-        calls.push(`import:${agentPath}:${bytes.byteLength}`);
+        const names = Object.keys(unzipSync(new Uint8Array(bytes)));
+        imported.push(names);
+        calls.push(`import:${agentPath}:${names.length}`);
         const result: MigrationImportResult = {
-          written: bytes.byteLength,
+          written: names.length,
           skipped: 0,
-          rejected: bytes.byteLength === 6 ? [{ path: "x", reason: "r" }] : [],
+          rejected: names.length === 6 ? [{ path: "x", reason: "r" }] : [],
           sessionsRebuilt: true,
         };
         return result;
       },
     };
-    const outcome = await copyAgentChats(engine, "src", "dst");
+    let n = 0;
+    const outcome = await copyAgentChats(
+      engine,
+      "src",
+      "dst",
+      () => `new${n++}`,
+    );
     // 31 paths (board + 30 transcripts) in batches of 25: 25 then 6.
     deepStrictEqual(calls, [
       "list:src",
@@ -88,5 +115,9 @@ describe("copyAgentChats", () => {
     strictEqual(outcome.conversations, 30);
     strictEqual(outcome.written, 31);
     deepStrictEqual(outcome.rejected, [{ path: "x", reason: "r" }]);
+    // Nothing lands under a source id: every transcript wears its new key.
+    const all = imported.flat();
+    ok(all.includes(".houston/runtime/conversations/activity-new0.json"));
+    ok(!all.some((rel) => rel.includes("activity-t")));
   });
 });

--- a/app/tests/copy-agent-chats.test.ts
+++ b/app/tests/copy-agent-chats.test.ts
@@ -105,6 +105,9 @@ describe("copyAgentChats", () => {
       async migrationImport(agentPath, bytes, opts) {
         const names = Object.keys(unzipSync(new Uint8Array(bytes)));
         imported.push(names);
+        // Every import asks for NO pi session: the transcripts carry the
+        // replay marker instead.
+        strictEqual(opts?.sessions, false);
         calls.push(
           `import:${agentPath}:${names.length}${opts?.overwrite ? ":overwrite" : ""}`,
         );

--- a/app/tests/copy-agent-chats.test.ts
+++ b/app/tests/copy-agent-chats.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { deepStrictEqual, ok, rejects, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import type {
   ConversationEntry,
@@ -9,25 +9,27 @@ import {
   ACTIVITY_PATH,
   batchPaths,
   type ChatCopyEngine,
+  chatCopyBatches,
+  chatCopyComplete,
   chatCopyPaths,
   copyAgentChats,
   transcriptPath,
+  withWakingRetry,
 } from "../src/lib/copy-agent-chats.ts";
 
 const entry = (session_key: string) =>
   ({ session_key }) as Pick<ConversationEntry, "session_key">;
 
 describe("chatCopyPaths", () => {
-  it("carries the board file first, then one transcript per conversation", () => {
+  it("carries one transcript per conversation", () => {
     deepStrictEqual(chatCopyPaths([entry("abc"), entry("def")]), [
-      ACTIVITY_PATH,
       ".houston/runtime/conversations/abc.json",
       ".houston/runtime/conversations/def.json",
     ]);
   });
 
   it("collapses duplicate session keys", () => {
-    strictEqual(chatCopyPaths([entry("a"), entry("a")]).length, 2);
+    strictEqual(chatCopyPaths([entry("a"), entry("a")]).length, 1);
   });
 
   it("names transcripts the way the runtime does, safely inside the scope", () => {
@@ -37,6 +39,21 @@ describe("chatCopyPaths", () => {
       transcriptPath("activity/1"),
       ".houston/runtime/conversations/activity%2F1.json",
     );
+  });
+});
+
+describe("chatCopyBatches", () => {
+  it("sends the transcripts first and the board alone, last", () => {
+    deepStrictEqual(chatCopyBatches([entry("a"), entry("b"), entry("c")], 2), [
+      [
+        ".houston/runtime/conversations/a.json",
+        ".houston/runtime/conversations/b.json",
+      ],
+      [".houston/runtime/conversations/c.json"],
+      [ACTIVITY_PATH],
+    ]);
+    // A source with no conversations still ships its (empty) board.
+    deepStrictEqual(chatCopyBatches([], 2), [[ACTIVITY_PATH]]);
   });
 });
 
@@ -58,6 +75,7 @@ describe("copyAgentChats", () => {
     const engine: ChatCopyEngine = {
       async listConversations(agentPath) {
         calls.push(`list:${agentPath}`);
+        if (agentPath === "dst") return [];
         return Array.from(
           { length: 30 },
           (_, i) =>
@@ -84,14 +102,16 @@ describe("copyAgentChats", () => {
           zip.byteOffset + zip.byteLength,
         ) as ArrayBuffer;
       },
-      async migrationImport(agentPath, bytes) {
+      async migrationImport(agentPath, bytes, opts) {
         const names = Object.keys(unzipSync(new Uint8Array(bytes)));
         imported.push(names);
-        calls.push(`import:${agentPath}:${names.length}`);
+        calls.push(
+          `import:${agentPath}:${names.length}${opts?.overwrite ? ":overwrite" : ""}`,
+        );
         const result: MigrationImportResult = {
           written: names.length,
           skipped: 0,
-          rejected: names.length === 6 ? [{ path: "x", reason: "r" }] : [],
+          rejected: [],
           sessionsRebuilt: true,
         };
         return result;
@@ -104,20 +124,109 @@ describe("copyAgentChats", () => {
       "dst",
       () => `new${n++}`,
     );
-    // 31 paths (board + 30 transcripts) in batches of 25: 25 then 6.
+    // 30 transcripts in batches of 10, then the board on its own.
     deepStrictEqual(calls, [
       "list:src",
-      "export:src:25",
-      "import:dst:25",
-      "export:src:6",
-      "import:dst:6",
+      "export:src:10",
+      "import:dst:10",
+      "export:src:10",
+      "import:dst:10",
+      "export:src:10",
+      "import:dst:10",
+      "export:src:1",
+      "list:dst",
+      "import:dst:1:overwrite",
     ]);
     strictEqual(outcome.conversations, 30);
-    strictEqual(outcome.written, 31);
-    deepStrictEqual(outcome.rejected, [{ path: "x", reason: "r" }]);
-    // Nothing lands under a source id: every transcript wears its new key.
+    strictEqual(outcome.transcriptsWritten, 30);
+    strictEqual(outcome.boardWritten, true);
+    ok(chatCopyComplete(outcome));
+    // The board is the LAST thing to land, and nothing lands under a source
+    // id: every transcript wears its new key.
+    deepStrictEqual(imported[imported.length - 1], [ACTIVITY_PATH]);
     const all = imported.flat();
     ok(all.includes(".houston/runtime/conversations/activity-new0.json"));
     ok(!all.some((rel) => rel.includes("activity-t")));
+  });
+
+  it("reports a board the target already had, and rejected files, as incomplete", async () => {
+    const engine: ChatCopyEngine = {
+      async listConversations(agentPath) {
+        // The target already holds a task: the board must not be replaced.
+        return [
+          {
+            id: agentPath === "dst" ? "mine" : "t1",
+            session_key: "activity-x",
+          } as ConversationEntry,
+        ];
+      },
+      async migrationExport(_agentPath, paths) {
+        const files: Record<string, Uint8Array> = {};
+        for (const rel of paths)
+          files[rel] = strToU8(rel.endsWith("activity.json") ? "[]" : "{}");
+        const zip = zipSync(files);
+        return zip.buffer.slice(
+          zip.byteOffset,
+          zip.byteOffset + zip.byteLength,
+        ) as ArrayBuffer;
+      },
+      async migrationImport(_agentPath, bytes, opts) {
+        const names = Object.keys(unzipSync(new Uint8Array(bytes)));
+        // The board already exists on the target: the importer skips it,
+        // and the copy never asked to overwrite it.
+        const board = names[0] === ACTIVITY_PATH;
+        ok(!opts?.overwrite);
+        return {
+          written: board ? 0 : 1,
+          skipped: board ? 1 : 0,
+          rejected: [],
+          sessionsRebuilt: true,
+        };
+      },
+    };
+    const outcome = await copyAgentChats(engine, "src", "dst", () => "n1");
+    strictEqual(outcome.transcriptsWritten, 1);
+    strictEqual(outcome.boardWritten, false);
+    ok(!chatCopyComplete(outcome));
+    ok(
+      !chatCopyComplete({
+        conversations: 1,
+        transcriptsWritten: 1,
+        boardWritten: true,
+        rejected: [{ path: "x", reason: "too-large" }],
+      }),
+    );
+  });
+});
+
+describe("withWakingRetry", () => {
+  it("re-runs a leg only for refusals the caller names, then gives up", async () => {
+    let calls = 0;
+    const waking = new Error("waking");
+    const out = await withWakingRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw waking;
+        return "ok";
+      },
+      (err) => err === waking,
+      { attempts: 5, delayMs: 0 },
+    );
+    strictEqual(out, "ok");
+    strictEqual(calls, 3);
+    // An unrelated failure is not retried.
+    calls = 0;
+    await rejects(
+      withWakingRetry(
+        async () => {
+          calls++;
+          throw new Error("boom");
+        },
+        (err) => err === waking,
+        { attempts: 5, delayMs: 0 },
+      ),
+      /boom/,
+    );
+    strictEqual(calls, 1);
   });
 });

--- a/app/tests/copy-agent-chats.test.ts
+++ b/app/tests/copy-agent-chats.test.ts
@@ -1,0 +1,92 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type {
+  ConversationEntry,
+  MigrationImportResult,
+} from "@houston-ai/engine-client";
+import {
+  ACTIVITY_PATH,
+  batchPaths,
+  type ChatCopyEngine,
+  chatCopyPaths,
+  copyAgentChats,
+  transcriptPath,
+} from "../src/lib/copy-agent-chats.ts";
+
+const entry = (session_key: string) =>
+  ({ session_key }) as Pick<ConversationEntry, "session_key">;
+
+describe("chatCopyPaths", () => {
+  it("carries the board file first, then one transcript per conversation", () => {
+    deepStrictEqual(chatCopyPaths([entry("abc"), entry("def")]), [
+      ACTIVITY_PATH,
+      ".houston/runtime/conversations/abc.json",
+      ".houston/runtime/conversations/def.json",
+    ]);
+  });
+
+  it("collapses duplicate session keys", () => {
+    strictEqual(chatCopyPaths([entry("a"), entry("a")]).length, 2);
+  });
+
+  it("names transcripts the way the runtime does, safely inside the scope", () => {
+    // The runtime encodes the id; a key with a slash could otherwise read as
+    // a path segment, which the host's export refuses.
+    strictEqual(
+      transcriptPath("activity/1"),
+      ".houston/runtime/conversations/activity%2F1.json",
+    );
+  });
+});
+
+describe("batchPaths", () => {
+  it("splits into batches of the given size, last one short", () => {
+    deepStrictEqual(batchPaths(["a", "b", "c", "d", "e"], 2), [
+      ["a", "b"],
+      ["c", "d"],
+      ["e"],
+    ]);
+    deepStrictEqual(batchPaths([], 2), []);
+  });
+});
+
+describe("copyAgentChats", () => {
+  it("exports every batch from the source and imports it into the target", async () => {
+    const calls: string[] = [];
+    const engine: ChatCopyEngine = {
+      async listConversations(agentPath) {
+        calls.push(`list:${agentPath}`);
+        return Array.from(
+          { length: 30 },
+          (_, i) => ({ session_key: `c${i}` }) as ConversationEntry,
+        );
+      },
+      async migrationExport(agentPath, paths) {
+        calls.push(`export:${agentPath}:${paths.length}`);
+        return new ArrayBuffer(paths.length);
+      },
+      async migrationImport(agentPath, bytes) {
+        calls.push(`import:${agentPath}:${bytes.byteLength}`);
+        const result: MigrationImportResult = {
+          written: bytes.byteLength,
+          skipped: 0,
+          rejected: bytes.byteLength === 6 ? [{ path: "x", reason: "r" }] : [],
+          sessionsRebuilt: true,
+        };
+        return result;
+      },
+    };
+    const outcome = await copyAgentChats(engine, "src", "dst");
+    // 31 paths (board + 30 transcripts) in batches of 25: 25 then 6.
+    deepStrictEqual(calls, [
+      "list:src",
+      "export:src:25",
+      "import:dst:25",
+      "export:src:6",
+      "import:dst:6",
+    ]);
+    strictEqual(outcome.conversations, 30);
+    strictEqual(outcome.written, 31);
+    deepStrictEqual(outcome.rejected, [{ path: "x", reason: "r" }]);
+  });
+});

--- a/app/tests/copy-agent-wizard-model.test.ts
+++ b/app/tests/copy-agent-wizard-model.test.ts
@@ -46,7 +46,7 @@ describe("copyWizardSteps", () => {
     ]);
   });
 
-  it("skips screens the source has nothing for", () => {
+  it("skips the list screens the source has nothing for", () => {
     deepStrictEqual(
       copyWizardSteps({
         claudeMd: null,
@@ -54,27 +54,17 @@ describe("copyWizardSteps", () => {
         routines: [routine("r1")],
         learnings: [],
       }),
-      ["source", "routines", "name"],
+      ["source", "instructions", "routines", "name"],
     );
-    // A bare agent goes straight from the list to its name.
+  });
+
+  it("always shows the know screen: the chats choice exists for every source", () => {
     deepStrictEqual(
       copyWizardSteps({
         claudeMd: null,
         skills: [],
         routines: [],
         learnings: [],
-      }),
-      ["source", "name"],
-    );
-  });
-
-  it("shows the instructions screen for learnings alone", () => {
-    deepStrictEqual(
-      copyWizardSteps({
-        claudeMd: null,
-        skills: [],
-        routines: [],
-        learnings: [learning("l1")],
       }),
       ["source", "instructions", "name"],
     );

--- a/app/tests/copy-agent-wizard-model.test.ts
+++ b/app/tests/copy-agent-wizard-model.test.ts
@@ -1,0 +1,111 @@
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { PortableInventoryPreview } from "@houston-ai/engine-client";
+import {
+  copyWizardSteps,
+  fullCopySelection,
+  toCopySelection,
+} from "../src/components/copy-agent/copy-agent-wizard-model.ts";
+
+const skill = (slug: string) => ({
+  slug,
+  description: "",
+  category: null,
+  image: null,
+  integrations: [],
+  featured: false,
+});
+const routine = (id: string) => ({
+  id,
+  name: id,
+  promptExcerpt: "",
+  enabled: true,
+  integrations: [],
+});
+const learning = (id: string) => ({ id, text: id, createdAt: "" });
+
+const full: PortableInventoryPreview = {
+  claudeMd: { byteCount: 12, excerpt: "You are Ops." },
+  skills: [skill("a"), skill("b")],
+  routines: [routine("r1")],
+  learnings: [learning("l1"), learning("l2")],
+};
+
+describe("copyWizardSteps", () => {
+  it("is only the source list before a source is read", () => {
+    deepStrictEqual(copyWizardSteps(null), ["source"]);
+  });
+
+  it("walks every content screen the source fills, then naming", () => {
+    deepStrictEqual(copyWizardSteps(full), [
+      "source",
+      "instructions",
+      "routines",
+      "skills",
+      "name",
+    ]);
+  });
+
+  it("skips screens the source has nothing for", () => {
+    deepStrictEqual(
+      copyWizardSteps({
+        claudeMd: null,
+        skills: [],
+        routines: [routine("r1")],
+        learnings: [],
+      }),
+      ["source", "routines", "name"],
+    );
+    // A bare agent goes straight from the list to its name.
+    deepStrictEqual(
+      copyWizardSteps({
+        claudeMd: null,
+        skills: [],
+        routines: [],
+        learnings: [],
+      }),
+      ["source", "name"],
+    );
+  });
+
+  it("shows the instructions screen for learnings alone", () => {
+    deepStrictEqual(
+      copyWizardSteps({
+        claudeMd: null,
+        skills: [],
+        routines: [],
+        learnings: [learning("l1")],
+      }),
+      ["source", "instructions", "name"],
+    );
+  });
+});
+
+describe("fullCopySelection", () => {
+  it("starts with everything on", () => {
+    const sel = fullCopySelection(full);
+    strictEqual(sel.claudeMd, true);
+    deepStrictEqual([...sel.skillSlugs], ["a", "b"]);
+    deepStrictEqual([...sel.routineIds], ["r1"]);
+    deepStrictEqual([...sel.learningIds], ["l1", "l2"]);
+  });
+
+  it("leaves the job description off when the source has none", () => {
+    ok(!fullCopySelection({ ...full, claudeMd: null }).claudeMd);
+  });
+});
+
+describe("toCopySelection", () => {
+  it("carries exactly what is still switched on", () => {
+    const sel = fullCopySelection(full);
+    sel.skillSlugs.delete("a");
+    sel.learningIds.delete("l2");
+    sel.claudeMd = false;
+    deepStrictEqual(toCopySelection(sel), {
+      includeClaudeMd: false,
+      includeSkillSlugs: ["b"],
+      includeRoutineIds: ["r1"],
+      includeLearningIds: ["l1"],
+    });
+  });
+});

--- a/app/tests/copy-chat-remap.test.ts
+++ b/app/tests/copy-chat-remap.test.ts
@@ -87,13 +87,22 @@ describe("remapChatArchive", () => {
     // Native session and routine-run references name things only the source has.
     ok(!("claude_session_id" in (rows[0] as object)));
     ok(!("routine_run_id" in (rows[0] as object)));
+    const moved = JSON.parse(
+      strFromU8(
+        out[".houston/runtime/conversations/activity-n1.json"] as Uint8Array,
+      ),
+    );
+    strictEqual(moved.id, "activity-n1");
+    // Every copied transcript asks its first turn to replay the history: the
+    // copy has no backend session for it, on any provider.
+    strictEqual(moved.needsSessionReplay, true);
     strictEqual(
       JSON.parse(
         strFromU8(
-          out[".houston/runtime/conversations/activity-n1.json"] as Uint8Array,
+          out[".houston/runtime/conversations/routine-r9.json"] as Uint8Array,
         ),
-      ).id,
-      "activity-n1",
+      ).needsSessionReplay,
+      true,
     );
     strictEqual(strFromU8(out["notes/keep.txt"] as Uint8Array), "untouched");
     // The row the conversation list never named still got a fresh id, and the

--- a/app/tests/copy-chat-remap.test.ts
+++ b/app/tests/copy-chat-remap.test.ts
@@ -10,7 +10,7 @@ const mintFrom = (ids: string[]) => {
 
 const conversations = [
   { id: "a1", session_key: "activity-a1" },
-  { id: "b2", session_key: "sess-b2" },
+  { id: "b2", session_key: "routine-r9" },
 ];
 
 describe("planChatIdMap", () => {
@@ -23,11 +23,12 @@ describe("planChatIdMap", () => {
         ["b2", "n2"],
       ],
     );
+    // A routine chat keeps its key: the copied routine carries the same id.
     deepStrictEqual(
       [...map.session],
       [
         ["activity-a1", "activity-n1"],
-        ["sess-b2", "activity-n2"],
+        ["routine-r9", "routine-r9"],
       ],
     );
   });
@@ -37,8 +38,14 @@ describe("remapChatArchive", () => {
   it("rewrites the board rows, renames transcripts, and leaves the rest alone", () => {
     const map = planChatIdMap(conversations, mintFrom(["n1", "n2"]));
     const board = [
-      { id: "a1", title: "A", status: "done" },
-      { id: "b2", title: "B", status: "done", session_key: "sess-b2" },
+      {
+        id: "a1",
+        title: "A",
+        status: "running",
+        claude_session_id: "native-1",
+        routine_run_id: "run-1",
+      },
+      { id: "b2", title: "B", status: "done", session_key: "routine-r9" },
       // Started by the agent from A's chat: the parent link follows.
       {
         id: "c3",
@@ -52,8 +59,8 @@ describe("remapChatArchive", () => {
       ".houston/runtime/conversations/activity-a1.json": strToU8(
         JSON.stringify({ id: "activity-a1", title: "A", messages: [] }),
       ),
-      ".houston/runtime/conversations/sess-b2.json": strToU8(
-        JSON.stringify({ id: "sess-b2", title: "B", messages: [] }),
+      ".houston/runtime/conversations/routine-r9.json": strToU8(
+        JSON.stringify({ id: "routine-r9", title: "B", messages: [] }),
       ),
       "notes/keep.txt": strToU8("untouched"),
     });
@@ -62,27 +69,31 @@ describe("remapChatArchive", () => {
     deepStrictEqual(Object.keys(out).sort(), [
       ".houston/activity/activity.json",
       ".houston/runtime/conversations/activity-n1.json",
-      ".houston/runtime/conversations/activity-n2.json",
+      ".houston/runtime/conversations/routine-r9.json",
       "notes/keep.txt",
     ]);
     const rows = JSON.parse(
       strFromU8(out[".houston/activity/activity.json"] as Uint8Array),
     ) as Record<string, unknown>[];
     deepStrictEqual(
-      rows.map((r) => [r.id, r.session_key, r.origin_session_key]),
+      rows.map((r) => [r.id, r.session_key, r.origin_session_key, r.status]),
       [
-        ["n1", undefined, undefined],
-        ["n2", "activity-n2", undefined],
-        ["n3", undefined, "activity-n1"],
+        // A running task cannot be running in the copy; it waits for the user.
+        ["n1", undefined, undefined, "needs_you"],
+        ["n2", "routine-r9", undefined, "done"],
+        ["n3", undefined, "activity-n1", "done"],
       ],
     );
+    // Native session and routine-run references name things only the source has.
+    ok(!("claude_session_id" in (rows[0] as object)));
+    ok(!("routine_run_id" in (rows[0] as object)));
     strictEqual(
       JSON.parse(
         strFromU8(
-          out[".houston/runtime/conversations/activity-n2.json"] as Uint8Array,
+          out[".houston/runtime/conversations/activity-n1.json"] as Uint8Array,
         ),
       ).id,
-      "activity-n2",
+      "activity-n1",
     );
     strictEqual(strFromU8(out["notes/keep.txt"] as Uint8Array), "untouched");
     // The row the conversation list never named still got a fresh id, and the

--- a/app/tests/copy-chat-remap.test.ts
+++ b/app/tests/copy-chat-remap.test.ts
@@ -1,0 +1,93 @@
+import { deepStrictEqual, notStrictEqual, ok, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+import { planChatIdMap, remapChatArchive } from "../src/lib/copy-chat-remap.ts";
+
+const mintFrom = (ids: string[]) => {
+  let i = 0;
+  return () => ids[i++] ?? `extra-${i}`;
+};
+
+const conversations = [
+  { id: "a1", session_key: "activity-a1" },
+  { id: "b2", session_key: "sess-b2" },
+];
+
+describe("planChatIdMap", () => {
+  it("mints one id per conversation and derives the copy's key from it", () => {
+    const map = planChatIdMap(conversations, mintFrom(["n1", "n2"]));
+    deepStrictEqual(
+      [...map.activity],
+      [
+        ["a1", "n1"],
+        ["b2", "n2"],
+      ],
+    );
+    deepStrictEqual(
+      [...map.session],
+      [
+        ["activity-a1", "activity-n1"],
+        ["sess-b2", "activity-n2"],
+      ],
+    );
+  });
+});
+
+describe("remapChatArchive", () => {
+  it("rewrites the board rows, renames transcripts, and leaves the rest alone", () => {
+    const map = planChatIdMap(conversations, mintFrom(["n1", "n2"]));
+    const board = [
+      { id: "a1", title: "A", status: "done" },
+      { id: "b2", title: "B", status: "done", session_key: "sess-b2" },
+      // Started by the agent from A's chat: the parent link follows.
+      {
+        id: "c3",
+        title: "C",
+        status: "done",
+        origin_session_key: "activity-a1",
+      },
+    ];
+    const zip = zipSync({
+      ".houston/activity/activity.json": strToU8(JSON.stringify(board)),
+      ".houston/runtime/conversations/activity-a1.json": strToU8(
+        JSON.stringify({ id: "activity-a1", title: "A", messages: [] }),
+      ),
+      ".houston/runtime/conversations/sess-b2.json": strToU8(
+        JSON.stringify({ id: "sess-b2", title: "B", messages: [] }),
+      ),
+      "notes/keep.txt": strToU8("untouched"),
+    });
+
+    const out = unzipSync(remapChatArchive(zip, map, mintFrom(["n3"])));
+    deepStrictEqual(Object.keys(out).sort(), [
+      ".houston/activity/activity.json",
+      ".houston/runtime/conversations/activity-n1.json",
+      ".houston/runtime/conversations/activity-n2.json",
+      "notes/keep.txt",
+    ]);
+    const rows = JSON.parse(
+      strFromU8(out[".houston/activity/activity.json"] as Uint8Array),
+    ) as Record<string, unknown>[];
+    deepStrictEqual(
+      rows.map((r) => [r.id, r.session_key, r.origin_session_key]),
+      [
+        ["n1", undefined, undefined],
+        ["n2", "activity-n2", undefined],
+        ["n3", undefined, "activity-n1"],
+      ],
+    );
+    strictEqual(
+      JSON.parse(
+        strFromU8(
+          out[".houston/runtime/conversations/activity-n2.json"] as Uint8Array,
+        ),
+      ).id,
+      "activity-n2",
+    );
+    strictEqual(strFromU8(out["notes/keep.txt"] as Uint8Array), "untouched");
+    // The row the conversation list never named still got a fresh id, and the
+    // map remembers it for a later batch.
+    ok(map.activity.has("c3"));
+    notStrictEqual(map.activity.get("c3"), "c3");
+  });
+});

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -36,6 +36,10 @@ async function parseBody(
   req: Request,
 ): Promise<Record<string, unknown> | undefined> {
   if (req.method === "GET" || req.method === "HEAD") return undefined;
+  // A binary upload (the migration import's zip) keeps its body stream for
+  // the route: `req.json()` would consume it and leave nothing to unpack.
+  if (req.headers.get("content-type")?.includes("application/zip"))
+    return undefined;
   return (await req.json().catch(() => undefined)) as
     | Record<string, unknown>
     | undefined;

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -23,6 +23,7 @@ import { handleAgents } from "./routes";
 import { handleAgentTeamsRoutes } from "./routes-agent-teams";
 import { handleUserRoutes } from "./routes-integrations";
 import { handleMeRoutes } from "./routes-me";
+import { lastPortableExport, resetPortable } from "./routes-portable";
 import { handleSetupRuntime } from "./routes-setup-runtime";
 import { handleSharedSkillsRoutes } from "./routes-shared-skills";
 import { handleSpaceInvitesControl, handleSpacesRoutes } from "./routes-spaces";
@@ -68,8 +69,13 @@ export async function handle(req: Request): Promise<Response> {
   // --- test-control plane (called server-to-server by the harness) ---
   if (path === "/__test__/reset" && method === "POST") {
     clearChatStreams();
+    resetPortable();
     state.reset();
     return json({ ok: true });
+  }
+  // What the last portable export carried — the copy wizard's selection.
+  if (path === "/__test__/portable-export" && method === "GET") {
+    return json({ selection: lastPortableExport() });
   }
   if (path === "/__test__/emit" && method === "POST") {
     const body = await parseBody(req);

--- a/packages/fake-host/src/routes-migration.ts
+++ b/packages/fake-host/src/routes-migration.ts
@@ -1,0 +1,93 @@
+/**
+ * The agent-scoped migration routes (`/agents/:id/migration/export|import`),
+ * the pair "Copy an agent" moves chats through. Modeled over the fake's own
+ * state: the board file rides as `.houston/activity/activity.json` and each
+ * conversation's history as `.houston/runtime/conversations/<key>.json`, the
+ * real host's layout, so the app's path planning is exercised as is. The
+ * transcript body here is the fake's history shape, not the runtime's, since
+ * only this fake reads it back.
+ */
+
+import type { ChatMessage } from "@houston/runtime-client";
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+import { CORS, json, noContent } from "./http";
+import * as state from "./state";
+import { ACTIVITY_PATH, fileKey } from "./state-store";
+
+const TRANSCRIPTS = ".houston/runtime/conversations/";
+
+interface FakeTranscript {
+  id: string;
+  messages: ChatMessage[];
+}
+
+function conversationKeys(agentId: string): string[] {
+  return state
+    .listActivities(agentId)
+    .map((a) => a.session_key ?? `activity-${a.id}`);
+}
+
+function exportZip(agentId: string, paths: string[]): Response {
+  const files: Record<string, Uint8Array> = {};
+  for (const rel of paths) {
+    if (rel === ACTIVITY_PATH) {
+      const doc = state.state.files.get(fileKey(agentId, ACTIVITY_PATH));
+      if (doc !== undefined) files[rel] = strToU8(doc);
+      continue;
+    }
+    if (rel.startsWith(TRANSCRIPTS) && rel.endsWith(".json")) {
+      const key = decodeURIComponent(
+        rel.slice(TRANSCRIPTS.length, -".json".length),
+      );
+      if (!conversationKeys(agentId).includes(key)) continue;
+      const transcript: FakeTranscript = {
+        id: key,
+        messages: state.getHistory(agentId, key),
+      };
+      files[rel] = strToU8(JSON.stringify(transcript));
+      continue;
+    }
+    return json({ error: `path outside migration scope: ${rel}` }, 400);
+  }
+  const bytes = zipSync(files);
+  return new Response(new Uint8Array(bytes).buffer as ArrayBuffer, {
+    status: 200,
+    headers: { ...CORS, "Content-Type": "application/zip" },
+  });
+}
+
+async function importZip(agentId: string, req: Request): Promise<Response> {
+  const entries = unzipSync(new Uint8Array(await req.arrayBuffer()));
+  let written = 0;
+  for (const [rel, bytes] of Object.entries(entries)) {
+    const text = strFromU8(bytes);
+    if (rel === ACTIVITY_PATH) {
+      state.state.files.set(fileKey(agentId, ACTIVITY_PATH), text);
+      state.emitDomain("ActivityChanged", agentId);
+      written++;
+    } else if (rel.startsWith(TRANSCRIPTS)) {
+      const transcript = JSON.parse(text) as FakeTranscript;
+      state.seedHistory(agentId, transcript.id, transcript.messages);
+      written++;
+    }
+  }
+  return json({ written, skipped: 0, rejected: [], sessionsRebuilt: true });
+}
+
+/** Dispatch `/agents/:id/migration/<action>`. */
+export function handleMigrationRoutes(
+  method: string,
+  agentId: string,
+  action: string | undefined,
+  req: Request,
+  body: Record<string, unknown> | undefined,
+): Response | Promise<Response> {
+  if (action === "export" && method === "POST") {
+    const paths = Array.isArray(body?.paths)
+      ? body.paths.filter((p): p is string => typeof p === "string")
+      : [];
+    return exportZip(agentId, paths);
+  }
+  if (action === "import" && method === "POST") return importZip(agentId, req);
+  return noContent(405);
+}

--- a/packages/fake-host/src/routes-migration.ts
+++ b/packages/fake-host/src/routes-migration.ts
@@ -56,22 +56,39 @@ function exportZip(agentId: string, paths: string[]): Response {
   });
 }
 
+/** Skip-existing per entry, like the real importer; `?overwrite=1` replaces. */
 async function importZip(agentId: string, req: Request): Promise<Response> {
+  const overwrite = new URL(req.url).searchParams.get("overwrite") === "1";
   const entries = unzipSync(new Uint8Array(await req.arrayBuffer()));
   let written = 0;
+  let skipped = 0;
   for (const [rel, bytes] of Object.entries(entries)) {
     const text = strFromU8(bytes);
     if (rel === ACTIVITY_PATH) {
+      if (
+        !overwrite &&
+        state.state.files.has(fileKey(agentId, ACTIVITY_PATH))
+      ) {
+        skipped++;
+        continue;
+      }
       state.state.files.set(fileKey(agentId, ACTIVITY_PATH), text);
       state.emitDomain("ActivityChanged", agentId);
       written++;
     } else if (rel.startsWith(TRANSCRIPTS)) {
       const transcript = JSON.parse(text) as FakeTranscript;
+      if (
+        !overwrite &&
+        state.state.histories.has(`${agentId}:${transcript.id}`)
+      ) {
+        skipped++;
+        continue;
+      }
       state.seedHistory(agentId, transcript.id, transcript.messages);
       written++;
     }
   }
-  return json({ written, skipped: 0, rejected: [], sessionsRebuilt: true });
+  return json({ written, skipped, rejected: [], sessionsRebuilt: true });
 }
 
 /** Dispatch `/agents/:id/migration/<action>`. */

--- a/packages/fake-host/src/routes-portable.ts
+++ b/packages/fake-host/src/routes-portable.ts
@@ -1,0 +1,155 @@
+/**
+ * The agent-scoped portable routes (`/agents/:id/portable/*`): the export
+ * inventory the share and copy wizards read, and the `.houstonagent` package
+ * they build. Backed by the SAME per-agent state the Skills, Routines and
+ * Memory surfaces serve.
+ *
+ * The archive is packed here with fflate in the domain's own layout
+ * (`packages/domain/src/portable.ts`: manifest.json, CLAUDE.md,
+ * skills/<slug>/SKILL.md, routines.json, learnings.json) rather than through
+ * `@houston/domain`, whose module graph reaches JSON schema imports Node's ESM
+ * loader refuses without import attributes. The browser unpacks the result
+ * with the REAL `unpackAgent`, so any drift here fails the copy spec loudly.
+ */
+
+import { type Learning, PORTABLE_FORMAT_VERSION } from "@houston/protocol";
+import { strToU8, zipSync } from "fflate";
+import { CORS, json, noContent } from "./http";
+import * as state from "./state";
+import { fileKey, ISO, LEARNINGS_PATH } from "./state-store";
+
+const CLAUDE_MD = "CLAUDE.md";
+
+/** The wire selection the web adapter posts (`portable-map.ts toWireSelection`). */
+export interface WirePortableSelection {
+  includeClaudeMd: boolean;
+  skillSlugs: string[];
+  routineIds: string[];
+  learningIds: string[];
+}
+
+/** The last export's selection, for a spec to assert what the copy carried. */
+let lastExportSelection: WirePortableSelection | null = null;
+export function lastPortableExport(): WirePortableSelection | null {
+  return lastExportSelection;
+}
+export function resetPortable(): void {
+  lastExportSelection = null;
+}
+
+function excerpt(text: string, max = 160): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length <= max ? flat : `${flat.slice(0, max)}…`;
+}
+
+function learningsOf(agentId: string): Learning[] {
+  try {
+    return JSON.parse(
+      state.state.files.get(fileKey(agentId, LEARNINGS_PATH)) || "[]",
+    ) as Learning[];
+  } catch {
+    return [];
+  }
+}
+
+function preview(agentId: string): Response {
+  const md = state.readAgentFile(agentId, CLAUDE_MD);
+  return json({
+    claudeMd:
+      md.trim() === ""
+        ? null
+        : { byteCount: Buffer.byteLength(md, "utf8"), excerpt: excerpt(md) },
+    skills: state.listSkills(agentId).map((s) => ({
+      slug: s.name,
+      description: s.description,
+      category: s.category,
+      image: s.image,
+      integrations: s.integrations,
+      featured: s.featured,
+    })),
+    routines: state.listRoutines(agentId).map((r) => ({
+      id: r.id,
+      name: r.name,
+      promptExcerpt: excerpt(r.prompt),
+      schedule: r.schedule,
+      enabled: r.enabled,
+      integrations: r.integrations,
+    })),
+    learnings: learningsOf(agentId).map((l) => ({
+      id: l.id,
+      text: l.text,
+      createdAt: l.created_at,
+    })),
+  });
+}
+
+function readSelection(
+  body: Record<string, unknown> | undefined,
+): WirePortableSelection {
+  const sel = (body?.selection ?? {}) as Partial<WirePortableSelection>;
+  const strings = (v: unknown) =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  return {
+    includeClaudeMd: Boolean(sel.includeClaudeMd),
+    skillSlugs: strings(sel.skillSlugs),
+    routineIds: strings(sel.routineIds),
+    learningIds: strings(sel.learningIds),
+  };
+}
+
+function exportPackage(
+  agentId: string,
+  body: Record<string, unknown> | undefined,
+): Response {
+  const agent = state.state.agents.find((a) => a.id === agentId);
+  if (!agent) return json({ error: { message: "agent not found" } }, 404);
+  const sel = readSelection(body);
+  lastExportSelection = sel;
+  const files: Record<string, Uint8Array> = {
+    "manifest.json": strToU8(
+      JSON.stringify({
+        agentName: agent.name,
+        houstonVersion: "fake-host",
+        createdAt: ISO,
+        anonymized: false,
+        formatVersion: PORTABLE_FORMAT_VERSION,
+      }),
+    ),
+  };
+  const md = state.readAgentFile(agentId, CLAUDE_MD);
+  if (sel.includeClaudeMd && md.trim() !== "") files[CLAUDE_MD] = strToU8(md);
+  for (const slug of sel.skillSlugs) {
+    const detail = state.loadSkill(agentId, slug);
+    if (detail) files[`skills/${slug}/SKILL.md`] = strToU8(detail.content);
+  }
+  const routines = state
+    .listRoutines(agentId)
+    .filter((r) => sel.routineIds.includes(r.id));
+  if (routines.length)
+    files["routines.json"] = strToU8(JSON.stringify(routines));
+  const learnings = learningsOf(agentId).filter((l) =>
+    sel.learningIds.includes(l.id),
+  );
+  if (learnings.length)
+    files["learnings.json"] = strToU8(JSON.stringify(learnings));
+  const bytes = zipSync(files);
+  // Copy into a fresh ArrayBuffer-backed view: `BodyInit` rejects a view over a
+  // possibly-shared buffer.
+  return new Response(new Uint8Array(bytes).buffer as ArrayBuffer, {
+    status: 200,
+    headers: { ...CORS, "Content-Type": "application/zip" },
+  });
+}
+
+/** Dispatch `/agents/:id/portable/<action>`. */
+export function handlePortableRoutes(
+  method: string,
+  agentId: string,
+  action: string | undefined,
+  body: Record<string, unknown> | undefined,
+): Response {
+  if (action === "preview" && method === "GET") return preview(agentId);
+  if (action === "export" && method === "POST")
+    return exportPackage(agentId, body);
+  return noContent(405);
+}

--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -19,6 +19,7 @@ import type { ProviderId } from "@houston/runtime-client";
 import { cancelChat, openChatStream, sendMessage } from "./chat";
 import { json, noContent } from "./http";
 import { handleWorkspaceFiles } from "./routes-files";
+import { handlePortableRoutes } from "./routes-portable";
 import * as state from "./state";
 
 /** Canned repo skills for the Add Skills GitHub tab (list-from-repo). A dozen
@@ -309,17 +310,9 @@ export function handleAgents(
     }
 
     case "portable":
-      // Share-with-a-friend export inventory. An empty (but well-shaped)
-      // preview is enough for the wizard to open; the default `{items: []}`
-      // fallthrough made `preview.skills.map` throw, silently closing it.
-      if (rest[2] === "preview" && method === "GET")
-        return json({
-          claudeMd: null,
-          skills: [],
-          routines: [],
-          learnings: [],
-        });
-      return noContent(405);
+      // Share / copy: the export inventory and the packaged `.houstonagent`,
+      // both from this agent's own state (routes-portable.ts).
+      return handlePortableRoutes(method, id, rest[2], body);
 
     default:
       console.warn(

--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -19,6 +19,7 @@ import type { ProviderId } from "@houston/runtime-client";
 import { cancelChat, openChatStream, sendMessage } from "./chat";
 import { json, noContent } from "./http";
 import { handleWorkspaceFiles } from "./routes-files";
+import { handleMigrationRoutes } from "./routes-migration";
 import { handlePortableRoutes } from "./routes-portable";
 import * as state from "./state";
 
@@ -48,7 +49,7 @@ export function handleAgents(
   rest: string[],
   req: Request,
   body: Record<string, unknown> | undefined,
-): Response {
+): Response | Promise<Response> {
   // /agents
   if (rest.length === 0) {
     if (method === "GET") return json(state.listAgents());
@@ -313,6 +314,11 @@ export function handleAgents(
       // Share / copy: the export inventory and the packaged `.houstonagent`,
       // both from this agent's own state (routes-portable.ts).
       return handlePortableRoutes(method, id, rest[2], body);
+
+    case "migration":
+      // The chats leg of "Copy an agent": zip the board + transcripts out of
+      // one agent, unpack them into another (routes-migration.ts).
+      return handleMigrationRoutes(method, id, rest[2], req, body);
 
     default:
       console.warn(

--- a/packages/host/src/routes/migration.test.ts
+++ b/packages/host/src/routes/migration.test.ts
@@ -413,3 +413,38 @@ test("export from one agent imports into another on the same host, sessions rebu
     board,
   );
 });
+
+test("import with sessions=0 writes the transcript but rebuilds no pi session", async () => {
+  const vfs = new FsVfs(tmp);
+  const agentDir = join(tmp, ROOT, "nosessions");
+  const transcript = JSON.stringify({
+    id: "activity-9",
+    title: "Copied",
+    createdAt: 1,
+    updatedAt: 2,
+    messages: [
+      { role: "user", content: "hi", ts: 1 },
+      { role: "assistant", content: "hello!", ts: 2 },
+    ],
+    needsSessionReplay: true,
+  });
+  const r = await call(
+    vfs,
+    "POST",
+    "migration/import",
+    zipOf({ ".houston/runtime/conversations/activity-9.json": transcript }),
+    { agentDir, url: "/?sessions=0" },
+  );
+  expect(r.status).toBe(200);
+  expect((r.body as { written: number }).written).toBe(1);
+  expect((r.body as { sessionsRebuilt: boolean }).sessionsRebuilt).toBe(false);
+  expect(
+    existsSync(join(agentDir, ".houston", "runtime", "sessions", "activity-9")),
+  ).toBe(false);
+  // The marker rides through verbatim for the runtime's first turn to consume.
+  expect(
+    await vfs.readText(
+      `${ROOT}/.houston/runtime/conversations/activity-9.json`,
+    ),
+  ).toContain('"needsSessionReplay":true');
+});

--- a/packages/host/src/routes/migration.test.ts
+++ b/packages/host/src/routes/migration.test.ts
@@ -343,3 +343,73 @@ test("imported transcripts re-synthesize pi sessions anchored at agentDir", asyn
   );
   expect((again.body as { skipped: number }).skipped).toBe(1);
 });
+
+// ── agent-to-agent copy ("Copy an agent" with chats) ────────────────────────
+
+test("export from one agent imports into another on the same host, sessions rebuilt", async () => {
+  const vfs = new FsVfs(tmp);
+  const copy: Agent = {
+    id: "Personal/Helper copy",
+    workspaceId: "Personal",
+    name: "Helper copy",
+    createdAt: 0,
+  };
+  const board = JSON.stringify([
+    { id: "act-9", title: "Plan a trip", status: "done", session_key: "s-9" },
+  ]);
+  const transcript = JSON.stringify({
+    id: "s-9",
+    title: "Plan a trip",
+    createdAt: 1,
+    updatedAt: 2,
+    messages: [
+      { role: "user", content: "plan it", ts: 1 },
+      { role: "assistant", content: "done", ts: 2 },
+    ],
+  });
+  await vfs.writeText(`${ROOT}/.houston/activity/activity.json`, board);
+  await vfs.writeText(
+    `${ROOT}/.houston/runtime/conversations/s-9.json`,
+    transcript,
+  );
+  // The paths the app plans: the board file plus one transcript per
+  // conversation, encoded the way the runtime names them.
+  const exported = await call(vfs, "POST", "migration/export", {
+    paths: [
+      ".houston/activity/activity.json",
+      ".houston/runtime/conversations/s-9.json",
+    ],
+  });
+  expect(exported.status).toBe(200);
+
+  const events: HoustonEvent[] = [];
+  const { res, captured } = fakeRes();
+  const copyDir = join(tmp, copy.id);
+  await handleMigration(
+    { vfs, paths, agentDir: copyDir },
+    { workspace: ws, agent: copy },
+    "POST",
+    "migration/import",
+    reqOf(exported.bytes as Buffer),
+    res,
+    (e) => events.push(e),
+  );
+  expect(captured.status).toBe(200);
+  const result = JSON.parse(captured.body?.toString("utf8") ?? "{}");
+  expect(result.written).toBe(2);
+  expect(result.sessionsRebuilt).toBe(true);
+  expect(events.map((e) => e.type).sort()).toEqual([
+    "ActivityChanged",
+    "ConversationsChanged",
+  ]);
+  expect(await vfs.readText(`${copy.id}/.houston/activity/activity.json`)).toBe(
+    board,
+  );
+  expect(
+    existsSync(join(copyDir, ".houston", "runtime", "sessions", "s-9")),
+  ).toBe(true);
+  // The source is untouched.
+  expect(await vfs.readText(`${ROOT}/.houston/activity/activity.json`)).toBe(
+    board,
+  );
+});

--- a/packages/host/src/routes/migration.ts
+++ b/packages/host/src/routes/migration.ts
@@ -103,11 +103,16 @@ export async function handleMigration(
       return true;
     }
     const url = new URL(req.url ?? "", "http://local");
+    // `sessions=0`: write the transcripts but rebuild no pi session from them.
+    // A caller that stamps `needsSessionReplay` on the transcripts instead
+    // ("Copy an agent") gets the history replayed into whichever backend the
+    // next turn runs on; a synthesized pi session on top would double it.
+    const synthesize = url.searchParams.get("sessions") !== "0";
     try {
       const { result, events } = await applyMigrationArchive({
         vfs,
         root,
-        agentDir: deps.agentDir,
+        agentDir: synthesize ? deps.agentDir : undefined,
         bytes,
         overwrite: url.searchParams.get("overwrite") === "1",
       });

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -39,6 +39,7 @@ import {
   appendUserMessage,
   consumeSessionReplay,
   getHistory,
+  stampSessionReplay,
 } from "../store/conversations";
 import { type ActingContext, runWithActingContext } from "./acting-context";
 import {
@@ -187,6 +188,11 @@ export async function execTurn(
   // finally's revoked-token eviction (PRODUCT-1355) can read it — the catch's
   // own `typed` is block-scoped. Streamed failures land in `providerError`.
   let thrownTyped: ProviderError | undefined;
+  // Whether THIS turn carried the conversation in as a replay preamble (a
+  // consumed `needsSessionReplay` marker or a cross-backend rebuild). Read at
+  // the end: a turn that replayed and then failed without a reply must re-arm
+  // the marker on a backend that persists nothing from a failed prompt.
+  let replayedHistory = false;
 
   // Stall watchdog: a provider stream that goes silent mid-turn resolves neither
   // success nor error and would hold the workdir lock until the socket dies.
@@ -340,6 +346,7 @@ export async function execTurn(
     // the same turn replays anyway, and a still-set marker would replay a
     // second copy on the turn after.
     const sessionWasReset = consumeSessionReplay(id);
+    replayedHistory = rebuilt || sessionWasReset;
     if (rebuilt) {
       // Cross-backend rebuild: the new backend cannot read the old backend's
       // session store, so the fresh session carries the conversation over via a
@@ -605,6 +612,20 @@ export async function execTurn(
       !interaction.pending
         ? planReadyFallback()
         : interaction.pending;
+    // The replay rode a prompt the model never answered. pi's session store
+    // keeps that prompt (the preamble is already in its history, so the next
+    // turn must NOT replay again); the Claude SDK persists nothing for a failed
+    // prompt, so without the marker the next attempt would start blank — the
+    // rate-limited first turn of a copied chat, then "what was my first
+    // message?" answered as if new.
+    if (
+      replayedHistory &&
+      (providerError || stopped) &&
+      !assistantText.trim() &&
+      conv.backendId !== "pi"
+    ) {
+      stampSessionReplay(id);
+    }
     appendAssistantMessage(id, assistantText, {
       tools,
       thinking: thinkingText || undefined,
@@ -746,6 +767,11 @@ export async function execTurn(
       );
     const typed = thrown.kind !== "unknown" ? thrown : undefined;
     thrownTyped = typed;
+    // The thrown twin of the re-arm above: a replayed turn that died before
+    // any reply leaves the Claude SDK with no persisted prompt to resume.
+    if (replayedHistory && !assistantText.trim() && conv.backendId !== "pi") {
+      stampSessionReplay(id);
+    }
     appendAssistantMessage(id, assistantText, {
       tools,
       thinking: thinkingText || undefined,

--- a/packages/runtime/src/store/conversation-truncate.test.ts
+++ b/packages/runtime/src/store/conversation-truncate.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./conversation-file";
 import {
   consumeSessionReplayAt,
+  stampSessionReplayAt,
   truncateConversationMutationAt,
 } from "./conversation-truncate";
 
@@ -93,4 +94,16 @@ test("consume on an untruncated or unknown conversation is false", () => {
   seedTwoTurns(dir);
   expect(consumeSessionReplayAt(dir, "c1")).toBe(false);
   expect(consumeSessionReplayAt(dir, "ghost")).toBe(false);
+});
+
+test("stampSessionReplayAt re-arms the marker durably, and only for a known conversation", () => {
+  const dir = freshDir();
+  seedTwoTurns(dir);
+  expect(consumeSessionReplayAt(dir, "c1")).toBe(false);
+  expect(stampSessionReplayAt(dir, "c1")).toBe(true);
+  expect(loadConversation(dir, "c1")?.needsSessionReplay).toBe(true);
+  // Consumed once, gone again: the re-arm is the same one-shot marker.
+  expect(consumeSessionReplayAt(dir, "c1")).toBe(true);
+  expect(consumeSessionReplayAt(dir, "c1")).toBe(false);
+  expect(stampSessionReplayAt(dir, "ghost")).toBe(false);
 });

--- a/packages/runtime/src/store/conversation-truncate.ts
+++ b/packages/runtime/src/store/conversation-truncate.ts
@@ -44,3 +44,18 @@ export function consumeSessionReplayAt(dir: string, id: string): boolean {
   saveConversation(dir, conv);
   return true;
 }
+
+/**
+ * Re-arm the replay marker without touching the transcript. exec-turn calls
+ * this when a turn that consumed the marker ended with NO assistant reply on a
+ * backend whose session store keeps nothing from a failed prompt (the Claude
+ * SDK): the replayed history never reached a persisted session, so the next
+ * attempt must carry it in again or the conversation starts blank.
+ */
+export function stampSessionReplayAt(dir: string, id: string): boolean {
+  const conv = loadConversation(dir, id);
+  if (!conv) return false;
+  conv.needsSessionReplay = true;
+  saveConversation(dir, conv);
+  return true;
+}

--- a/packages/runtime/src/store/conversations.ts
+++ b/packages/runtime/src/store/conversations.ts
@@ -19,6 +19,7 @@ import {
 } from "./conversation-file";
 import {
   consumeSessionReplayAt,
+  stampSessionReplayAt,
   truncateConversationMutationAt,
 } from "./conversation-truncate";
 import { snapshotMessage, type TranscriptShadow } from "./transcript-shadow";
@@ -104,6 +105,7 @@ export function createConversationStore(
       return { removed: result.removed };
     },
     consumeSessionReplay: (id: string) => consumeSessionReplayAt(dir, id),
+    stampSessionReplay: (id: string) => stampSessionReplayAt(dir, id),
   };
 }
 
@@ -168,3 +170,4 @@ export const renameConversation = store.renameConversation;
 export const deleteConversation = store.deleteConversation;
 export const truncateConversation = store.truncateConversation;
 export const consumeSessionReplay = store.consumeSessionReplay;
+export const stampSessionReplay = store.stampSessionReplay;

--- a/packages/web/e2e/copy-agent.spec.ts
+++ b/packages/web/e2e/copy-agent.spec.ts
@@ -1,4 +1,9 @@
 import {
+  FAKE_HOST_URL,
+  SEED_AGENT_ID,
+  SEED_AGENT_NAME,
+} from "@houston/fake-host";
+import {
   COPY_SOURCE,
   createDialog,
   lastCopySelection,
@@ -8,7 +13,7 @@ import {
   seedCopySource,
 } from "./support/copy-agent";
 import { expect, test } from "./support/fixtures";
-import { rail, screen } from "./support/team-nav";
+import { litRows, rail, screen } from "./support/team-nav";
 
 /**
  * "Copy an agent": the create dialog's third door. Pick one of your agents,
@@ -134,4 +139,68 @@ test("a bare source skips the list screens; chats stay behind by default", async
     rail(page).getByText("Houston copy", { exact: true }),
   ).toBeVisible();
   await expect(screen(page).getByText("Plan a trip to Tokyo")).toHaveCount(0);
+});
+
+/**
+ * On a server-backed host the copy is filed in a team by a gateway write, and
+ * the roster only knows it after the round trip. Landing must wait for that:
+ * navigating before it resolved the copy to the DEFAULT team, so the rail
+ * lit "New Team" and its board showed the source's tasks instead of the copy.
+ */
+test("a copy started from a server team's New agent row lands on that team, focused on the copy", async ({
+  page,
+}) => {
+  const OPS_TEAM = "team-ops";
+  const base = FAKE_HOST_URL;
+  await page.request.post(`${base}/__test__/capabilities`, {
+    data: { multiplayer: true, teams: true, agentTeams: true, role: "owner" },
+  });
+  await page.request.post(`${base}/__test__/org`, {
+    data: { agents: [{ id: SEED_AGENT_ID, name: SEED_AGENT_NAME }] },
+  });
+  await page.request.post(`${base}/__test__/agent-teams`, {
+    data: {
+      teams: [
+        { id: "team-acme", name: "Acme", isDefault: true, sortOrder: 0 },
+        {
+          id: OPS_TEAM,
+          name: "Operations",
+          sortOrder: 1,
+          members: [{ userId: "u-self", owner: true }],
+        },
+      ],
+    },
+  });
+  await page.goto("/");
+  await expect(page.getByText("Your teams")).toBeVisible();
+
+  const opsBlock = rail(page).locator(
+    `[data-sidebar-drop-section="${OPS_TEAM}"]`,
+  );
+  await opsBlock.getByRole("button", { name: "New agent" }).click();
+  await openCopyWizard(page);
+  const dialog = createDialog(page);
+  await dialog.getByRole("button", { name: "Houston", exact: true }).click();
+  await expect(dialog.getByText("Based on Houston"))
+    .toBeVisible()
+    .catch(async () => {
+      // Walk past whichever content screens the seed fills.
+      for (let i = 0; i < 4; i++) {
+        if (await dialog.getByText("Based on Houston").isVisible()) break;
+        await next(page);
+      }
+    });
+  await expect(dialog.getByText("Based on Houston")).toBeVisible();
+  await dialog.getByRole("button", { name: "Create Agent" }).click();
+  await expect(dialog).toBeHidden();
+
+  // The copy sits in Operations, its rail row is the current one, and the
+  // screen is the copy's own board: not the default team's.
+  await expect(opsBlock).toContainText("Houston copy");
+  await expect(litRows(opsBlock.locator("[data-sidebar-item]"))).toContainText(
+    "Houston copy",
+  );
+  await expect(screen(page).locator("[data-agent-screen]")).toContainText(
+    "Houston copy",
+  );
 });

--- a/packages/web/e2e/copy-agent.spec.ts
+++ b/packages/web/e2e/copy-agent.spec.ts
@@ -201,15 +201,12 @@ test("a copy started from a server team's New agent row lands on that team, focu
   await openCopyWizard(page);
   const dialog = createDialog(page);
   await dialog.getByRole("button", { name: "Houston", exact: true }).click();
-  await expect(dialog.getByText("Based on Houston"))
-    .toBeVisible()
-    .catch(async () => {
-      // Walk past whichever content screens the seed fills.
-      for (let i = 0; i < 4; i++) {
-        if (await dialog.getByText("Based on Houston").isVisible()) break;
-        await next(page);
-      }
-    });
+  // The seed carries learnings but no routines or skills: the know screen,
+  // then the name.
+  await expect(
+    dialog.getByRole("heading", { name: "What should the copy know?" }),
+  ).toBeVisible();
+  await next(page);
   await expect(dialog.getByText("Based on Houston")).toBeVisible();
   await dialog.getByRole("button", { name: "Create Agent" }).click();
   await expect(dialog).toBeHidden();

--- a/packages/web/e2e/copy-agent.spec.ts
+++ b/packages/web/e2e/copy-agent.spec.ts
@@ -46,7 +46,7 @@ test("copies an agent, leaving chosen items behind and bringing the chats", asyn
   await rowSwitch(page, COPY_SOURCE.learnings[1]).click();
   await expect(rowSwitch(page, COPY_SOURCE.learnings[1])).not.toBeChecked();
   // Chats start OFF; bring them this time.
-  const chats = rowSwitch(page, "Tasks and their conversations");
+  const chats = rowSwitch(page, "Conversations");
   await expect(chats).not.toBeChecked();
   await chats.click();
   await expect(chats).toBeChecked();
@@ -125,9 +125,7 @@ test("a bare source skips the list screens; chats stay behind by default", async
   await expect(
     dialog.getByText("Houston has no job description yet."),
   ).toBeVisible();
-  await expect(
-    rowSwitch(page, "Tasks and their conversations"),
-  ).not.toBeChecked();
+  await expect(rowSwitch(page, "Conversations")).not.toBeChecked();
   await next(page);
   await expect(dialog.getByText("Based on Houston")).toBeVisible();
   await dialog.getByRole("button", { name: "Create Agent" }).click();

--- a/packages/web/e2e/copy-agent.spec.ts
+++ b/packages/web/e2e/copy-agent.spec.ts
@@ -8,16 +8,18 @@ import {
   seedCopySource,
 } from "./support/copy-agent";
 import { expect, test } from "./support/fixtures";
-import { rail } from "./support/team-nav";
+import { rail, screen } from "./support/team-nav";
 
 /**
  * "Copy an agent": the create dialog's third door. Pick one of your agents,
  * then decide, item by item, what the new agent keeps: job description and
- * learnings, routines, skills, everything ON to start. The copy is the
- * portable pipeline (preview, package, install) fed that selection, so the
- * fake host records what the package carried and the spec asserts it.
+ * learnings, routines, skills, everything ON to start, and the chats, OFF to
+ * start. The copy is the portable pipeline (preview, package, install) fed
+ * that selection, so the fake host records what the package carried and the
+ * spec asserts it; the chats ride the agent-scoped migration routes afterwards
+ * and land on the copy's board.
  */
-test("copies an agent, leaving chosen items behind", async ({
+test("copies an agent, leaving chosen items behind and bringing the chats", async ({
   page,
   request,
 }) => {
@@ -43,6 +45,11 @@ test("copies an agent, leaving chosen items behind", async ({
   }
   await rowSwitch(page, COPY_SOURCE.learnings[1]).click();
   await expect(rowSwitch(page, COPY_SOURCE.learnings[1])).not.toBeChecked();
+  // Chats start OFF; bring them this time.
+  const chats = rowSwitch(page, "Tasks and their conversations");
+  await expect(chats).not.toBeChecked();
+  await chats.click();
+  await expect(chats).toBeChecked();
   await next(page);
 
   // Routines, then skills. Keep the routine, drop the skill with "Clear".
@@ -81,14 +88,21 @@ test("copies an agent, leaving chosen items behind", async ({
     routineIds: [routineId],
     learningIds: ["learn-1"],
   });
+
+  // The chats followed in the background: the source's tasks are on the
+  // copy's board (the landing screen), and the toast says so.
+  await expect(page.getByText("Chats copied")).toBeVisible();
+  await expect(screen(page).getByText("Plan a trip to Tokyo")).toBeVisible();
+  await expect(screen(page).getByText("Draft the launch email")).toBeVisible();
 });
 
 /**
- * A source with nothing to pick from goes straight from the list to its name:
- * no screen ever renders empty. Back from the source list returns to the
+ * A source with no routines or skills skips those screens; the "know" screen
+ * always shows since the chats choice exists for every source. Left OFF, the
+ * copy's board starts empty. Back from the source list returns to the
  * dialog's chooser.
  */
-test("a bare source skips the content screens; back returns to the chooser", async ({
+test("a bare source skips the list screens; chats stay behind by default", async ({
   page,
 }) => {
   await page.goto("/");
@@ -111,6 +125,15 @@ test("a bare source skips the content screens; back returns to the chooser", asy
   await expect(
     dialog.getByText("Houston has no job description yet."),
   ).toBeVisible();
+  await expect(
+    rowSwitch(page, "Tasks and their conversations"),
+  ).not.toBeChecked();
   await next(page);
   await expect(dialog.getByText("Based on Houston")).toBeVisible();
+  await dialog.getByRole("button", { name: "Create Agent" }).click();
+  await expect(dialog).toBeHidden();
+  await expect(
+    rail(page).getByText("Houston copy", { exact: true }),
+  ).toBeVisible();
+  await expect(screen(page).getByText("Plan a trip to Tokyo")).toHaveCount(0);
 });

--- a/packages/web/e2e/copy-agent.spec.ts
+++ b/packages/web/e2e/copy-agent.spec.ts
@@ -99,6 +99,26 @@ test("copies an agent, leaving chosen items behind and bringing the chats", asyn
   await expect(page.getByText("Chats copied")).toBeVisible();
   await expect(screen(page).getByText("Plan a trip to Tokyo")).toBeVisible();
   await expect(screen(page).getByText("Draft the launch email")).toBeVisible();
+
+  // Under FRESH ids: a task id and its chat key are global in the app, so a
+  // verbatim copy would resolve the copy's chats to the source agent.
+  const agents = (await (
+    await request.get(`${FAKE_HOST_URL}/agents`)
+  ).json()) as {
+    id: string;
+    name: string;
+  }[];
+  const copy = agents.find((a) => a.name === "Houston copy");
+  expect(copy).toBeTruthy();
+  const rows = (await (
+    await request.get(`${FAKE_HOST_URL}/agents/${copy?.id}/activities`)
+  ).json()) as { items: { id: string; title: string }[] };
+  expect(rows.items.map((r) => r.title).sort()).toEqual([
+    "Draft the launch email",
+    "Plan a trip to Tokyo",
+  ]);
+  expect(rows.items.map((r) => r.id)).not.toContain("act-1");
+  expect(rows.items.map((r) => r.id)).not.toContain("act-2");
 });
 
 /**

--- a/packages/web/e2e/copy-agent.spec.ts
+++ b/packages/web/e2e/copy-agent.spec.ts
@@ -1,0 +1,116 @@
+import {
+  COPY_SOURCE,
+  createDialog,
+  lastCopySelection,
+  next,
+  openCopyWizard,
+  rowSwitch,
+  seedCopySource,
+} from "./support/copy-agent";
+import { expect, test } from "./support/fixtures";
+import { rail } from "./support/team-nav";
+
+/**
+ * "Copy an agent": the create dialog's third door. Pick one of your agents,
+ * then decide, item by item, what the new agent keeps: job description and
+ * learnings, routines, skills, everything ON to start. The copy is the
+ * portable pipeline (preview, package, install) fed that selection, so the
+ * fake host records what the package carried and the spec asserts it.
+ */
+test("copies an agent, leaving chosen items behind", async ({
+  page,
+  request,
+}) => {
+  const { routineId } = await seedCopySource(request);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "New agent" }).click();
+  await openCopyWizard(page);
+
+  // The seeded agent is the one source; picking it reads its content and
+  // moves on to the first content screen by itself.
+  const dialog = createDialog(page);
+  await dialog.getByRole("button", { name: "Houston", exact: true }).click();
+  await expect(
+    dialog.getByRole("heading", { name: "What should the copy know?" }),
+  ).toBeVisible();
+
+  // Job description and both learnings, all on. Leave one learning behind.
+  await expect(rowSwitch(page, "Job description and rules")).toBeChecked();
+  await expect(dialog.getByText(COPY_SOURCE.instructions)).toBeVisible();
+  for (const text of COPY_SOURCE.learnings) {
+    await expect(rowSwitch(page, text)).toBeChecked();
+  }
+  await rowSwitch(page, COPY_SOURCE.learnings[1]).click();
+  await expect(rowSwitch(page, COPY_SOURCE.learnings[1])).not.toBeChecked();
+  await next(page);
+
+  // Routines, then skills. Keep the routine, drop the skill with "Clear".
+  await expect(
+    dialog.getByRole("heading", { name: "Which routines should come along?" }),
+  ).toBeVisible();
+  await expect(rowSwitch(page, COPY_SOURCE.routine.name)).toBeChecked();
+  await next(page);
+  await expect(
+    dialog.getByRole("heading", { name: "Which skills should come along?" }),
+  ).toBeVisible();
+  await expect(rowSwitch(page, "Invoice Triage")).toBeChecked();
+  await dialog.getByRole("button", { name: "Clear", exact: true }).click();
+  await expect(rowSwitch(page, "Invoice Triage")).not.toBeChecked();
+  await next(page);
+
+  // The naming screen is the create dialog's own, pre-filled with the first
+  // free "<name> copy" and headed by the source.
+  await expect(dialog.getByText("Based on Houston")).toBeVisible();
+  const nameField = dialog.getByPlaceholder(
+    "e.g. Product manager, Sales, Jerry",
+  );
+  await expect(nameField).toHaveValue("Houston copy");
+  await dialog.getByRole("button", { name: "Create Agent" }).click();
+
+  // The copy lands in the rail and the dialog is gone.
+  await expect(
+    rail(page).getByText("Houston copy", { exact: true }),
+  ).toBeVisible();
+  await expect(dialog).toBeHidden();
+
+  // What the package carried is exactly what stayed switched on.
+  expect(await lastCopySelection(request)).toEqual({
+    includeClaudeMd: true,
+    skillSlugs: [],
+    routineIds: [routineId],
+    learningIds: ["learn-1"],
+  });
+});
+
+/**
+ * A source with nothing to pick from goes straight from the list to its name:
+ * no screen ever renders empty. Back from the source list returns to the
+ * dialog's chooser.
+ */
+test("a bare source skips the content screens; back returns to the chooser", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New agent" }).click();
+  await openCopyWizard(page);
+
+  const dialog = createDialog(page);
+  await dialog.getByRole("button", { name: "Back", exact: true }).click();
+  await expect(
+    dialog.getByRole("button", { name: "Create new", exact: true }),
+  ).toBeVisible();
+
+  await openCopyWizard(page);
+  await dialog.getByRole("button", { name: "Houston", exact: true }).click();
+  // The seed's Memory tab has learnings, so the first content screen shows;
+  // no job description, no routines, no skills.
+  await expect(
+    dialog.getByRole("heading", { name: "What should the copy know?" }),
+  ).toBeVisible();
+  await expect(
+    dialog.getByText("Houston has no job description yet."),
+  ).toBeVisible();
+  await next(page);
+  await expect(dialog.getByText("Based on Houston")).toBeVisible();
+});

--- a/packages/web/e2e/mobile/copy-agent.spec.ts
+++ b/packages/web/e2e/mobile/copy-agent.spec.ts
@@ -1,0 +1,63 @@
+import {
+  COPY_SOURCE,
+  createDialog,
+  next,
+  openCopyWizard,
+  rowSwitch,
+  seedCopySource,
+} from "../support/copy-agent";
+import { expect, test } from "../support/fixtures";
+import { screen } from "../support/team-nav";
+
+/**
+ * The phone runs the SAME copy wizard inside the same create dialog; only the
+ * door differs (the Agents home title row's New-agent control). The chooser's
+ * tiles stack as full-width rows below 768px, and every wizard screen fits
+ * the phone dialog without horizontal overflow.
+ */
+test("copies an agent from the Agents home on the phone", async ({
+  page,
+  request,
+}) => {
+  await seedCopySource(request);
+  await page.goto("/");
+  await expect(screen(page)).toHaveAttribute("data-screen", "agents-home");
+
+  await screen(page).getByTestId("agents-home-new-agent").click();
+  const dialog = createDialog(page);
+  // Three choices, stacked: each tile is as wide as the dialog's content.
+  const tiles = dialog.getByRole("button", {
+    name: /^(From the store|Create new|Copy an agent)$/,
+  });
+  await expect(tiles).toHaveCount(3);
+  const boxes = await tiles.evaluateAll((els) =>
+    els.map((el) => el.getBoundingClientRect()),
+  );
+  for (const box of boxes) expect(box.width).toBe(boxes[0].width);
+  expect(boxes[1].top).toBeGreaterThan(boxes[0].bottom - 1);
+
+  await openCopyWizard(page);
+  await dialog.getByRole("button", { name: "Houston", exact: true }).click();
+  await expect(rowSwitch(page, "Job description and rules")).toBeChecked();
+  await rowSwitch(page, COPY_SOURCE.learnings[0]).click();
+  await next(page);
+  await expect(rowSwitch(page, COPY_SOURCE.routine.name)).toBeChecked();
+  await next(page);
+  await expect(rowSwitch(page, "Invoice Triage")).toBeChecked();
+  await next(page);
+
+  await expect(dialog.getByText("Based on Houston")).toBeVisible();
+  await dialog.getByRole("button", { name: "Create Agent" }).click();
+  await expect(dialog).toBeHidden();
+
+  // Nothing forced the document wider than the phone.
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth,
+  );
+  expect(overflow).toBe(false);
+  // The copy opens on its own Tasks screen, the same landing every create
+  // door uses; its header names it.
+  await expect(
+    screen(page).getByRole("heading", { level: 1, name: "Houston copy" }),
+  ).toBeVisible();
+});

--- a/packages/web/e2e/support/copy-agent.ts
+++ b/packages/web/e2e/support/copy-agent.ts
@@ -1,0 +1,80 @@
+import { FAKE_HOST_URL, SEED_AGENT_ID } from "@houston/fake-host";
+import {
+  type APIRequestContext,
+  expect,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+
+/**
+ * The create dialog's "Copy an agent" door, shared by the desktop and phone
+ * specs: the same wizard renders on both breakpoints, only the control that
+ * opens the dialog differs (the rail's row vs the Agents home title row).
+ */
+
+/** Content the seeded agent gets so every wizard screen has something to show. */
+export const COPY_SOURCE = {
+  instructions: "You are the ops assistant. Keep answers short.",
+  routine: { name: "Daily digest", prompt: "Summarize yesterday's tickets." },
+  skill: { name: "invoice-triage", description: "Sort incoming invoices." },
+  // From the fake host's seeded Memory tab.
+  learnings: [
+    "Exclude churned accounts from pipeline math.",
+    "Prefers metric units in every report.",
+  ],
+};
+
+/** Give the seeded agent a job description, one routine and one skill. */
+export async function seedCopySource(
+  request: APIRequestContext,
+): Promise<{ routineId: string }> {
+  const base = `${FAKE_HOST_URL}/agents/${SEED_AGENT_ID}`;
+  await request.put(`${base}/agentfile/CLAUDE.md`, {
+    data: { content: COPY_SOURCE.instructions },
+  });
+  const routine = await request.post(`${base}/routines`, {
+    data: COPY_SOURCE.routine,
+  });
+  const { id } = (await routine.json()) as { id: string };
+  await request.post(`${base}/skills`, {
+    data: { ...COPY_SOURCE.skill, content: "# Invoice triage" },
+  });
+  return { routineId: id };
+}
+
+/** The selection the last export carried, as the fake host recorded it. */
+export async function lastCopySelection(request: APIRequestContext): Promise<{
+  includeClaudeMd: boolean;
+  skillSlugs: string[];
+  routineIds: string[];
+  learningIds: string[];
+} | null> {
+  const res = await request.get(`${FAKE_HOST_URL}/__test__/portable-export`);
+  return ((await res.json()) as { selection: never }).selection;
+}
+
+export function createDialog(page: Page): Locator {
+  return page.getByRole("dialog");
+}
+
+/** From the open create dialog, walk into the copy wizard's source list. */
+export async function openCopyWizard(page: Page): Promise<void> {
+  const tile = createDialog(page).getByRole("button", {
+    name: "Copy an agent",
+    exact: true,
+  });
+  await tile.waitFor({ state: "visible" });
+  await tile.click();
+  await expect(page.getByTestId("copy-agent-sources")).toBeVisible();
+}
+
+/** The switch for one row, by the row's title (the switch's accessible name). */
+export function rowSwitch(page: Page, title: string): Locator {
+  return createDialog(page).getByRole("switch", { name: title });
+}
+
+export async function next(page: Page): Promise<void> {
+  await createDialog(page)
+    .getByRole("button", { name: "Continue", exact: true })
+    .click();
+}

--- a/packages/web/src/engine-adapter/client/portable-mixin.ts
+++ b/packages/web/src/engine-adapter/client/portable-mixin.ts
@@ -1,4 +1,5 @@
 import type {
+  MigrationImportOptions,
   MigrationImportResult,
   PortableAnonymizeRequest,
   PortableAnonymizeResponse,
@@ -79,7 +80,7 @@ export function PortableMixin<TBase extends BaseCtor>(Base: TBase) {
     async migrationImport(
       agentPath: string,
       bytes: ArrayBuffer,
-      opts?: { overwrite?: boolean },
+      opts?: MigrationImportOptions,
     ): Promise<MigrationImportResult> {
       if (!this.ctx.cp)
         throw new Error("Copying agent data needs a connected host.");

--- a/packages/web/src/engine-adapter/client/portable-mixin.ts
+++ b/packages/web/src/engine-adapter/client/portable-mixin.ts
@@ -9,6 +9,7 @@ import type {
   PortableScanResponse,
   PortableUploadPreviewResponse,
 } from "../../../../../ui/engine-client/src/types";
+import * as migration from "../migration";
 import * as portable from "../portable";
 import { importFromStoreLink } from "../portable-from-store";
 import type { BaseCtor } from "./mixin";
@@ -73,7 +74,7 @@ export function PortableMixin<TBase extends BaseCtor>(Base: TBase) {
     ): Promise<ArrayBuffer> {
       if (!this.ctx.cp)
         throw new Error("Copying agent data needs a connected host.");
-      return portable.migrationExport(this.ctx.cp, agentPath, paths);
+      return migration.migrationExport(this.ctx.cp, agentPath, paths);
     }
     async migrationImport(
       agentPath: string,
@@ -82,7 +83,7 @@ export function PortableMixin<TBase extends BaseCtor>(Base: TBase) {
     ): Promise<MigrationImportResult> {
       if (!this.ctx.cp)
         throw new Error("Copying agent data needs a connected host.");
-      return portable.migrationImport(this.ctx.cp, agentPath, bytes, opts);
+      return migration.migrationImport(this.ctx.cp, agentPath, bytes, opts);
     }
   }
   return Portable;

--- a/packages/web/src/engine-adapter/client/portable-mixin.ts
+++ b/packages/web/src/engine-adapter/client/portable-mixin.ts
@@ -1,4 +1,5 @@
 import type {
+  MigrationImportResult,
   PortableAnonymizeRequest,
   PortableAnonymizeResponse,
   PortableExportRequest,
@@ -64,6 +65,24 @@ export function PortableMixin<TBase extends BaseCtor>(Base: TBase) {
       if (!this.ctx.cp)
         throw new Error("Importing an agent needs a connected host.");
       return portable.install(this.ctx.cp, req);
+    }
+    // ---- agent data migration (agent-scoped export/import) — host only ----
+    async migrationExport(
+      agentPath: string,
+      paths: string[],
+    ): Promise<ArrayBuffer> {
+      if (!this.ctx.cp)
+        throw new Error("Copying agent data needs a connected host.");
+      return portable.migrationExport(this.ctx.cp, agentPath, paths);
+    }
+    async migrationImport(
+      agentPath: string,
+      bytes: ArrayBuffer,
+      opts?: { overwrite?: boolean },
+    ): Promise<MigrationImportResult> {
+      if (!this.ctx.cp)
+        throw new Error("Copying agent data needs a connected host.");
+      return portable.migrationImport(this.ctx.cp, agentPath, bytes, opts);
     }
   }
   return Portable;

--- a/packages/web/src/engine-adapter/migration.ts
+++ b/packages/web/src/engine-adapter/migration.ts
@@ -1,0 +1,44 @@
+/**
+ * The agent-scoped migration routes on the new engine: the export/import pair
+ * the desktop→cloud migration uses, reachable for any agent the caller manages
+ * ("Copy an agent" moves the source's chats through it). Same transport as the
+ * portable routes (`hostFetch`: live bearer + 401 replay + active space pin).
+ */
+
+import type { MigrationImportResult } from "../../../../ui/engine-client/src/types";
+import type { ControlPlaneConfig } from "./control-plane";
+import { hostFetch } from "./portable";
+
+/** Zip the requested in-scope paths of one agent (the migration export route). */
+export async function migrationExport(
+  cfg: ControlPlaneConfig,
+  agentId: string,
+  paths: string[],
+): Promise<ArrayBuffer> {
+  const res = await hostFetch(
+    cfg,
+    `/agents/${encodeURIComponent(agentId)}/migration/export`,
+    { method: "POST", body: JSON.stringify({ paths }) },
+  );
+  return await res.arrayBuffer();
+}
+
+/** Unpack one zip chunk into an agent (the migration import route). */
+export async function migrationImport(
+  cfg: ControlPlaneConfig,
+  agentId: string,
+  bytes: ArrayBuffer,
+  opts?: { overwrite?: boolean },
+): Promise<MigrationImportResult> {
+  const query = opts?.overwrite ? "?overwrite=1" : "";
+  const res = await hostFetch(
+    cfg,
+    `/agents/${encodeURIComponent(agentId)}/migration/import${query}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/zip" },
+      body: bytes,
+    },
+  );
+  return (await res.json()) as MigrationImportResult;
+}

--- a/packages/web/src/engine-adapter/migration.ts
+++ b/packages/web/src/engine-adapter/migration.ts
@@ -5,7 +5,10 @@
  * portable routes (`hostFetch`: live bearer + 401 replay + active space pin).
  */
 
-import type { MigrationImportResult } from "../../../../ui/engine-client/src/types";
+import type {
+  MigrationImportOptions,
+  MigrationImportResult,
+} from "../../../../ui/engine-client/src/types";
 import type { ControlPlaneConfig } from "./control-plane";
 import { hostFetch } from "./portable";
 
@@ -28,9 +31,12 @@ export async function migrationImport(
   cfg: ControlPlaneConfig,
   agentId: string,
   bytes: ArrayBuffer,
-  opts?: { overwrite?: boolean },
+  opts?: MigrationImportOptions,
 ): Promise<MigrationImportResult> {
-  const query = opts?.overwrite ? "?overwrite=1" : "";
+  const q = new URLSearchParams();
+  if (opts?.overwrite) q.set("overwrite", "1");
+  if (opts?.sessions === false) q.set("sessions", "0");
+  const query = q.size ? `?${q.toString()}` : "";
   const res = await hostFetch(
     cfg,
     `/agents/${encodeURIComponent(agentId)}/migration/import${query}`,

--- a/packages/web/src/engine-adapter/portable.ts
+++ b/packages/web/src/engine-adapter/portable.ts
@@ -19,6 +19,7 @@ import {
   unpackAgent,
 } from "@houston/domain";
 import type {
+  MigrationImportResult,
   PortableAnonymizeRequest,
   PortableAnonymizeResponse,
   PortableExportRequest,
@@ -182,4 +183,38 @@ export async function install(
     requiredIntegrations: [],
     agent,
   };
+}
+
+/** Zip the requested in-scope paths of one agent (the migration export route). */
+export async function migrationExport(
+  cfg: ControlPlaneConfig,
+  agentId: string,
+  paths: string[],
+): Promise<ArrayBuffer> {
+  const res = await hostFetch(
+    cfg,
+    `/agents/${encodeURIComponent(agentId)}/migration/export`,
+    { method: "POST", body: JSON.stringify({ paths }) },
+  );
+  return await res.arrayBuffer();
+}
+
+/** Unpack one zip chunk into an agent (the migration import route). */
+export async function migrationImport(
+  cfg: ControlPlaneConfig,
+  agentId: string,
+  bytes: ArrayBuffer,
+  opts?: { overwrite?: boolean },
+): Promise<MigrationImportResult> {
+  const query = opts?.overwrite ? "?overwrite=1" : "";
+  const res = await hostFetch(
+    cfg,
+    `/agents/${encodeURIComponent(agentId)}/migration/import${query}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/zip" },
+      body: bytes,
+    },
+  );
+  return (await res.json()) as MigrationImportResult;
 }

--- a/packages/web/src/engine-adapter/portable.ts
+++ b/packages/web/src/engine-adapter/portable.ts
@@ -19,7 +19,6 @@ import {
   unpackAgent,
 } from "@houston/domain";
 import type {
-  MigrationImportResult,
   PortableAnonymizeRequest,
   PortableAnonymizeResponse,
   PortableExportRequest,
@@ -183,38 +182,4 @@ export async function install(
     requiredIntegrations: [],
     agent,
   };
-}
-
-/** Zip the requested in-scope paths of one agent (the migration export route). */
-export async function migrationExport(
-  cfg: ControlPlaneConfig,
-  agentId: string,
-  paths: string[],
-): Promise<ArrayBuffer> {
-  const res = await hostFetch(
-    cfg,
-    `/agents/${encodeURIComponent(agentId)}/migration/export`,
-    { method: "POST", body: JSON.stringify({ paths }) },
-  );
-  return await res.arrayBuffer();
-}
-
-/** Unpack one zip chunk into an agent (the migration import route). */
-export async function migrationImport(
-  cfg: ControlPlaneConfig,
-  agentId: string,
-  bytes: ArrayBuffer,
-  opts?: { overwrite?: boolean },
-): Promise<MigrationImportResult> {
-  const query = opts?.overwrite ? "?overwrite=1" : "";
-  const res = await hostFetch(
-    cfg,
-    `/agents/${encodeURIComponent(agentId)}/migration/import${query}`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/zip" },
-      body: bytes,
-    },
-  );
-  return (await res.json()) as MigrationImportResult;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       canvas-confetti:
         specifier: 1.9.4
         version: 1.9.4
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
       framer-motion:
         specifier: 12.42.2
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -76,6 +76,7 @@ import type {
   IntegrationProviderStatus,
   IntegrationToolkit,
   ListWorktreesRequest,
+  MigrationImportOptions,
   MigrationImportResult,
   MyAgent,
   NewActivity,
@@ -2691,9 +2692,12 @@ export class HoustonClient {
   async migrationImport(
     agentPath: string,
     bytes: ArrayBuffer,
-    opts?: { overwrite?: boolean },
+    opts?: MigrationImportOptions,
   ): Promise<MigrationImportResult> {
-    const query = opts?.overwrite ? "?overwrite=1" : "";
+    const q = new URLSearchParams();
+    if (opts?.overwrite) q.set("overwrite", "1");
+    if (opts?.sessions === false) q.set("sessions", "0");
+    const query = q.size ? `?${q.toString()}` : "";
     const res = await this.send(
       () => ({
         url: `${this.baseUrl}/v1/agents/${encodeURIComponent(agentPath)}/migration/import${query}`,

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -2688,18 +2688,31 @@ export class HoustonClient {
     if (!res.ok) throw await this.toError(res);
     return await res.arrayBuffer();
   }
-  migrationImport(
+  async migrationImport(
     agentPath: string,
     bytes: ArrayBuffer,
     opts?: { overwrite?: boolean },
   ): Promise<MigrationImportResult> {
     const query = opts?.overwrite ? "?overwrite=1" : "";
-    return this.rawRequest(
-      "POST",
-      `/agents/${encodeURIComponent(agentPath)}/migration/import${query}`,
-      bytes,
-      "application/zip",
+    const res = await this.send(
+      () => ({
+        url: `${this.baseUrl}/v1/agents/${encodeURIComponent(agentPath)}/migration/import${query}`,
+        init: {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            ...this.orgHeaders(),
+            "Content-Type": "application/zip",
+          },
+          body: bytes,
+        },
+      }),
+      // Idempotent by design (skip-existing per entry), so a replay against a
+      // host still coming up lands the same files once.
+      true,
     );
+    if (!res.ok) throw await this.toError(res);
+    return (await res.json()) as MigrationImportResult;
   }
 
   // ---------- Agent Store publication (account-based, no manage tokens) ----------

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -76,6 +76,7 @@ import type {
   IntegrationProviderStatus,
   IntegrationToolkit,
   ListWorktreesRequest,
+  MigrationImportResult,
   MyAgent,
   NewActivity,
   NewRoutine,
@@ -2656,6 +2657,49 @@ export class HoustonClient {
   }
   importInstall(req: PortableInstallRequest): Promise<PortableInstalledAgent> {
     return this.request("POST", "/store/imports/install", req);
+  }
+
+  // ---------- agent data migration (agent-scoped, HOU-719 routes) ----------
+  //
+  // The same export/import pair the desktop→cloud migration uses, reachable on
+  // any host for any agent the caller manages: "Copy an agent" moves the
+  // source's chats into the copy through it. Paths are agent-root relative
+  // and must sit inside the host's migration scope.
+
+  async migrationExport(
+    agentPath: string,
+    paths: string[],
+  ): Promise<ArrayBuffer> {
+    const res = await this.send(
+      () => ({
+        url: `${this.baseUrl}/v1/agents/${encodeURIComponent(agentPath)}/migration/export`,
+        init: {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            ...this.orgHeaders(),
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ paths }),
+        },
+      }),
+      true, // read-only POST: zips and returns, writes nothing
+    );
+    if (!res.ok) throw await this.toError(res);
+    return await res.arrayBuffer();
+  }
+  migrationImport(
+    agentPath: string,
+    bytes: ArrayBuffer,
+    opts?: { overwrite?: boolean },
+  ): Promise<MigrationImportResult> {
+    const query = opts?.overwrite ? "?overwrite=1" : "";
+    return this.rawRequest(
+      "POST",
+      `/agents/${encodeURIComponent(agentPath)}/migration/import${query}`,
+      bytes,
+      "application/zip",
+    );
   }
 
   // ---------- Agent Store publication (account-based, no manage tokens) ----------

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1960,6 +1960,15 @@ export interface PortableManifestSummary {
   formatVersion: number;
 }
 
+/** One import request's outcome on the agent-scoped migration route. */
+export interface MigrationImportResult {
+  written: number;
+  skipped: number;
+  rejected: { path: string; reason: string }[];
+  /** False when the deployment has no on-disk agent dir to anchor chat sessions. */
+  sessionsRebuilt: boolean;
+}
+
 export interface PortableUploadPreviewResponse {
   packageId: string;
   manifest: PortableManifestSummary;

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1960,6 +1960,15 @@ export interface PortableManifestSummary {
   formatVersion: number;
 }
 
+export interface MigrationImportOptions {
+  /** Replace files the target already has (a retry over a partial first try). */
+  overwrite?: boolean;
+  /** `false`: write the transcripts but rebuild no pi session from them; the
+   *  caller stamps `needsSessionReplay` on the transcripts instead so the
+   *  next turn replays the history into whichever backend runs it. */
+  sessions?: boolean;
+}
+
 /** One import request's outcome on the agent-scoped migration route. */
 export interface MigrationImportResult {
   written: number;


### PR DESCRIPTION
## Summary

PRODUCT-1678 asks for a third option in the create-agent dialog that lets a non-technical user model a new agent on one they already have, choosing item by item what comes along.

This adds a **Copy an agent** tile next to *From the store* and *Create new*. Picking it opens a short wizard inside the same dialog:

1. **Which agent should we copy?** One row per agent the user manages.
2. **What should the copy know?** The job description (one switch, with an excerpt) and each learning, all on by default, plus **Chats**: one "Conversations" switch, OFF by default, subtitled with how many conversations the source has had. A source with none shows that instead of a switch.
3. **Which routines should come along?** One switch per routine.
4. **Which skills should come along?** One switch per skill.
5. The regular naming screen, pre-filled with the first free `<name> copy` and the source's color, headed *Based on \<source\>*.

The routines and skills screens are skipped when the source has none; the "know" screen always shows because the chats choice exists for every source.

### How it works

- The copy reuses the portable pipeline the Settings *Copy agent* row already runs (`useCopyAgent`: preview, package, in-browser unpack, create-with-seeds), now accepting a `selection`, a `color`, and the analytics `source`. No new host or gateway route, so it works on the local host and the cloud gateway alike.
- The wizard's state lives in `useCopyAgentWizard`; the pure step list and selection rules are in `copy-agent-wizard-model.ts` (unit-tested).
- The import wizard's private pick list was extracted to `portable/pick-list-step.tsx` and shared with the new screens.
- Copies do not start the self-setup mission, the same as the Settings copy row.
- **Chats** ride the agent-scoped migration export/import routes the desktop-to-cloud migration already uses (`/agents/:id/migration/export` + `/import`), batch by batch (board file + one transcript per conversation), after the copy exists and in the background, since on the hosted profile the copy's pod may still be waking. The import re-synthesizes the chat sessions on the target. A toast reports when the chats land or fail. Every archive is rewritten before import so the copy's tasks and conversations get **fresh ids** (`app/src/lib/copy-chat-remap.ts`): a task id and its conversation key are global in the app (the cross-agent sweep, the chat panel and notifications resolve a conversation by key alone), so a verbatim copy made the copy's chats resolve to the source agent and reads as "messages in the copy are not sent". `migrationExport`/`migrationImport` were added to the engine client and the web adapter.
- After the copy is filed in a server team, the board opens only once that move has settled (`useMoveAgentTeam` now resolves on settle). Navigating earlier resolved the copy to the default team, so the rail lit that team and its board showed the source's tasks.
- The wizard footer stacks its padding on the safe-area inset (`pb-safe` alone replaced it with 0 on desktop, leaving Back/Continue flush with the card edge).

### Web app and phone

- The create-dialog chooser and the sidebar's create chooser render their tiles as full-width rows below 768px (`md:` keeps the square tiles on desktop, pixel-identical), so three choices fit a phone dialog.
- The wizard's body scrolls under a fixed footer with the safe-area padding on both breakpoints.
- Desktop and phone e2e specs walk the whole flow.

### Fake host

The fake host now serves the portable preview from its per-agent state (job description, skills, routines, learnings) and packs a real `.houstonagent` archive with fflate in the domain's layout. It also models the migration export/import pair over its board and history state so the chats copy runs end to end in the spec. The browser unpacks it with the real `unpackAgent`, and a `/__test__/portable-export` control route exposes what the last export carried so the spec asserts the selection.

### Review round

Two independent reviews (Fable 5.1 and GPT-6 Astra) of the diff both confirmed the id-collision root cause above and raised the following, all applied: transcripts land before the board file, which goes last and replaces only an empty target board; a board the copy already filled or a rejected file is reported as a partial copy, never as success; the team move resolves through `mutateAsync` so a dismissed dialog cannot strand the landing and the chats copy; copied chats keep their key families (a routine chat stays `routine-<id>`) and drop running status and native-session / run references; the import leg waits out a waking engine and is replay-safe; the Copy tile only shows when the caller manages an agent; wizard copy no longer says conversations stay behind; one shared `SwitchRow`; h1s on the type scale; the fake importer skips existing files like the real one.

### Continuity on every provider

Copied transcripts carry the runtime's one-shot `needsSessionReplay` marker and the import skips the pi session synthesis (`?sessions=0`), so the copy's first turn in each chat replays the history as the HOU-951 preamble on whichever backend runs it (pi providers and the Claude SDK alike). The copied task rows drop the source's `claude_session_id`, which made the copy try to resume an SDK session it never had. A replayed turn that ends without a reply (a rate limit on the first try) re-arms the marker on the Claude backend, whose session store keeps nothing from a failed prompt. Verified on a scratch local host: every prompt in the copy's session file starts with the "Continuing an existing conversation" preamble followed by the source transcript.

**Known limitations, not addressed here (pre-existing in the migration import):** on the cloud profile the gateway's transcript authority learns a conversation only from runtime appends, so an imported chat is invisible while the copy is asleep under database authority until its first turn. Mission Control also still keys its cross-agent maps by session key alone, which the fresh ids avoid rather than fix.

## Verification

Checks run: Biome, app `tsgo`, app unit tests, `check-locales`, fake-host typecheck and vitest, web typecheck and e2e typecheck, `check:boundaries`, and the Playwright specs `copy-agent` (chromium + mobile) plus a host test proving the real migration routes move a board and transcript between two agents and rebuild the session, and the existing `agents`, `agent-onboarding`, `boot`, `agent-teams`, `tour`, `mobile/agents-home`, and `mobile/onboarding` specs.

**Before:** open *New agent* from the rail (or the Agents home on a phone). The dialog offers only *From the store* and *Create new*; the only way to duplicate an agent is the Settings *Copy agent* row, which copies everything with no per-item choice.

**After:**
1. Open *New agent*. A third tile, *Copy an agent*, is present (on a phone the three tiles stack as rows).
2. Pick it, then pick a source agent.
3. Turn off one learning on the first screen, switch Chats on, keep the routines, clear the skills, continue to the name.
4. Create. The copy lands in the rail with the chosen name and color, its Settings show only the items left switched on, and a moment later a "Chats copied" toast appears with the source's tasks and conversations on the copy's board.
5. Same flow at 390px wide in the web app: no horizontal overflow, the copy opens on its Tasks screen.

## Screenshots

Desktop and phone screenshots of the chooser, the first content screen, and the naming screen are attached to the Linear issue.






