### PR TITLE
fix(runtime): a completed provider login clears the stale auth-failure mark

### DIFF
--- a/packages/runtime/src/auth/login-clears-marks.test.ts
+++ b/packages/runtime/src/auth/login-clears-marks.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+
+// The data dir is pinned BEFORE the dynamic imports: the marks are persisted
+// there and auth.json is written by the completed login.
+process.env.HOUSTON_DATA_DIR = mkdtempSync(join(tmpdir(), "houston-login-"));
+
+// Never spawn the real Claude CLI from a test.
+vi.mock("./anthropic-cli-binary", () => ({
+  resolveClaudeCliBinary: () => null,
+}));
+// A fingerprint that CANNOT see the new credential — the macOS Keychain case,
+// where the Claude CLI writes nothing the fingerprint reads. Without this the
+// fingerprint change would heal the mark on its own and prove nothing.
+vi.mock("./credential-fingerprint", () => ({
+  credentialFingerprint: () => "absent|absent",
+}));
+
+const { authFailureActive, noteAuthFailure, resetAuthFailures } = await import(
+  "./credential-health"
+);
+const { getAuthStatus, startLogin } = await import("./login");
+const { modelRuntime } = await import("./storage");
+
+test("a completed login clears the provider's stale auth-failure mark even when the fingerprint cannot see the new credential", async () => {
+  noteAuthFailure("openai-codex");
+  expect(authFailureActive("openai-codex")).toBe(true);
+
+  const spy = vi.spyOn(modelRuntime, "getProvider").mockImplementation(
+    (id: string) =>
+      ({
+        id,
+        name: id,
+        auth: {
+          oauth: {
+            name: id,
+            login: async (
+              interaction: import("@earendil-works/pi-ai").AuthInteraction,
+            ) => {
+              interaction.notify({
+                type: "device_code",
+                userCode: "ABCD-1234",
+                verificationUri: "https://auth.example/device",
+              });
+              return {
+                type: "oauth",
+                access: "access",
+                refresh: "refresh",
+                expires: Date.now() + 60_000,
+              };
+            },
+          },
+        },
+      }) as never,
+  );
+  try {
+    await startLogin("openai-codex", true);
+    await vi.waitFor(async () => {
+      const row = (await getAuthStatus()).providers.find(
+        (p) => p.provider === "openai-codex",
+      );
+      expect(row?.login?.status).toBe("complete");
+    });
+    expect(authFailureActive("openai-codex")).toBe(false);
+  } finally {
+    spy.mockRestore();
+    resetAuthFailures();
+  }
+});

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -36,6 +36,7 @@ import {
 import { resolveClaudeCliBinary } from "./anthropic-cli-binary";
 import { runAnthropicLogin } from "./anthropic-cli-login";
 import { preflightCodexCallbackPort } from "./codex-port-preflight";
+import { clearProviderMarks } from "./credential-health";
 import {
   anthropicServedHere,
   serveModeOn,
@@ -466,6 +467,12 @@ export async function startLogin(
   void login
     .then(() => {
       clearLoginExpiry(state);
+      // A completed login IS a new credential, whether or not the fingerprint
+      // can see it: on macOS the Claude CLI lands the credential in the
+      // Keychain, which the fingerprint never reads, so a stale "this
+      // credential failed" mark would outlive the re-login and keep reporting
+      // the provider disconnected right after the user signed in.
+      clearProviderMarks(provider);
       state.status = "complete";
       console.log(`[oauth:${provider}] login complete`);
     })


### PR DESCRIPTION
## Summary

On a Mac-hosted engine (dev host, self-host), signing in to Claude again after a token expiry left the provider reporting **needs_reconnect / Connect** even though the login completed and the toast said "Signed in to Anthropic".

Cause: a turn had failed `unauthenticated` (expired OAuth session), which persisted an auth-failure mark keyed by the credential fingerprint. On macOS the Claude CLI lands the new credential in the Keychain, which the fingerprint never reads, so the fingerprint stayed `absent|absent` and the mark could only heal on a clean turn. Meanwhile `providerUsable` reported the provider not configured, so the UI kept offering Connect.

Fix: a completed login (any provider) clears that provider's marks in `login.ts`, the one change the fingerprint cannot see. A failed or cancelled login clears nothing.

## Tests

`packages/runtime/src/auth/login-clears-marks.test.ts` pins the fingerprint to `absent|absent`, records a mark, completes a stubbed device-code login, and asserts the mark is gone. Fails without the fix.

Gates: `pnpm check`, runtime typecheck, runtime auth tests (34 pass).