### PR TITLE
fix(app): settle a deferred migration task quietly instead of reporting the dead source host

### DIFF
--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -74,6 +74,9 @@ export type AnalyticsEventName =
   | "cloud_migration_started"
   | "cloud_migration_agent_done"
   | "cloud_migration_agent_failed"
+  // The user chose "Migrate later" while this agent's task was in flight, so
+  // the task was abandoned, never failed (`step` is where it stood).
+  | "cloud_migration_agent_deferred"
   | "cloud_migration_completed"
   | "cloud_migration_skipped"
   | "cloud_migration_deferred"

--- a/app/src/lib/cloud-migration-runner.ts
+++ b/app/src/lib/cloud-migration-runner.ts
@@ -2,7 +2,9 @@
  * Per-agent migration runner (HOU-719): drives ONE task through
  * creating → warming → uploading → finalizing, reporting each transition to
  * the store. Throws `MigrationStepError` (carrying the failed step) so the
- * store can park the task in a retryable error state — never a silent skip.
+ * store can park the task in a retryable error state — never a silent skip —
+ * and `MigrationAbandonedError` once the user has deferred the run (see
+ * `cloud-migration-step.ts`).
  */
 
 import { runProvisioningProbe } from "./agent-provisioning";
@@ -10,8 +12,8 @@ import { chunkPaths, type MigrationTask } from "./cloud-migration";
 import type {
   AgentMigrationProgress,
   MigrationCounts,
-  MigrationStep,
 } from "./cloud-migration-progress";
+import { type RunnableStep, runStep } from "./cloud-migration-step";
 import {
   completeAgentMigration,
   exportSourceZip,
@@ -19,15 +21,6 @@ import {
   type SourceHostHandshake,
 } from "./cloud-migration-transport";
 import { getEngine } from "./engine";
-
-export class MigrationStepError extends Error {
-  readonly step: Exclude<MigrationStep, "error">;
-  constructor(step: Exclude<MigrationStep, "error">, cause: unknown) {
-    super(cause instanceof Error ? cause.message : String(cause));
-    this.name = "MigrationStepError";
-    this.step = step;
-  }
-}
 
 /** The cloud agents are created as ordinary personal assistants. */
 const MIGRATED_AGENT_CONFIG_ID = "personal-assistant";
@@ -41,19 +34,9 @@ export interface RunTaskDeps {
   patchProgress: (patch: Partial<AgentMigrationProgress>) => void;
   /** Retry run — imports pass `overwrite=1` to land over a partial attempt. */
   overwrite: boolean;
-}
-
-async function step<T>(
-  name: Exclude<MigrationStep, "error">,
-  work: () => Promise<T>,
-): Promise<T> {
-  try {
-    return await work();
-  } catch (err) {
-    throw err instanceof MigrationStepError
-      ? err
-      : new MigrationStepError(name, err);
-  }
+  /** True once the user chose "Migrate later": no further step may start,
+   *  the source host every export needs is already gone. */
+  isAbandoned: () => boolean;
 }
 
 /**
@@ -86,6 +69,8 @@ export async function runMigrationTask(
   task: MigrationTask,
   deps: RunTaskDeps,
 ): Promise<MigrationCounts> {
+  const step = <T>(name: RunnableStep, work: () => Promise<T>) =>
+    runStep(name, work, deps.isAbandoned);
   // 1. Create the cloud agent — unless a previous attempt already did (the
   //    Retry path must never mint a duplicate).
   let agentId = deps.getProgress().createdAgentId;

--- a/app/src/lib/cloud-migration-step.ts
+++ b/app/src/lib/cloud-migration-step.ts
@@ -1,0 +1,75 @@
+/**
+ * The per-step envelope of the cloud-migration runner (HOU-719), kept
+ * dependency-free so it is `node --test`-able: a failure carries the step it
+ * failed in (`MigrationStepError`) so the store can park the row in a
+ * retryable error state, and no step starts once the user has bailed out of
+ * the run (`MigrationAbandonedError`).
+ */
+
+import type { MigrationStep } from "./cloud-migration-progress.ts";
+
+export type RunnableStep = Exclude<MigrationStep, "error">;
+
+export class MigrationStepError extends Error {
+  readonly step: RunnableStep;
+  constructor(step: RunnableStep, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "MigrationStepError";
+    this.step = step;
+  }
+}
+
+/**
+ * The user chose "Migrate later" while this task was in flight. Deferring
+ * kills the loopback source host at once, so any later export against it is
+ * guaranteed to fail with a transport error that looks like a bug but is the
+ * user's own bail-out. The runner throws this instead of starting the step.
+ */
+export class MigrationAbandonedError extends Error {
+  constructor() {
+    super("migration deferred by the user while a task was in flight");
+    this.name = "MigrationAbandonedError";
+  }
+}
+
+/** Run one step: refuse to start once abandoned, tag any failure with `name`. */
+export async function runStep<T>(
+  name: RunnableStep,
+  work: () => Promise<T>,
+  isAbandoned: () => boolean,
+): Promise<T> {
+  if (isAbandoned()) throw new MigrationAbandonedError();
+  try {
+    return await work();
+  } catch (err) {
+    throw err instanceof MigrationStepError
+      ? err
+      : new MigrationStepError(name, err);
+  }
+}
+
+export type TaskFailureOutcome =
+  /** Expected: the run was deferred; the row goes back to `pending`. */
+  | { kind: "abandoned" }
+  /** A real failure: park the row in `error` and report it. */
+  | { kind: "failed"; step: RunnableStep; message: string };
+
+/**
+ * A failure that lands after the user deferred is the consequence of the
+ * teardown, not a defect — whether the runner refused the step or a fetch
+ * raced the source-host stop between the guard and the request — so
+ * `deferred` decides, never the error's shape.
+ */
+export function taskFailureOutcome(
+  err: unknown,
+  deferred: boolean,
+): TaskFailureOutcome {
+  if (deferred || err instanceof MigrationAbandonedError) {
+    return { kind: "abandoned" };
+  }
+  return {
+    kind: "failed",
+    step: err instanceof MigrationStepError ? err.step : "uploading",
+    message: err instanceof Error ? err.message : String(err),
+  };
+}

--- a/app/src/stores/cloud-migration-finish.ts
+++ b/app/src/stores/cloud-migration-finish.ts
@@ -1,13 +1,15 @@
 /**
- * Shared tail of a cloud-migration run (HOU-719): stop the source host,
- * refresh the agent list the shell will render, fire the completion analytics.
- * Split from `stores/cloud-migration.ts` so the driver store stays focused on
- * the per-task state machine.
+ * Shared tails of a cloud-migration run (HOU-719): how one task's failure
+ * settles, and the end of the whole run (stop the source host, refresh the
+ * agent list the shell will render, fire the completion analytics). Split
+ * from `stores/cloud-migration.ts` so the driver store stays focused on the
+ * per-task state machine.
  */
 
 import { analytics } from "../lib/analytics";
 import type { MigrationTask } from "../lib/cloud-migration";
 import type { AgentMigrationProgress } from "../lib/cloud-migration-progress";
+import { taskFailureOutcome } from "../lib/cloud-migration-step";
 import { reportError } from "../lib/error-report";
 import { osStopMigrationSourceHost } from "../lib/os-bridge";
 import { useAgentStore } from "./agents";
@@ -16,6 +18,34 @@ import { useWorkspaceStore } from "./workspaces";
 export interface FinishSnapshot {
   tasks: MigrationTask[];
   progress: Record<string, AgentMigrationProgress>;
+}
+
+/**
+ * A task that failed AFTER the user chose "Migrate later" was abandoned, not
+ * broken: the source host is already gone, so the failure is the bail-out's
+ * own consequence. It goes back to `pending` (the Settings resume re-runs
+ * it) with nothing to report. Any other failure parks the row in the
+ * retryable `error` state and reaches Sentry.
+ */
+export function settleTaskFailure(
+  patch: (patch: Partial<AgentMigrationProgress>) => void,
+  current: AgentMigrationProgress | undefined,
+  err: unknown,
+  deferred: boolean,
+): void {
+  const outcome = taskFailureOutcome(err, deferred);
+  if (outcome.kind === "abandoned") {
+    analytics.track("cloud_migration_agent_deferred", { step: current?.step });
+    patch({ step: "pending", errorStep: undefined, errorMessage: undefined });
+    return;
+  }
+  patch({
+    step: "error",
+    errorStep: outcome.step,
+    errorMessage: outcome.message,
+  });
+  analytics.track("cloud_migration_agent_failed", { step: outcome.step });
+  reportError("cloud_migration_agent", outcome.message, err);
 }
 
 export async function finishRun(

--- a/app/src/stores/cloud-migration.ts
+++ b/app/src/stores/cloud-migration.ts
@@ -21,10 +21,7 @@ import {
   type AgentMigrationProgress,
   initialProgress,
 } from "../lib/cloud-migration-progress";
-import {
-  MigrationStepError,
-  runMigrationTask,
-} from "../lib/cloud-migration-runner";
+import { runMigrationTask } from "../lib/cloud-migration-runner";
 import type { SourceHostHandshake } from "../lib/cloud-migration-transport";
 import { reportError } from "../lib/error-report";
 import {
@@ -33,7 +30,7 @@ import {
   osStopMigrationSourceHost,
 } from "../lib/os-bridge";
 import { useAgentStore } from "./agents";
-import { finishRun } from "./cloud-migration-finish";
+import { finishRun, settleTaskFailure } from "./cloud-migration-finish";
 import { useWorkspaceStore } from "./workspaces";
 
 export type CloudMigrationScreen = "offer" | "progress" | "done";
@@ -104,25 +101,24 @@ export const useCloudMigrationStore = create<CloudMigrationState>(
           getProgress: () => get().progress[task.sourceId],
           patchProgress: (patch) => patchProgress(set, task.sourceId, patch),
           overwrite,
+          isAbandoned: () => get().deferred,
         });
         analytics.track("cloud_migration_agent_done", {
           bytes: task.manifest.totalBytes,
         });
       } catch (err) {
-        const step = err instanceof MigrationStepError ? err.step : "uploading";
-        const message = err instanceof Error ? err.message : String(err);
-        patchProgress(set, task.sourceId, {
-          step: "error",
-          errorStep: step,
-          errorMessage: message,
-        });
-        analytics.track("cloud_migration_agent_failed", { step });
-        reportError("cloud_migration_agent", message, err);
+        settleTaskFailure(
+          (patch) => patchProgress(set, task.sourceId, patch),
+          get().progress[task.sourceId],
+          err,
+          get().deferred,
+        );
       }
     };
 
-    // Shared tail (stop source host, refresh agents, analytics) lives in
-    // `cloud-migration-finish.ts`; it flips the screen through this callback.
+    // Shared tails (per-task failure; stop source host, refresh agents,
+    // analytics) live in `cloud-migration-finish.ts`; the run tail flips the
+    // screen through this callback.
     const finish = () => finishRun(get, () => set(() => ({ screen: "done" })));
 
     const settleIfAllDone = async () => {

--- a/app/tests/cloud-migration-step.test.ts
+++ b/app/tests/cloud-migration-step.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MigrationAbandonedError,
+  MigrationStepError,
+  runStep,
+  taskFailureOutcome,
+} from "../src/lib/cloud-migration-step.ts";
+
+// ── runStep ────────────────────────────────────────────────────────────
+
+test("runStep resolves the work's value while the run is live", async () => {
+  const value = await runStep(
+    "uploading",
+    async () => 42,
+    () => false,
+  );
+  assert.equal(value, 42);
+});
+
+test("runStep tags a raw failure with the step it failed in", async () => {
+  await assert.rejects(
+    runStep(
+      "warming",
+      async () => {
+        throw new TypeError("Load failed (127.0.0.1:60003)");
+      },
+      () => false,
+    ),
+    (err: unknown) =>
+      err instanceof MigrationStepError &&
+      err.step === "warming" &&
+      err.message === "Load failed (127.0.0.1:60003)",
+  );
+});
+
+test("runStep passes an already-tagged failure through unchanged", async () => {
+  const inner = new MigrationStepError("creating", new Error("boom"));
+  await assert.rejects(
+    runStep(
+      "uploading",
+      async () => {
+        throw inner;
+      },
+      () => false,
+    ),
+    (err: unknown) => err === inner,
+  );
+});
+
+// "Migrate later" mid-run: the source host is already stopped, so the step
+// must never start (the export would only produce a phantom transport error).
+test("runStep refuses to start once the run is abandoned", async () => {
+  let started = false;
+  await assert.rejects(
+    runStep(
+      "uploading",
+      async () => {
+        started = true;
+      },
+      () => true,
+    ),
+    (err: unknown) => err instanceof MigrationAbandonedError,
+  );
+  assert.equal(started, false);
+});
+
+test("runStep re-reads the abandon flag at every step", async () => {
+  let deferred = false;
+  await runStep(
+    "creating",
+    async () => undefined,
+    () => deferred,
+  );
+  deferred = true;
+  await assert.rejects(
+    runStep(
+      "warming",
+      async () => undefined,
+      () => deferred,
+    ),
+    MigrationAbandonedError,
+  );
+});
+
+// ── taskFailureOutcome ─────────────────────────────────────────────────
+
+test("an abandoned step settles as abandoned", () => {
+  assert.deepEqual(taskFailureOutcome(new MigrationAbandonedError(), true), {
+    kind: "abandoned",
+  });
+});
+
+test("a transport error racing the source-host stop is abandoned, not failed", () => {
+  // The fetch left before the guard saw `deferred`; the store reads the flag
+  // at settle time, so the phantom "Load failed" never becomes an error row.
+  const err = new MigrationStepError(
+    "uploading",
+    new TypeError("Load failed (127.0.0.1:60003)"),
+  );
+  assert.deepEqual(taskFailureOutcome(err, true), { kind: "abandoned" });
+});
+
+test("the same transport error on a live run is a real failure", () => {
+  const err = new MigrationStepError(
+    "uploading",
+    new TypeError("Load failed (127.0.0.1:60003)"),
+  );
+  assert.deepEqual(taskFailureOutcome(err, false), {
+    kind: "failed",
+    step: "uploading",
+    message: "Load failed (127.0.0.1:60003)",
+  });
+});
+
+test("an untagged failure defaults to the uploading step", () => {
+  assert.deepEqual(taskFailureOutcome("disk full", false), {
+    kind: "failed",
+    step: "uploading",
+    message: "disk full",
+  });
+});


### PR DESCRIPTION
## Sentry

[HOUSTON-APP-4PG](https://houston-cd.sentry.io/issues/7555911741/) flipped to regressed on 2026-09-07 with one 0.6.18 event: `cloud_migration_agent: Load failed (127.0.0.1:60003)` thrown from the migration runner's `step`.

## Root cause

The event's breadcrumbs (and 4 of the 5 earlier `Load failed (127.0.0.1:<port>)` events on 0.5.x) show the same sequence:

1. A task sits in **warming**: the new cloud agent's `config.json` probe answers 503 while its pod wakes.
2. The user clicks **Migrate later**. `deferMigration()` flips `deferred` and invokes `stop_migration_source_host`; the wizard unmounts.
3. The in-flight task keeps running. When the probe answers 200 the runner moves to **uploading** and POSTs `/migration/export` to the loopback source host that was just killed. WebKit reports `Load failed`.
4. `runTask`'s catch parks the row in `error` and calls `reportError("cloud_migration_agent")`, so a failure the user caused on purpose reaches Sentry as a bug.

Nothing was lost in any of these runs: the migration stays resumable from Settings, and the gateway's per-agent import markers skip agents that already landed.

### Why 4PG keeps "regressing"

4PG is a bucket. The Sentry project's server-side rule `value:"Load failed*" -> renderer-load-failed` groups every "Load failed" from any source into it (PRODUCT-1665). It was resolved for the offline quiet-class leak in 0.6.18 (PR #1484) and for the unhandled-rejection flavor in 0.6.3 (PR #1334); both fixes hold. This is a third, unrelated flavor that has existed since the wizard shipped and was rare enough never to surface on its own.

## Fix

- `lib/cloud-migration-step.ts` (new, dependency-free): `runStep` refuses to start a step once the run is abandoned (`MigrationAbandonedError`) and still tags real failures with their step (`MigrationStepError` moved here). `taskFailureOutcome(err, deferred)` decides how a failure settles: `deferred` wins, so a fetch that raced the stop between the guard and the request is also abandoned, never an error.
- Runner takes an `isAbandoned` dep; the store passes `() => get().deferred`.
- `settleTaskFailure` (in `cloud-migration-finish.ts`): an abandoned task goes back to `pending` with a `cloud_migration_agent_deferred` analytics event and no Sentry capture. Any other failure parks in `error`, tracks `cloud_migration_agent_failed` and reports, exactly as before.

## Tests

`app/tests/cloud-migration-step.test.ts`: step tagging, pass-through of tagged errors, refusal once abandoned (work never starts), flag re-read per step, and the three settle outcomes (abandoned error, racing transport error while deferred, same transport error on a live run = real failure).

`pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (4026 pass), `pnpm check-locales` all green.

PRODUCT-1690