### PR TITLE
fix(app): keep migration uploads under the ingress body deadline (PRODUCT-1688)

### DIFF
--- a/app/src/lib/cloud-migration-step.ts
+++ b/app/src/lib/cloud-migration-step.ts
@@ -7,13 +7,19 @@
  */
 
 import type { MigrationStep } from "./cloud-migration-progress.ts";
+import { isNetworkTransportError } from "./network-transport-error.ts";
 
 export type RunnableStep = Exclude<MigrationStep, "error">;
 
+/**
+ * Keeps the wrapped failure on `cause`: the error-surfacing layer classifies
+ * a connectivity drop by the browser's `TypeError`, which the envelope alone
+ * would hide (every upload cut by the network then filed as a bug).
+ */
 export class MigrationStepError extends Error {
   readonly step: RunnableStep;
   constructor(step: RunnableStep, cause: unknown) {
-    super(cause instanceof Error ? cause.message : String(cause));
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
     this.name = "MigrationStepError";
     this.step = step;
   }
@@ -52,7 +58,22 @@ export type TaskFailureOutcome =
   /** Expected: the run was deferred; the row goes back to `pending`. */
   | { kind: "abandoned" }
   /** A real failure: park the row in `error` and report it. */
-  | { kind: "failed"; step: RunnableStep; message: string };
+  | {
+      kind: "failed";
+      step: RunnableStep;
+      message: string;
+      /** The failure under the step envelope: what Sentry classifies on. */
+      cause: unknown;
+      /** The request never got an answer (device offline, upload cut by the
+       *  network): the row shows authored copy, the report takes the quiet
+       *  connectivity path instead of filing a bug. */
+      transport: boolean;
+    };
+
+/** The failure a step envelope wraps; anything else is its own cause. */
+export function migrationFailureCause(err: unknown): unknown {
+  return err instanceof MigrationStepError ? err.cause : err;
+}
 
 /**
  * A failure that lands after the user deferred is the consequence of the
@@ -67,9 +88,12 @@ export function taskFailureOutcome(
   if (deferred || err instanceof MigrationAbandonedError) {
     return { kind: "abandoned" };
   }
+  const cause = migrationFailureCause(err);
   return {
     kind: "failed",
     step: err instanceof MigrationStepError ? err.step : "uploading",
     message: err instanceof Error ? err.message : String(err),
+    cause,
+    transport: isNetworkTransportError(cause),
   };
 }

--- a/app/src/lib/cloud-migration.ts
+++ b/app/src/lib/cloud-migration.ts
@@ -140,11 +140,14 @@ export function buildMigrationPlan(
 }
 
 /**
- * Per-request budget of RAW (pre-zip) bytes. The gateway caps a compressed
- * import request at 64 MB; 48 MB of raw input stays safely under it even for
- * incompressible content.
+ * Per-request budget of RAW (pre-zip) bytes. The binding constraint is TIME,
+ * not the gateway's 64 MB import cap: the cloud ingress closes any request
+ * whose body has not fully arrived within 60 s, with no response, so the
+ * wizard sees a bare transport drop ("Failed to fetch" / "Load failed") and
+ * every retry of that chunk dies the same way. 48 MB chunks needed a 6+ Mbps
+ * uplink to make it; 8 MB clears the deadline on a 2 Mbps home connection.
  */
-export const MAX_CHUNK_RAW_BYTES = 48 * 1024 * 1024;
+export const MAX_CHUNK_RAW_BYTES = 8 * 1024 * 1024;
 
 export interface UploadChunk {
   paths: string[];

--- a/app/src/locales/en/migration.json
+++ b/app/src/locales/en/migration.json
@@ -1,6 +1,7 @@
 {
   "transport": {
     "notConnected": "We can't reach the cloud right now. Check your connection and try again.",
+    "interrupted": "The upload was interrupted. Check your connection and retry.",
     "signedOut": "Sign in again to keep moving your data."
   },
   "offer": {

--- a/app/src/locales/es/migration.json
+++ b/app/src/locales/es/migration.json
@@ -1,6 +1,7 @@
 {
   "transport": {
     "notConnected": "No podemos conectarnos a la nube en este momento. Revisa tu conexión e intenta de nuevo.",
+    "interrupted": "La subida se interrumpió. Revisa tu conexión e intenta de nuevo.",
     "signedOut": "Inicia sesión de nuevo para seguir moviendo tus datos."
   },
   "offer": {

--- a/app/src/locales/pt/migration.json
+++ b/app/src/locales/pt/migration.json
@@ -1,6 +1,7 @@
 {
   "transport": {
     "notConnected": "Não conseguimos falar com a nuvem agora. Verifique sua conexão e tente de novo.",
+    "interrupted": "O envio foi interrompido. Verifique sua conexão e tente de novo.",
     "signedOut": "Entre na sua conta de novo para continuar movendo seus dados."
   },
   "offer": {

--- a/app/src/stores/cloud-migration-finish.ts
+++ b/app/src/stores/cloud-migration-finish.ts
@@ -11,6 +11,7 @@ import type { MigrationTask } from "../lib/cloud-migration";
 import type { AgentMigrationProgress } from "../lib/cloud-migration-progress";
 import { taskFailureOutcome } from "../lib/cloud-migration-step";
 import { reportError } from "../lib/error-report";
+import i18n from "../lib/i18n";
 import { osStopMigrationSourceHost } from "../lib/os-bridge";
 import { useAgentStore } from "./agents";
 import { useWorkspaceStore } from "./workspaces";
@@ -25,7 +26,9 @@ export interface FinishSnapshot {
  * broken: the source host is already gone, so the failure is the bail-out's
  * own consequence. It goes back to `pending` (the Settings resume re-runs
  * it) with nothing to report. Any other failure parks the row in the
- * retryable `error` state and reaches Sentry.
+ * retryable `error` state and reaches Sentry — a connectivity drop with
+ * authored copy on the row and the quiet connectivity report (the browser's
+ * raw "Failed to fetch" is neither a message for the user nor a bug).
  */
 export function settleTaskFailure(
   patch: (patch: Partial<AgentMigrationProgress>) => void,
@@ -42,10 +45,12 @@ export function settleTaskFailure(
   patch({
     step: "error",
     errorStep: outcome.step,
-    errorMessage: outcome.message,
+    errorMessage: outcome.transport
+      ? i18n.t("migration:transport.interrupted")
+      : outcome.message,
   });
   analytics.track("cloud_migration_agent_failed", { step: outcome.step });
-  reportError("cloud_migration_agent", outcome.message, err);
+  reportError("cloud_migration_agent", outcome.message, outcome.cause);
 }
 
 export async function finishRun(

--- a/app/tests/cloud-migration-step.test.ts
+++ b/app/tests/cloud-migration-step.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   MigrationAbandonedError,
   MigrationStepError,
+  migrationFailureCause,
   runStep,
   taskFailureOutcome,
 } from "../src/lib/cloud-migration-step.ts";
@@ -32,6 +33,32 @@ test("runStep tags a raw failure with the step it failed in", async () => {
       err.step === "warming" &&
       err.message === "Load failed (127.0.0.1:60003)",
   );
+});
+
+// The envelope must not hide the browser's TypeError: the quiet connectivity
+// classifier keys on it, and a wrapper without `cause` filed every upload cut
+// by the network as a bug (HOUSTON-APP-4PQ / 4PG).
+test("runStep keeps the wrapped failure on cause", async () => {
+  const inner = new TypeError("Failed to fetch (gateway.gethouston.ai)");
+  await assert.rejects(
+    runStep(
+      "uploading",
+      async () => {
+        throw inner;
+      },
+      () => false,
+    ),
+    (err: unknown) =>
+      err instanceof MigrationStepError &&
+      err.cause === inner &&
+      migrationFailureCause(err) === inner,
+  );
+});
+
+test("migrationFailureCause passes an unwrapped failure through", () => {
+  const plain = new Error("boom");
+  assert.equal(migrationFailureCause(plain), plain);
+  assert.equal(migrationFailureCause("disk full"), "disk full");
 });
 
 test("runStep passes an already-tagged failure through unchanged", async () => {
@@ -102,14 +129,45 @@ test("a transport error racing the source-host stop is abandoned, not failed", (
 });
 
 test("the same transport error on a live run is a real failure", () => {
-  const err = new MigrationStepError(
-    "uploading",
-    new TypeError("Load failed (127.0.0.1:60003)"),
-  );
+  const cause = new TypeError("Load failed (127.0.0.1:60003)");
+  const err = new MigrationStepError("uploading", cause);
   assert.deepEqual(taskFailureOutcome(err, false), {
     kind: "failed",
     step: "uploading",
     message: "Load failed (127.0.0.1:60003)",
+    cause,
+    transport: true,
+  });
+});
+
+// A 48 MB chunk cut by the ingress's 60 s body deadline arrives exactly like
+// this: Chromium's bare "Failed to fetch" with no response. The row gets
+// authored copy and Sentry the quiet connectivity class, both keyed on
+// `transport`.
+test("an upload cut mid-flight is a transport failure of the uploading step", () => {
+  const cause = new TypeError("Failed to fetch (gateway.gethouston.ai)");
+  const outcome = taskFailureOutcome(
+    new MigrationStepError("uploading", cause),
+    false,
+  );
+  assert.equal(outcome.kind, "failed");
+  if (outcome.kind !== "failed") return;
+  assert.equal(outcome.transport, true);
+  assert.equal(outcome.cause, cause);
+});
+
+test("a gateway rejection is not a transport failure", () => {
+  const cause = new Error("migration import: HTTP 413");
+  const outcome = taskFailureOutcome(
+    new MigrationStepError("uploading", cause),
+    false,
+  );
+  assert.deepEqual(outcome, {
+    kind: "failed",
+    step: "uploading",
+    message: "migration import: HTTP 413",
+    cause,
+    transport: false,
   });
 });
 
@@ -118,5 +176,7 @@ test("an untagged failure defaults to the uploading step", () => {
     kind: "failed",
     step: "uploading",
     message: "disk full",
+    cause: "disk full",
+    transport: false,
   });
 });

--- a/app/tests/cloud-migration.test.ts
+++ b/app/tests/cloud-migration.test.ts
@@ -7,6 +7,7 @@ import {
   doneScreenOutcome,
   hasReconnectAppsStep,
   isPlausibleMigrationTarget,
+  MAX_CHUNK_RAW_BYTES,
   type SourceAgent,
   type SourceManifestEntry,
 } from "../src/lib/cloud-migration.ts";
@@ -130,6 +131,15 @@ const entry = (
   size: number,
   kind: "core" | "file" = "file",
 ): SourceManifestEntry => ({ path, size, kind });
+
+// The cloud ingress drops a request whose body takes over 60 s to arrive.
+// 2 Mbps is the slow end of home uplinks; a chunk must clear the deadline
+// there with margin, or the wizard fails the same chunk on every retry.
+test("a chunk uploads within the ingress body deadline on a 2 Mbps uplink", () => {
+  const bytesPerSecondAt2Mbps = (2 * 1_000_000) / 8;
+  const seconds = MAX_CHUNK_RAW_BYTES / bytesPerSecondAt2Mbps;
+  assert.ok(seconds < 45, `a chunk takes ${seconds.toFixed(0)}s at 2 Mbps`);
+});
 
 test("packs entries greedily under the byte budget", () => {
   const chunks = chunkPaths(


### PR DESCRIPTION
## Root cause

Every `cloud_migration_agent: Failed to fetch (gateway.gethouston.ai)` event in HOUSTON-APP-4PQ (and the `Load failed` twin in 4PG on macOS) is a **40-54 MB import chunk** whose POST dies about 60 s after the preceding export, with no HTTP response. The cloud ingress closes any request whose body has not fully arrived within 60 s, so anyone uploading slower than ~6 Mbps loses the same chunk on every retry. Smaller chunks from the same users landed in 5-8 s.

Two client defects compounded it:

- `MAX_CHUNK_RAW_BYTES` was 48 MB, sized against the gateway's 64 MB cap, not against upload time.
- `MigrationStepError` dropped the browser's `TypeError`, so the transport drop bypassed the quiet connectivity class and reached Sentry as a bug, while the wizard row showed the raw "Failed to fetch" text.

## Fix

- Chunks are 8 MB, which clears the deadline on a 2 Mbps uplink with margin.
- The step envelope keeps its `cause`; `taskFailureOutcome` exposes `cause` and `transport`.
- A transport drop shows authored copy on the row (en/es/pt) and reports through the quiet connectivity path. Other failures are unchanged.

The ingress-side limit itself lives in the Traefik Helm values (entrypoint `respondingTimeouts.readTimeout`, 60 s default), outside this repo; raising it is a separate infra change.

## Before

1. On a desktop with a legacy `~/.houston` tree holding an agent with >48 MB of working files, throttle upload to 4 Mbps (Chrome devtools or `tc`).
2. Run the cloud-migration wizard.
3. The agent's import POST fails ~60 s in with "Failed to fetch (gateway.gethouston.ai)" (macOS: "Load failed"); the row shows that raw text; Retry fails identically; Sentry gets a `cloud_migration_agent` bug event.

## After

1. Same setup: every chunk is at most 8 MB and completes in ~16 s at 4 Mbps; the agent migrates.
2. Pull the network mid-upload: the row reads "The upload was interrupted. Check your connection and retry.", Retry resumes, and the report lands in the quiet `offline` fingerprint (warning), not a new issue.
3. `cd app && pnpm test` covers the new cases in `tests/cloud-migration-step.test.ts` and `tests/cloud-migration.test.ts`.
