### PR TITLE
fix(host): bound the heal's runtime export and report an unreachable runtime once per incident (PRODUCT-1687)

### DIFF
--- a/packages/host/src/channel/capture-credential.test.ts
+++ b/packages/host/src/channel/capture-credential.test.ts
@@ -513,3 +513,28 @@ test("anthropic behind the gateway keeps the capture chain: stored centrally, th
   expect(puts.map((p) => p.credential.provider)).toEqual(["anthropic"]);
   expect(calls.some((c) => c.includes("/auth/scrub-refresh"))).toBe(true);
 });
+
+test("the runtime export read carries a timeout budget (PRODUCT-1687)", async () => {
+  // A stalled runtime must not hold the heal for undici's 300s headers
+  // timeout: the runtime's own serve probe gives up at 10s.
+  const { credentials } = recordingStore();
+  const inits: (RequestInit | undefined)[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      if (String(input).includes("/auth/export")) {
+        inits.push(init);
+        return Response.json({});
+      }
+      return new Response("not found", { status: 404 });
+    }),
+  );
+  await captureRuntimeCredential({
+    endpoint: { baseUrl: "http://runtime", token: "runtime-token" },
+    credentials,
+    workspaceId: "workspace",
+    provider: "xai",
+  });
+  expect(inits).toHaveLength(1);
+  expect(inits[0]?.signal).toBeInstanceOf(AbortSignal);
+});

--- a/packages/host/src/channel/capture-credential.ts
+++ b/packages/host/src/channel/capture-credential.ts
@@ -2,6 +2,15 @@ import { deadGoogleApiKey } from "@houston/protocol/google-key";
 import type { CaptureResult, CredentialStore, RuntimeEndpoint } from "../ports";
 import { scrubRuntimeRefreshToken } from "./scrub-refresh";
 
+/**
+ * Budget for reading the runtime's export. The serve healer's caller — the
+ * runtime's own probe (auth/serve-probe.ts) — gives up at 10s, so an export
+ * still pending past that answers nobody; without a budget a stalled runtime
+ * held every provider's heal for undici's 300s headers timeout and logged one
+ * Sentry error per provider when they finally died (PRODUCT-1687).
+ */
+const RUNTIME_EXPORT_TIMEOUT_MS = 8_000;
+
 type ExportedCredential = {
   provider?: string;
   kind?: "oauth" | "api_key";
@@ -93,6 +102,7 @@ export async function captureRuntimeCredential(args: {
       Authorization: `Bearer ${endpoint.token}`,
       ...(actingAs ? { "x-houston-acting-as": actingAs } : {}),
     },
+    signal: AbortSignal.timeout(RUNTIME_EXPORT_TIMEOUT_MS),
   });
   if (!exported.ok) {
     return {

--- a/packages/host/src/routes/credential-healer.test.ts
+++ b/packages/host/src/routes/credential-healer.test.ts
@@ -228,3 +228,62 @@ test("a heal that fails on a live host stays a loud error and names the cause", 
   expect(errors.mock.calls[0]?.[1]).toBe("fetch failed (cause: ECONNREFUSED)");
   errors.mockRestore();
 });
+
+test("a runtime unreachable for the whole sweep reports one Sentry error per incident (PRODUCT-1687)", async () => {
+  // The runtime's sync heals every provider through the same socket; a
+  // stalled runtime failed 40 heals at once and each was a Sentry error.
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  let now = 1_700_000_000_000;
+  const refused = () =>
+    new TypeError("fetch failed", {
+      cause: Object.assign(new Error("connect ECONNREFUSED"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+  const healer = new CredentialServeHealer(
+    async () => {
+      throw refused();
+    },
+    () => now,
+  );
+  const base = { workspaceId: "ws", agentId: "ws/agent" };
+  await Promise.all(
+    ["xai", "openai", "mistral"].map((provider) =>
+      healer.attempt({ ...base, provider }),
+    ),
+  );
+  expect(errors).toHaveBeenCalledTimes(1);
+  expect(errors.mock.calls[0]?.[1]).toBe("fetch failed (cause: ECONNREFUSED)");
+  expect(warns).toHaveBeenCalledTimes(2);
+  expect(warns.mock.calls[0]?.[0]).toContain("same incident");
+
+  // Still failing 4 minutes on: the same incident, still one error. The
+  // cooldown is per provider, so a fourth provider heals (and fails) now.
+  now += 4 * 60_000;
+  await healer.attempt({ ...base, provider: "groq" });
+  expect(errors).toHaveBeenCalledTimes(1);
+
+  // A different runtime is a different incident.
+  await healer.attempt({ ...base, agentId: "ws/other", provider: "cerebras" });
+  expect(errors).toHaveBeenCalledTimes(2);
+
+  // Quiet for longer than the gap, then failing again: a new incident.
+  now += 6 * 60_000;
+  await healer.attempt({ ...base, provider: "xai" });
+  expect(errors).toHaveBeenCalledTimes(3);
+  errors.mockRestore();
+  warns.mockRestore();
+});
+
+test("a non-network heal failure is never collapsed into an incident", async () => {
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const healer = new CredentialServeHealer(async () => {
+    throw new Error("gateway rejected the credential");
+  });
+  const base = { workspaceId: "ws", agentId: "ws/agent" };
+  await healer.attempt({ ...base, provider: "xai" });
+  await healer.attempt({ ...base, provider: "openai" });
+  expect(errors).toHaveBeenCalledTimes(2);
+  errors.mockRestore();
+});

--- a/packages/host/src/routes/credential-healer.ts
+++ b/packages/host/src/routes/credential-healer.ts
@@ -7,6 +7,13 @@ import { LauncherClosedError } from "../ports";
 
 const HEAL_COOLDOWN_MS = 5 * 60_000;
 
+/**
+ * Two network-level failures against the same runtime closer than this are
+ * one incident. Matches the heal cooldown: a persistent outage re-reports once
+ * per cooldown, never once per provider per sweep.
+ */
+const NETWORK_INCIDENT_GAP_MS = HEAL_COOLDOWN_MS;
+
 export type CredentialHeal = (args: {
   workspaceId: string;
   agentId: string;
@@ -33,6 +40,22 @@ function describeHealError(error: unknown): string {
 }
 
 /**
+ * A failure of the wire, not of the credential: undici's bare `fetch failed`
+ * (connection refused/reset, a socket closed under the request) or the export
+ * budget expiring (`AbortSignal.timeout` rejects with a TimeoutError). Either
+ * says "this runtime is unreachable", which is one fact per runtime — not one
+ * per provider the sweep happened to probe.
+ */
+function isNetworkFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message === "fetch failed" ||
+    error.name === "TimeoutError" ||
+    error.name === "AbortError"
+  );
+}
+
+/**
  * Coalesces serve-miss recovery and limits each provider to one attempt/5m.
  *
  * Per (workspace, SCOPE, provider): one member's miss must not hand its result
@@ -47,10 +70,19 @@ function describeHealError(error: unknown): string {
  * server's catch, which answers 503 + Retry-After — the runtime's probe reads
  * that as transient and keeps its copy, instead of a marked 404 it would act
  * on as a verdict.
+ *
+ * A network failure on a LIVE host is reported once per runtime per incident:
+ * the runtime's sync probes every known provider (40+, 8 at a time), and each
+ * miss heals through the same runtime socket, so a stalled or unreachable
+ * runtime logged one Sentry error per provider — the HOUSTON-APP-5AD bucket
+ * (PRODUCT-1687). The first failure stays a loud error naming the cause; the
+ * rest of the incident is a warn breadcrumb.
  */
 export class CredentialServeHealer {
   private readonly inFlight = new Map<string, Promise<boolean>>();
   private readonly attemptedAt = new Map<string, number>();
+  /** Last network failure per (runtime, cause) — see `sameIncident`. */
+  private readonly networkFailureAt = new Map<string, number>();
 
   constructor(
     private readonly heal: CredentialHeal,
@@ -105,14 +137,38 @@ export class CredentialServeHealer {
             ? error
             : new LauncherClosedError();
         }
+        const detail = describeHealError(error);
+        if (
+          isNetworkFailure(error) &&
+          this.sameIncident(args.agentId, detail)
+        ) {
+          console.warn(
+            `[sandbox/credential] heal failed provider=${args.provider} agent=${args.agentId}: ${detail} (same incident as the last reported failure)`,
+          );
+          return false;
+        }
         console.error(
           `[sandbox/credential] heal failed provider=${args.provider} agent=${args.agentId}:`,
-          describeHealError(error),
+          detail,
         );
         return false;
       })
       .finally(() => this.inFlight.delete(key));
     this.inFlight.set(key, attempt);
     return attempt;
+  }
+
+  /**
+   * Whether a network failure with this cause was already seen against this
+   * runtime within the incident gap. Every failure extends the incident, so a
+   * runtime that stays unreachable reports once, and again only after a quiet
+   * gap — the runtime-side serve-log posture (PRODUCT-1399).
+   */
+  private sameIncident(agentId: string, detail: string): boolean {
+    const key = `${agentId}|${detail}`;
+    const now = this.now();
+    const last = this.networkFailureAt.get(key);
+    this.networkFailureAt.set(key, now);
+    return last !== undefined && now - last < NETWORK_INCIDENT_GAP_MS;
   }
 }


### PR DESCRIPTION
## Summary

Sentry bucket HOUSTON-APP-5AD (`[sandbox/credential] heal failed provider=<p> agent=<a>: fetch failed`, 1,197 events / 408 users) is keyed on the healer's `console.error` line, so one unreachable runtime became one Sentry error **per provider** the runtime's serve sync probed (40+ providers, 8 at a time).

PR #1498 (PRODUCT-1672) already quiets the drain flavor (a roll killing the runtime mid-sync). Every event in the bucket is still on pre-fix builds (`engine-pod@4e8471fc7` = v0.6.17 and older); `engine-pod-v0.6.18` carrying #1498 was tagged 2026-09-07 11:54 UTC, after the last event (06:01 UTC). But the bucket also holds two shapes #1498 does not cover:

- **Stalled runtime on a long-lived pod** (2026-09-04 21:00, 2026-09-05 21:06–21:18): every heal's `/auth/export` read failed exactly 300 s after the attempt, i.e. undici's headers timeout. The runtime's own serve probe gives up at 10 s, so those heals answered nobody, and 40 of them died together as 40 Sentry errors.
- **Runtime unreachable at boot** (2026-09-07 06:01, 24 s after host start): one pod, 46 heals, one cause, 2 sampled errors per sweep.

## Fix

- `channel/capture-credential.ts`: the runtime export read carries an 8 s `AbortSignal.timeout`, under the probe's 10 s budget, so a stalled runtime fails the heal while its caller is still listening instead of pinning every provider's heal for 300 s.
- `routes/credential-healer.ts`: a network-level failure (undici's bare `fetch failed`, or the export timeout) is reported once per (runtime, cause) per 5-minute incident. The first failure stays a `console.error` naming the cause (already added by #1498); the rest of the incident logs at `warn` (a Sentry breadcrumb, not an event). Non-network failures are never collapsed.

Root cause of the stall itself is environmental and not visible from the pre-fix message; v0.6.18 events will carry `(cause: <code>)`.

## Verification

Before: on a host running v0.6.17 or older, make the agent runtime unreachable to the host (e.g. `kill -STOP` the pi runtime process) and trigger a serve sync (open the model picker or send a turn). After ~300 s the host log shows one `heal failed ... fetch failed` **error** per known provider.

After: same setup, the host log shows one `heal failed ... (cause: ...)` error within ~8 s and the remaining providers as `warn` lines suffixed `(same incident as the last reported failure)`.

Tests: `pnpm --filter @houston/host test` (186 files, 1671 passed), `pnpm check`, host `tsc --noEmit`.