### PR TITLE
fix(runtime): move the Codex default off gpt-5.5 and retire gpt-5.4 (PRODUCT-1695)

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -2132,7 +2132,7 @@ export function useAgentChatPanel({
             }}
             onSwitchModel={
               isModelUnsupported
-                ? () => selectModel("openai", "gpt-5.5")
+                ? () => selectModel("openai", getDefaultModel("openai"))
                 : undefined
             }
           />

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -203,6 +203,9 @@ export const VISIBLE_MODELS: Readonly<Record<string, ReadonlySet<string>>> = {
     "gpt-5.4",
     "gpt-5.4-mini",
   ]),
+  // No gpt-5.4: OpenAI retired it for ChatGPT accounts (400 "not supported
+  // when using Codex with a ChatGPT account"); a conversation already pinned
+  // to it keeps working on the wire, it just can't be picked anymore.
   openai: new Set([
     "gpt-6-astra",
     "gpt-5.5",
@@ -210,7 +213,6 @@ export const VISIBLE_MODELS: Readonly<Record<string, ReadonlySet<string>>> = {
     "gpt-5.6-terra",
     "gpt-5.6-luna",
     "gpt-5.3-codex-spark",
-    "gpt-5.4",
     "gpt-5.4-mini",
   ]),
   anthropic: new Set([
@@ -321,7 +323,9 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     cost: "Your ChatGPT subscription",
     installUrl: "https://github.com/openai/codex",
     auth: "oauth",
-    defaultModel: "gpt-5.5",
+    // Twin of runtime config.codexModel / domain DEFAULT_MODEL: chatgpt.com
+    // answers gpt-5.5 with 404 for ChatGPT accounts since 2026-09-07.
+    defaultModel: "gpt-5.6-terra",
     models: {
       "gpt-6-astra": {
         label: "GPT-6 Astra",
@@ -330,7 +334,7 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       },
       "gpt-5.5": {
         label: "GPT-5.5",
-        description: "OpenAI's frontier model.",
+        description: "Previous-generation model.",
       },
       "gpt-5.6-sol": {
         label: "GPT-5.6 Sol",

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -4,6 +4,7 @@ import {
   EFFORT_ORDER,
   getConnectProviders,
   getContextWindowConfig,
+  getDefaultModel,
   getEffortLevels,
   getProvider,
   getVisibleProviders,
@@ -120,12 +121,7 @@ test("effort levels are derived per model from pi's thinking ladder", () => {
   // Every reasoning model derives the four-tier low→xhigh spectrum from pi
   // (the fixture gives each the full ladder); the retired `max` never appears.
   const FULL = ["low", "medium", "high", "xhigh"];
-  for (const id of [
-    "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.3-codex-spark",
-  ]) {
+  for (const id of ["gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
     assert.deepEqual(getEffortLevels("openai", id), FULL, id);
   }
   for (const id of [
@@ -212,17 +208,16 @@ test("validModelOrNull rejects retired aliases and accepts catalog IDs", () => {
     validModelOrNull("anthropic", "claude-sonnet-4-6"),
     "claude-sonnet-4-6",
   );
-  // Full Codex lineup is catalogued (gpt-5.5 + the gpt-5.4 / mini / spark
-  // models added in HOU-589); the phantom gpt-5.5-codex never shipped.
-  for (const id of [
-    "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.3-codex-spark",
-  ]) {
+  // Full Codex lineup is catalogued (gpt-5.5 + the mini / spark models added
+  // in HOU-589); the phantom gpt-5.5-codex never shipped.
+  for (const id of ["gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
     assert.equal(validModelOrNull("openai", id), id);
   }
   assert.equal(validModelOrNull("openai", "gpt-5.5-codex"), null);
+  // gpt-5.4 is retired for ChatGPT accounts: still in pi's catalog, hidden by
+  // VISIBLE_MODELS, so a stored pick falls through to the provider default.
+  assert.equal(validModelOrNull("openai", "gpt-5.4"), null);
+  assert.equal(getDefaultModel("openai"), "gpt-5.6-terra");
 });
 
 test("normalizeLegacyModel maps retired aliases, passes everything else through", () => {

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -217,7 +217,7 @@
     },
     "modelDescriptions": {
       "gpt-6-astra": "Newest and most capable. Uses your allowance 2.5x faster than Sol.",
-      "gpt-5_5": "OpenAI's frontier model.",
+      "gpt-5_5": "Previous-generation model.",
       "gpt-5_6-sol": "Previous frontier model. Strong for complex work.",
       "gpt-5_6-terra": "Balanced mid-tier model.",
       "gpt-5_6-luna": "Fast and cost-efficient for simpler tasks.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -217,7 +217,7 @@
     },
     "modelDescriptions": {
       "gpt-6-astra": "El más nuevo y capaz. Consume tu cuota 2.5 veces más rápido que Sol.",
-      "gpt-5_5": "El modelo más avanzado de OpenAI.",
+      "gpt-5_5": "Modelo de la generación anterior.",
       "gpt-5_6-sol": "Modelo frontera anterior. Fuerte en trabajo complejo.",
       "gpt-5_6-terra": "Modelo intermedio equilibrado.",
       "gpt-5_6-luna": "Rápido y económico para tareas más simples.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -217,7 +217,7 @@
     },
     "modelDescriptions": {
       "gpt-6-astra": "O mais novo e mais capaz. Consome sua cota 2,5 vezes mais rápido que o Sol.",
-      "gpt-5_5": "O modelo mais avançado da OpenAI.",
+      "gpt-5_5": "Modelo da geração anterior.",
       "gpt-5_6-sol": "Modelo de fronteira anterior. Forte em trabalho complexo.",
       "gpt-5_6-terra": "Modelo intermediário equilibrado.",
       "gpt-5_6-luna": "Rápido e econômico para tarefas mais simples.",

--- a/packages/domain/src/provider-model-catalog.ts
+++ b/packages/domain/src/provider-model-catalog.ts
@@ -63,7 +63,10 @@ export const DEFAULT_PROVIDER: ProviderId = "openai-codex";
  */
 export const DEFAULT_MODEL: Partial<Record<ProviderId, string>> = {
   anthropic: "claude-sonnet-4-6",
-  "openai-codex": "gpt-5.5",
+  // gpt-5.6-terra: chatgpt.com started answering gpt-5.5 with 404 for ChatGPT
+  // accounts on 2026-09-07 (the Codex CLI fails the same way), so the default
+  // had to move off it. Twin of runtime config.codexModel.
+  "openai-codex": "gpt-5.6-terra",
   // Copilot uses DOTTED model ids (claude-sonnet-4.6), unlike native Anthropic.
   "github-copilot": "claude-sonnet-4.6",
   opencode: "claude-sonnet-4-6",
@@ -120,9 +123,12 @@ export const VALID_MODELS: Partial<Record<ProviderId, ReadonlySet<string>>> = {
     "claude-sonnet-4-6",
     "claude-sonnet-5",
   ]),
+  // gpt-5.4 is deliberately absent: OpenAI retired it for ChatGPT accounts
+  // (400 "not supported when using Codex with a ChatGPT account", and it is
+  // gone from chatgpt.com's own model list), so a stored pick migrates to the
+  // default instead of failing every turn.
   "openai-codex": new Set([
     "gpt-5.3-codex-spark",
-    "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.5",
     "gpt-5.6-luna",

--- a/packages/domain/src/provider-model.test.ts
+++ b/packages/domain/src/provider-model.test.ts
@@ -48,7 +48,6 @@ const PI_MODELS: Record<string, Set<string>> = {
   ]),
   "openai-codex": new Set([
     "gpt-5.3-codex-spark",
-    "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.5",
     "gpt-5.6-luna",
@@ -137,8 +136,8 @@ test("CLI-era codex model ids map to the closest current tier", () => {
 });
 
 test("an already-valid pi provider+model passes through unchanged", () => {
-  const r = migrateProviderModel("openai-codex", "gpt-5.4");
-  expect(r).toMatchObject({ provider: "openai-codex", model: "gpt-5.4" });
+  const r = migrateProviderModel("openai-codex", "gpt-5.6-luna");
+  expect(r).toMatchObject({ provider: "openai-codex", model: "gpt-5.6-luna" });
   expect(r.diagnostics).toEqual([]);
   assertValid(r, "passthrough");
 });
@@ -172,7 +171,7 @@ test("a genuinely new pi-ai provider id passes through UNCHANGED (not → Codex)
 test("missing provider/model fall soft to the defaults with provider diagnostic", () => {
   const r = migrateProviderModel(undefined, undefined);
   expect(r.provider).toBe(DEFAULT_PROVIDER);
-  expect(r.model).toBe("gpt-5.5");
+  expect(r.model).toBe("gpt-5.6-terra");
   // Missing provider is reported; a missing model on a defaulted provider just
   // uses the default (no extra noise needed once the provider is known).
   expect(r.diagnostics.some((d) => d.message.includes("provider"))).toBe(true);
@@ -241,4 +240,14 @@ test("the diagnostic key defaults to the config doc path and is overridable", ()
     migrateProviderModel("anthropic", "totally-made-up", "Work/Sales")
       .diagnostics[0]?.key,
   ).toBe("Work/Sales");
+});
+
+test("a retired Codex pick (gpt-5.4) migrates to the current default with a diagnostic", () => {
+  // OpenAI retired gpt-5.4 for ChatGPT accounts (400 "not supported when using
+  // Codex with a ChatGPT account"), so it left VALID_MODELS: a stored pick must
+  // land on the default rather than fail every turn.
+  const r = migrateProviderModel("openai", "gpt-5.4");
+  expect(r).toMatchObject({ provider: "openai-codex", model: "gpt-5.6-terra" });
+  expect(r.diagnostics[0]?.message).toContain("gpt-5.4");
+  assertValid(r, "openai/gpt-5.4");
 });

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -496,9 +496,50 @@ test("Bedrock's own fallback never self-suggests", () => {
     expect(err.suggested_fallback).toBeNull();
 });
 
-test("OpenAI model_not_found → model_unavailable, no fallback for a non-Copilot provider", () => {
+test("Codex 404 model_not_found → model_unavailable + gpt-5.6-terra fallback (PRODUCT-1695)", () => {
+  // chatgpt.com's exact body for gpt-5.5 on a ChatGPT account since 2026-09-07.
   const err = classifyProviderError({
     provider: "openai-codex",
+    model: "gpt-5.5",
+    message:
+      "Codex error: The model `gpt-5.5` does not exist or you do not have access to it.",
+  });
+  expect(err).toMatchObject({
+    kind: "model_unavailable",
+    model: "gpt-5.5",
+    suggested_fallback: "gpt-5.6-terra",
+  });
+});
+
+test("Codex retired-model 400 → model_unavailable + gpt-5.6-terra fallback (PRODUCT-1695)", () => {
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    message:
+      "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+  });
+  expect(err).toMatchObject({
+    kind: "model_unavailable",
+    model: "gpt-5.4",
+    suggested_fallback: "gpt-5.6-terra",
+  });
+});
+
+test("Codex fallback is never the failing model itself", () => {
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: "gpt-5.6-terra",
+    message:
+      "OpenAI API error (404): The model `gpt-5.6-terra` does not exist or you do not have access to it. (model_not_found)",
+  });
+  expect(err.kind).toBe("model_unavailable");
+  if (err.kind === "model_unavailable")
+    expect(err.suggested_fallback).toBeNull();
+});
+
+test("OpenAI model_not_found on a provider without a known fallback offers none", () => {
+  const err = classifyProviderError({
+    provider: "openai",
     model: "gpt-9",
     message:
       "OpenAI API error (404): The model `gpt-9` does not exist or you do not have access to it. (model_not_found)",
@@ -506,7 +547,6 @@ test("OpenAI model_not_found → model_unavailable, no fallback for a non-Copilo
   expect(err.kind).toBe("model_unavailable");
   if (err.kind === "model_unavailable") {
     expect(err.model).toBe("gpt-9");
-    // We only know a safe fallback for Copilot; elsewhere offer none.
     expect(err.suggested_fallback).toBeNull();
   }
 });

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -292,6 +292,17 @@ const PLAN_LIMIT_PATTERNS = [
  */
 const COPILOT_BASE_FALLBACK = "gpt-5-mini";
 
+/**
+ * The ChatGPT / Codex model offered as the one-click switch target when
+ * chatgpt.com rejects a pick: 404 "does not exist or you do not have access"
+ * for gpt-5.5 (since 2026-09-07, on ChatGPT accounts that still list it) and
+ * 400 "not supported when using Codex with a ChatGPT account" for the retired
+ * gpt-5.4. The gpt-5.6 line answers on every account we have evidence from.
+ * Twin of `config.codexModel`, duplicated on purpose like COPILOT_BASE_FALLBACK
+ * so this classifier stays pure.
+ */
+const CODEX_BROAD_FALLBACK = "gpt-5.6-terra";
+
 /** Longest excerpt we keep for the `unknown` card / bug report. */
 const EXCERPT_MAX = 300;
 
@@ -604,13 +615,15 @@ function broadFallback(provider: string, model: string): string | null {
   const fallback =
     provider === "github-copilot"
       ? COPILOT_BASE_FALLBACK
-      : provider === "moonshotai"
-        ? MOONSHOT_BROAD_FALLBACK
-        : provider === "xiaomi"
-          ? XIAOMI_BROAD_FALLBACK
-          : provider === "amazon-bedrock"
-            ? BEDROCK_BROAD_FALLBACK
-            : null;
+      : provider === "openai-codex"
+        ? CODEX_BROAD_FALLBACK
+        : provider === "moonshotai"
+          ? MOONSHOT_BROAD_FALLBACK
+          : provider === "xiaomi"
+            ? XIAOMI_BROAD_FALLBACK
+            : provider === "amazon-bedrock"
+              ? BEDROCK_BROAD_FALLBACK
+              : null;
   return fallback && fallback !== model ? fallback : null;
 }
 

--- a/packages/runtime/src/ai/providers.test.ts
+++ b/packages/runtime/src/ai/providers.test.ts
@@ -95,7 +95,7 @@ test("providerDefaultModel returns each provider's catalog default", () => {
   );
   expect(providerDefaultModel("minimax")).toBe("MiniMax-M3[1m]");
   // Unknown falls back to the Codex default (never throws / undefined).
-  expect(providerDefaultModel("nope")).toBe("gpt-5.5");
+  expect(providerDefaultModel("nope")).toBe("gpt-5.6-terra");
 });
 
 test("uncurated providers with a hand-picked default skip pi's dead first row (PRODUCT-1411)", () => {

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -47,8 +47,15 @@ export const config = {
   shutdownDrainMs: Math.max(0, Number(env.HOUSTON_RUNTIME_DRAIN_MS || 3000)),
   /** Default Anthropic model (Claude Pro/Max subscription). */
   model: env.HOUSTON_MODEL || "claude-sonnet-5",
-  /** Default Codex model (ChatGPT subscription — the cloud's only provider). */
-  codexModel: env.HOUSTON_CODEX_MODEL || "gpt-5.5",
+  /**
+   * Default Codex model (ChatGPT subscription — the cloud's only provider).
+   * gpt-5.6-terra, not gpt-5.5: since 2026-09-07 chatgpt.com answers gpt-5.5
+   * with 404 "does not exist or you do not have access" for ChatGPT accounts
+   * (the Codex CLI fails identically), so a first turn on the old default died
+   * on the switch-model card. Twin of the domain DEFAULT_MODEL and the frontend
+   * PROVIDER_OVERRIDES.openai.defaultModel.
+   */
+  codexModel: env.HOUSTON_CODEX_MODEL || "gpt-5.6-terra",
   /**
    * Default GitHub Copilot model (subscription OAuth). A pi-ai `github-copilot`
    * model id — note Copilot's ids use dots (`gpt-5.4`), unlike the native

--- a/packages/web/src/engine-adapter/translate.test.ts
+++ b/packages/web/src/engine-adapter/translate.test.ts
@@ -169,7 +169,7 @@ describe("configWriteToSettings (model-pick → engine settings bridge)", () => 
     // default provider's model) so the turn still resolves.
     expect(
       configWriteToSettings(CONFIG, JSON.stringify({ provider: "gemini" })),
-    ).toEqual({ activeProvider: "gemini", model: "gpt-5.5" });
+    ).toEqual({ activeProvider: "gemini", model: "gpt-5.6-terra" });
   });
 
   test("skips non-config files, missing provider, and bad JSON", () => {


### PR DESCRIPTION
Closes PRODUCT-1695.

## Problem

Picking GPT-5.5 or GPT-5.4 on a ChatGPT (Codex) connection fails every turn with the "Model not available" card. Verified live on 2026-09-07: `chatgpt.com/backend-api/codex/responses` answers `gpt-5.5` with **404 "The model gpt-5.5 does not exist or you do not have access to it"** (over SSE and WebSocket, with pi-ai 0.85.1, with a raw request carrying Codex's own originator, and from the Codex CLI itself, which exhausts its 5 retries on the same 404) and `gpt-5.4` with **400 "not supported when using Codex with a ChatGPT account"**. `gpt-5.4` is gone from OpenAI's own model list; `gpt-5.5` is still listed, so it stays offered.

Houston's Codex default was `gpt-5.5` (runtime, domain, frontend), so a fresh ChatGPT connection failed its first turn. Codex CLI's built-in default is now `gpt-6-astra`.

## Change

- Codex default → `gpt-5.6-terra` in `config.codexModel`, the domain `DEFAULT_MODEL` and `PROVIDER_OVERRIDES.openai.defaultModel` (twins, comments cross-reference).
- `gpt-5.4` removed from `VISIBLE_MODELS.openai` and the domain `VALID_MODELS`: hidden from the picker, a stored pick migrates to the default with a diagnostic, an already-pinned conversation keeps working on the wire.
- Runtime classifier: a Codex `model_unavailable` carries `gpt-5.6-terra` as `suggested_fallback` (never the failing model itself), so the card offers a one-click switch instead of only "Pick another model".
- Chat panel's unsupported-model retry uses `getDefaultModel("openai")` instead of a hardcoded `gpt-5.5`.
- Copy: GPT-5.5 is "Previous-generation model." (en/es/pt), matching OpenAI's own description.

## Tests

- domain: retired `gpt-5.4` migrates to the default with a diagnostic; missing provider/model land on `gpt-5.6-terra`.
- runtime: Codex 404 and retired-model 400 both classify as `model_unavailable` with the `gpt-5.6-terra` fallback; fallback is null when the failing model is the fallback; providers without a known fallback still offer none.
- app: `gpt-5.4` is no longer a valid picker id; default is `gpt-5.6-terra`.

`pnpm check`, `pnpm --filter @houston/runtime --filter @houston/domain --filter @houston/host test`, `cd app && pnpm test && pnpm tsgo --noEmit && pnpm check-locales`, `pnpm --filter houston-web typecheck` all pass.