### PR TITLE
fix(board): keep a slow sweep from rolling back patched missions and reword the waking toast (PRODUCT-1696)

### DIFF
--- a/app/src/components/board/open-conversation-identity.ts
+++ b/app/src/components/board/open-conversation-identity.ts
@@ -1,0 +1,70 @@
+import type { KanbanItem } from "@houston-ai/board";
+import type { CreatedMission } from "../../lib/created-mission-handoff";
+
+/**
+ * The two facts the cross-agent board needs to render the OPEN conversation:
+ * which session to read the feed from, and which agent it belongs to. Tagged
+ * with the activity it was resolved for, so a remembered identity is only ever
+ * reused for the same selection.
+ */
+export interface OpenConversationIdentity {
+  activityId: string;
+  sessionKey: string;
+  agentPath: string | null;
+}
+
+export interface ResolveOpenConversationArgs {
+  selectedId: string | null;
+  /** The selected card, when the board's item list currently holds it. */
+  selectedItem: Pick<KanbanItem, "id" | "metadata"> | null;
+  /** A mission created on this board whose row the sweep has not returned. */
+  created: CreatedMission | null;
+  /** The identity this hook last resolved from a REAL card. */
+  lastResolved: OpenConversationIdentity | null;
+}
+
+/**
+ * Resolve the open conversation, in order of trust: the selected card itself,
+ * then the just-created fallback, then the identity the same selection last
+ * resolved to.
+ *
+ * The third source is what keeps a chat on screen while its card is
+ * TRANSIENTLY absent from the item list. The list is rebuilt from the
+ * cross-agent aggregate, and a sweep that settles with an older snapshot
+ * (see `lib/all-conversations-freshness.ts`) can drop a card the user is
+ * looking at for a beat; keying the feed off card presence turned that beat
+ * into an empty panel with no title, which read as "my chat got wiped". A
+ * deletion or an archive clears the selection explicitly, so the fallback
+ * never resurrects a card the user closed on purpose.
+ */
+export function resolveOpenConversation({
+  selectedId,
+  selectedItem,
+  created,
+  lastResolved,
+}: ResolveOpenConversationArgs): OpenConversationIdentity | null {
+  if (!selectedId) return null;
+  if (selectedItem) {
+    const sessionKey = selectedItem.metadata?.sessionKey;
+    const agentPath = selectedItem.metadata?.agentPath;
+    return {
+      activityId: selectedId,
+      sessionKey:
+        typeof sessionKey === "string" && sessionKey.length > 0
+          ? sessionKey
+          : `activity-${selectedId}`,
+      agentPath: typeof agentPath === "string" ? agentPath : null,
+    };
+  }
+  if (created && created.activityId === selectedId) {
+    return {
+      activityId: selectedId,
+      sessionKey: created.sessionKey,
+      agentPath: created.agentPath,
+    };
+  }
+  if (lastResolved && lastResolved.activityId === selectedId) {
+    return lastResolved;
+  }
+  return null;
+}

--- a/app/src/components/board/use-mc-open-conversation.ts
+++ b/app/src/components/board/use-mc-open-conversation.ts
@@ -1,8 +1,12 @@
 import type { KanbanItem } from "@houston-ai/board";
 import type { FeedItem } from "@houston-ai/chat";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useConversationVm } from "../../hooks/use-conversation-vm";
 import { tauriChat } from "../../lib/tauri";
+import {
+  type OpenConversationIdentity,
+  resolveOpenConversation,
+} from "./open-conversation-identity";
 import { useJustCreatedMission } from "./use-just-created-mission";
 
 /**
@@ -10,10 +14,13 @@ import { useJustCreatedMission } from "./use-just-created-mission";
  *
  * Two facts name it — the session key and the agent path — and on a
  * cross-agent board neither is implicit: the selected CARD carries both in its
- * metadata. The one case where the card does not exist yet is a mission created
- * on this board, whose row the sweep has not returned; `useJustCreatedMission`
- * holds its identity for exactly that beat, so the panel that just opened never
- * loses the user's first message.
+ * metadata. Two cases have no card to read. A mission created on this board,
+ * whose row the sweep has not returned: `useJustCreatedMission` holds its
+ * identity for exactly that beat, so the panel that just opened never loses
+ * the user's first message. And a card TRANSIENTLY absent from the list (a
+ * sweep settling with an older snapshot): the identity the same selection
+ * last resolved to keeps the chat painted instead of blanking it
+ * (`resolveOpenConversation`).
  *
  * `AIBoard` only ever reads `feedItems[activeSessionKey]`, so the single-entry
  * map is the whole contract.
@@ -29,14 +36,19 @@ export function useMcOpenConversation(
   const justCreated = useJustCreatedMission(items);
   const created = justCreated.fallbackFor(selectedId);
 
-  const activeSessionKey = selectedItem
-    ? ((selectedItem.metadata?.sessionKey as string | undefined) ??
-      `activity-${selectedItem.id}`)
-    : (created?.sessionKey ?? null);
-  const activeAgentPath =
-    (selectedItem?.metadata?.agentPath as string | undefined) ??
-    created?.agentPath ??
-    null;
+  // Render-time write, idempotent per (selectedId, items): only a REAL card
+  // refreshes the remembered identity, so it never carries a fallback forward.
+  const lastResolvedRef = useRef<OpenConversationIdentity | null>(null);
+  const identity = resolveOpenConversation({
+    selectedId,
+    selectedItem,
+    created,
+    lastResolved: lastResolvedRef.current,
+  });
+  if (identity && selectedItem) lastResolvedRef.current = identity;
+
+  const activeSessionKey = identity?.sessionKey ?? null;
+  const activeAgentPath = identity?.agentPath ?? null;
 
   const activeVm = useConversationVm(activeAgentPath, activeSessionKey);
   const feedItems = useMemo<Record<string, FeedItem[]>>(

--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -6,7 +6,10 @@ import {
 import { useEffect } from "react";
 import { agentRosterSettled } from "../../lib/agent-gone";
 import { latestCachedAllConversations } from "../../lib/all-conversations-cache";
-import { mergePartialSweep } from "../../lib/all-conversations-recovery";
+import {
+  foldSweep,
+  sliceFreshness,
+} from "../../lib/all-conversations-freshness";
 import { queryKeys } from "../../lib/query-keys";
 import { type RawConversation, tauriChat } from "../../lib/tauri";
 import { useAgentStore } from "../../stores/agents";
@@ -47,13 +50,25 @@ export function useAllConversations(agentPaths: string[]) {
   return useQuery({
     queryKey,
     queryFn: async () => {
+      const startedAt = Date.now();
       const { items, failedAgents } = await sweepWithRetry(agentPaths);
       // A partial sweep must never present itself as the whole board: the
       // agents that did not answer keep their last-known missions (HOU-981).
-      const merged = mergePartialSweep(
+      const failedPaths = failedAgents.map((f) => f.agentPath);
+      const failed = new Set(failedPaths);
+      // Nor may a SLOW sweep roll the board back: its reads were taken at
+      // `startedAt`, and every agent the push stream patched while one slow
+      // agent held the settle open has a newer slice in cache than the rows
+      // this sweep carries (lib/all-conversations-freshness.ts).
+      const overtaken = sliceFreshness.patchedSince(
+        agentPaths.filter((p) => !failed.has(p)),
+        startedAt,
+      );
+      const merged = foldSweep(
         items,
         previousRows(queryClient, queryKey),
-        failedAgents.map((f) => f.agentPath),
+        failedPaths,
+        overtaken,
       );
       recoverFromSweep(failedAgents, roster, queryClient);
       return merged;

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { planInvalidation } from "../lib/agent-invalidation-plan";
+import { sliceFreshness } from "../lib/all-conversations-freshness";
 import { consumeCustomOAuthReturn } from "../lib/custom-oauth-return";
 import { onEngineRestarted } from "../lib/engine";
 import { subscribeHoustonEvents } from "../lib/events";
@@ -33,6 +34,9 @@ export function useAgentInvalidation() {
     // pod is touched (it just emitted, so it is awake by definition), and the
     // sidebar badges / Mission Control read the patched cache unchanged.
     const patchAllConversations = (agentPath: string) => {
+      // Stamped at the read: a sweep that started before this patch carries
+      // an older slice for the agent and must not overwrite it on settle.
+      sliceFreshness.notePatched(agentPath, Date.now());
       void tauriConversations
         .list(agentPath)
         .then((rows) => {

--- a/app/src/lib/all-conversations-freshness.ts
+++ b/app/src/lib/all-conversations-freshness.ts
@@ -1,0 +1,81 @@
+/**
+ * Slice freshness for the cross-agent conversation sweep: the guard against
+ * the sweep-vs-patch race.
+ *
+ * The `all-conversations` aggregate is written by two hands. The SWEEP
+ * (`hooks/queries/use-conversations.ts`) fans out one read per agent and
+ * writes the whole board when the LAST agent answers. The push-event PATCH
+ * (`hooks/use-agent-invalidation.ts`) rewrites ONE agent's slice the moment
+ * that agent emits. The sweep's reads are taken at its start, but its write
+ * lands at its end, and one slow agent holds that end open for the whole
+ * transport wake budget (~15s for a pod that only ever answers 503, minutes
+ * for a real cold start). Every slice patched in between is then overwritten
+ * by the sweep's older snapshot. Observed shape: a mission created and
+ * answered during the hold vanished from the board seven seconds after its
+ * reply, and with it the open chat (the panel keys its feed off the selected
+ * card), while the waking toast for the slow agent covered the composer.
+ *
+ * The guard is bookkeeping, not ordering: each patch stamps its agent, the
+ * sweep remembers when it started, and on settle every agent patched since is
+ * folded exactly like an agent that failed to answer, so its cached slice
+ * (the newer one) is carried forward and the sweep's stale rows for it are
+ * dropped ({@link foldSweep}). Dependency-free so `node --test` exercises it;
+ * the wiring imports the shared {@link sliceFreshness} instance.
+ */
+
+import {
+  type AgentScopedRow,
+  mergePartialSweep,
+} from "./all-conversations-recovery.ts";
+
+export interface SliceFreshness {
+  /** A push-event patch is rewriting this agent's slice from a read taken at
+   *  `at` (epoch ms). Stamped at the READ, not the write, so a sweep that
+   *  started between the two still counts the patch as newer. */
+  notePatched(agentPath: string, at: number): void;
+  /** The agents among `agentPaths` whose slice was patched at or after
+   *  `since` (epoch ms). Same-millisecond ties count as patched: the patch's
+   *  rows are fresh either way, the sweep's may not be. */
+  patchedSince(agentPaths: readonly string[], since: number): string[];
+}
+
+export function createSliceFreshness(): SliceFreshness {
+  const patchedAt = new Map<string, number>();
+  return {
+    notePatched(agentPath, at) {
+      patchedAt.set(agentPath, Math.max(patchedAt.get(agentPath) ?? 0, at));
+    },
+    patchedSince(agentPaths, since) {
+      return agentPaths.filter((p) => (patchedAt.get(p) ?? -1) >= since);
+    },
+  };
+}
+
+/** The app-wide instance: one aggregate, one ledger. */
+export const sliceFreshness: SliceFreshness = createSliceFreshness();
+
+/**
+ * Fold a settled sweep into the cache. Fresh rows win for every agent that
+ * answered AND was not overtaken by a patch; the cached slice is carried
+ * forward for the agents that failed ({@link mergePartialSweep}) and for the
+ * overtaken ones, whose sweep rows are dropped as the older snapshot.
+ *
+ * With no cache to carry from (`previous` undefined: the first sweep of a
+ * session) the overtaken list is ignored rather than dropping those agents'
+ * only rows. An EMPTY cache is a real state (a patch may have emptied the
+ * slice) and is honored.
+ */
+export function foldSweep<T extends AgentScopedRow>(
+  fresh: T[],
+  previous: T[] | undefined,
+  failedAgentPaths: readonly string[],
+  overtakenAgentPaths: readonly string[],
+): T[] {
+  if (overtakenAgentPaths.length === 0 || previous === undefined) {
+    return mergePartialSweep(fresh, previous, failedAgentPaths);
+  }
+  const overtaken = new Set(overtakenAgentPaths);
+  const kept = fresh.filter((row) => !overtaken.has(row.agent_path));
+  const carried = previous.filter((row) => overtaken.has(row.agent_path));
+  return mergePartialSweep([...kept, ...carried], previous, failedAgentPaths);
+}

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -441,7 +441,7 @@
     "offlineTitle": "Houston, connection lost",
     "offlineDescription": "We can't reach Houston right now. Check your internet connection and try again.",
     "engineWakingTitle": "Houston, your agent is waking up",
-    "engineWakingDescription": "It will be ready in a moment. Try again shortly.",
+    "engineWakingDescription": "It usually takes about 20 seconds. You don't need to send your message again.",
     "updateStuckTitle": "Houston, updates can't reach you",
     "updateStuckDescription": "We haven't been able to check for updates. Your network may be blocking them. You can always get the latest version at gethouston.ai.",
     "noAgentTitle": "Houston, you need an agent first",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -441,7 +441,7 @@
     "offlineTitle": "Houston, sin conexión",
     "offlineDescription": "No podemos conectarnos a Houston en este momento. Revisa tu conexión a internet e inténtalo de nuevo.",
     "engineWakingTitle": "Houston, tu agente se está despertando",
-    "engineWakingDescription": "Estará listo en un momento. Inténtalo de nuevo en breve.",
+    "engineWakingDescription": "Suele tardar unos 20 segundos. No necesitas enviar tu mensaje de nuevo.",
     "updateStuckTitle": "Houston, las actualizaciones no te llegan",
     "updateStuckDescription": "No hemos podido buscar actualizaciones. Puede que tu red las esté bloqueando. Siempre puedes descargar la última versión en gethouston.ai.",
     "noAgentTitle": "Houston, primero necesitas un agente",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -441,7 +441,7 @@
     "offlineTitle": "Houston, sem conexão",
     "offlineDescription": "Não conseguimos conectar ao Houston agora. Verifique sua conexão com a internet e tente novamente.",
     "engineWakingTitle": "Houston, seu agente está acordando",
-    "engineWakingDescription": "Ele estará pronto em um momento. Tente novamente em breve.",
+    "engineWakingDescription": "Costuma levar cerca de 20 segundos. Você não precisa enviar sua mensagem de novo.",
     "updateStuckTitle": "Houston, as atualizações não estão chegando",
     "updateStuckDescription": "Não conseguimos verificar atualizações. Sua rede pode estar bloqueando. Você sempre pode baixar a versão mais recente em gethouston.ai.",
     "noAgentTitle": "Houston, você precisa de um agente primeiro",

--- a/app/tests/all-conversations-freshness.test.ts
+++ b/app/tests/all-conversations-freshness.test.ts
@@ -1,0 +1,97 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  createSliceFreshness,
+  foldSweep,
+} from "../src/lib/all-conversations-freshness.ts";
+
+const O1 = "7bf0d5bf921ac7d5";
+const GHOST = "77b724ee607282cf";
+const CEO = "1894c0b8d4212ed0";
+
+const row = (id: string, agent_path: string, status = "needs_you") => ({
+  id,
+  agent_path,
+  status,
+});
+
+describe("createSliceFreshness", () => {
+  it("names the agents patched at or after the sweep started", () => {
+    const freshness = createSliceFreshness();
+    freshness.notePatched(O1, 1_000);
+    freshness.notePatched(CEO, 500);
+
+    deepStrictEqual(freshness.patchedSince([O1, CEO, GHOST], 900), [O1]);
+    deepStrictEqual(freshness.patchedSince([O1, CEO], 1_000), [O1]);
+    deepStrictEqual(freshness.patchedSince([O1, CEO], 1_001), []);
+  });
+
+  it("keeps the newest stamp when patches land out of order", () => {
+    const freshness = createSliceFreshness();
+    freshness.notePatched(O1, 2_000);
+    freshness.notePatched(O1, 1_000);
+
+    deepStrictEqual(freshness.patchedSince([O1], 1_500), [O1]);
+  });
+
+  it("never names an agent that was never patched", () => {
+    deepStrictEqual(createSliceFreshness().patchedSince([O1], 0), []);
+  });
+});
+
+/**
+ * The incident shape: a sweep starts right before a mission is created on O1,
+ * is held ~15s by a stranded agent that only answers 503, and settles after
+ * the mission's reply landed through push-event patches. The sweep's O1 rows
+ * are the older snapshot; the patched slice must win.
+ */
+describe("foldSweep", () => {
+  it("carries the patched slice forward over the sweep's older snapshot", () => {
+    const sweepSnapshot = [row("buenas", O1, "needs_you"), row("c1", CEO)];
+    const cache = [
+      row("hola", O1, "needs_you"),
+      row("buenas", O1, "needs_you"),
+      row("c1", CEO),
+      row("g1", GHOST),
+    ];
+
+    const merged = foldSweep(sweepSnapshot, cache, [GHOST], [O1]);
+
+    deepStrictEqual(
+      merged.map((r) => r.id),
+      ["c1", "hola", "buenas", "g1"],
+      "CEO fresh, O1 from the newer patch, the ghost carried as a failed agent",
+    );
+  });
+
+  it("drops the sweep's rows for an overtaken agent even when they carry a newer-looking status", () => {
+    // The patch emptied O1's slice (its last mission was archived while the
+    // sweep was held). The sweep's stale row must not resurrect it.
+    const merged = foldSweep(
+      [row("old", O1, "running"), row("c1", CEO)],
+      [row("c1", CEO)],
+      [],
+      [O1],
+    );
+    deepStrictEqual(
+      merged.map((r) => r.id),
+      ["c1"],
+    );
+  });
+
+  it("is mergePartialSweep when nothing was overtaken", () => {
+    const fresh = [row("c1", CEO)];
+    strictEqual(foldSweep(fresh, [row("g1", GHOST)], [], []), fresh);
+    deepStrictEqual(
+      foldSweep(fresh, [row("g1", GHOST)], [GHOST], []).map((r) => r.id),
+      ["c1", "g1"],
+    );
+  });
+
+  it("ignores the overtaken list with no cache to carry from", () => {
+    // First sweep of the session: the sweep's rows are the ONLY rows for O1;
+    // dropping them would blank the agent, not refresh it.
+    const fresh = [row("hola", O1)];
+    strictEqual(foldSweep(fresh, undefined, [], [O1]), fresh);
+  });
+});

--- a/app/tests/open-conversation-identity.test.ts
+++ b/app/tests/open-conversation-identity.test.ts
@@ -1,0 +1,122 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { resolveOpenConversation } from "../src/components/board/open-conversation-identity.ts";
+
+const card = {
+  id: "hola",
+  metadata: { sessionKey: "activity-hola", agentPath: "Personal/O1" },
+};
+const routineCard = {
+  id: "digest",
+  metadata: { sessionKey: "routine-digest", agentPath: "Personal/CEO" },
+};
+const legacyCard = { id: "legacy", metadata: { agentPath: "Personal/O1" } };
+
+describe("resolveOpenConversation", () => {
+  it("reads the selected card first", () => {
+    deepStrictEqual(
+      resolveOpenConversation({
+        selectedId: "digest",
+        selectedItem: routineCard,
+        created: {
+          activityId: "digest",
+          agentPath: "elsewhere",
+          sessionKey: "activity-digest",
+        },
+        lastResolved: null,
+      }),
+      {
+        activityId: "digest",
+        sessionKey: "routine-digest",
+        agentPath: "Personal/CEO",
+      },
+    );
+  });
+
+  it("derives activity-{id} for a legacy card without a stored session key", () => {
+    deepStrictEqual(
+      resolveOpenConversation({
+        selectedId: "legacy",
+        selectedItem: legacyCard,
+        created: null,
+        lastResolved: null,
+      }),
+      {
+        activityId: "legacy",
+        sessionKey: "activity-legacy",
+        agentPath: "Personal/O1",
+      },
+    );
+  });
+
+  it("falls back to the just-created mission before its row lands", () => {
+    deepStrictEqual(
+      resolveOpenConversation({
+        selectedId: "hola",
+        selectedItem: null,
+        created: {
+          activityId: "hola",
+          agentPath: "Personal/O1",
+          sessionKey: "activity-hola",
+        },
+        lastResolved: null,
+      }),
+      {
+        activityId: "hola",
+        sessionKey: "activity-hola",
+        agentPath: "Personal/O1",
+      },
+    );
+  });
+
+  it("keeps the last resolved identity while the card is transiently absent", () => {
+    const resolved = resolveOpenConversation({
+      selectedId: "hola",
+      selectedItem: card,
+      created: null,
+      lastResolved: null,
+    });
+    // A stale sweep settled and the card fell out of the list for a beat.
+    deepStrictEqual(
+      resolveOpenConversation({
+        selectedId: "hola",
+        selectedItem: null,
+        created: null,
+        lastResolved: resolved,
+      }),
+      resolved,
+    );
+  });
+
+  it("never reuses an identity resolved for another selection", () => {
+    strictEqual(
+      resolveOpenConversation({
+        selectedId: "other",
+        selectedItem: null,
+        created: null,
+        lastResolved: {
+          activityId: "hola",
+          sessionKey: "activity-hola",
+          agentPath: "Personal/O1",
+        },
+      }),
+      null,
+    );
+  });
+
+  it("resolves nothing without a selection", () => {
+    strictEqual(
+      resolveOpenConversation({
+        selectedId: null,
+        selectedItem: null,
+        created: null,
+        lastResolved: {
+          activityId: "hola",
+          sessionKey: "activity-hola",
+          agentPath: "Personal/O1",
+        },
+      }),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

PRODUCT-1696. Two user-visible bugs on the hosted profile, one shared trigger.

**Trigger.** One of the user's agents is a ghost: its create never settled on the control-plane (the Deployment was never built), and every delete since left the registry row in `provisioning`, so every request to it answers `503 engine unavailable`. The client correctly classes that as "waking", but it never wakes. The server-side fix is a separate control-plane PR in the cloud repo (the delete handler only tombstoned `active` rows).

**Bug 2 (chat emptied after a reply).** The cross-agent sweep reads every agent at its start but writes the whole board when the LAST agent answers. The ghost's read spends the whole ~15s cold-start retry budget, so a sweep that started right before a mission was created settled after the reply had landed through push-event patches, and overwrote the board with its older snapshot. The just-created card dropped out of the list, the panel keys its feed and title off the selected card, and the chat went blank, with the ghost's waking toast over the composer.

**Bug 1 (misleading toast).** The waking toast said "Try again shortly". Sends to a waking agent already park and flush on their own, so the copy now says it usually takes about 20 seconds and the message does not need to be sent again (en / es / pt).

## Changes

- `app/src/lib/all-conversations-freshness.ts`: push-event patches stamp their agent at the read; the sweep remembers when it started; on settle, agents patched since are folded like failed agents (cached slice carried forward, the sweep's stale rows dropped).
- `app/src/components/board/open-conversation-identity.ts`: the open panel keeps the identity its selection last resolved to while the card is transiently absent from the item list, instead of blanking.
- `hooks/queries/use-conversations.ts`, `hooks/use-agent-invalidation.ts`, `components/board/use-mc-open-conversation.ts`: wiring.
- `shell.json` (en/es/pt): `errorToast.engineWakingDescription`.

## Before the fix

1. Hosted account with two agents, one of which answers 503 to everything for 15s+ (a stranded `provisioning` row; any pod mid cold-start also works, it just widens the window).
2. Open Mission Control, wait for the first partial-sweep notice toast, then keep sending short messages to the healthy agent in NEW chats.
3. Within a few re-sweeps, a reply lands and a few seconds later the card disappears from the board and the open chat blanks (no task subtitle, empty feed), with "your agent is waking up" toasting for the other agent.

## After the fix

1. Same setup. The board keeps the just-created card across every re-sweep settle; the open chat keeps its title and feed.
2. The waking toast reads "It usually takes about 20 seconds. You don't need to send your message again."
3. Unit: `cd app && pnpm test` (new `all-conversations-freshness.test.ts`, `open-conversation-identity.test.ts`).

## Checks

`pnpm check` (Biome), `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (4049 pass), `cd app && pnpm check-locales`, `pnpm --filter houston-web typecheck`.
