### PR TITLE
fix(routines): honest connection badge, optimistic edits, fail-closed writes on a fenced pod (PRODUCT-1706)

### DIFF
--- a/app/src/hooks/queries/use-routines.ts
+++ b/app/src/hooks/queries/use-routines.ts
@@ -1,4 +1,8 @@
-import type { NewRoutine, RoutineUpdate } from "@houston-ai/engine-client";
+import type {
+  NewRoutine,
+  Routine,
+  RoutineUpdate,
+} from "@houston-ai/engine-client";
 import {
   type QueryClient,
   useMutation,
@@ -6,6 +10,10 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
+import {
+  patchRoutineList,
+  replaceRoutineInList,
+} from "../../lib/routine-optimistic";
 import { tauriRoutines } from "../../lib/tauri";
 
 /**
@@ -85,6 +93,12 @@ export interface RoutineWriteFor {
  */
 export function useRoutineWritesForAnyAgent() {
   const qc = useQueryClient();
+  // Optimistic (PRODUCT-1706): the row and the screen paint the edit the
+  // instant it is sent. On the hosted profile a write can take seconds (the
+  // agent's pod may have to wake first), and painting the OLD schedule for
+  // that window made a saved time look ignored. The host's applied routine
+  // replaces the guess when it lands; a rejected write rolls the cache back
+  // and refetches, and the caller's onError shows the authored toast.
   const update = useMutation({
     mutationFn: ({
       agentPath,
@@ -92,7 +106,28 @@ export function useRoutineWritesForAnyAgent() {
       updates,
     }: RoutineWriteFor & { updates: RoutineUpdate }) =>
       tauriRoutines.update(agentPath, routineId, updates),
-    onSuccess: (_r, { agentPath }) => afterRoutineWrite(qc, agentPath),
+    onMutate: async ({ agentPath, routineId, updates }) => {
+      const key = queryKeys.routines(agentPath);
+      // An in-flight refetch would overwrite the optimistic row with the
+      // pre-edit truth the moment it lands.
+      await qc.cancelQueries({ queryKey: key });
+      const previous = qc.getQueryData<Routine[]>(key);
+      qc.setQueryData<Routine[]>(key, (list) =>
+        patchRoutineList(list, routineId, updates, new Date().toISOString()),
+      );
+      return { previous };
+    },
+    onError: (_err, { agentPath }, context) => {
+      const key = queryKeys.routines(agentPath);
+      if (context?.previous) qc.setQueryData(key, context.previous);
+      qc.invalidateQueries({ queryKey: key });
+    },
+    onSuccess: (routine, { agentPath }) => {
+      qc.setQueryData<Routine[]>(queryKeys.routines(agentPath), (list) =>
+        replaceRoutineInList(list, routine),
+      );
+      afterRoutineWrite(qc, agentPath);
+    },
   });
   const remove = useMutation({
     mutationFn: ({ agentPath, routineId }: RoutineWriteFor) =>

--- a/app/src/lib/routine-optimistic.ts
+++ b/app/src/lib/routine-optimistic.ts
@@ -1,0 +1,63 @@
+/**
+ * The optimistic shape of a routine edit (PRODUCT-1706): what the routines
+ * list shows the instant a save is sent, before the host answers.
+ *
+ * A routine write on the hosted profile can take seconds (the agent's pod may
+ * have to wake first), and the list used to keep painting the OLD schedule
+ * for that whole window — a saved 7:00 still read 11:30, so the save looked
+ * ignored. This mirrors the host's own `applyRoutineUpdate` closely enough
+ * for the interim paint: defined keys replace, `null` clears a pin or the
+ * trigger, and setting one wake mechanism drops the other. The host's applied
+ * routine replaces the guess as soon as it lands.
+ *
+ * Pure + dependency-free so it is unit-tested without a query client
+ * (`app/tests/routine-optimistic.test.ts`).
+ */
+
+import type { Routine, RoutineUpdate } from "@houston-ai/engine-client";
+
+export function applyOptimisticRoutineUpdate(
+  current: Routine,
+  updates: RoutineUpdate,
+  nowIso: string,
+): Routine {
+  const next: Record<string, unknown> = { ...current, updated_at: nowIso };
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    if (value === null) {
+      delete next[key];
+      continue;
+    }
+    next[key] = value;
+  }
+  // Exactly one wake mechanism: a real schedule clears the trigger and a real
+  // trigger clears the schedule, exactly as the host applies it.
+  if (updates.schedule) delete next.trigger;
+  if (updates.trigger) delete next.schedule;
+  return next as unknown as Routine;
+}
+
+/** The cached list with one routine's edit applied; untouched rows are the
+ *  same objects, so unaffected rows do not re-render. */
+export function patchRoutineList(
+  list: Routine[] | undefined,
+  routineId: string,
+  updates: RoutineUpdate,
+  nowIso: string,
+): Routine[] | undefined {
+  if (!list) return undefined;
+  return list.map((routine) =>
+    routine.id === routineId
+      ? applyOptimisticRoutineUpdate(routine, updates, nowIso)
+      : routine,
+  );
+}
+
+/** The cached list with the host's applied routine in place of the guess. */
+export function replaceRoutineInList(
+  list: Routine[] | undefined,
+  routine: Routine,
+): Routine[] | undefined {
+  if (!list || !routine?.id) return list;
+  return list.map((entry) => (entry.id === routine.id ? routine : entry));
+}

--- a/app/src/lib/routine-provider-health.ts
+++ b/app/src/lib/routine-provider-health.ts
@@ -20,6 +20,17 @@
  * probe saying "I could not confirm", which renders as the neutral `checking`
  * — never as a healthy or a broken claim (the HOU-979 rule).
  *
+ * WHEN THE TWO DISAGREE, `authenticated` wins on the connected/not-connected
+ * axis. While an agent's pod is asleep the gateway answers `/providers` from
+ * the pod's LAST captured view with only `configured` (→ `authenticated`)
+ * overlaid from the credential store; the captured `health` is whatever the
+ * pod computed for whoever asked last, and in a team space that was often a
+ * `not_connected` for a different member's scope. Reading `health` first
+ * painted "Not connected" on every routine of an account whose chat picker
+ * (which reads `authenticated`) said Connected, until the pod woke and the
+ * proxied answer replaced the capture. `needs_reconnect` and `out_of_credits`
+ * are kept: both describe a credential that IS present.
+ *
  * Pure + DOM/i18n-free so every state is unit-tested without a renderer
  * (`app/tests/routine-provider-health.test.ts`).
  */
@@ -54,14 +65,33 @@ export function routineProviderHealth(
   status: RoutineProviderStatusLike | undefined,
 ): RoutineProviderHealth {
   if (!status) return "checking";
-  if (status.health) {
-    return status.health === "unreachable" ? "checking" : status.health;
+  // `unknown` is "could not confirm", never "signed out" — the same reading
+  // the rest of the app gives the tri-state.
+  if (status.auth_state === "unknown" || status.health === "unreachable") {
+    return "checking";
   }
-  // Older engine: no `health` field at all. Read the tri-state exactly as the
-  // rest of the app does — `unknown` is "could not confirm", never "signed
-  // out" — and fall back to the denormalized boolean for the rest.
-  if (status.auth_state === "unknown") return "checking";
-  return status.authenticated ? "connected" : "not_connected";
+  const configured = connectedClaim(status);
+  if (status.health) {
+    if (configured === undefined) return status.health;
+    if (!configured) return "not_connected";
+    return status.health === "not_connected" ? "connected" : status.health;
+  }
+  // Older engine: no `health` field at all — the denormalized boolean is all
+  // there is.
+  return configured ? "connected" : "not_connected";
+}
+
+/**
+ * The probe's connected/not-connected claim (`configured` on the wire), or
+ * `undefined` when the status carries neither field — a hand-built fixture
+ * with only `health`, which is then taken at its word.
+ */
+function connectedClaim(
+  status: RoutineProviderStatusLike,
+): boolean | undefined {
+  if (status.authenticated !== undefined) return status.authenticated;
+  if (status.auth_state === undefined) return undefined;
+  return status.auth_state === "authenticated";
 }
 
 /**

--- a/app/tests/routine-optimistic.test.ts
+++ b/app/tests/routine-optimistic.test.ts
@@ -1,0 +1,112 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Routine } from "@houston-ai/engine-client";
+import {
+  applyOptimisticRoutineUpdate,
+  patchRoutineList,
+  replaceRoutineInList,
+} from "../src/lib/routine-optimistic.ts";
+
+/**
+ * PRODUCT-1706 — a routine edit paints immediately. These pin that the interim
+ * shape matches what the host will apply: the schedule moves at once, a wake
+ * mechanism switch never leaves both set, and a null clears a pin.
+ */
+const NOW = "2026-09-08T13:28:21.755Z";
+
+function routine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    name: "Daily cut",
+    prompt: "Cut a release",
+    schedule: "30 11 * * 1-5",
+    enabled: true,
+    provider: "anthropic",
+    model: "claude-opus-5",
+    created_at: "2026-09-01T00:00:00.000Z",
+    updated_at: "2026-09-01T00:00:00.000Z",
+    ...overrides,
+  } as Routine;
+}
+
+describe("applyOptimisticRoutineUpdate", () => {
+  it("moves the schedule and stamps updated_at at once", () => {
+    const next = applyOptimisticRoutineUpdate(
+      routine(),
+      { schedule: "0 7 * * 1-5" },
+      NOW,
+    );
+    strictEqual(next.schedule, "0 7 * * 1-5");
+    strictEqual(next.updated_at, NOW);
+    strictEqual(next.name, "Daily cut");
+  });
+
+  it("leaves undefined keys alone", () => {
+    const next = applyOptimisticRoutineUpdate(
+      routine(),
+      { name: "Renamed", prompt: undefined },
+      NOW,
+    );
+    strictEqual(next.name, "Renamed");
+    strictEqual(next.prompt, "Cut a release");
+  });
+
+  it("a null clears a pin back to inherit", () => {
+    const next = applyOptimisticRoutineUpdate(
+      routine(),
+      { provider: null, model: null },
+      NOW,
+    );
+    strictEqual("provider" in next, false);
+    strictEqual("model" in next, false);
+  });
+
+  it("setting a schedule drops an event trigger, and vice versa", () => {
+    const trigger = { kind: "webhook" } as unknown as Routine["trigger"];
+    const withTrigger = applyOptimisticRoutineUpdate(
+      routine(),
+      { trigger },
+      NOW,
+    );
+    strictEqual("schedule" in withTrigger, false);
+    deepStrictEqual(withTrigger.trigger, trigger);
+
+    const backToCron = applyOptimisticRoutineUpdate(
+      withTrigger,
+      { schedule: "0 9 * * *", trigger: null },
+      NOW,
+    );
+    strictEqual(backToCron.schedule, "0 9 * * *");
+    strictEqual("trigger" in backToCron, false);
+  });
+});
+
+describe("patchRoutineList", () => {
+  it("patches only the addressed routine and keeps other rows identical", () => {
+    const other = routine({ id: "r2", name: "Other" });
+    const list = [routine(), other];
+    const next = patchRoutineList(list, "r1", { enabled: false }, NOW);
+    strictEqual(next?.[0]?.enabled, false);
+    strictEqual(next?.[1], other);
+  });
+
+  it("an empty cache stays empty", () => {
+    strictEqual(
+      patchRoutineList(undefined, "r1", { enabled: false }, NOW),
+      undefined,
+    );
+  });
+});
+
+describe("replaceRoutineInList", () => {
+  it("swaps the host's applied routine in for the guess", () => {
+    const applied = routine({ schedule: "0 7 * * 1-5", updated_at: NOW });
+    const next = replaceRoutineInList([routine()], applied);
+    strictEqual(next?.[0], applied);
+  });
+
+  it("ignores an answer without an id (a non-hosted adapter's empty echo)", () => {
+    const list = [routine()];
+    strictEqual(replaceRoutineInList(list, {} as Routine), list);
+  });
+});

--- a/app/tests/routine-provider-health.test.ts
+++ b/app/tests/routine-provider-health.test.ts
@@ -34,7 +34,7 @@ describe("routineProviderHealth", () => {
     strictEqual(routineProviderHealth({ health: "unreachable" }), "checking");
   });
 
-  it("health wins over the denormalized boolean when both are present", () => {
+  it("a present credential keeps its richer health", () => {
     // Out of credits is an AUTHENTICATED credential with no quota: reading
     // `authenticated` alone would call it connected and the run would fail.
     strictEqual(
@@ -42,12 +42,53 @@ describe("routineProviderHealth", () => {
       "out_of_credits",
     );
     strictEqual(
+      routineProviderHealth({ authenticated: true, health: "needs_reconnect" }),
+      "needs_reconnect",
+    );
+  });
+
+  // A sleeping pod's `/providers` is the pod's LAST captured answer with only
+  // `configured` overlaid from the credential store (PRODUCT-1706): the
+  // captured `health` can be another member's "not connected" while THIS
+  // viewer's account is stored and usable. The store's claim wins.
+  it("a stored credential overrides a captured 'not connected'", () => {
+    strictEqual(
+      routineProviderHealth({
+        authenticated: true,
+        auth_state: "authenticated",
+        health: "not_connected",
+      }),
+      "connected",
+    );
+  });
+
+  it("a missing credential overrides a captured 'connected'", () => {
+    strictEqual(
       routineProviderHealth({
         authenticated: false,
         auth_state: "unauthenticated",
         health: "connected",
       }),
-      "connected",
+      "not_connected",
+    );
+    strictEqual(
+      routineProviderHealth({
+        authenticated: false,
+        auth_state: "unauthenticated",
+        health: "needs_reconnect",
+      }),
+      "not_connected",
+    );
+  });
+
+  it("an unknown probe is checking even when a stale health is captured", () => {
+    strictEqual(
+      routineProviderHealth({
+        authenticated: false,
+        auth_state: "unknown",
+        health: "not_connected",
+      }),
+      "checking",
     );
   });
 

--- a/packages/host/src/routes/store-fence-gate.test.ts
+++ b/packages/host/src/routes/store-fence-gate.test.ts
@@ -1,0 +1,140 @@
+import type { ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  handleStoreFenceGate,
+  isFencedWrite,
+  resetStoreFenceReport,
+  STORE_FENCED_ERROR,
+} from "./store-fence-gate";
+
+type FakeResponse = ServerResponse & {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+};
+
+function fakeResponse(): FakeResponse {
+  const res = {
+    status: 0,
+    headers: {} as Record<string, string>,
+    body: undefined as unknown,
+    headersSent: false,
+    writeHead(status: number, headers: Record<string, string>) {
+      res.status = status;
+      res.headers = headers;
+      res.headersSent = true;
+      return res;
+    },
+    end(buf?: Buffer) {
+      if (buf) res.body = JSON.parse(buf.toString("utf8"));
+    },
+  };
+  return res as unknown as FakeResponse;
+}
+
+describe("isFencedWrite", () => {
+  it("gates user-facing agent-data mutations and nothing else", () => {
+    expect(isFencedWrite("PATCH", "/agents/a/routines/r1", "agents")).toBe(
+      true,
+    );
+    expect(isFencedWrite("POST", "/agents/a/activities", "agents")).toBe(true);
+    expect(isFencedWrite("DELETE", "/agents/a/routines/r1", "agents")).toBe(
+      true,
+    );
+    expect(isFencedWrite("GET", "/agents/a/routines", "agents")).toBe(false);
+    expect(isFencedWrite("POST", "/feedback", "agents")).toBe(false);
+  });
+
+  it("gates the runtime's routine/learning/mission/skill saves only", () => {
+    expect(isFencedWrite("POST", "/sandbox/routines", "sandbox")).toBe(true);
+    expect(isFencedWrite("PATCH", "/sandbox/routines/r1", "sandbox")).toBe(
+      true,
+    );
+    expect(isFencedWrite("POST", "/sandbox/learnings", "sandbox")).toBe(true);
+    expect(isFencedWrite("POST", "/sandbox/missions/start", "sandbox")).toBe(
+      true,
+    );
+    expect(isFencedWrite("POST", "/sandbox/skills/install", "sandbox")).toBe(
+      true,
+    );
+    // The credential serve and the integration proxy never touch the tree.
+    expect(isFencedWrite("POST", "/sandbox/credential", "sandbox")).toBe(false);
+    expect(
+      isFencedWrite("POST", "/sandbox/integrations/execute", "sandbox"),
+    ).toBe(false);
+    // The user-facing prefix is not this scope's job (it is gated post-auth).
+    expect(isFencedWrite("PATCH", "/agents/a/routines/r1", "sandbox")).toBe(
+      false,
+    );
+  });
+});
+
+describe("handleStoreFenceGate", () => {
+  afterEach(() => {
+    resetStoreFenceReport();
+    vi.restoreAllMocks();
+  });
+
+  it("passes every request through while the fence is held or absent", () => {
+    const res = fakeResponse();
+    expect(
+      handleStoreFenceGate({}, "PATCH", "/agents/a/routines/r1", res, "agents"),
+    ).toBe(false);
+    expect(
+      handleStoreFenceGate(
+        { storeFenced: () => false },
+        "PATCH",
+        "/agents/a/routines/r1",
+        res,
+        "agents",
+      ),
+    ).toBe(false);
+    expect(res.headersSent).toBe(false);
+  });
+
+  it("refuses a write with a distinct 503 once the fence is lost, and reports once", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const deps = { storeFenced: () => true };
+    const first = fakeResponse();
+    expect(
+      handleStoreFenceGate(
+        deps,
+        "PATCH",
+        "/agents/a/routines/r1",
+        first,
+        "agents",
+      ),
+    ).toBe(true);
+    expect(first.status).toBe(503);
+    expect(first.body).toEqual({
+      error: STORE_FENCED_ERROR,
+      code: "store_fenced",
+    });
+    // Not the gateway's waking shape: no Retry-After, so the client surfaces
+    // it as a real failure instead of a quiet wake.
+    expect(first.headers["Retry-After"]).toBeUndefined();
+
+    const second = fakeResponse();
+    expect(
+      handleStoreFenceGate(
+        deps,
+        "POST",
+        "/sandbox/routines",
+        second,
+        "sandbox",
+      ),
+    ).toBe(true);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0]?.[0]).toContain("write fence was lost");
+
+    // Reads are untouched: the pod's copy is still the freshest answer.
+    const read = fakeResponse();
+    expect(
+      handleStoreFenceGate(deps, "GET", "/agents/a/routines", read, "agents"),
+    ).toBe(false);
+  });
+
+  it("names the state in the body so the toast and Sentry carry it", () => {
+    expect(STORE_FENCED_ERROR).toContain("newer engine");
+  });
+});

--- a/packages/host/src/routes/store-fence-gate.ts
+++ b/packages/host/src/routes/store-fence-gate.ts
@@ -1,0 +1,78 @@
+import type { ServerResponse } from "node:http";
+import { json } from "./http";
+
+/**
+ * Fail closed on agent-data writes once this pod has lost its object-store
+ * write fence (PRODUCT-1706).
+ *
+ * A managed pod claims a per-agent write lease at boot; when a NEWER boot
+ * takes it (a roll's replacement pod, a pool worker running the agent while
+ * the registry called it asleep), the store answers this pod's syncs with 409
+ * and the sync daemon halts for good — by design, it is no longer the writer.
+ * But the gateway kept proxying to the pod, and the pod kept answering
+ * routine/mission/config writes with 200: they landed on its own disk, showed
+ * in every read served by that pod, and were gone the moment the pod was
+ * recycled and the next one hydrated the store's copy. A routine edited to
+ * 7:00 fired at 7:00 for days, then silently reverted to its old 11:30.
+ *
+ * The write is refused instead. The 503 carries a distinct reason (not the
+ * gateway's waking shape), so the client shows its authored "couldn't save"
+ * copy and reports it: a fenced pod still receiving writes is a bug we want
+ * to see, never a quiet retry loop. Reads keep flowing — what the pod has is
+ * still the freshest answer until it is recycled.
+ */
+
+export const STORE_FENCED_ERROR =
+  "this agent's data can't be saved right now: a newer engine owns it, try again in a moment";
+
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/** Runtime-tool write families that land in the agent's synced tree. */
+const SANDBOX_WRITE = /^\/sandbox\/(routines|learnings|missions|skills)(\/|$)/;
+
+/**
+ * Whether a request would write agent data. `scope` follows the server's
+ * ordering: the sandbox families are gated before their HMAC routes, the
+ * user-facing `/agents/` routes only after the bearer has been verified (an
+ * anonymous caller must keep getting 401, not a hint about pod state).
+ */
+export function isFencedWrite(
+  method: string,
+  path: string,
+  scope: "sandbox" | "agents",
+): boolean {
+  if (!MUTATING.has(method.toUpperCase())) return false;
+  if (scope === "sandbox") return SANDBOX_WRITE.test(path);
+  return path.startsWith("/agents/");
+}
+
+let reported = false;
+
+/** Answer 503 and return true when the write must be refused. */
+export function handleStoreFenceGate(
+  deps: { storeFenced?: () => boolean },
+  method: string,
+  path: string,
+  res: ServerResponse,
+  scope: "sandbox" | "agents",
+): boolean {
+  if (!deps.storeFenced?.() || !isFencedWrite(method, path, scope)) {
+    return false;
+  }
+  if (!reported) {
+    // Once per process: the fence loss itself is logged as a breadcrumb by
+    // the sync daemon (superseded setup pods lose it routinely); a REFUSED
+    // write is the moment a user's edit would have been lost, and reports.
+    reported = true;
+    console.error(
+      `[local-host] refusing ${method} ${path}: the object-store write fence was lost; this pod's writes would not persist`,
+    );
+  }
+  json(res, 503, { error: STORE_FENCED_ERROR, code: "store_fenced" });
+  return true;
+}
+
+/** Test seam: forget the once-per-process report. */
+export function resetStoreFenceReport(): void {
+  reported = false;
+}

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -72,6 +72,7 @@ import { handleSetupRuntime } from "./routes/setup-runtime";
 import { handleSharedSkills } from "./routes/shared-skills";
 import { handleSkillsDirectory } from "./routes/skills-directory";
 import { handleSandboxSkills } from "./routes/skills-sandbox";
+import { handleStoreFenceGate } from "./routes/store-fence-gate";
 import { handleSandboxTranscripts } from "./routes/transcripts-sandbox";
 import { handleTriggerEvents } from "./routes/trigger-events";
 import type { FireLock } from "./schedule/fire-lock";
@@ -345,6 +346,10 @@ async function handle(
   // browser lands here from the service's consent screen with no Houston
   // bearer token — the single-use `state` is its authentication.
   if (await handleCustomOAuthCallback(deps, method, path, url, res)) return;
+  // A pod that lost its object-store write fence must not accept writes it
+  // can no longer persist (PRODUCT-1706): the runtime's own saves first, the
+  // user-facing /agents/ writes after auth below.
+  if (handleStoreFenceGate(deps, method, path, res, "sandbox")) return;
   // Runtime-facing scheduled-task save (merge-safe; HMAC sandbox token). The
   // agent's save_routine tool calls this instead of writing routines.json.
   if (await handleSandboxRoutines(deps, method, path, url, req, res)) return;
@@ -367,6 +372,7 @@ async function handle(
   // Everything past here is authenticated.
   const userId = await principal(deps, req, url);
   if (!userId) return json(res, 401, { error: "unauthorized" });
+  if (handleStoreFenceGate(deps, method, path, res, "agents")) return;
   // An AUTHENTICATED /agents/<id>/ request names the agent this host is
   // addressed as — the doc shadow's binding signal on hosts whose workspace
   // holds more than one agent directory (rename leftovers). After auth only:


### PR DESCRIPTION
Fixes PRODUCT-1706.

## What the user saw

1. Every routine in the Houston org read **Not connected** (list chip + the routine screen's Connect button) while Anthropic and OpenAI were connected and chat worked. It cleared by itself after editing a routine.
2. A routine the user had set to 7:00 showed 11:30 again, and fired at both times on some days.
3. Saving a new time kept painting the old one for a couple of seconds.

## Root causes and fixes

**False "Not connected" (client).** While the agent's pod is asleep, the gateway answers `/providers` from the pod's last captured view and overlays only `configured` from the credential store; the captured `health` field stays whatever the pod computed for whoever asked last (in a team space, often another member's `not_connected`). The routine badge read `health` first, the chat picker reads `configured`, so the two disagreed until a write woke the pod. `routineProviderHealth` now lets the configured claim win on the connected/not-connected axis and keeps `needs_reconnect` / `out_of_credits` for a credential that is present. (The gateway overlay should also rewrite `health`; that is a separate change in the cloud repo.)

**Schedule reverting (host).** Live run history for the affected routine shows fires at 7:00 on Sep 2-4 and at 11:30 on Sep 1, 4 and 7, and the stored cron was 11:30 again this morning: two schedules were alive at once and the 7:00 edit did not survive a pod recycle. A managed pod claims a per-agent write lease at boot; once a newer boot takes it (a roll's replacement pod, a pool worker running the agent while the registry called it asleep) the object store answers the pod's syncs with 409 and the sync daemon halts for good. The gateway never reads that state and kept proxying to the pod, which kept answering writes with 200: they landed on its own disk, showed in every read it served, and vanished when the next pod hydrated the store's copy. New `routes/store-fence-gate.ts` refuses agent-data writes (`/agents/*` after auth, and the runtime's routine/learning/mission/skill saves) with a distinct `503 {code:"store_fenced"}` once the fence is lost, reporting once per process. Reads keep flowing. Desktop and self-host have no fence and are untouched.

**No optimistic update (client).** `useRoutineWritesForAnyAgent().update` now patches the cached routines list on mutate (new pure helper `lib/routine-optimistic.ts`, mirroring the host's `applyRoutineUpdate`), swaps in the host's applied routine on success, and rolls back plus refetches on error while the existing authored toast reports the failure. Covers the routine screen and the list rows.

## Verification

Before the fix:
1. Sign in to a team org whose agent is asleep, open an agent's Routines tab: every routine shows "Not connected" although the chat picker shows the provider connected. Edit any routine (wakes the pod), go back: the chips are gone.
2. Open a routine, change its time, save: the old time stays on screen until the refetch lands.
3. Host: with a pod whose sync daemon has latched `fenced` (`GET /health` shows `storeFenced: true`), `PATCH /agents/<id>/routines/<rid>` answers 200 and the edit is lost on the next recycle.

After the fix:
1. Same sleeping-pod org: routines show no chip and the screen shows Connected, matching the chat picker.
2. Change a time and save: the field, the row summary and "next run" update immediately; a failed save rolls back and shows the "couldn't update" toast.
3. Fenced pod: the same PATCH answers `503 {"error":"…a newer engine owns it…","code":"store_fenced"}`, the app shows the update-failed toast, and Sentry gets one host error per process.

Checks: `pnpm check`, `pnpm check:boundaries`, `pnpm --filter @houston/host test` (187 files), `pnpm --filter @houston/host typecheck`, `cd app && pnpm tsgo --noEmit && pnpm test` (4060 tests), `pnpm --filter houston-web typecheck`.
