### PR TITLE
fix(runtime): rerun a Claude turn fresh when the resumed session comes up without Houston's tool server (PRODUCT-1706)

### DIFF
--- a/packages/runtime/src/backends/claude/session.test.ts
+++ b/packages/runtime/src/backends/claude/session.test.ts
@@ -501,3 +501,129 @@ test("subscribeAssistantMessageStart fires per main-thread message_start, never 
   await session.prompt("again");
   expect(starts).toBe(2);
 });
+
+// PRODUCT-1706: a resumed session that comes up without Houston's tool server
+// reruns fresh (with the canonical history) instead of letting the model finish
+// a tool-less turn and report the integrations as "missing".
+function initMsg(servers: unknown, sessionId = "s"): SDKMessage {
+  return {
+    type: "system",
+    subtype: "init",
+    session_id: sessionId,
+    mcp_servers: servers,
+  } as unknown as SDKMessage;
+}
+function missingHoustonToolResult(sessionId = "s"): SDKMessage {
+  return {
+    type: "user",
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "t1",
+          is_error: true,
+          content:
+            "<tool_use_error>Error: No such tool available: mcp__houston__integration_execute</tool_use_error>",
+        },
+      ],
+    },
+    session_id: sessionId,
+  } as unknown as SDKMessage;
+}
+
+test("a resume whose init lacks the houston server reruns fresh with the history prefix", async () => {
+  const store = fakeStore("sess-old");
+  const prompts: string[] = [];
+  const optionsSeen: Options[] = [];
+  const query: ClaudeQuery = (params) => {
+    prompts.push(params.prompt);
+    optionsSeen.push(params.options);
+    if (params.options.resume)
+      return arrayQuery([
+        initMsg([{ name: "houston", status: "failed" }], "sess-old"),
+        textMsg("tool-less answer", "sess-old"),
+        usageMsg("sess-old"),
+      ])(params);
+    return arrayQuery([
+      initMsg([{ name: "houston", status: "connected" }], "sess-new"),
+      textMsg("recovered", "sess-new"),
+      usageMsg("sess-new"),
+    ])(params);
+  };
+  const session = make({
+    query,
+    store,
+    freshRetryPromptPrefix: "[canonical replay]\n",
+  });
+  const events: WireEvent[] = [];
+  session.subscribe((e) => events.push(e));
+
+  await session.prompt("run the routine");
+
+  expect(prompts).toEqual([
+    "run the routine",
+    "[canonical replay]\nrun the routine",
+  ]);
+  expect(optionsSeen[0]?.resume).toBe("sess-old");
+  expect(optionsSeen[1] && "resume" in optionsSeen[1]).toBe(false);
+  expect(optionsSeen[0]?.abortController?.signal.aborted).toBe(true);
+  // The abandoned attempt's answer never reaches the wire; the fresh one does.
+  expect(events.filter((e) => e.type === "text")).toEqual([
+    { type: "text", data: "recovered" },
+  ]);
+  expect(events.some((e) => e.type === "provider_error")).toBe(false);
+  // The dropped mapping is not re-stored from the abandoned attempt.
+  expect(store.setCalls).toEqual([["c1", "sess-new"]]);
+});
+
+test("the live signature (a houston tool answered 'No such tool') also reruns fresh", async () => {
+  const store = fakeStore("sess-old");
+  let call = 0;
+  const query: ClaudeQuery = (params) => {
+    call++;
+    if (call === 1)
+      return arrayQuery([
+        initMsg([{ name: "houston", status: "connected" }], "sess-old"),
+        missingHoustonToolResult("sess-old"),
+        textMsg("integrations are missing", "sess-old"),
+        usageMsg("sess-old"),
+      ])(params);
+    return arrayQuery([textMsg("recovered", "sess-new"), usageMsg("sess-new")])(
+      params,
+    );
+  };
+  const session = make({ query, store });
+  const events: WireEvent[] = [];
+  session.subscribe((e) => events.push(e));
+
+  await session.prompt("go");
+
+  expect(call).toBe(2);
+  expect(events.filter((e) => e.type === "text")).toEqual([
+    { type: "text", data: "recovered" },
+  ]);
+});
+
+test("a FRESH session without the houston server fails the turn visibly, no retry loop", async () => {
+  let call = 0;
+  const query: ClaudeQuery = (params) => {
+    call++;
+    return arrayQuery([
+      initMsg([], "sess-new"),
+      textMsg("tool-less answer", "sess-new"),
+      usageMsg("sess-new"),
+    ])(params);
+  };
+  const session = make({ query, store: fakeStore() });
+  const events: WireEvent[] = [];
+  session.subscribe((e) => events.push(e));
+
+  await session.prompt("go");
+
+  expect(call).toBe(1);
+  expect(events.some((e) => e.type === "text")).toBe(false);
+  const error = events.find((e) => e.type === "provider_error");
+  expect(error).toBeDefined();
+  expect(JSON.stringify(error)).toContain("did not attach");
+});

--- a/packages/runtime/src/backends/claude/session.ts
+++ b/packages/runtime/src/backends/claude/session.ts
@@ -5,6 +5,7 @@ import { toSdkEffort } from "./effort";
 import { classifyText } from "./errors";
 import { toSdkModel } from "./model";
 import type { SessionsStore } from "./sessions-store";
+import { houstonToolServerLost } from "./tool-server-lost";
 import { createStreamTranslator } from "./translate";
 
 /**
@@ -91,6 +92,8 @@ export class ClaudeSession implements HarnessSession {
   private readonly messageStartListeners = new Set<() => void>();
   private disposed = false;
   private aborting = false;
+  /** Why the last attempt asked for a fresh rerun, for the warn line. */
+  private retryReason = "";
   private abortController: AbortController | undefined;
   private model: string;
   private thinkingLevel: ThinkingLevel | undefined;
@@ -167,11 +170,12 @@ export class ClaudeSession implements HarnessSession {
     const outcome = await this.runAttempt(text, resume, auth.env);
     if (outcome !== "retry-fresh") return;
     // The SDK refused the resume id (its cwd-scoped lookup missed the
-    // transcript — e.g. the workspace was renamed). The stale mapping is
+    // transcript — e.g. the workspace was renamed), or resumed it with
+    // Houston's tool server detached (PRODUCT-1706). The stale mapping is
     // already dropped; run the turn once more as a fresh session instead of
     // erroring a conversation that can never resume again.
     console.warn(
-      `[claude] resume for conversation ${this.deps.conversationId} was rejected by the SDK; starting a fresh session`,
+      `[claude] resume for conversation ${this.deps.conversationId} ${this.retryReason}; starting a fresh session`,
     );
     await this.runAttempt(
       `${this.deps.freshRetryPromptPrefix ?? ""}${text}`,
@@ -230,6 +234,33 @@ export class ClaudeSession implements HarnessSession {
         if (isAssistantMessageStart(msg))
           for (const l of this.messageStartListeners) l();
         if (hasSessionId(msg)) capturedSessionId = msg.session_id;
+        if (houstonToolServerLost(msg)) {
+          // The turn is running without Houston's tools (PRODUCT-1706). On a
+          // resume, abandon this attempt and rerun fresh with the canonical
+          // history — never let the model finish a tool-less turn and report
+          // the integrations as "missing". A fresh session that still lacks
+          // them is a real failure: surface it as one.
+          abortController.abort();
+          if (resume !== undefined) {
+            // The mapping is dropped on purpose; the finally block must not
+            // re-store the session id this attempt captured.
+            capturedSessionId = undefined;
+            this.retryReason = "came up without Houston's tool server";
+            this.deps.sessionsStore.remove(this.deps.conversationId);
+            return "retry-fresh";
+          }
+          providerErrored = true;
+          this.emit({
+            type: "provider_error",
+            data: classifyText(
+              "Houston's tools did not attach to this turn (the houston MCP server is not connected); the turn was stopped instead of running without them",
+              this.model,
+              null,
+              this.usedAccessDigest,
+            ),
+          });
+          return "done";
+        }
         for (const wire of translator.translate(msg)) {
           if (wire.type === "provider_error") {
             const errText =
@@ -237,6 +268,7 @@ export class ClaudeSession implements HarnessSession {
                 ? wire.data.raw_excerpt
                 : wire.data.message;
             if (danglingResume(errText)) {
+              this.retryReason = "was rejected by the SDK";
               this.deps.sessionsStore.remove(this.deps.conversationId);
               return "retry-fresh";
             }
@@ -257,6 +289,7 @@ export class ClaudeSession implements HarnessSession {
       // throw is just the SDK closing the iterator — don't re-report it.
       if (providerErrored) return "done";
       if (danglingResume(errMessage(err))) {
+        this.retryReason = "was rejected by the SDK";
         this.deps.sessionsStore.remove(this.deps.conversationId);
         return "retry-fresh";
       }

--- a/packages/runtime/src/backends/claude/tool-server-lost.test.ts
+++ b/packages/runtime/src/backends/claude/tool-server-lost.test.ts
@@ -1,0 +1,80 @@
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { expect, test } from "vitest";
+import { houstonToolServerLost } from "./tool-server-lost";
+
+const init = (servers: unknown): SDKMessage =>
+  ({
+    type: "system",
+    subtype: "init",
+    session_id: "s",
+    mcp_servers: servers,
+  }) as unknown as SDKMessage;
+
+const toolResult = (content: unknown, isError = true): SDKMessage =>
+  ({
+    type: "user",
+    message: {
+      role: "user",
+      content: [
+        { type: "tool_result", tool_use_id: "t1", is_error: isError, content },
+      ],
+    },
+    session_id: "s",
+  }) as unknown as SDKMessage;
+
+test("an init that lists houston as connected is fine", () => {
+  expect(
+    houstonToolServerLost(init([{ name: "houston", status: "connected" }])),
+  ).toBe(false);
+});
+
+test("an init with houston failed or absent means the tools are gone", () => {
+  expect(
+    houstonToolServerLost(init([{ name: "houston", status: "failed" }])),
+  ).toBe(true);
+  expect(houstonToolServerLost(init([]))).toBe(true);
+  expect(
+    houstonToolServerLost(init([{ name: "other", status: "connected" }])),
+  ).toBe(true);
+});
+
+test("an init without the servers list (an older CLI) is not a verdict", () => {
+  expect(houstonToolServerLost(init(undefined))).toBe(false);
+});
+
+test("the live signature: an error tool_result naming a houston tool as unavailable", () => {
+  expect(
+    houstonToolServerLost(
+      toolResult(
+        "<tool_use_error>Error: No such tool available: mcp__houston__integration_execute</tool_use_error>",
+      ),
+    ),
+  ).toBe(true);
+  expect(
+    houstonToolServerLost(
+      toolResult([
+        {
+          type: "text",
+          text: "No such tool available: mcp__houston__ask_user",
+        },
+      ]),
+    ),
+  ).toBe(true);
+});
+
+test("other tool errors and successful results are left alone", () => {
+  expect(
+    houstonToolServerLost(toolResult("No such tool available: WebSearch")),
+  ).toBe(false);
+  expect(
+    houstonToolServerLost(
+      toolResult("No such tool available: mcp__houston__x", false),
+    ),
+  ).toBe(false);
+  expect(
+    houstonToolServerLost({
+      type: "assistant",
+      message: { content: [] },
+    } as unknown as SDKMessage),
+  ).toBe(false);
+});

--- a/packages/runtime/src/backends/claude/tool-server-lost.ts
+++ b/packages/runtime/src/backends/claude/tool-server-lost.ts
@@ -1,0 +1,78 @@
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { HOUSTON_MCP_SERVER_NAME } from "./custom-tools";
+
+/**
+ * Whether an SDK message proves this turn is running WITHOUT Houston's tools
+ * (PRODUCT-1706).
+ *
+ * Seen live on a scheduled routine, twice, with one signature: the SDK resumed
+ * a session whose previous turn had left a background shell running, injected
+ * its own "no completion record for that task" notification ahead of our
+ * prompt, and then served the turn with the in-process `houston` MCP server
+ * detached. The runtime had registered the server (its own allowedTools
+ * warning listed every Houston tool), the model's first call answered "No such
+ * tool available: mcp__houston__integration_execute", and the permission
+ * stream closed on the next Bash. The model did the only thing it could and
+ * reported that the integrations were "missing" — a routine that needs GitHub
+ * and Slack skipped its work and nothing surfaced as a failure.
+ *
+ * Two signals, both cheap to read on the stream:
+ *  - the `init` system message lists every MCP server with its status; a
+ *    missing or non-`connected` `houston` entry means no Houston tool will
+ *    answer this turn;
+ *  - a tool_result whose error names a `mcp__houston__*` tool as unavailable,
+ *    for an SDK that reports `connected` yet never routes the call.
+ *
+ * The session treats either as a lost resume: abandon the attempt, drop the
+ * SDK session mapping, and rerun the prompt as a fresh session carrying the
+ * canonical history — the same path a rejected resume already takes.
+ */
+
+const MISSING_HOUSTON_TOOL = /No such tool available:\s*mcp__houston__/;
+
+export function houstonToolServerLost(msg: SDKMessage): boolean {
+  if (msg.type === "system" && msg.subtype === "init") {
+    const servers = (msg as { mcp_servers?: unknown }).mcp_servers;
+    if (!Array.isArray(servers)) return false;
+    const houston = servers.find(
+      (s): s is { name: string; status: string } =>
+        typeof s === "object" &&
+        s !== null &&
+        (s as { name?: unknown }).name === HOUSTON_MCP_SERVER_NAME,
+    );
+    return houston === undefined || houston.status !== "connected";
+  }
+  if (msg.type === "user") {
+    const content = (msg as { message?: { content?: unknown } }).message
+      ?.content;
+    return toolResultTexts(content).some((text) =>
+      MISSING_HOUSTON_TOOL.test(text),
+    );
+  }
+  return false;
+}
+
+/** The text of every error tool_result block in a user message's content. */
+function toolResultTexts(content: unknown): string[] {
+  if (!Array.isArray(content)) return [];
+  const out: string[] = [];
+  for (const block of content) {
+    if (
+      typeof block !== "object" ||
+      block === null ||
+      (block as { type?: unknown }).type !== "tool_result" ||
+      (block as { is_error?: unknown }).is_error !== true
+    ) {
+      continue;
+    }
+    const inner = (block as { content?: unknown }).content;
+    if (typeof inner === "string") out.push(inner);
+    else if (Array.isArray(inner)) {
+      for (const part of inner) {
+        const text = (part as { text?: unknown })?.text;
+        if (typeof text === "string") out.push(text);
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Part of PRODUCT-1706. Second PR; #1512 covers the routines UI and the fenced-pod write refusal.

## What happened

The "Houston daily cloud release cut" routine skipped its work on Sep 4 and Sep 7 at 11:30 (America/Bogota) and told the user the GitHub and Slack integrations were "missing". The run rows counted as completed, so nothing surfaced as a failure.

The pod's Claude SDK transcript for the routine's conversation shows the same signature both times:

1. The SDK resumed the session and first injected its own `<task-notification>` saying the previous run's background shell (the release-build poll) had no completion record.
2. The model's first call, `mcp__houston__integration_execute`, answered `No such tool available`.
3. The next `Bash` call answered `Tool permission request failed: AbortError: Stream closed`.

The runtime had registered the `houston` MCP server for that query (its own `allowedTools` warning lists every Houston tool at 16:30:02), so the in-process tool bridge was detached for that resumed turn. Every other turn in the file (Aug 15 to Sep 8) ran the integration tool normally. Pool workers were not involved: prod runs with `GW_POOL_SERVE_ROUTINES=0` and zero pool replicas.

## Fix

`backends/claude/tool-server-lost.ts` recognises the state from the stream: an `init` message whose `mcp_servers` lacks a connected `houston` entry, or an error tool_result naming a `mcp__houston__*` tool as unavailable. The session treats it like a rejected resume: abort the attempt, drop the SDK session mapping, and rerun the prompt as a fresh session with the canonical history prefix. A fresh session that still lacks the server fails the turn with a typed provider error instead of running tool-less.

## Verification

Before: resume a Claude session whose previous turn left a background shell running, fire a routine that needs an integration; the run "completes" with the model reporting the tool is missing.

After: the same fire logs `resume for conversation … came up without Houston's tool server; starting a fresh session` and the rerun uses the integration tool. Unit tests cover both signals and the no-retry-loop case.

`pnpm --filter @houston/runtime test` (188 files), `pnpm --filter @houston/runtime typecheck`, `pnpm check`.
