### PR TITLE
fix(domain): salvage raw control characters inside .houston JSON strings (PRODUCT-1708)

### DIFF
--- a/packages/domain/src/json-salvage.test.ts
+++ b/packages/domain/src/json-salvage.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "vitest";
-import { firstJsonValueEnd, salvageLeadingJson } from "./json-salvage";
+import {
+  escapeControlCharsInStrings,
+  firstJsonValueEnd,
+  salvageJsonDoc,
+  salvageLeadingJson,
+} from "./json-salvage";
 import { loadRoutineRuns, loadRoutines } from "./routines";
 import { loadJson, parseJsonDoc, type TextStore } from "./store";
 
@@ -43,6 +48,62 @@ test("salvageLeadingJson refuses when nothing is cleanly recoverable", () => {
   expect(salvageLeadingJson("{not json")).toBeUndefined();
   expect(salvageLeadingJson(doc.slice(0, -10))).toBeUndefined();
   expect(salvageLeadingJson('{"a": tru}xyz')).toBeUndefined();
+});
+
+test("escapeControlCharsInStrings re-escapes raw control characters inside strings only", () => {
+  // The wild shape (HOUSTON-APP-5D6): an in-place edit of a long prompt left a
+  // literal tab and newline inside the string literal.
+  const raw = '[{"id":"r1","prompt":"Line one\nLine\ttwo \u0001 end"}]\n';
+  const fixed = escapeControlCharsInStrings(raw);
+  expect(fixed).toBe(
+    '[{"id":"r1","prompt":"Line one\\nLine\\ttwo \\u0001 end"}]\n',
+  );
+  expect(JSON.parse(fixed as string)).toEqual([
+    { id: "r1", prompt: "Line one\nLine\ttwo \u0001 end" },
+  ]);
+  // Already-clean text (whitespace between tokens is legal) is left alone.
+  expect(escapeControlCharsInStrings(doc)).toBeUndefined();
+  // `\"` inside a string never closes it early, so the newline after it is
+  // still recognised as inside the string.
+  expect(escapeControlCharsInStrings('{"a":"x\\"\ny"}')).toBe(
+    '{"a":"x\\"\\ny"}',
+  );
+  // A control character between tokens is a real syntax error, not ours.
+  expect(escapeControlCharsInStrings('{"a":\u00011}')).toBeUndefined();
+});
+
+test("salvageJsonDoc repairs raw control characters, then trailing junk", () => {
+  const rawNewline = '[{"id":"r1","prompt":"a\nb"}]\n';
+  expect(salvageJsonDoc(rawNewline)).toEqual([{ id: "r1", prompt: "a\nb" }]);
+  // Both shapes at once: an appended partial copy of a doc with a raw tab.
+  const rawTab = '[{"id":"r1","prompt":"a\tb"}]\n';
+  expect(salvageJsonDoc(`${rawTab}${rawTab.slice(0, 12)}`)).toEqual([
+    { id: "r1", prompt: "a\tb" },
+  ]);
+  expect(salvageJsonDoc(`${doc}]}`)).toEqual([routine]);
+  // Mangled beyond a lossless repair: the caller keeps its throw.
+  expect(salvageJsonDoc('[{"id":"r1","prompt":"a\nb"}')).toBeUndefined();
+  expect(salvageJsonDoc("{oops")).toBeUndefined();
+});
+
+test("loadRoutines survives a raw newline inside a prompt (HOUSTON-APP-5D6)", async () => {
+  const store = memStore();
+  const key = `${ROOT}/.houston/routines/routines.json`;
+  const edited = {
+    ...routine,
+    prompt: "Every morning:\n- check mail\n\t- reply",
+  };
+  // A hand edit that pasted the multi-line prompt in raw.
+  await store.writeText(
+    key,
+    JSON.stringify([edited], null, 2).replace(
+      JSON.stringify(edited.prompt),
+      `"${edited.prompt}"`,
+    ),
+  );
+  const { items, diagnostics } = await loadRoutines(store, ROOT);
+  expect(items.map((r) => r.prompt)).toEqual([edited.prompt]);
+  expect(diagnostics).toEqual([]);
 });
 
 test("loadRoutines survives trailing junk after the array (list_routines no longer 500s)", async () => {

--- a/packages/domain/src/json-salvage.ts
+++ b/packages/domain/src/json-salvage.ts
@@ -1,13 +1,22 @@
 /**
  * Salvage for `.houston` JSON docs that fail `JSON.parse` without the user
- * having lost anything: a complete value followed by trailing bytes. Seen in
- * the wild as `routines.json` = the full array + a second partial copy of it
- * (an outside writer appended/overlapped; the host's own writes are atomic).
- * The Rust engine kept the first value in that case; the TS cutover dropped
- * it, so one mangled file 500'd `list_routines` on every poll and bricked
- * the Routines tab for that agent. Only a prefix that parses on its own is
- * salvaged; anything else still surfaces as the caller's "not valid JSON"
- * throw, because a lossy reset would destroy the user's data on next write.
+ * having lost anything. Two shapes seen in the wild on `routines.json`, both
+ * from an outside writer (the host's own writes are `JSON.stringify` + atomic,
+ * so they never produce either):
+ *
+ *  1. A complete value followed by trailing bytes: the full array + a second
+ *     partial copy of it (an appended/overlapped write). The Rust engine kept
+ *     the first value; the TS cutover dropped it.
+ *  2. A raw control character (a literal newline or tab) inside a string
+ *     literal: an agent's in-place edit of a long `prompt`. `JSON.parse`
+ *     rejects the whole file for one byte.
+ *
+ * Either way one mangled file 500'd `list_routines` on every poll and bricked
+ * the Routines tab for that agent. Both repairs are lossless: the raw newline
+ * becomes the newline it meant, the trailing junk was never user data, and the
+ * next save rewrites the file clean. Anything else still surfaces as the
+ * caller's "not valid JSON" throw, because a lossy reset would destroy the
+ * user's data on next write.
  */
 
 /**
@@ -40,6 +49,34 @@ export function firstJsonValueEnd(text: string): number {
 }
 
 /**
+ * `text` with every raw control character (U+0000..U+001F) that sits INSIDE
+ * a string literal replaced by its JSON escape, or `undefined` when there is
+ * none. Control characters between tokens are left alone: whitespace there is
+ * legal and anything else is a real syntax error, not ours to guess. Escape
+ * sequences are skipped as a pair so a `\"` never closes the string early.
+ */
+export function escapeControlCharsInStrings(text: string): string | undefined {
+  let out = "";
+  let last = 0;
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (!inString) {
+      if (ch === '"') inString = true;
+      continue;
+    }
+    if (ch === "\\") i++;
+    else if (ch === '"') inString = false;
+    else if (text.charCodeAt(i) < 0x20) {
+      out += text.slice(last, i) + jsonEscape(text.charCodeAt(i));
+      last = i + 1;
+    }
+  }
+  if (last === 0) return undefined;
+  return out + text.slice(last);
+}
+
+/**
  * Parse the leading complete value of a doc that has trailing junk after it.
  * Returns `undefined` when there is nothing to salvage (no complete leading
  * value, or the prefix itself is not valid JSON): the caller keeps its throw.
@@ -54,6 +91,28 @@ export function salvageLeadingJson(text: string): unknown {
     // Mangled inside the leading value, not just after it: not ours to guess.
     return undefined;
   }
+}
+
+/**
+ * Every lossless repair in turn, for a doc `JSON.parse` already rejected:
+ * re-escape raw control characters inside strings, then keep the leading
+ * value when trailing junk follows. `undefined` = nothing recoverable.
+ */
+export function salvageJsonDoc(text: string): unknown {
+  const escaped = escapeControlCharsInStrings(text);
+  if (escaped !== undefined) {
+    try {
+      return JSON.parse(escaped) as unknown;
+    } catch {
+      // Still broken elsewhere: fall through to the trailing-junk repair.
+    }
+  }
+  return salvageLeadingJson(escaped ?? text);
+}
+
+/** The JSON escape for one control character: `\n`, `\t`, or `\u00XX`. */
+function jsonEscape(code: number): string {
+  return JSON.stringify(String.fromCharCode(code)).slice(1, -1);
 }
 
 function isJsonWhitespace(ch: string | undefined): boolean {

--- a/packages/domain/src/store.ts
+++ b/packages/domain/src/store.ts
@@ -1,4 +1,4 @@
-import { salvageLeadingJson } from "./json-salvage";
+import { salvageJsonDoc } from "./json-salvage";
 
 /**
  * The domain layer's only I/O dependency: a keyed text store. The host's Vfs
@@ -46,17 +46,18 @@ export async function loadJson<T>(
  * publish) must parse identically or the doc-served and pod-served answers
  * drift. A leading byte-order mark is an encoding artifact, not content:
  * files-first docs get hand-written by agents, users and editors, and
- * `JSON.parse` rejects a BOM outright (HOU-953). A complete value followed by
- * trailing bytes (an outside writer appended or overlapped the doc) keeps the
- * value: nothing the user wrote is lost, and the next save rewrites the file
- * clean. Anything else throws with the key named.
+ * `JSON.parse` rejects a BOM outright (HOU-953). What an outside writer
+ * mangled losslessly (trailing bytes after a complete value, a raw newline or
+ * tab inside a string) is repaired (`json-salvage.ts`): nothing the user wrote
+ * is lost, and the next save rewrites the file clean. Anything else throws
+ * with the key named.
  */
 export function parseJsonDoc(raw: string, key: string): unknown {
   const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
   try {
     return JSON.parse(text) as unknown;
   } catch (err) {
-    const salvaged = salvageLeadingJson(text);
+    const salvaged = salvageJsonDoc(text);
     if (salvaged !== undefined) return salvaged;
     throw new Error(
       `${key} is not valid JSON (${err instanceof Error ? err.message : String(err)})`,


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-5D6 (PRODUCT-1708): `list_routines` 500'd on every poll for one agent because its `routines.json` had a raw control character inside a string literal:

```
routines.json is not valid JSON (Bad control character in string literal in JSON at position 2461 (line 32 column 420))
```

The Routines tab was bricked for that agent until someone hand-repaired the file.

## Root cause

The host writes `routines.json` through `JSON.stringify`, which always escapes control characters, so this file came from an outside writer. `.houston/routines/routines.json` is one of the two turn-owned doc files an agent's file tools may write (`turn-agent-scope.ts`), and an in-place edit of a long `prompt` string left a literal tab/newline in it. `parseJsonDoc` only had the trailing-junk salvage from PRODUCT-1449, so one raw byte inside a string still rejected the whole file.

## Fix

`packages/domain/src/json-salvage.ts` gains a second lossless repair: re-escape raw control characters (U+0000..U+001F) that sit inside string literals, then parse. Escape pairs are skipped so a `\"` never closes the string early; control characters between tokens are left alone (whitespace is legal there, anything else is a real syntax error and still throws). `salvageJsonDoc` composes both repairs and `parseJsonDoc` (the one parse path for every `.houston` doc) calls it. The user's text is kept verbatim: the raw newline becomes the newline the writer meant, and the next save rewrites the file clean.

## Before

```js
JSON.parse('[{"id":"r1","prompt":"a\nb"}]\n')
// Bad control character in string literal in JSON at position 23
```
Drop such a file at `~/.houston/workspaces/<W>/<Agent>/.houston/routines/routines.json`, open the agent's Routines tab: `GET /agents/<id>/routines` returns 500, the tab shows nothing, Sentry receives `list_routines: ... is not valid JSON`.

## After

Same file: `loadRoutines` returns the routine with `prompt: "a\nb"`, the Routines tab lists it, and the next save through `save_routine` rewrites the file with the escape. Covered by the new tests in `packages/domain/src/json-salvage.test.ts` (raw tab/newline/U+0001 inside strings, the `\"` edge, control chars outside strings untouched, both repairs composed, and a `loadRoutines` round-trip of a hand-pasted multi-line prompt).

## Verification

- `pnpm --filter @houston/domain test`: 203 passed
- `pnpm --filter @houston/host --filter @houston/runtime test`: 1671 + 1595 passed
- `pnpm check`: clean