### PR TITLE
fix(host): view docs follow an agent rename on the pod that woke for it (PRODUCT-1709)

### DIFF
--- a/packages/host/src/docs/project-family.ts
+++ b/packages/host/src/docs/project-family.ts
@@ -41,6 +41,42 @@ export async function listAgentIds(store: WorkspaceStore): Promise<string[]> {
   return agents;
 }
 
+/**
+ * The agent the doc route binds to at boot seed, or undefined when the host
+ * cannot tell yet. Zero agents: cloud pods can reach boot before the
+ * workspace tree hydrates (seen live: real agent pods with zero agents at
+ * seed time) — not an error and NOT a poison, the hydration writes fire
+ * watcher events and the first projection binds late. Several agents (rename
+ * leftovers beside the live one): the gateway's first addressed request
+ * decides.
+ */
+export async function bootBindingId(
+  store: WorkspaceStore,
+): Promise<string | undefined> {
+  const agents = await listAgentIds(store);
+  if (agents.length === 1) return agents[0];
+  console.warn(
+    agents.length === 0
+      ? "[doc-shadow] no agents at boot seed; binding on first projection"
+      : `[doc-shadow] host serves ${agents.length} agents; binding deferred to the first addressed agent`,
+  );
+  return undefined;
+}
+
+/**
+ * The host's ONE agent, or null when it serves none or several. The doc
+ * route names a single agent, so every doc-side actor (projector binding,
+ * view warm) stands down on any other host shape. Re-read from the store on
+ * each call: the answer changes under a rename, which moves the directory
+ * (the local store's ids are directory names).
+ */
+export async function singleAgentId(
+  store: WorkspaceStore,
+): Promise<string | null> {
+  const agents = await listAgentIds(store);
+  return agents.length === 1 ? (agents[0] ?? null) : null;
+}
+
 /** Read one agent's family file and PUT it into the doc shadow. */
 export async function putFamilyDoc(
   deps: ProjectorDeps,

--- a/packages/host/src/docs/projector.test.ts
+++ b/packages/host/src/docs/projector.test.ts
@@ -306,7 +306,11 @@ test("a vanished family file converges the doc back to empty", async () => {
   );
   projector.onEvent({ type: "RoutinesChanged", agentPath: agent.id });
   await projector.flush();
-  expect((puts.at(-1)?.doc as unknown[]).length).toBe(1);
+  // The first projection also back-fills the other families; only the
+  // routines doc carries the file.
+  expect(
+    (puts.find((p) => p.family === "routines")?.doc as unknown[]).length,
+  ).toBe(1);
 
   await vfs.deleteKey(docKey(root, "routines"));
   projector.onEvent({ type: "RoutinesChanged", agentPath: agent.id });
@@ -513,5 +517,129 @@ test("cross-agent refusals are a latched warn, never repeated per family", async
   } finally {
     warns.mockRestore();
     errors.mockRestore();
+  }
+});
+
+// A rename moves the agent's directory, and the rename request is often the
+// wake that booted this pod: the seed bound the OLD name. Every projection
+// for the new name was refused as cross-agent until the next pod restart, so
+// asleep readers kept the pre-rename docs (HOUSTON-APP-5AP). The binding
+// must follow the move.
+test("the binding follows a rename: the moved directory re-binds and re-seeds", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const old = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Old Name",
+  });
+  const puts: { family: string; doc: unknown }[] = [];
+  const shadow: DocShadow = {
+    async seed() {},
+    async put(family, doc) {
+      puts.push({ family, doc });
+    },
+  };
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+    projector.seed();
+    await projector.flush();
+    expect(await projector.boundAgent()).toBe(old.id);
+    puts.length = 0;
+
+    // The rename (memory store ids are stable, so delete + create models the
+    // directory move) and the renamed agent's first file change.
+    await store.deleteAgent(old.id);
+    const renamed = await store.createAgent({
+      workspaceId: workspace.id,
+      name: "New Name",
+    });
+    await vfs.writeText(
+      docKey(paths.agentRoot(workspace, renamed), "learnings"),
+      JSON.stringify([{ id: "l1", text: "after rename", created_at: "now" }]),
+    );
+    projector.onEvent({ type: "LearningsChanged", agentPath: renamed.id });
+    await projector.flush();
+
+    expect(puts.find((p) => p.family === "learnings")?.doc).toEqual([
+      { id: "l1", text: "after rename", created_at: "now" },
+    ]);
+    // The whole seed re-runs under the new name, each family once.
+    expect(puts.map((p) => p.family).sort()).toEqual([
+      "activity",
+      "config",
+      "learnings",
+      "routine_runs",
+      "routines",
+    ]);
+    expect(await projector.boundAgent()).toBe(renamed.id);
+    expect(
+      warns.mock.calls.some((call) =>
+        String(call[0]).includes("refusing cross-agent projection"),
+      ),
+    ).toBe(false);
+    expect(errors).not.toHaveBeenCalled();
+  } finally {
+    warns.mockRestore();
+    errors.mockRestore();
+  }
+});
+
+// The view sink asks boundAgent() before every publish; a view captured for
+// the renamed agent must land, not be refused against the stale binding.
+test("boundAgent follows a rename before the first projection", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const old = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Old Name",
+  });
+  const shadow: DocShadow = { async seed() {}, async put() {} };
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+    projector.seed();
+    expect(await projector.boundAgent()).toBe(old.id);
+    await store.deleteAgent(old.id);
+    const renamed = await store.createAgent({
+      workspaceId: workspace.id,
+      name: "New Name",
+    });
+    expect(await projector.boundAgent()).toBe(renamed.id);
+    await projector.flush();
+  } finally {
+    warns.mockRestore();
+  }
+});
+
+// A delete leaves no agent, and a leftover directory beside the live one
+// leaves several: neither is a move the projector can follow on its own.
+test("the binding stays put when the bound agent vanishes without a single successor", async () => {
+  const store = new MemoryWorkspaceStore();
+  const vfs = new MemoryVfs();
+  const paths = new LocalPaths();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const old = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Old Name",
+  });
+  const shadow: DocShadow = { async seed() {}, async put() {} };
+  const warns = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const projector = new DocShadowProjector({ store, vfs, paths, shadow });
+    projector.seed();
+    expect(await projector.boundAgent()).toBe(old.id);
+    await store.deleteAgent(old.id);
+    expect(await projector.boundAgent()).toBe(old.id);
+    await store.createAgent({ workspaceId: workspace.id, name: "A" });
+    await store.createAgent({ workspaceId: workspace.id, name: "B" });
+    expect(await projector.boundAgent()).toBe(old.id);
+  } finally {
+    warns.mockRestore();
   }
 });

--- a/packages/host/src/docs/projector.ts
+++ b/packages/host/src/docs/projector.ts
@@ -1,10 +1,11 @@
 import type { HoustonFamily } from "@houston/domain";
 import type { HoustonEvent } from "@houston/protocol";
 import {
+  bootBindingId,
   EVENT_FAMILY,
-  listAgentIds,
   type ProjectorDeps,
   putFamilyDoc,
+  singleAgentId,
 } from "./project-family";
 
 /**
@@ -24,6 +25,7 @@ export class DocShadowProjector {
   // refused — nothing may cross-post into the bound agent's doc.
   private bound: string | undefined;
   private addressing = false;
+  private rebinding: Promise<void> | undefined;
   private readonly refused = new Set<string>();
 
   constructor(private readonly deps: ProjectorDeps) {}
@@ -39,33 +41,15 @@ export class DocShadowProjector {
     // keeps repeat boots at one GET per family, no revision churn.
     this.ready = this.deps.shadow
       .seed()
-      .then(() => this.seedContent())
+      .then(async () => {
+        const only = await bootBindingId(this.deps.store);
+        if (only === undefined) return;
+        this.bound = only;
+        await this.seedBound(only);
+      })
       .catch((error: unknown) => {
         console.error("[doc-shadow] boot seed failed", error);
       });
-  }
-
-  private async seedContent(): Promise<void> {
-    const agents = await listAgentIds(this.deps.store);
-    if (agents.length === 0) {
-      // Cloud pods can reach boot before the workspace tree hydrates (seen
-      // live: real agent pods with zero agents at seed time). Not an error
-      // and NOT a poison: the hydration writes fire watcher events, and the
-      // first projection binds late and back-fills the whole seed.
-      console.warn(
-        "[doc-shadow] no agents at boot seed; binding on first projection",
-      );
-      return;
-    }
-    const only = agents.length === 1 ? agents[0] : undefined;
-    if (only === undefined) {
-      console.warn(
-        `[doc-shadow] host serves ${agents.length} agents; binding deferred to the first addressed agent`,
-      );
-      return;
-    }
-    this.bound = only;
-    await this.seedBound(only);
   }
 
   private async seedBound(agentId: string): Promise<void> {
@@ -139,6 +123,7 @@ export class DocShadowProjector {
    */
   async boundAgent(): Promise<string | undefined> {
     await this.ready;
+    await this.rebindIfMoved();
     return this.bound;
   }
 
@@ -148,8 +133,13 @@ export class DocShadowProjector {
   }
 
   private async project(agentId: string, family: HoustonFamily): Promise<void> {
-    if (this.bound === undefined && !(await this.lazyBind(agentId, family))) {
-      return;
+    if (this.bound === undefined) {
+      // Bind on first projection when boot found no agents; several agents
+      // stay ambiguous until bindAddressed.
+      if ((await singleAgentId(this.deps.store)) !== agentId) return;
+      this.rebind(agentId, family, "agent hydrated after boot");
+    } else if (agentId !== this.bound) {
+      await this.rebindIfMoved(family);
     }
     if (agentId !== this.bound) {
       // The refusal is the DESIGNED outcome (rename leftovers beside the live
@@ -168,24 +158,43 @@ export class DocShadowProjector {
   }
 
   /**
-   * Bind on first projection when boot found no agents. True = agentId is
-   * the host's single agent; the remaining families are enqueued so the
-   * boot seed this pod missed still happens. Several agents = still
-   * ambiguous: wait for bindAddressed.
+   * Follow a rename. The binding is a directory name and a rename moves the
+   * directory — often on the very wake that booted this pod, since the rename
+   * request is what woke it. Left alone, every projection and view publish
+   * for the renamed agent is refused as cross-agent until the next pod
+   * restart, and asleep readers keep getting the pre-rename docs
+   * (HOUSTON-APP-5AP). Re-binds only when the bound directory is gone AND
+   * exactly one remains; a delete (none left) or a leftover beside the live
+   * agent (several) keeps the old binding, as ambiguous as at seed.
    */
-  private async lazyBind(
+  private rebindIfMoved(family?: HoustonFamily): Promise<void> {
+    this.rebinding ??= (async () => {
+      const bound = this.bound;
+      if (bound === undefined) return;
+      if ((await this.deps.store.getAgent(bound)) !== null) return;
+      const only = await singleAgentId(this.deps.store);
+      if (only === null || only === bound) return;
+      this.refused.clear();
+      this.rebind(only, family, `agent directory moved from ${bound}`);
+    })().finally(() => {
+      this.rebinding = undefined;
+    });
+    return this.rebinding;
+  }
+
+  /** Bind late; every family but the one in flight is enqueued so the boot
+   *  seed this pod missed (or seeded under another name) still happens. */
+  private rebind(
     agentId: string,
-    family: HoustonFamily,
-  ): Promise<boolean> {
-    const agents = await listAgentIds(this.deps.store);
-    if (agents.length !== 1 || agents[0] !== agentId) return false;
+    inFlight: HoustonFamily | undefined,
+    why: string,
+  ): void {
     this.bound = agentId;
     console.warn(
-      `[doc-shadow] bound to ${agentId} on first projection (agent hydrated after boot); seeding remaining families`,
+      `[doc-shadow] bound to ${agentId} (${why}); seeding remaining families`,
     );
     for (const other of Object.values(EVENT_FAMILY)) {
-      if (other && other !== family) this.enqueue(agentId, other);
+      if (other && other !== inFlight) this.enqueue(agentId, other);
     }
-    return true;
   }
 }

--- a/packages/host/src/docs/view-warm.test.ts
+++ b/packages/host/src/docs/view-warm.test.ts
@@ -146,6 +146,84 @@ test("a bare 503 without Retry-After still reports", async () => {
   vi.useRealTimers();
 });
 
+// A rename moves the agent's directory, and the rename request is often the
+// very wake this warm runs under: boot listed the OLD name, the client reads
+// the NEW one. The warm must follow the move, never 404 the old id for the
+// rest of its window (HOUSTON-APP-5AP, the 404 flavor).
+test("boot warm follows an agent renamed mid-window", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const old = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Old Name",
+  });
+  const start = Date.now();
+  const urls: string[] = [];
+  const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+    urls.push(String(url));
+    // The runtime is still booting when the warm's first attempt lands.
+    if (Date.now() - start < 5_000) return stillStarting();
+    // The disk store's ids are directory names: only the current one serves.
+    const agent = (await store.listAgents(workspace.id))[0];
+    const served = String(url).includes(encodeURIComponent(agent?.id ?? ""));
+    return served
+      ? new Response("{}", { status: 200 })
+      : new Response('{"error":"agent not found"}', { status: 404 });
+  }) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  warmViewDocs({ port: 4318, token: "t", store, fetchImpl });
+  // First attempt lands on the old id, then the rename moves the directory
+  // (the memory store keeps ids stable, so model the move as delete+create).
+  await vi.advanceTimersByTimeAsync(50);
+  await store.deleteAgent(old.id);
+  const renamed = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "New Name",
+  });
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(urls[0]).toContain(encodeURIComponent(old.id));
+  const renamedUrls = urls.filter((u) =>
+    u.includes(encodeURIComponent(renamed.id)),
+  );
+  // Every view route warmed under the new name, none reported.
+  expect(renamedUrls).toHaveLength(4);
+  expect(errorSpy).not.toHaveBeenCalled();
+  expect(warnSpy).not.toHaveBeenCalled();
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// A host that stops serving exactly one agent mid-window (delete, or a
+// leftover directory appearing beside the live one) has no view to warm: the
+// warm stands down as a breadcrumb, never an error.
+test("boot warm stands down quietly when the single agent goes away", async () => {
+  vi.useFakeTimers();
+  const store = new MemoryWorkspaceStore();
+  const workspace = await store.getOrCreatePersonalWorkspace("alice");
+  const only = await store.createAgent({
+    workspaceId: workspace.id,
+    name: "Only",
+  });
+  const fetchImpl = vi.fn(
+    async () => new Response('{"error":"agent not found"}', { status: 404 }),
+  ) as unknown as typeof fetch;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  warmViewDocs({ port: 4318, token: "t", store, fetchImpl });
+  await vi.advanceTimersByTimeAsync(50);
+  await store.deleteAgent(only.id);
+  await vi.advanceTimersByTimeAsync(1_000_000);
+  expect(errorSpy).not.toHaveBeenCalled();
+  expect(warnSpy).toHaveBeenCalledTimes(4);
+  expect(warnSpy.mock.calls[0]?.[0]).toMatch(/no longer serves exactly one/);
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  vi.useRealTimers();
+});
+
 test("a SkillsChanged event re-fetches /skills for that agent (debounced)", async () => {
   vi.useFakeTimers();
   const store = new MemoryWorkspaceStore();

--- a/packages/host/src/docs/view-warm.ts
+++ b/packages/host/src/docs/view-warm.ts
@@ -1,7 +1,7 @@
 import type { HoustonEvent } from "@houston/protocol";
 import type { EventHub } from "../events/hub";
 import type { WorkspaceStore } from "../ports";
-import { listAgentIds } from "./project-family";
+import { singleAgentId } from "./project-family";
 import { VIEW_RESTS } from "./view-capture";
 
 // The warm must OUTLAST the launcher's 60s boot-health budget
@@ -30,24 +30,35 @@ interface ViewAnswer {
    * host is mid-shutdown. Nothing about the view itself failed.
    */
   notNow: boolean;
+  /** The host stopped serving exactly one agent mid-window; no view to warm. */
+  noAgent: boolean;
 }
 
 /**
  * GET one of our own view routes so the server's capture re-publishes it.
  * Retries every RETRY_DELAY_MS until a 200 or until `budgetMs` elapses; a zero
- * budget is a single attempt.
+ * budget is a single attempt. The agent is resolved on EVERY attempt: a
+ * rename moves the agent's directory, and the request that renames it is
+ * often the very wake this warm runs under (HOUSTON-APP-5AP) — a boot-time
+ * id would 404 for the rest of the window.
  */
 async function fetchView(
   self: SelfFetch,
-  agentId: string,
+  resolveAgentId: () => Promise<string | null>,
   rest: string,
   budgetMs: number,
 ): Promise<ViewAnswer> {
   const fetchImpl = self.fetchImpl ?? fetch;
-  const url = `http://127.0.0.1:${self.port}/agents/${encodeURIComponent(agentId)}/${rest}`;
   const deadline = Date.now() + budgetMs;
-  const answer: ViewAnswer = { status: 0, notNow: false };
+  const answer: ViewAnswer = { status: 0, notNow: false, noAgent: false };
   for (;;) {
+    const agentId = await resolveAgentId();
+    if (agentId === null) {
+      answer.noAgent = true;
+      break;
+    }
+    answer.noAgent = false;
+    const url = `http://127.0.0.1:${self.port}/agents/${encodeURIComponent(agentId)}/${rest}`;
     try {
       const response = await fetchImpl(url, {
         headers: { Authorization: `Bearer ${self.token}` },
@@ -68,13 +79,6 @@ async function fetchView(
   return answer;
 }
 
-async function singleAgentId(store: WorkspaceStore): Promise<string | null> {
-  const agents = await listAgentIds(store);
-  // Same single-agent rule as the doc projector: the doc route names ONE
-  // agent; on any other host shape the warm quietly stands down.
-  return agents.length === 1 ? (agents[0] ?? null) : null;
-}
-
 /**
  * Boot self-warm: GET each view route against our own server once so an
  * agent whose pod slept since before view docs existed still gets its docs
@@ -86,16 +90,27 @@ export function warmViewDocs(
   opts: SelfFetch & { store: WorkspaceStore },
 ): void {
   void (async () => {
-    const only = await singleAgentId(opts.store);
-    if (only === null) return;
+    // Same single-agent rule as the doc projector: the doc route names ONE
+    // agent; on any other host shape the warm quietly stands down.
+    const resolve = () => singleAgentId(opts.store);
+    if ((await resolve()) === null) return;
     for (const rest of Object.keys(VIEW_RESTS)) {
-      const { status, notNow } = await fetchView(
+      const { status, notNow, noAgent } = await fetchView(
         opts,
-        only,
+        resolve,
         rest,
         WARM_BUDGET_MS,
       );
       if (status === 200) continue;
+      if (noAgent) {
+        // The agent was deleted, or a second directory appeared (a leftover
+        // beside a rename): the doc route no longer names one agent, so
+        // there is no view to warm — the projector stands down the same way.
+        console.warn(
+          `[view-docs] boot warm for ${rest} stood down: host no longer serves exactly one agent`,
+        );
+        continue;
+      }
       // A runtime still not up after the whole window is the launcher's
       // failure, and it is already loud there (the eager spawn's "never became
       // healthy" error). The warm is best-effort on top: the previously
@@ -145,7 +160,7 @@ export function refreshViewsOnEvents(
             ? event.agentPath
             : await singleAgentId(opts.store);
         if (agentId === null) return;
-        const { status } = await fetchView(opts, agentId, rest, 0);
+        const { status } = await fetchView(opts, async () => agentId, rest, 0);
         if (status !== 200) {
           // An agent delete/rename unlinks `.agents/skills/**`, and the FS
           // watcher classifies each unlink as SkillsChanged for the now-gone


### PR DESCRIPTION
## Summary

Third flavor of Sentry HOUSTON-APP-5AP (`[view-docs] boot warm for <view> gave up (last status 404)`, four events per pod ~170s apart; seen 2026-08-31 and 2026-09-08). Linear: PRODUCT-1709.

**Root cause.** A rename request often wakes the very pod it renames. Boot lists the agent under its OLD directory name, so:

1. `warmViewDocs` snapshots that id once and retries `GET /agents/<old>/<view>` every 10s for the whole 180s window, per view: 12 minutes of `404 agent not found`, then four `console.error` events.
2. `DocShadowProjector` seeds bound to the old name and never re-binds. Every family projection and view publish for the renamed agent is refused as cross-agent (`refusing providers publish for Personal/New (route bound to Personal/Old)` breadcrumbs in every event) until the next pod restart, so the gateway keeps serving pre-rename routines/activity/config/views to asleep readers.

**Fix.**

- The warm resolves the host's single agent on every retry (`singleAgentId`, now shared in `project-family.ts`). A renamed agent is followed; a host that stops serving exactly one agent stands down as a `console.warn` (breadcrumb, not a Sentry event).
- The projector re-binds when its bound directory is gone and exactly one agent remains, clearing the refusal latch and re-seeding every family. A delete (none left) or a leftover beside the live agent (several) keeps the old binding, as ambiguous as at seed. The check runs on a cross-agent projection and before every view publish, single-flight.
- Boot-time binding moved to `bootBindingId` in `project-family.ts` (projector at the 200-line cap).

## Before (reproduce)

1. Cloud agent `Personal/Old` with an asleep pod.
2. Rename it to `Personal/New` from the app (the PATCH wakes the pod).
3. Pod log: `[doc-shadow] refusing cross-agent projection Personal/New#...` and `[view-docs] refusing ... publish for Personal/New (route bound to Personal/Old)` on every change; ~3/6/9/12 minutes after boot, `[view-docs] boot warm for <view> gave up (last status 404)` x4 reach Sentry. Routines/activity docs served while asleep stay pre-rename until the pod restarts.

## After (verify)

1. Same steps. Pod log shows `[doc-shadow] bound to Personal/New (agent directory moved from Personal/Old); seeding remaining families`, no refusals, no `gave up (last status 404)`.
2. Unit: `pnpm --filter @houston/host exec vitest run src/docs` — new tests `boot warm follows an agent renamed mid-window`, `boot warm stands down quietly when the single agent goes away`, `the binding follows a rename`, `boundAgent follows a rename before the first projection`, `the binding stays put when the bound agent vanishes without a single successor`.
3. Sentry: after the engine roll, no new 5AP events whose breadcrumbs carry `route bound to` a different name.

## Checks

`pnpm check`, `pnpm -r typecheck`, `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` (host 1685 passed).
