### PR TITLE
chore(ci): Playwright report upload never fails a green shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
+        # The report is a debugging aid; a GitHub artifact-service hiccup
+        # (403 on FinalizeArtifact, seen on green shards) must not fail the job.
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-shard-${{ matrix.shard }}
@@ -204,6 +207,9 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
+        # The report is a debugging aid; a GitHub artifact-service hiccup
+        # (403 on FinalizeArtifact, seen on green shards) must not fail the job.
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: playwright-visual-report


### PR DESCRIPTION
## Summary

`actions/upload-artifact@v4` answered `403 Forbidden` on FinalizeArtifact for one Web shard on two consecutive runs (PR #1516 shard 4, and main run 34252201586 shard 6) after all 61 Playwright tests passed. The other five shards uploaded fine each time, so it is a transient artifact-service error, not the tests.

The report is a debugging aid: both Playwright report upload steps now run with `continue-on-error: true`, so a failed upload shows as a warning instead of failing a green job.

## Verify

Next run where a shard's upload 403s: the job stays green with the upload step marked as failed-but-continued. The test step itself is untouched and still fails the job on any test failure.