### PR TITLE
fix(local-models): stop polling a gateway without the bridge, show honest copy (PRODUCT-1717)

### DIFF
--- a/app/src/components/shell/local-model-dialog-parts.tsx
+++ b/app/src/components/shell/local-model-dialog-parts.tsx
@@ -100,9 +100,12 @@ export function EmptyScreen({
 
 /** Calm error screen with retry + the manual escape hatch. */
 export function ErrorScreen({
+  body,
   onRetry,
   onManual,
 }: {
+  /** Authored copy for this failure; defaults to the generic connect error. */
+  body?: string;
   onRetry: () => void;
   onManual: () => void;
 }) {
@@ -110,7 +113,7 @@ export function ErrorScreen({
   return (
     <div className="flex flex-col gap-4 py-2">
       <p className="text-[13px] leading-relaxed text-ink-muted">
-        {t("localModel.error.body")}
+        {body ?? t("localModel.error.body")}
       </p>
       <div className="flex items-center justify-between gap-2">
         <ManualLink onClick={onManual} />

--- a/app/src/components/shell/local-model-dialog.tsx
+++ b/app/src/components/shell/local-model-dialog.tsx
@@ -130,6 +130,13 @@ export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
         {mode === "error" && (
           <ErrorScreen onRetry={() => void runDetect()} onManual={goManual} />
         )}
+        {mode === "unsupported" && (
+          <ErrorScreen
+            body={t("localModel.unsupported.body")}
+            onRetry={() => void connect()}
+            onManual={goManual}
+          />
+        )}
         {isManual && (
           <LocalModelManualForm
             onConnected={onConnected}

--- a/app/src/hooks/use-local-model-connect.ts
+++ b/app/src/hooks/use-local-model-connect.ts
@@ -11,6 +11,7 @@ import {
   detectLocalModels,
 } from "../lib/local-model-connect";
 import {
+  connectFailureMode,
   LOCAL_MODEL_CONNECT_TIMEOUT_MS,
   LOCAL_MODEL_DETECT_TIMEOUT_MS,
   type LocalModelMode,
@@ -150,10 +151,11 @@ export function useLocalModelConnect(opts: {
       if (controller.signal.aborted || !mounted.current) return;
       onConnected?.(model);
       onClose();
-    } catch {
-      // The failing step already toasted (Report-bug); an abort/timeout rolled
-      // the bridge back. Show a calm retry state unless we were cancelled/closed.
-      if (!controller.signal.aborted && mounted.current) setMode("error");
+    } catch (error) {
+      // The failing step already reported; an abort/timeout rolled the bridge
+      // back. Show a calm retry state unless we were cancelled/closed.
+      if (!controller.signal.aborted && mounted.current)
+        setMode(connectFailureMode(error));
     }
   }, [
     servers,

--- a/app/src/lib/local-bridge-ports.ts
+++ b/app/src/lib/local-bridge-ports.ts
@@ -3,6 +3,7 @@ import type {
   LocalBridgeNativeEvent,
   LocalModelBridgePorts,
 } from "@houston/sdk";
+import { isBridgeUnsupported } from "@houston/sdk/local-model-bridge/unsupported";
 import type { LocalModelBridgeAccess } from "@houston-ai/engine-client";
 import { showErrorToast } from "./error-toast";
 import {
@@ -17,8 +18,27 @@ import {
   osStartLocalBridge,
   osStopLocalBridge,
 } from "./os-bridge";
+import { reportQuietError } from "./quiet-error-report";
 
+/**
+ * A gateway without the bridge capability is an expected deployment state,
+ * not a broken connection: the guided dialog shows its own copy for it and the
+ * boot-time resume stays silent to the user, so it reports only as the quiet
+ * `bridge_unsupported` class instead of one bug per desktop boot.
+ */
 export function reportLocalBridgeError(error: unknown): void {
+  if (isBridgeUnsupported(error)) {
+    console.warn(
+      "[local_model_bridge] this server offers no local model bridge",
+    );
+    reportQuietError(
+      "bridge_unsupported",
+      "local_model_bridge",
+      "Local model bridge not offered by this server",
+      error,
+    );
+    return;
+  }
   showErrorToast("local_model_bridge", "Local model connection failed", error);
 }
 

--- a/app/src/lib/local-model-connect-state.ts
+++ b/app/src/lib/local-model-connect-state.ts
@@ -1,3 +1,7 @@
+// Dependency-free subpath: the app's node:test entry points cannot load the
+// SDK root (it pulls @houston/domain, whose extensionless imports node rejects).
+import { isBridgeUnsupported } from "@houston/sdk/local-model-bridge/unsupported";
+
 /** Screens in the guided local-model connection flow. */
 export type LocalModelMode =
   | "detecting"
@@ -5,7 +9,17 @@ export type LocalModelMode =
   | "pick"
   | "connecting"
   | "error"
+  | "unsupported"
   | "manual";
+
+/**
+ * The screen a failed connect lands on. A server that offers no bridge gets
+ * its own copy: "keep the app open and retry" would send the user chasing a
+ * local app that was never the problem.
+ */
+export function connectFailureMode(error: unknown): LocalModelMode {
+  return isBridgeUnsupported(error) ? "unsupported" : "error";
+}
 
 /** Maximum time allowed for the quick local-server scan. */
 export const LOCAL_MODEL_DETECT_TIMEOUT_MS = 20_000;

--- a/app/src/lib/quiet-error-class.ts
+++ b/app/src/lib/quiet-error-class.ts
@@ -13,13 +13,27 @@
 // class (`quiet-error-report.ts`), so each class is one Sentry issue with a
 // count and searchable bodies, and a deploy roll can never file new issues.
 
+// Dependency-free subpath: the app's node:test entry points cannot load the
+// SDK root (it pulls @houston/domain, whose extensionless imports node rejects).
+import { isBridgeUnsupported } from "@houston/sdk/local-model-bridge/unsupported";
 import { isEngineWakingError } from "./engine-waking-error.ts";
 import { isNetworkTransportError } from "./network-transport-error.ts";
 
 /** Doubles as the Sentry fingerprint, so the value is the issue's identity. */
-export type QuietErrorClass = "engine_waking" | "offline";
+export type QuietErrorClass =
+  | "engine_waking"
+  | "offline"
+  | "bridge_unsupported";
 
+/**
+ * `bridge_unsupported` is the deployment honestly declining local models: the
+ * gateway advertises no `localModelBridge` capability (relay not activated on
+ * that environment, or an older self-host). Every desktop boot asks, so it is
+ * one fingerprinted warning, never a per-user bug. It is checked before the
+ * waking class because it also rides a 503.
+ */
 export function classifyQuietError(err: unknown): QuietErrorClass | null {
+  if (isBridgeUnsupported(err)) return "bridge_unsupported";
   if (isEngineWakingError(err)) return "engine_waking";
   if (isNetworkTransportError(err)) return "offline";
   return null;

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -201,6 +201,9 @@
       "body": "Something went wrong while connecting. Make sure the app is still open on your computer, then try again.",
       "retry": "Try again"
     },
+    "unsupported": {
+      "body": "Local models aren't available on this server yet. Try again later, or enter details manually."
+    },
     "manual": {
       "title": "Enter details manually",
       "description": "Already have a model server address? Enter it here.",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -201,6 +201,9 @@
       "body": "Algo salió mal al conectar. Asegúrate de que la app siga abierta en tu computador e inténtalo de nuevo.",
       "retry": "Intentar de nuevo"
     },
+    "unsupported": {
+      "body": "Los modelos locales aún no están disponibles en este servidor. Inténtalo más tarde o ingresa los datos manualmente."
+    },
     "manual": {
       "title": "Ingresar datos manualmente",
       "description": "¿Ya tienes la dirección de un servidor de modelos? Ingrésala aquí.",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -201,6 +201,9 @@
       "body": "Algo deu errado ao conectar. Confira se o app ainda está aberto no seu computador e tente de novo.",
       "retry": "Tentar de novo"
     },
+    "unsupported": {
+      "body": "Modelos locais ainda não estão disponíveis neste servidor. Tente de novo mais tarde ou insira os dados manualmente."
+    },
     "manual": {
       "title": "Inserir dados manualmente",
       "description": "Já tem o endereço de um servidor de modelos? Insira aqui.",

--- a/app/tests/local-model.test.ts
+++ b/app/tests/local-model.test.ts
@@ -8,6 +8,7 @@ import {
   defaultEndpointName,
   defaultModelFor,
 } from "../src/lib/local-model.ts";
+import { connectFailureMode } from "../src/lib/local-model-connect-state.ts";
 import { looksLikeReasoningModel } from "../src/lib/local-model-reasoning.ts";
 
 function server(extra: Partial<DetectedServer> = {}): DetectedServer {
@@ -107,5 +108,31 @@ describe("reasoning model discovery", () => {
   it("does not flag ordinary chat models", () => {
     for (const id of ["llama-3.1", "gemma-2-9b", "mistral-7b", "gpt-4o-mini"])
       strictEqual(looksLikeReasoningModel(id), false, id);
+  });
+});
+
+describe("guided connect failure screen", () => {
+  // PRODUCT-1717: a server without the bridge gets its own copy; "keep the
+  // app open and retry" would blame a local app that was never the problem.
+  it("lands on the unsupported screen only for bridge_not_supported", () => {
+    strictEqual(
+      connectFailureMode(
+        Object.assign(new Error("engine error 503"), {
+          status: 503,
+          body: { code: "bridge_not_supported", error: "unsupported" },
+        }),
+      ),
+      "unsupported",
+    );
+    strictEqual(
+      connectFailureMode(
+        Object.assign(new Error("engine error 503"), {
+          status: 503,
+          body: { error: "engine unavailable" },
+        }),
+      ),
+      "error",
+    );
+    strictEqual(connectFailureMode(new Error("tunnel closed")), "error");
   });
 });

--- a/app/tests/quiet-error-class.test.ts
+++ b/app/tests/quiet-error-class.test.ts
@@ -43,6 +43,36 @@ describe("classifyQuietError", () => {
     strictEqual(classifyQuietError(new TypeError("x is not a function")), null);
   });
 
+  // PRODUCT-1717: a gateway without the local-model bridge answers every
+  // desktop boot; it is one quiet class, and it wins over the waking 503.
+  it("names the bridge_unsupported class off the adapter's 503 body", () => {
+    strictEqual(
+      classifyQuietError(
+        named(
+          "HoustonEngineError",
+          "This server does not support local model connections. (engine error 503)",
+          {
+            status: 503,
+            body: {
+              code: "bridge_not_supported",
+              error: "This server does not support local model connections.",
+            },
+          },
+        ),
+      ),
+      "bridge_unsupported",
+    );
+    strictEqual(
+      classifyQuietError(
+        named("HoustonEngineError", "engine unavailable (engine error 503)", {
+          status: 503,
+          body: { error: "engine unavailable" },
+        }),
+      ),
+      "engine_waking",
+    );
+  });
+
   // PRODUCT-1666: the three shapes that escaped the waking class.
   it("names the waking class for the still-starting 503 and the activities shape", () => {
     strictEqual(

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,6 +22,10 @@
     "./provider-catalog": {
       "types": "./src/provider-catalog.ts",
       "import": "./src/provider-catalog.ts"
+    },
+    "./local-model-bridge/unsupported": {
+      "types": "./src/local-model-bridge/unsupported.ts",
+      "import": "./src/local-model-bridge/unsupported.ts"
     }
   },
   "files": [

--- a/packages/sdk/src/local-model-bridge/bootstrap.test.ts
+++ b/packages/sdk/src/local-model-bridge/bootstrap.test.ts
@@ -53,3 +53,19 @@ test("authentication denial and unsupported capabilities never retry", async () 
   ).toBeNull();
   expect(vi.getTimerCount()).toBe(0);
 });
+test.each([
+  { status: 503, body: { code: "bridge_not_supported" } },
+  { status: 503, code: "bridge_not_supported" },
+])("a deployment without bridge support is reported once, never polled %j", async (error) => {
+  vi.useFakeTimers();
+  const factory = vi.fn().mockRejectedValue(error);
+  const report = vi.fn();
+  await expect(
+    bootstrapLocalModelBridge(factory, new AbortController().signal, {
+      report,
+    }),
+  ).rejects.toBe(error);
+  expect(factory).toHaveBeenCalledTimes(1);
+  expect(report).not.toHaveBeenCalled();
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/packages/sdk/src/local-model-bridge/errors.ts
+++ b/packages/sdk/src/local-model-bridge/errors.ts
@@ -1,3 +1,5 @@
+export { isBridgeUnsupported } from "./unsupported";
+
 export class BridgeStateError extends Error {
   constructor(
     readonly status:

--- a/packages/sdk/src/local-model-bridge/index.ts
+++ b/packages/sdk/src/local-model-bridge/index.ts
@@ -1,4 +1,4 @@
 export { bootstrapLocalModelBridge } from "./bootstrap";
 export { LocalModelBridgeController } from "./controller";
-export { BridgeStateError } from "./errors";
+export { BridgeStateError, isBridgeUnsupported } from "./errors";
 export type * from "./types";

--- a/packages/sdk/src/local-model-bridge/retry.ts
+++ b/packages/sdk/src/local-model-bridge/retry.ts
@@ -1,6 +1,7 @@
 import {
   BridgeStateError,
   isAuthorizationFailure,
+  isBridgeUnsupported,
   isPermanentBridgeFailure,
 } from "./errors";
 import type { LocalBridgeStatus } from "./types";
@@ -10,6 +11,7 @@ export function bridgeRetry(
   attempt: number,
   random: () => number,
 ): { status: LocalBridgeStatus; delay: number | null } {
+  if (isBridgeUnsupported(error)) return { status: "disabled", delay: null };
   const migrationMismatch =
     typeof error === "object" &&
     error !== null &&

--- a/packages/sdk/src/local-model-bridge/unsupported.ts
+++ b/packages/sdk/src/local-model-bridge/unsupported.ts
@@ -1,0 +1,23 @@
+/**
+ * The deployment answered `/v1/capabilities` without bridge v1 (the engine
+ * adapter's `bridge_not_supported` 503). A server's shape does not change on a
+ * retry curve, so discovery must stop instead of polling it every 30s.
+ * HoustonEngineError keeps the adapter's top-level code on `body`, not `code`.
+ *
+ * Kept in its own erasable-syntax-only module: the app's node:test entry
+ * points load it through the `@houston/sdk/local-model-bridge/unsupported`
+ * subpath, and node's type stripping rejects the parameter properties in
+ * `errors.ts`.
+ */
+export function isBridgeUnsupported(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  if ("code" in error && error.code !== undefined)
+    return error.code === "bridge_not_supported";
+  const body = "body" in error ? error.body : undefined;
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "code" in body &&
+    body.code === "bridge_not_supported"
+  );
+}

--- a/packages/web/tests/local-model-bridge-access.test.ts
+++ b/packages/web/tests/local-model-bridge-access.test.ts
@@ -1,3 +1,4 @@
+import { isBridgeUnsupported } from "@houston/sdk";
 import { afterEach, expect, test, vi } from "vitest";
 import { AdapterContext } from "../src/engine-adapter/client/context";
 import { localModelBridgeAccess } from "../src/engine-adapter/client/local-model-bridge";
@@ -41,9 +42,11 @@ test.each([
   ["http://localhost:4318", { profile: "local", tunnel: true }],
 ])("refuses unsupported remote or hosted deployment %s", async (url, capabilities) => {
   responses(capabilities);
-  await expect(
-    localModelBridgeAccess(context(url), "owner"),
-  ).rejects.toMatchObject({ status: 503 });
+  const refusal = localModelBridgeAccess(context(url), "owner");
+  await expect(refusal).rejects.toMatchObject({ status: 503 });
+  // The SDK's discovery stops (no 30s poll) and the app files it as the quiet
+  // bridge_unsupported class only if the thrown shape carries this code.
+  await expect(refusal).rejects.toSatisfy(isBridgeUnsupported);
 });
 
 test("a capability outage does not downgrade to a direct connection", async () => {


### PR DESCRIPTION
## Summary

PRODUCT-1717. Local model connections fail on the hosted gateway since the 0.6.20 desktop.

**Root cause (two halves).** #1515 replaced the FRP tunnel with the native bridge and made the desktop require the gateway's `localModelBridge` capability (`packages/web/src/engine-adapter/client/local-model-bridge.ts`). That capability is only advertised after the manual bridge activation job runs on an environment. 0.6.20 shipped before it ran anywhere, so every hosted desktop got a `bridge_not_supported` 503 right after a 200 from `/v1/capabilities`. On the client that answer was handled as a transient failure:

- `bootstrapLocalModelBridge` runs on every desktop boot and put the 503 on the 30s retry curve, reporting each attempt as a bug (Sentry HOUSTON-APP-5DB/5DG/5D9, 15 distinct users in one hour).
- The guided dialog landed on "Something went wrong while connecting. Make sure the app is still open on your computer", blaming a local app that was never the problem.

The activation itself is an ops step in the cloud repo (staging was activated while investigating; production is not yet, see the issue).

**Fix.**

- `@houston/sdk`: `isBridgeUnsupported` (new erasable-syntax subpath `@houston/sdk/local-model-bridge/unsupported`, so the app's node tests can load it). `bridgeRetry` stops discovery on it: no retry curve, no per-attempt report.
- app: `bridge_unsupported` joins the quiet Sentry classes (one fingerprinted warning per burst instead of one bug per boot). The matching `tags.quiet_class` fingerprint rule is already on the Sentry project.
- app: the guided dialog gets an `unsupported` screen with its own copy (en/es/pt) and keeps manual entry as the escape hatch. Retry re-checks capabilities.

## Before

1. Desktop 0.6.20 signed into a hosted gateway without bridge activation (production today).
2. Open the console: `[toast:local_model_bridge] Local model connection failed` on boot, repeating at the retry curve, one Sentry error per attempt.
3. AI models > Local model > pick a detected model > Connect: the dialog says to keep the local app open and try again.

## After

1. Same gateway, this branch: boot logs one `[local_model_bridge] this server offers no local model bridge` warning, no red toast, no Sentry error (one `bridge_unsupported` quiet warning).
2. Same connect flow: the dialog says local models aren't available on this server yet and offers manual entry. Try again re-checks the server.
3. Against a gateway with the bridge activated (staging), connect still completes and the status pill goes Online.

## Checks

`pnpm check`, `pnpm check:boundaries`, `pnpm --filter @houston/sdk test`, `pnpm --filter houston-web typecheck` + bridge unit tests, `cd app && pnpm tsgo --noEmit && pnpm check-locales && pnpm test` all green.
