### PR TITLE
fix(shell): restart-to-update pill wears the action fill and gets its own room (PRODUCT-1719)

### DIFF
--- a/app/src/components/shell/update-checker.tsx
+++ b/app/src/components/shell/update-checker.tsx
@@ -10,6 +10,9 @@ import { useUpdatePreview } from "./update-preview";
  * already running), the restart pill for a mid-session find once the
  * download has landed. A background download in flight, or one that failed
  * and will retry on the next check, shows nothing at all.
+ *
+ * Mounted inside the shell's top strip: the overlay is fixed and covers the
+ * window from anywhere, while the pill is in-flow and the strip sizes to it.
  */
 export function UpdateChecker() {
   const { status, installAndRelaunch, relaunchInstalledApp } =

--- a/app/src/components/shell/update-pill.tsx
+++ b/app/src/components/shell/update-pill.tsx
@@ -1,3 +1,4 @@
+import { motion, type Transition, useReducedMotion } from "framer-motion";
 import { Loader2, RotateCw } from "lucide-react";
 import { useId } from "react";
 import { useTranslation } from "react-i18next";
@@ -10,6 +11,10 @@ export type UpdatePillStatus = Extract<
   { state: "downloaded" } | { state: "installing" } | { state: "error" }
 >;
 
+/** Motion tokens: `easing.entrance` + `duration.fast` (200ms). One short
+ *  ease-out as the pill lands, so the eye catches it; it never moves again. */
+const ENTRANCE: Transition = { duration: 0.2, ease: [0.16, 1, 0.3, 1] };
+
 /**
  * The "Restart to update" pill. A mid-session find downloads silently and
  * ends here: a small pill in the top corner of the window that names the
@@ -18,10 +23,22 @@ export type UpdatePillStatus = Extract<
  * its own. That is the whole point: a running turn, a draft in the composer
  * or a co-located engine mid-task is never interrupted by an update.
  *
- * Fixed to the viewport so it holds the same corner on every screen, above
- * the canvas but below dialogs. The hint (which version, or what failed) is
- * the button's description for assistive tech; the visible pill stays two
- * words, as the corner has no room for a sentence.
+ * It wears the solid `action` fill (dark ink on light, light ink on dark),
+ * not a bordered dialog surface: the corner it holds is the window gutter,
+ * and a gutter-coloured pill with a hairline was invisible in dark mode. It
+ * is a plain button rather than the core `Button` primitive on purpose: the
+ * canvas theme restyles the primitive's default variant into a translucent
+ * frost pill in dark mode (`ui/core/src/canvas.css`), which on the gutter is
+ * exactly the low-contrast look this replaces. The launch overlay's button
+ * takes the same solid fill, so the two update surfaces match.
+ *
+ * It lives in the shell's top strip (`workspace-shell.tsx`), which grows to
+ * fit it, so it holds the window's top corner on every screen without ever
+ * covering the control that sits under that corner on the canvas. The hint
+ * (which version, or what failed) is the button's description for assistive
+ * tech; the visible pill stays short, as the corner has no room for a
+ * sentence, but shows the version it will restart into so the label is not
+ * the only thing that says "an update".
  */
 export function UpdatePill({
   status,
@@ -34,6 +51,7 @@ export function UpdatePill({
 }) {
   const { t } = useTranslation("shell");
   const hintId = useId();
+  const reduce = useReducedMotion() ?? false;
   const installing = status.state === "installing";
   const failed = status.state === "error";
   const relaunchOnly = failed && status.phase === "relaunch";
@@ -52,28 +70,37 @@ export function UpdatePill({
       : t("updateChecker.restartHint", { version: status.info.version });
 
   return (
-    <div
+    <motion.div
       role="status"
       aria-live="polite"
-      className="pointer-events-none fixed right-3 top-3 z-50"
+      data-testid="update-pill"
+      className="px-3 py-1"
+      initial={reduce ? { opacity: 0 } : { opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={ENTRANCE}
     >
       <button
         type="button"
         onClick={relaunchOnly ? onRelaunch : onInstall}
         disabled={installing}
         aria-describedby={hintId}
-        className="pointer-events-auto inline-flex h-8 items-center gap-2 rounded-full border border-line bg-dialog px-3 text-sm font-medium text-ink transition-[transform,opacity] duration-200 hover:bg-hover hover:text-hover-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus active:scale-[0.96] disabled:cursor-default disabled:opacity-70"
+        className="inline-flex h-8 items-center gap-2 rounded-full bg-action pr-3.5 pl-2.5 font-medium text-action-text text-sm transition-[transform,opacity] duration-200 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-gutter active:scale-[0.96] disabled:cursor-default disabled:opacity-80"
       >
         {installing ? (
-          <Loader2 className="size-4 animate-spin" />
+          <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
         ) : (
           <RotateCw className="size-4" />
         )}
         {label}
+        {!failed && !installing && (
+          <span className="text-action-text/70 text-xs tabular-nums">
+            v{status.info.version}
+          </span>
+        )}
       </button>
       <span id={hintId} className="sr-only">
         {hint}
       </span>
-    </div>
+    </motion.div>
   );
 }

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -76,6 +76,7 @@ export function WorkspaceShell({
   useKeyboardShortcuts();
 
   const isMobile = useIsMobile();
+  const overlayTitleBar = osIsTauri() && isMac;
   // The phone's pushed chat screen (PRODUCT-1555 arc): chat is a PLACE below
   // md — full-screen over the content, both mobile bars hidden while it is
   // up (a push, not a tab; the back affordances are the way out). Desktop
@@ -105,9 +106,22 @@ export function WorkspaceShell({
             Only the macOS desktop build uses the overlay title bar, so the
             strip is gated to that — on web and other platforms it would just
             be a dead gap. */}
-        {osIsTauri() && isMac && (
-          <div data-tauri-drag-region className="h-7 shrink-0" />
-        )}
+        {/* The strip is also where the restart pill lands (`UpdateChecker`):
+            a pill floated over the corner covers whatever control sits there
+            (the board's New task, the phone's new-agent button), so instead
+            the strip makes room for it, growing to fit when a release is
+            waiting. On platforms without the title strip it exists only
+            while the pill is up. The drag region only reacts to a press on
+            the strip itself, so the pill inside it still takes the click. */}
+        <div
+          data-tauri-drag-region={overlayTitleBar ? true : undefined}
+          className={cn(
+            "flex shrink-0 items-center justify-end",
+            overlayTitleBar && "min-h-7",
+          )}
+        >
+          <UpdateChecker />
+        </div>
         <div className="flex min-h-0 flex-1">
           <Sidebar>
             {/* Transparent row: on the desktop the window gutter shows in the
@@ -171,9 +185,6 @@ export function WorkspaceShell({
         <CommandPalette />
         <ShortcutCheatsheet />
         <ToastContainer toasts={toasts} onDismiss={onDismissToast} />
-        {/* Window-level chrome, not a sidebar row: the launch overlay covers
-            the shell and the restart pill holds the window's top corner. */}
-        <UpdateChecker />
       </div>
       {inAppOnboardingActive && <InAppOnboarding />}
       {/* The guided setup OWNS the screen while it runs: both surfaces spotlight

--- a/packages/web/e2e/update-pill.spec.ts
+++ b/packages/web/e2e/update-pill.spec.ts
@@ -1,0 +1,121 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * The "Restart to update" pill: the one surface a mid-session update find
+ * ends in. It sits on the window gutter, so it has to be the high-contrast
+ * element there in BOTH themes: it wears the primary action fill, never the
+ * gutter-coloured dialog surface that made it disappear in dark mode.
+ *
+ * Driven through the dev-only preview harness (`__HOUSTON_UPDATE_PREVIEW__`,
+ * `app/src/components/shell/update-preview.ts`): the real updater only runs
+ * in packaged builds, and the harness renders the same component with a
+ * simulated status.
+ */
+
+const pill = (page: Page) => page.getByTestId("update-pill");
+const restartButton = (page: Page) =>
+  pill(page).getByRole("button", { name: /Restart to update/ });
+
+type PreviewScene = "pill" | "error";
+type PreviewWindow = Window & {
+  __HOUSTON_UPDATE_PREVIEW__?: (scene: PreviewScene | null) => void;
+};
+
+async function showScene(page: Page, scene: PreviewScene) {
+  await page.evaluate((s: PreviewScene) => {
+    (window as PreviewWindow).__HOUSTON_UPDATE_PREVIEW__?.(s);
+  }, scene);
+}
+
+/** The `action` role's fill under the CURRENT theme, read off a throwaway
+ *  `bg-action` probe so the spec pins the role, not a value that the token
+ *  files own. */
+async function actionFill(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const probe = document.createElement("div");
+    probe.className = "bg-action";
+    document.body.appendChild(probe);
+    const fill = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    return fill;
+  });
+}
+
+async function setTheme(page: Page, theme: "light" | "dark") {
+  await page.evaluate((t: "light" | "dark") => {
+    if (t === "dark")
+      document.documentElement.setAttribute("data-theme", "dark");
+    else document.documentElement.removeAttribute("data-theme");
+  }, theme);
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("[data-tour-target='sidebar']")).toBeVisible();
+});
+
+test("names the restart, the version it lands on, and wears the action fill in both themes", async ({
+  page,
+}) => {
+  await showScene(page, "pill");
+  const button = restartButton(page);
+  await expect(button).toBeVisible();
+  await expect(button).toBeEnabled();
+  await expect(button).toContainText("v0.6.16");
+  await expect(button).toHaveAccessibleDescription(
+    /Version 0\.6\.16 is downloaded/,
+  );
+
+  await setTheme(page, "light");
+  const lightFill = await actionFill(page);
+  await expect(button).toHaveCSS("background-color", lightFill);
+  await setTheme(page, "dark");
+  const darkFill = await actionFill(page);
+  await expect(button).toHaveCSS("background-color", darkFill);
+  // The two themes flip the fill (dark ink on light, light ink on dark), so
+  // the pill is never the gutter's own colour in either.
+  expect(darkFill).not.toBe(lightFill);
+
+  // The pill holds the window's top-right corner, and the shell makes room
+  // for it there: it never covers the board's own top-right control (New
+  // task), which a pill floated over the corner used to sit on.
+  const box = await button.boundingBox();
+  const viewport = page.viewportSize();
+  const newTask = await page
+    .getByRole("button", { name: "New task" })
+    .first()
+    .boundingBox();
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(newTask).not.toBeNull();
+  if (box && viewport && newTask) {
+    expect(box.y).toBeLessThan(40);
+    expect(viewport.width - (box.x + box.width)).toBeLessThan(40);
+    expect(box.y + box.height).toBeLessThanOrEqual(newTask.y);
+  }
+});
+
+test("a click restarts: the pill reads Restarting and stops taking clicks", async ({
+  page,
+}) => {
+  await showScene(page, "pill");
+  await restartButton(page).click();
+  const restarting = pill(page).getByRole("button", { name: /Restarting/ });
+  await expect(restarting).toBeVisible();
+  await expect(restarting).toBeDisabled();
+});
+
+test("a failed install offers the retry with the failure as its description", async ({
+  page,
+}) => {
+  await showScene(page, "error");
+  const retry = pill(page).getByRole("button", {
+    name: /Update failed\. Try again/,
+  });
+  await expect(retry).toBeVisible();
+  await expect(retry).toBeEnabled();
+  await expect(retry).toHaveAccessibleDescription(
+    /couldn't install the update/,
+  );
+});


### PR DESCRIPTION
## Summary

PRODUCT-1719

The mid-session "Restart to update" pill was a gutter-coloured dialog surface with a hairline, floated over the window's top-right corner. Two problems:

- **Invisible in dark mode.** `bg-dialog` + `border-line` on the dark gutter is dark-on-dark.
- **It covered real controls.** The corner it floated over is where the board's New task button sits, and on the phone the new-agent button. Only the macOS title strip gave it free space; on hosts without that strip it sat on top of the primary action.

## Fix

- The pill wears the solid `action` fill (dark ink on light, light ink on dark), the same fill as the launch overlay's button, so the two update surfaces match. It shows the version it restarts into (`v0.6.16`) as a muted tag, and slides in once (200ms entrance easing, opacity-only under reduced motion).
- It is a plain button on purpose, not the core `Button` primitive: the canvas theme restyles the primitive's default variant into a translucent frost pill in dark mode (`ui/core/src/canvas.css`), which on the gutter is exactly the low-contrast look this replaces.
- It renders inside the shell's top strip (the macOS title strip, now a flex row that grows to fit the pill; on other platforms the strip only exists while the pill is up). Nothing is covered anymore. The drag-region attribute stays gated to the macOS overlay title bar, and only fires for a press on the strip itself, so the pill still takes the click.

## Tests

- New `packages/web/e2e/update-pill.spec.ts` (driven by the dev preview harness `__HOUSTON_UPDATE_PREVIEW__`): the pill names the restart and the version, wears the `action` fill in both themes (read off a `bg-action` probe, so the token files stay the source of truth), holds the top-right corner without overlapping New task, a click flips it to "Restarting..." and disables it, and a failed install offers the retry with the failure as its description.
- `pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (4191 pass), `pnpm check-locales`, `pnpm --filter houston-web typecheck` + `typecheck:e2e`, and boot / shell-panel-ownership / mobile-shell / theme-pin specs plus the whole `mobile` Playwright project all green.

## Verify

Before (on `main`): `pnpm dev`, open DevTools, run `__HOUSTON_UPDATE_PREVIEW__("pill")` in dark mode. The pill is a dark rounded outline in the top-right corner, and in the web build it sits on top of the New task button.

After (this branch): same steps. The pill is a solid light pill (dark theme) or solid dark pill (light theme) reading "Restart to update v0.6.16", in its own strip above the canvas; New task is fully visible and clickable. `__HOUSTON_UPDATE_PREVIEW__("error")` shows the retry state; clicking the pill shows "Restarting...". `__HOUSTON_UPDATE_PREVIEW__(null)` closes it. Narrow the window below 768px to see the phone layout: the strip sits above the page header instead of covering the new-agent button.
