### PR TITLE
fix(sdk): unsupported deployments disable the local model bridge instead of retrying and reporting every 30s

### DIFF
--- a/app/src/lib/local-bridge-ports.ts
+++ b/app/src/lib/local-bridge-ports.ts
@@ -1,7 +1,8 @@
 import type { LocalBridgeIdentity } from "@houston/protocol";
-import type {
-  LocalBridgeNativeEvent,
-  LocalModelBridgePorts,
+import {
+  isBridgeUnsupported,
+  type LocalBridgeNativeEvent,
+  type LocalModelBridgePorts,
 } from "@houston/sdk";
 import type { LocalModelBridgeAccess } from "@houston-ai/engine-client";
 import { showErrorToast } from "./error-toast";
@@ -18,8 +19,21 @@ import {
   osStopLocalBridge,
 } from "./os-bridge";
 
+/**
+ * Report-only (no toast): a bridge failure is background state. A deployment
+ * that serves no local model connections at all is not a failure — the
+ * bridge is simply off there — so it is never reported. The cause rides in
+ * the message: without it every report read as the same bare label.
+ */
 export function reportLocalBridgeError(error: unknown): void {
-  showErrorToast("local_model_bridge", "Local model connection failed", error);
+  if (isBridgeUnsupported(error)) return;
+  const cause =
+    error instanceof Error && error.message ? `: ${error.message}` : "";
+  showErrorToast(
+    "local_model_bridge",
+    `Local model connection failed${cause}`,
+    error,
+  );
 }
 
 export function bridgeIdentityKey(identity: LocalBridgeIdentity): string {

--- a/packages/sdk/src/local-model-bridge/bootstrap.test.ts
+++ b/packages/sdk/src/local-model-bridge/bootstrap.test.ts
@@ -53,3 +53,45 @@ test("authentication denial and unsupported capabilities never retry", async () 
   ).toBeNull();
   expect(vi.getTimerCount()).toBe(0);
 });
+test("an unsupported deployment is terminal: one attempt, no retry, no report", async () => {
+  vi.useFakeTimers();
+  const report = vi.fn();
+  const unsupported = Object.assign(new Error("not here"), {
+    status: 503,
+    body: { code: "bridge_not_supported" },
+  });
+  const factory = vi.fn().mockRejectedValue(unsupported);
+  await expect(
+    bootstrapLocalModelBridge(factory, new AbortController().signal, {
+      report,
+      random: () => 0,
+    }),
+  ).rejects.toBe(unsupported);
+  expect(factory).toHaveBeenCalledTimes(1);
+  expect(report).not.toHaveBeenCalled();
+  expect(vi.getTimerCount()).toBe(0);
+});
+test("a failing streak is reported once, and again only when its cause changes", async () => {
+  vi.useFakeTimers();
+  const report = vi.fn();
+  const controller = {};
+  const factory = vi
+    .fn()
+    .mockRejectedValueOnce(new Error("offline"))
+    .mockRejectedValueOnce(new Error("offline"))
+    .mockRejectedValueOnce(new Error("offline"))
+    .mockRejectedValueOnce(new Error("dns"))
+    .mockResolvedValueOnce(controller);
+  const result = bootstrapLocalModelBridge(
+    factory,
+    new AbortController().signal,
+    { report, random: () => 0 },
+  );
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(await result).toBe(controller);
+  expect(factory).toHaveBeenCalledTimes(5);
+  expect(report.mock.calls.map(([e]) => (e as Error).message)).toEqual([
+    "offline",
+    "dns",
+  ]);
+});

--- a/packages/sdk/src/local-model-bridge/bootstrap.ts
+++ b/packages/sdk/src/local-model-bridge/bootstrap.ts
@@ -1,12 +1,26 @@
 import { bridgeRetry } from "./retry";
 
-/** Retry only discovery/port construction. The factory must never start inference or a bridge. */
+/** The identity of a failure for report deduping: its message, else its text. */
+function failureKey(error: unknown): string {
+  return error instanceof Error
+    ? `${error.name}:${error.message}`
+    : String(error);
+}
+
+/**
+ * Retry only discovery/port construction. The factory must never start
+ * inference or a bridge. A failing streak is reported ONCE, when it starts
+ * and whenever its cause changes: the retry loop runs every few seconds for
+ * as long as the app is open, and reporting every attempt turned one
+ * unreachable server into hundreds of identical events per desktop.
+ */
 export async function bootstrapLocalModelBridge<T>(
   factory: (signal: AbortSignal) => Promise<T | null>,
   signal: AbortSignal,
   options: { report(error: unknown): void; random?: () => number },
 ): Promise<T | null> {
   let attempt = 0;
+  let reported: string | undefined;
   for (;;) {
     signal.throwIfAborted();
     try {
@@ -21,7 +35,11 @@ export async function bootstrapLocalModelBridge<T>(
         options.random ?? Math.random,
       );
       if (delay === null) throw error;
-      options.report(error);
+      const key = failureKey(error);
+      if (key !== reported) {
+        reported = key;
+        options.report(error);
+      }
       signal.throwIfAborted();
       await new Promise<void>((resolve, reject) => {
         const abort = () => {

--- a/packages/sdk/src/local-model-bridge/errors.test.ts
+++ b/packages/sdk/src/local-model-bridge/errors.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { isBridgeUnsupported } from "./errors";
+import { bridgeRetry } from "./retry";
+
+test("isBridgeUnsupported reads the code at the top level and inside an engine error body", () => {
+  expect(
+    isBridgeUnsupported({ status: 503, code: "bridge_not_supported" }),
+  ).toBe(true);
+  expect(
+    isBridgeUnsupported({
+      status: 503,
+      body: { code: "bridge_not_supported" },
+    }),
+  ).toBe(true);
+  expect(
+    isBridgeUnsupported({ status: 503, body: { code: "engine_unavailable" } }),
+  ).toBe(false);
+  expect(isBridgeUnsupported(new Error("offline"))).toBe(false);
+  expect(isBridgeUnsupported(null)).toBe(false);
+});
+
+test("bridgeRetry disables the bridge for an unsupported deployment instead of reconnecting", () => {
+  expect(
+    bridgeRetry(
+      { status: 503, body: { code: "bridge_not_supported" } },
+      0,
+      () => 0,
+    ),
+  ).toEqual({
+    status: "disabled",
+    delay: null,
+  });
+  expect(
+    bridgeRetry(
+      { status: 503, body: { code: "engine_unavailable" } },
+      0,
+      () => 0,
+    ).status,
+  ).toBe("reconnecting");
+});

--- a/packages/sdk/src/local-model-bridge/errors.ts
+++ b/packages/sdk/src/local-model-bridge/errors.ts
@@ -29,6 +29,26 @@ export function isAuthorizationFailure(error: unknown) {
   );
 }
 
+/**
+ * The deployment serves no local model connections at all: the gateway's
+ * capabilities carry no bridge version, or the engine has no control plane
+ * (`bridge_not_supported`, answered 503 by the adapter). That is a fact
+ * about the server, not a failure to retry or report: 0.6.20 desktops on a
+ * gateway without the bridge retried it every 30 s and reported every try,
+ * 13,500 events in two days.
+ */
+export function isBridgeUnsupported(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  if ("code" in error && error.code === "bridge_not_supported") return true;
+  const body = "body" in error ? error.body : undefined;
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "code" in body &&
+    body.code === "bridge_not_supported"
+  );
+}
+
 export function isPermanentBridgeFailure(error: unknown) {
   if (typeof error !== "object" || error === null || !("status" in error))
     return false;

--- a/packages/sdk/src/local-model-bridge/index.ts
+++ b/packages/sdk/src/local-model-bridge/index.ts
@@ -1,4 +1,4 @@
 export { bootstrapLocalModelBridge } from "./bootstrap";
 export { LocalModelBridgeController } from "./controller";
-export { BridgeStateError } from "./errors";
+export { BridgeStateError, isBridgeUnsupported } from "./errors";
 export type * from "./types";

--- a/packages/sdk/src/local-model-bridge/retry.ts
+++ b/packages/sdk/src/local-model-bridge/retry.ts
@@ -1,6 +1,7 @@
 import {
   BridgeStateError,
   isAuthorizationFailure,
+  isBridgeUnsupported,
   isPermanentBridgeFailure,
 } from "./errors";
 import type { LocalBridgeStatus } from "./types";
@@ -15,6 +16,9 @@ export function bridgeRetry(
     error !== null &&
     "code" in error &&
     error.code === "migration_requires_reconnect";
+  // An unsupported deployment is terminal and quiet: the bridge is simply
+  // disabled here, nothing reconnects it.
+  if (isBridgeUnsupported(error)) return { status: "disabled", delay: null };
   const status =
     migrationMismatch || isPermanentBridgeFailure(error)
       ? "reconnect_required"


### PR DESCRIPTION
## Why

Since 0.6.20, `app_error_shown` jumped from about 60 a day to 8432 on 08 Sep and 5386 by midday on 09 Sep. 13,500 of those carry `source=local_model_bridge`, from 65 desktops, up to 900 per user (Sentry HOUSTON-APP-5DB, 5DG, 5D9). Users see nothing, since the reporter is report-only, but PostHog and Sentry are flooded and real errors are hidden.

On a gateway whose capabilities carry no bridge version, `localModelBridgeAccess` throws `bridge_not_supported` (503). `bridgeRetry` only treats 400/404/409/410/422 and 401/403 as terminal, so that answer read as a transient reconnect: `bootstrapLocalModelBridge` retried every 30 seconds or less for as long as the app was open, and `options.report(error)` fired on every attempt. The report also dropped the cause, so every event read as the same bare label.

## What

- **SDK:** `isBridgeUnsupported` recognises `bridge_not_supported` at the top level and inside an engine error body; `bridgeRetry` answers `{status: "disabled", delay: null}` for it. The bootstrap reports a failing streak once, and again only when its cause changes.
- **App:** `reportLocalBridgeError` skips unsupported deployments (a fact about the server, not a failure) and appends the cause message.

## Tests

- `bootstrap.test.ts`: unsupported deployment is one attempt, no retry, no report; a repeating failure reports once and again on a changed cause.
- `errors.test.ts`: both code shapes; the retry classifier's `disabled` answer versus a plain 503.
- SDK suite green, web and app typechecks green, Biome clean.