### PR TITLE
fix(domain): salvage unescaped quotes inside .houston JSON strings; log a scan failure once, not every tick

### DIFF
--- a/packages/domain/src/json-salvage.test.ts
+++ b/packages/domain/src/json-salvage.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import {
   escapeControlCharsInStrings,
+  escapeStrayQuotesInStrings,
   firstJsonValueEnd,
   salvageJsonDoc,
   salvageLeadingJson,
@@ -138,4 +139,49 @@ test("parseJsonDoc strips a BOM, salvages trailing junk, and names the key", () 
   expect(() => parseJsonDoc("{oops", "learnings.json")).toThrow(
     /learnings\.json is not valid JSON/,
   );
+});
+
+// The wild shape behind a routines file that stopped one agent's routines
+// for a day and a half: a prompt pasted in place with a raw newline AND a
+// quoted word. The control-character pass alone left the quote to end the
+// string early; the quote pass finishes the repair.
+const strayQuoted = `[
+  {
+    "id": "r1",
+    "name": "Daily digest",
+    "prompt": "Delete mail from:\\n   - nemu@shop.example.com
+   - anything that contains "Temu" in the sender name or domain (removed)",
+    "schedule": "0 9 * * *"
+  }
+]
+`;
+
+test("escapeStrayQuotesInStrings escapes a quote that cannot end the string and leaves real terminators alone", () => {
+  expect(escapeStrayQuotesInStrings(doc)).toBeUndefined();
+  const fixed = escapeStrayQuotesInStrings('{"p": "say "hi" now", "k": 1}');
+  expect(fixed).toBe('{"p": "say \\"hi\\" now", "k": 1}');
+  expect(JSON.parse(fixed as string)).toEqual({ p: 'say "hi" now', k: 1 });
+  // A stray quote right before a comma reads as a terminator: the text
+  // after it is junk the grammar cannot place, so the parse still fails
+  // instead of guessing.
+  const ambiguous = escapeStrayQuotesInStrings('{"p": "say "hi", now"}');
+  expect(ambiguous).toBe('{"p": "say \\"hi", now"}');
+  expect(() => JSON.parse(ambiguous as string)).toThrow();
+});
+
+test("salvageJsonDoc repairs a raw newline and stray quotes in the same prompt", () => {
+  const value = salvageJsonDoc(strayQuoted) as Array<{ prompt: string }>;
+  expect(value).toHaveLength(1);
+  expect(value[0]?.prompt).toBe(
+    'Delete mail from:\n   - nemu@shop.example.com\n   - anything that contains "Temu" in the sender name or domain (removed)',
+  );
+});
+
+test("loadRoutines reads the stray-quote file and keeps the schedule", async () => {
+  const store = memStore();
+  await store.writeText(`${ROOT}/.houston/routines/routines.json`, strayQuoted);
+  const { items, diagnostics } = await loadRoutines(store, ROOT);
+  expect(items.map((r) => [r.id, r.schedule])).toEqual([["r1", "0 9 * * *"]]);
+  expect(items[0]?.prompt).toContain('"Temu"');
+  expect(diagnostics).toEqual([]);
 });

--- a/packages/domain/src/json-salvage.ts
+++ b/packages/domain/src/json-salvage.ts
@@ -10,11 +10,17 @@
  *  2. A raw control character (a literal newline or tab) inside a string
  *     literal: an agent's in-place edit of a long `prompt`. `JSON.parse`
  *     rejects the whole file for one byte.
+ *  3. An unescaped `"` inside a string literal: the same in-place edit
+ *     pasting a prompt that quotes a word (`contenga "Temu" en el nombre`).
+ *     The quote ends the string early and the parser trips on the next
+ *     word. Seen together with shape 2 in the same prompt, which is why
+ *     the passes chain.
  *
- * Either way one mangled file 500'd `list_routines` on every poll and bricked
- * the Routines tab for that agent. Both repairs are lossless: the raw newline
- * becomes the newline it meant, the trailing junk was never user data, and the
- * next save rewrites the file clean. Anything else still surfaces as the
+ * Any of them one mangled file 500'd `list_routines` on every poll, bricked
+ * the Routines tab for that agent, and stopped its routines from firing. All
+ * repairs are lossless: the raw newline becomes the newline it meant, the
+ * quote stays the quote it meant, the trailing junk was never user data, and
+ * the next save rewrites the file clean. Anything else still surfaces as the
  * caller's "not valid JSON" throw, because a lossy reset would destroy the
  * user's data on next write.
  */
@@ -77,6 +83,52 @@ export function escapeControlCharsInStrings(text: string): string | undefined {
 }
 
 /**
+ * `text` with every `"` that sits INSIDE a string literal but does not end it
+ * escaped, or `undefined` when there is none. A quote ends a string only
+ * when the next non-whitespace character is one JSON can accept after a
+ * string: `,` `}` `]` `:` or the end of the text. Any other `"` was a literal
+ * the writer forgot to escape. A stray quote that happens to sit before a
+ * comma still reads as a terminator, and the parse fails as before: this
+ * pass guesses nothing that the grammar cannot rule out.
+ */
+export function escapeStrayQuotesInStrings(text: string): string | undefined {
+  let out = "";
+  let last = 0;
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (!inString) {
+      if (ch === '"') inString = true;
+      continue;
+    }
+    if (ch === "\\") i++;
+    else if (ch === '"') {
+      if (closesString(text, i + 1)) inString = false;
+      else {
+        out += `${text.slice(last, i)}\\"`;
+        last = i + 1;
+      }
+    }
+  }
+  if (last === 0) return undefined;
+  return out + text.slice(last);
+}
+
+/** True when the text after a closing quote can legally follow a string. */
+function closesString(text: string, from: number): boolean {
+  let j = from;
+  while (j < text.length && isJsonWhitespace(text[j])) j++;
+  const next = text[j];
+  return (
+    next === undefined ||
+    next === "," ||
+    next === "}" ||
+    next === "]" ||
+    next === ":"
+  );
+}
+
+/**
  * Parse the leading complete value of a doc that has trailing junk after it.
  * Returns `undefined` when there is nothing to salvage (no complete leading
  * value, or the prefix itself is not valid JSON): the caller keeps its throw.
@@ -95,8 +147,9 @@ export function salvageLeadingJson(text: string): unknown {
 
 /**
  * Every lossless repair in turn, for a doc `JSON.parse` already rejected:
- * re-escape raw control characters inside strings, then keep the leading
- * value when trailing junk follows. `undefined` = nothing recoverable.
+ * re-escape raw control characters inside strings, then stray quotes inside
+ * strings, then keep the leading value when trailing junk follows.
+ * `undefined` = nothing recoverable.
  */
 export function salvageJsonDoc(text: string): unknown {
   const escaped = escapeControlCharsInStrings(text);
@@ -104,10 +157,18 @@ export function salvageJsonDoc(text: string): unknown {
     try {
       return JSON.parse(escaped) as unknown;
     } catch {
+      // Still broken elsewhere: keep repairing.
+    }
+  }
+  const quoted = escapeStrayQuotesInStrings(escaped ?? text);
+  if (quoted !== undefined) {
+    try {
+      return JSON.parse(quoted) as unknown;
+    } catch {
       // Still broken elsewhere: fall through to the trailing-junk repair.
     }
   }
-  return salvageLeadingJson(escaped ?? text);
+  return salvageLeadingJson(quoted ?? escaped ?? text);
 }
 
 /** The JSON escape for one control character: `\n`, `\t`, or `\u00XX`. */

--- a/packages/host/src/schedule/agent-scan.ts
+++ b/packages/host/src/schedule/agent-scan.ts
@@ -8,6 +8,7 @@ import type { Vfs } from "../vfs";
 import { burnRoutineFireInstant, type FireLock } from "./fire-lock";
 import { type ReconcileDeps, reconcileAgentRuns } from "./reconcile";
 import { fireRoutineRun, RoutineBusyError } from "./run";
+import { clearScanFailure, shouldLogScanFailure } from "./scan-failure-log";
 
 /** A due routine to run, with its resolved conversation + run id. */
 export interface FiringJob {
@@ -87,8 +88,14 @@ export async function scanAgent(
         if (won) await fireRoutine(deps, ws, agent, routine);
       }
     }
+    clearScanFailure(where);
   } catch (err) {
-    console.error(`[scheduler] ${where} routine scan failed:`, reason(err));
+    // Once per failure, not once per tick: a file that stays unreadable is
+    // one problem, not a new one every 30 seconds (scan-failure-log.ts).
+    const why = reason(err);
+    if (shouldLogScanFailure(where, why, Date.now())) {
+      console.error(`[scheduler] ${where} routine scan failed:`, why);
+    }
   }
 
   // Complete runs whose turn has finished (silent/surfaced/timeout). Runs live

--- a/packages/host/src/schedule/scan-failure-log.test.ts
+++ b/packages/host/src/schedule/scan-failure-log.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, expect, test } from "vitest";
+import {
+  clearScanFailure,
+  resetScanFailureLogForTests,
+  SCAN_FAILURE_REPEAT_MS,
+  shouldLogScanFailure,
+} from "./scan-failure-log";
+
+afterEach(resetScanFailureLogForTests);
+
+test("a failure logs when it starts, then once an hour while its reason holds", () => {
+  expect(shouldLogScanFailure("ws/a", "not valid JSON", 0)).toBe(true);
+  expect(shouldLogScanFailure("ws/a", "not valid JSON", 30_000)).toBe(false);
+  expect(
+    shouldLogScanFailure("ws/a", "not valid JSON", SCAN_FAILURE_REPEAT_MS - 1),
+  ).toBe(false);
+  expect(
+    shouldLogScanFailure("ws/a", "not valid JSON", SCAN_FAILURE_REPEAT_MS),
+  ).toBe(true);
+});
+
+test("a changed reason and another agent log at once; a success resets the streak", () => {
+  expect(shouldLogScanFailure("ws/a", "not valid JSON", 0)).toBe(true);
+  expect(shouldLogScanFailure("ws/a", "ENOENT", 1_000)).toBe(true);
+  expect(shouldLogScanFailure("ws/b", "ENOENT", 2_000)).toBe(true);
+  clearScanFailure("ws/a");
+  expect(shouldLogScanFailure("ws/a", "ENOENT", 3_000)).toBe(true);
+});

--- a/packages/host/src/schedule/scan-failure-log.ts
+++ b/packages/host/src/schedule/scan-failure-log.ts
@@ -1,0 +1,44 @@
+/**
+ * The scheduler's per-agent scan failure is logged at error level (the
+ * background sweep has no UI thread), and one unreadable routines file used
+ * to log it on EVERY tick: 120 identical Sentry events an hour for a day and
+ * a half, from a single agent. A failure is worth one line when it starts
+ * and one when its reason changes; the same reason repeats once an hour so
+ * a broken agent never goes silent either.
+ */
+export const SCAN_FAILURE_REPEAT_MS = 60 * 60 * 1000;
+
+interface LoggedFailure {
+  reason: string;
+  at: number;
+}
+
+const logged = new Map<string, LoggedFailure>();
+
+/** Whether this tick's failure for `where` is worth a log line. */
+export function shouldLogScanFailure(
+  where: string,
+  reason: string,
+  now: number,
+): boolean {
+  const previous = logged.get(where);
+  if (
+    previous &&
+    previous.reason === reason &&
+    now - previous.at < SCAN_FAILURE_REPEAT_MS
+  ) {
+    return false;
+  }
+  logged.set(where, { reason, at: now });
+  return true;
+}
+
+/** A scan that succeeded clears the agent's streak, so the next failure logs at once. */
+export function clearScanFailure(where: string): void {
+  logged.delete(where);
+}
+
+/** Test seam. */
+export function resetScanFailureLogForTests(): void {
+  logged.clear();
+}


### PR DESCRIPTION
## Why

One agent's `routines.json` was rewritten in place (two prompts, most likely by the agent editing the file) with a prompt carrying raw newlines and unescaped double quotes, `contenga "Temu" en el nombre`. The control-character salvage from #1514 repaired the newlines, but the stray quotes then ended the string early, the parse failed at the next word, `salvageJsonDoc` gave up and `loadRoutines` threw. The scheduler caught that per agent and logged it on every 30 second tick: 3974 error events (HOUSTON-APP-5D1) and a day and a half without that user's six daily routines.

## What

- **`json-salvage.ts`: a third lossless pass, `escapeStrayQuotesInStrings`.** A `"` inside a string literal ends it only when the next non-whitespace character is one JSON accepts after a string: `,` `}` `]` `:` or the end of the text. Any other `"` is the literal the writer forgot to escape. A stray quote that sits right before a comma still reads as a terminator and the parse still fails, so nothing the grammar cannot rule out is guessed. Chained after the control-character pass, before the trailing-junk repair. Verified against the real file: 3 control characters and 6 stray quotes escaped, the same 6 routines come back with their schedules, so the affected user's routines resume on the next release with no data edit.
- **`agent-scan.ts`: a scan failure logs once.** When it starts, when its reason changes, and once an hour while it holds; a successful scan clears the streak. One unreadable file is one problem, not a new one every 30 seconds.

## Tests

- `json-salvage.test.ts`: the quote pass on a clean doc (no-op), a quoted word, the before-a-comma case that must still fail, the combined newline plus quotes prompt, and `loadRoutines` on that file keeping the schedule.
- `scan-failure-log.test.ts`: first failure logs, repeats suppressed under an hour, changed reason and another agent log at once, success resets.
- Domain and host suites green, typechecks green, Biome clean.