### PR TITLE
fix(shell): assistant chat on the phone is a push, not a screen under the nav bar (PRODUCT-1724)

### DIFF
--- a/app/src/components/assistant/assistant-chat.tsx
+++ b/app/src/components/assistant/assistant-chat.tsx
@@ -21,6 +21,7 @@ import { useAgentChatPanel } from "../use-agent-chat-panel";
 import { useQueuedMessageLabels } from "../use-queued-message-labels";
 import { assistantAgent } from "./assistant-agent";
 import { AssistantEmptyState } from "./assistant-empty-state";
+import { AssistantPhoneHeader } from "./assistant-phone-header";
 import { useContextCommandMenu } from "./use-context-command-menu";
 
 const noop = () => {};
@@ -120,12 +121,13 @@ export function AssistantChat({ handle }: { handle: AssistantHandle }) {
     <div
       ref={rootRef}
       data-testid="assistant-chat"
-      className="flex h-full min-h-0 flex-col"
+      className="flex h-full min-h-0 flex-col pb-safe"
       // iOS does not shrink `dvh` when the keyboard opens, so the composer of a
       // full-height chat would sit under the keys. Zero on desktop and whenever
       // nothing occludes, so the one style serves both breakpoints.
       style={keyboardInset > 0 ? { paddingBottom: keyboardInset } : undefined}
     >
+      <AssistantPhoneHeader />
       <AIBoard
         panelOnly
         hidePanelClose

--- a/app/src/components/assistant/assistant-phone-header.tsx
+++ b/app/src/components/assistant/assistant-phone-header.tsx
@@ -1,0 +1,43 @@
+import { ChevronLeft } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { openMobileTab } from "../../lib/open-mobile-tab";
+import { useUIStore } from "../../stores/ui";
+import { HoustonLogo } from "./houston-logo";
+
+/**
+ * The phone's header for the assistant chat: a back chevron, the product
+ * mark, and the name. The desktop shows no header at all (the rail row names
+ * the screen and wears the mark), so the strip is CSS-hidden at md+.
+ *
+ * On the phone the chat is a PUSH like the mission chat: the nav bar leaves
+ * while it is up (`lib/mobile-tabs.ts` `phoneChromeHidden`), so this chevron
+ * is the way out. It retreats to wherever the More menu was opened from; with
+ * nothing behind it (a reload landing here) it goes home to the Agents tab
+ * rather than dead-ending.
+ */
+export function AssistantPhoneHeader() {
+  const { t } = useTranslation("assistant");
+  const canGoBack = useUIStore((s) => s.navIndex > 0);
+  const navBack = useUIStore((s) => s.navBack);
+  const back = () => {
+    if (canGoBack) navBack();
+    else openMobileTab("agents");
+  };
+  return (
+    <div className="flex shrink-0 items-center gap-3 px-4 py-3 md:hidden">
+      <button
+        type="button"
+        data-testid="assistant-back"
+        aria-label={t("back")}
+        onClick={back}
+        className="flex size-9 shrink-0 items-center justify-center rounded-full text-ink-muted transition-colors active:scale-95 hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+      >
+        <ChevronLeft className="size-5" />
+      </button>
+      <HoustonLogo className="size-6" />
+      <p className="min-w-0 flex-1 truncate text-sm font-semibold text-ink">
+        {t("title")}
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/assistant/houston-logo.tsx
+++ b/app/src/components/assistant/houston-logo.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@houston-ai/core";
 import houstonIcon from "../../assets/houston-icon.svg";
 import houstonIconWhite from "../../assets/houston-icon-white.svg";
 import { useIsDarkTheme } from "../../lib/use-is-dark-theme";
@@ -7,16 +8,17 @@ import { useIsDarkTheme } from "../../lib/use-is-dark-theme";
  * shared 16px `h-4 w-4` icon slot. The white variant carries the dark theme
  * (the primary mark is tuned for light surfaces), tracking the app's explicit
  * `data-theme` rather than the OS scheme. Decorative: the row's text label is
- * its accessible name.
+ * its accessible name. A caller outside the rail (the phone chat header)
+ * passes its own size.
  */
-export function HoustonLogo() {
+export function HoustonLogo({ className }: { className?: string }) {
   const dark = useIsDarkTheme();
   return (
     <img
       src={dark ? houstonIconWhite : houstonIcon}
       alt=""
       aria-hidden
-      className="h-4 w-4 shrink-0 object-contain"
+      className={cn("h-4 w-4 shrink-0 object-contain", className)}
     />
   );
 }

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -2,6 +2,7 @@ import { cn, type Toast, ToastContainer, useIsMobile } from "@houston-ai/core";
 import { useState } from "react";
 import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { useSurfaceGates } from "../../hooks/use-surface-gates";
+import { phoneChromeHidden } from "../../lib/mobile-tabs";
 import { osIsTauri } from "../../lib/os-bridge";
 import { isMac } from "../../lib/platform";
 import { useUIStore } from "../../stores/ui";
@@ -77,13 +78,13 @@ export function WorkspaceShell({
 
   const isMobile = useIsMobile();
   const overlayTitleBar = osIsTauri() && isMac;
-  // The phone's pushed chat screen (PRODUCT-1555 arc): chat is a PLACE below
-  // md — full-screen over the content, both mobile bars hidden while it is
-  // up (a push, not a tab; the back affordances are the way out). Desktop
-  // ignores the pair entirely.
+  // The phone's pushed chat screen: chat is a PLACE below md, full-screen
+  // over the content with the bottom chrome gone (`phoneChromeHidden` says
+  // when). Desktop ignores the pair entirely.
   const chatAgentId = useUIStore((s) => s.chatAgentId);
   const mobileChatOpen = isMobile && chatAgentId !== null;
-  const mobileBarsHidden = mobileChatOpen || (isMobile && missionPanelOpen);
+  const mobileBarsHidden =
+    isMobile && phoneChromeHidden({ viewMode, chatAgentId, missionPanelOpen });
 
   return (
     <DetailPanelProvider value={panelContainer}>
@@ -171,10 +172,10 @@ export function WorkspaceShell({
           </Sidebar>
         </div>
         {/* The floating nav bar (Agents / Teams / More + compose); CSS-hidden
-            at md+ and gone while a chat is up on the phone (pushed screen or
-            the board's full-screen panel): chat is a push, not a tab, so the
-            back affordances are the way out and the composer gets the full
-            height above the keyboard. */}
+            at md+ and gone while a chat is up on the phone (pushed screen,
+            the board's full-screen panel, the assistant): chat is a push, not
+            a tab, so the back affordances are the way out and the composer
+            gets the full height above the keyboard. */}
         {!mobileBarsHidden && <MobileNavBar />}
         <MobileMoreMenu />
         <MobileNewMissionSheet />

--- a/app/src/lib/mobile-tabs.ts
+++ b/app/src/lib/mobile-tabs.ts
@@ -18,6 +18,7 @@
 
 import {
   AGENTS_HOME_VIEW_ID,
+  ASSISTANT_VIEW_ID,
   TEAM_VIEW_ID,
   TEAMS_HOME_VIEW_ID,
 } from "./top-level-views.ts";
@@ -40,4 +41,26 @@ export function activeMobileTab(ui: { viewMode: string }): MobileTabId {
   if (ui.viewMode === TEAM_VIEW_ID || ui.viewMode === TEAMS_HOME_VIEW_ID)
     return "teams";
   return "more";
+}
+
+/**
+ * Whether the phone's bottom chrome (the floating nav bar with its compose
+ * button) stays off the screen. Chat is a PUSH, not a tab: the pushed mission
+ * chat and the board's full-screen mission panel drop the bar so the composer
+ * sits on the bottom edge above the keyboard and the back affordances are the
+ * way out. The assistant is a chat too, a 1-on-1 reached from the More menu
+ * with its own back chevron, so it drops the bar for the same reason; left in
+ * place it stacked a third row of controls under the composer, with a New
+ * task button beside a chat that already has one.
+ */
+export function phoneChromeHidden(ui: {
+  viewMode: string;
+  chatAgentId: string | null;
+  missionPanelOpen: boolean;
+}): boolean {
+  return (
+    ui.chatAgentId !== null ||
+    ui.missionPanelOpen ||
+    ui.viewMode === ASSISTANT_VIEW_ID
+  );
 }

--- a/app/src/locales/en/assistant.json
+++ b/app/src/locales/en/assistant.json
@@ -1,6 +1,7 @@
 {
   "title": "Houston",
   "opening": "Opening Houston",
+  "back": "Back",
   "empty": {
     "heading": "Hi, I'm Houston",
     "capabilities": "I can do anything you can do in Houston: create agents, set up automations, connect your apps, and find what you need.",

--- a/app/src/locales/es/assistant.json
+++ b/app/src/locales/es/assistant.json
@@ -1,6 +1,7 @@
 {
   "title": "Houston",
   "opening": "Abriendo Houston",
+  "back": "Atrás",
   "empty": {
     "heading": "Hola, soy Houston",
     "capabilities": "Puedo hacer todo lo que tú puedes hacer en Houston: crear agentes, configurar automatizaciones, conectar tus apps y encontrar lo que necesitas.",

--- a/app/src/locales/pt/assistant.json
+++ b/app/src/locales/pt/assistant.json
@@ -1,6 +1,7 @@
 {
   "title": "Houston",
   "opening": "Abrindo o Houston",
+  "back": "Voltar",
   "empty": {
     "heading": "Oi, eu sou o Houston",
     "capabilities": "Eu posso fazer tudo o que você faz no Houston: criar agentes, configurar automações, conectar seus apps e achar o que você precisa.",

--- a/app/tests/mobile-tabs.test.ts
+++ b/app/tests/mobile-tabs.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { activeMobileTab } from "../src/lib/mobile-tabs.ts";
+import { activeMobileTab, phoneChromeHidden } from "../src/lib/mobile-tabs.ts";
 
 // The phone nav bar's classification rule — which of the three items the
 // current location lights up. Pure; the tap side is store-bound and covered
@@ -35,5 +35,44 @@ describe("activeMobileTab", () => {
 
   it("leaves no location dark", () => {
     assert.equal(activeMobileTab(at("some-stale-view")), "more");
+  });
+});
+
+// The bottom chrome's own rule: a chat is a push, so the bar leaves while one
+// is up, whichever door led there.
+describe("phoneChromeHidden", () => {
+  const on = (viewMode: string) => ({
+    viewMode,
+    chatAgentId: null,
+    missionPanelOpen: false,
+  });
+
+  it("stays for the tab roots and the More menu's screens", () => {
+    for (const view of [
+      "agents-home",
+      "teams-home",
+      "team",
+      "settings",
+      "store",
+    ])
+      assert.equal(phoneChromeHidden(on(view)), false);
+  });
+
+  it("leaves under the pushed mission chat", () => {
+    assert.equal(
+      phoneChromeHidden({ ...on("team"), chatAgentId: "agent-1" }),
+      true,
+    );
+  });
+
+  it("leaves under the board's full-screen mission panel", () => {
+    assert.equal(
+      phoneChromeHidden({ ...on("team"), missionPanelOpen: true }),
+      true,
+    );
+  });
+
+  it("leaves under the assistant, a chat reached from More", () => {
+    assert.equal(phoneChromeHidden(on("assistant")), true);
   });
 });

--- a/packages/web/e2e/mobile/assistant.spec.ts
+++ b/packages/web/e2e/mobile/assistant.spec.ts
@@ -1,0 +1,68 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+import { navBar, openMoreMenu } from "../support/mobile-nav";
+import { screen } from "../support/team-nav";
+
+/**
+ * The assistant on the phone: a chat, so a PUSH like the mission chat rather
+ * than a screen under the tab bar. The floating nav bar leaves while it is up
+ * so the composer sits on the bottom edge and the header's own back chevron
+ * is the way out.
+ */
+
+async function openPhoneAssistant(page: Page): Promise<Locator> {
+  const menu = await openMoreMenu(page);
+  await menu.getByRole("button", { name: "Houston" }).tap();
+  const chat = page.getByTestId("assistant-chat");
+  await expect(chat).toBeVisible();
+  return chat;
+}
+
+test("opens from More as a full-height chat with no nav bar under it", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(navBar(page)).toBeVisible();
+
+  const chat = await openPhoneAssistant(page);
+  await expect(chat.getByText("Hi, I'm Houston")).toBeVisible();
+  await expect(navBar(page)).toHaveCount(0);
+
+  // The composer is the last thing on the screen: nothing sits below it.
+  const composer = chat.getByPlaceholder("Send a follow-up...");
+  await expect(composer).toBeVisible();
+  const composerBottom = await composer.evaluate((el) => {
+    const form = el.closest("form") ?? el;
+    return form.getBoundingClientRect().bottom;
+  });
+  const lowestControl = await page.evaluate(() =>
+    Math.max(
+      ...[...document.querySelectorAll("button")]
+        .filter((b) => b.getClientRects().length > 0)
+        .map((b) => b.getBoundingClientRect().bottom),
+    ),
+  );
+  // The composer's own toolbar row (mode, model) sits directly under the
+  // field, but no separate chrome does.
+  expect(lowestControl - composerBottom).toBeLessThan(60);
+
+  const overflow = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});
+
+test("the header's back chevron leaves for the Agents tab", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await openPhoneAssistant(page);
+
+  // A More-menu destination is a tab ROOT (the menu navigates with `reset`),
+  // so there is nothing behind the chat to pop: back goes home.
+  await page.getByTestId("assistant-back").tap();
+  await expect(screen(page)).toHaveAttribute("data-screen", "agents-home");
+  await expect(navBar(page)).toBeVisible();
+});


### PR DESCRIPTION
## Summary

PRODUCT-1724

Below 768px the assistant chat (the "Houston" row in the More menu) rendered as a bare top-level screen: no header and no back affordance of its own, while the floating nav bar with its New task button stayed under the chat composer and its toolbar. Three rows of controls at the bottom of a phone, one of them a compose button beside a chat that already has a composer.

The phone's pushed mission chat already treats chat as a push, not a tab: the bar leaves, the composer sits on the bottom edge above the keyboard, and a back chevron is the way out. The assistant is a chat too, so it now follows the same rule.

## Changes

- `phoneChromeHidden` in `app/src/lib/mobile-tabs.ts` is the one rule for when the phone's bottom chrome leaves: pushed mission chat, full-screen mission panel, the assistant. The shell reads it instead of its inline pair of conditions.
- `AssistantPhoneHeader`: back chevron, product mark, name. CSS-hidden at md+, so the desktop assistant renders exactly as before. Back retreats the nav stack when there is something behind the chat; from a More-menu root (the menu navigates with `reset`) it goes home to the Agents tab.
- The assistant root pads `pb-safe` now that the nav bar no longer carries the safe-area inset.
- `HoustonLogo` takes an optional `className` so the header can size the mark.
- Locale key `assistant:back` in en / es / pt.

## Tests

- `app/tests/mobile-tabs.test.ts`: the `phoneChromeHidden` rule.
- `packages/web/e2e/mobile/assistant.spec.ts`: the nav bar is gone under the chat, no chrome sits below the composer, no horizontal overflow, the back chevron lands on the Agents home with the bar back.
- Ran: `pnpm check`, `cd app && pnpm tsgo --noEmit && pnpm check-locales && pnpm test`, the full `mobile` Playwright project (51 passed), the desktop `assistant.spec.ts`, `typecheck:e2e`.

## Before

1. Open app.gethouston.ai in a browser at a phone width (DevTools, iPhone 14 Pro Max, 430 x 932).
2. Tap More in the floating nav bar, then Houston.
3. Send a message or two.
4. The chat has no header. The composer and its Ask first / model toolbar sit on top of the floating nav bar and the New task button.

## After

1. Same steps.
2. The chat opens with a header (back chevron, Houston mark, "Houston"), the nav bar is gone, and the composer is the last thing on the screen.
3. Tap the chevron: the Agents home returns with the nav bar.
4. At 768px and above nothing changes: the rail row opens the same headerless chat.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
