### PR TITLE
fix(runtime): fence model-spawned processes by the container memory limit (PRODUCT-1723)

### DIFF
--- a/packages/runtime/src/backends/claude/claude-env.test.ts
+++ b/packages/runtime/src/backends/claude/claude-env.test.ts
@@ -34,3 +34,27 @@ test("the credential store remains optional and must be absolute", () => {
     }),
   ).toThrow(/absolute path/);
 });
+
+test("the shell fence rides CLAUDE_CODE_SHELL_PREFIX, and only the fence does", () => {
+  const savedPrefix = process.env.CLAUDE_CODE_SHELL_PREFIX;
+  process.env.CLAUDE_CODE_SHELL_PREFIX = "/ambient/wrapper";
+  try {
+    const fenced = buildClaudeEnv(undefined, {
+      configDir: "/config",
+      shellFencePath: "/data/bin/claude-shell-fence",
+    });
+    expect(fenced.CLAUDE_CODE_SHELL_PREFIX).toBe(
+      "/data/bin/claude-shell-fence",
+    );
+
+    // No container limit → no wrapper; the ambient one never passes through.
+    const open = buildClaudeEnv(undefined, {
+      configDir: "/config",
+      shellFencePath: null,
+    });
+    expect(open.CLAUDE_CODE_SHELL_PREFIX).toBeUndefined();
+  } finally {
+    if (savedPrefix === undefined) delete process.env.CLAUDE_CODE_SHELL_PREFIX;
+    else process.env.CLAUDE_CODE_SHELL_PREFIX = savedPrefix;
+  }
+});

--- a/packages/runtime/src/backends/claude/claude-env.ts
+++ b/packages/runtime/src/backends/claude/claude-env.ts
@@ -1,4 +1,5 @@
 import { isAbsolute } from "node:path";
+import { claudeShellFencePath } from "../../session/child-memory-fence";
 import type { ClaudeToken } from "./backend-types";
 
 /**
@@ -127,6 +128,13 @@ function tokenEnv(token: ClaudeToken | undefined): Record<string, string> {
  * `anthropicCredentialStorageDir` (`./scope-guard`), which documents why.
  * Undefined (team / desktop / self-host) sets nothing, leaving this env
  * byte-identical to before that guard existed.
+ *
+ * `shellFencePath` is the wrapper the CLI runs its Bash tool through
+ * (`CLAUDE_CODE_SHELL_PREFIX`), capping the memory of what the model spawns
+ * inside a memory-limited container (session/child-memory-fence.ts). Left
+ * undefined it resolves from the container; null (or no container limit)
+ * sets nothing. An ambient prefix is never copied — it is not in the
+ * allowlist, and the fence is the only wrapper this subprocess may run.
  */
 export function buildClaudeEnv(
   token: ClaudeToken | undefined,
@@ -134,6 +142,7 @@ export function buildClaudeEnv(
     configDir: string;
     credentialStorageDir?: string;
     homeDir?: string;
+    shellFencePath?: string | null;
   },
 ): Record<string, string> {
   const env: Record<string, string> = {};
@@ -143,6 +152,11 @@ export function buildClaudeEnv(
     }
   }
   env.CLAUDE_CONFIG_DIR = opts.configDir;
+  const fence =
+    opts.shellFencePath === undefined
+      ? claudeShellFencePath()
+      : opts.shellFencePath;
+  if (fence !== null) env.CLAUDE_CODE_SHELL_PREFIX = fence;
   if (opts.homeDir !== undefined) env.HOME = opts.homeDir;
   if (opts.credentialStorageDir !== undefined) {
     // The CLI reads an EMPTY `CLAUDE_SECURESTORAGE_CONFIG_DIR` as `~/.houston`'s

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -248,6 +248,16 @@ export const config = {
    */
   sessionCacheIdleMs: Number(env.HOUSTON_SESSION_CACHE_IDLE_MS || 1_800_000),
 
+  /**
+   * What the engine itself (this runtime, its host, a Claude CLI subprocess)
+   * needs of the container's memory limit; the rest is the per-process cap on
+   * anything the model spawns (session/child-memory-fence.ts). Sized from
+   * production: an awake engine runs 0.7 to 1.5 GB resident before any user
+   * workload. Only meaningful inside a memory-limited container.
+   */
+  engineMemoryReserveBytes:
+    Number(env.HOUSTON_ENGINE_MEMORY_RESERVE_MB || 1280) * 1024 * 1024,
+
   version: "0.0.0",
 };
 

--- a/packages/runtime/src/session/child-memory-fence.test.ts
+++ b/packages/runtime/src/session/child-memory-fence.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  bashMemoryFencePrefix,
+  CGROUP_MEMORY_LIMIT_FILES,
+  CHILD_MEMORY_CAP_FLOOR_BYTES,
+  childMemoryCapBytes,
+  claudeShellFenceScript,
+  ensureClaudeShellFence,
+  parseCgroupMemoryLimit,
+  readCgroupMemoryLimit,
+} from "./child-memory-fence";
+
+const MiB = 1024 * 1024;
+const GiB = 1024 * MiB;
+
+describe("parseCgroupMemoryLimit", () => {
+  test("a numeric limit is bytes", () => {
+    expect(parseCgroupMemoryLimit("2147483648\n")).toBe(2 * GiB);
+  });
+
+  test("cgroup v2 'max' and the v1 no-limit sentinel mean no limit", () => {
+    expect(parseCgroupMemoryLimit("max\n")).toBeNull();
+    expect(parseCgroupMemoryLimit("9223372036854771712\n")).toBeNull();
+  });
+
+  test("unreadable or malformed content means no limit, never a throw", () => {
+    expect(parseCgroupMemoryLimit(null)).toBeNull();
+    expect(parseCgroupMemoryLimit("")).toBeNull();
+    expect(parseCgroupMemoryLimit("-1")).toBeNull();
+    expect(parseCgroupMemoryLimit("0")).toBeNull();
+    expect(parseCgroupMemoryLimit("lots")).toBeNull();
+  });
+});
+
+describe("readCgroupMemoryLimit", () => {
+  test("prefers the unified hierarchy and falls back to the v1 controller", () => {
+    const v2Only = (path: string) =>
+      path === CGROUP_MEMORY_LIMIT_FILES[0] ? "3221225472" : null;
+    expect(readCgroupMemoryLimit(v2Only, "linux")).toBe(3 * GiB);
+
+    const v1Only = (path: string) =>
+      path === CGROUP_MEMORY_LIMIT_FILES[1] ? "1073741824" : null;
+    expect(readCgroupMemoryLimit(v1Only, "linux")).toBe(1 * GiB);
+  });
+
+  test("a v2 'max' still lets a real v1 limit through", () => {
+    const read = (path: string) =>
+      path === CGROUP_MEMORY_LIMIT_FILES[0] ? "max" : "1073741824";
+    expect(readCgroupMemoryLimit(read, "linux")).toBe(1 * GiB);
+  });
+
+  test("no readable limit means no limit", () => {
+    expect(readCgroupMemoryLimit(() => null, "linux")).toBeNull();
+  });
+
+  test("never reads on a non-Linux platform", () => {
+    let reads = 0;
+    const read = () => {
+      reads++;
+      return "2147483648";
+    };
+    expect(readCgroupMemoryLimit(read, "darwin")).toBeNull();
+    expect(readCgroupMemoryLimit(read, "win32")).toBeNull();
+    expect(reads).toBe(0);
+  });
+});
+
+describe("childMemoryCapBytes", () => {
+  test("is the container limit minus the engine reserve", () => {
+    expect(childMemoryCapBytes(2 * GiB, 1280 * MiB)).toBe(768 * MiB);
+    expect(childMemoryCapBytes(4 * GiB, 1280 * MiB)).toBe(2816 * MiB);
+  });
+
+  test("never drops below the floor, even in a tiny container", () => {
+    expect(childMemoryCapBytes(1 * GiB, 1280 * MiB)).toBe(
+      CHILD_MEMORY_CAP_FLOOR_BYTES,
+    );
+  });
+
+  test("no container limit means no cap", () => {
+    expect(childMemoryCapBytes(null, 1280 * MiB)).toBeNull();
+  });
+});
+
+describe("the fence shell lines", () => {
+  test("the prefix applies RLIMIT_DATA in 1024-byte blocks, quietly", () => {
+    expect(bashMemoryFencePrefix(768 * MiB)).toBe(
+      "ulimit -d 786432 2>/dev/null",
+    );
+  });
+
+  test("the Claude wrapper re-enters bash with the command it was handed", () => {
+    const script = claudeShellFenceScript(768 * MiB);
+    expect(script.startsWith("#!/bin/bash\n")).toBe(true);
+    expect(script).toContain("ulimit -d 786432 2>/dev/null\n");
+    expect(script).toContain('exec "$BASH" -c "$1"\n');
+  });
+});
+
+describe("ensureClaudeShellFence", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true });
+  });
+
+  test("writes an executable wrapper and rewrites it for a new cap", () => {
+    const root = mkdtempSync(join(tmpdir(), "fence-"));
+    dirs.push(root);
+    const dir = join(root, "bin");
+
+    const path = ensureClaudeShellFence(dir, 768 * MiB);
+    expect(path).toBe(join(dir, "claude-shell-fence"));
+    expect(readFileSync(path, "utf8")).toBe(claudeShellFenceScript(768 * MiB));
+    if (process.platform !== "win32")
+      expect(statSync(path).mode & 0o111).toBe(0o111);
+
+    expect(ensureClaudeShellFence(dir, 512 * MiB)).toBe(path);
+    expect(readFileSync(path, "utf8")).toBe(claudeShellFenceScript(512 * MiB));
+  });
+});

--- a/packages/runtime/src/session/child-memory-fence.ts
+++ b/packages/runtime/src/session/child-memory-fence.ts
@@ -1,0 +1,175 @@
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { config } from "../config";
+
+/**
+ * A memory fence for the processes a model spawns (a bash command, the Claude
+ * CLI's Bash tool), sized from the container this runtime lives in.
+ *
+ * A hosted engine pod is ONE cgroup with a hard memory limit and group OOM
+ * kill: when any process in it pushes the sum past the limit, the kernel kills
+ * every process in the container — the host, this runtime, the model's shell —
+ * and the pod restarts. From the user's chair the turn simply vanishes ("The
+ * turn ended unexpectedly"): the exporter script the agent launched grew past
+ * ~1 GB in a 2 GiB pod and took the engine down with it (observed 2026-09-09,
+ * three restarts in one session).
+ *
+ * The kernel's only per-process lever inside such a cgroup is a resource limit.
+ * `RLIMIT_DATA` (bash `ulimit -d`) caps a process's private writable memory —
+ * heap plus anonymous mappings, which is what an interpreter's working set is —
+ * and is inherited by everything it spawns. A script that exceeds it fails IN
+ * PLACE (Python raises MemoryError, node's Buffer.alloc throws, a runaway heap
+ * aborts the one process) and the failure lands in the tool result, where the
+ * model can read it and change plan, instead of ending the conversation.
+ *
+ * The cap is the container's limit minus what the engine itself needs to stay
+ * alive ({@link config.engineMemoryReserveBytes}); no container limit (the
+ * desktop, a bare VM) means no fence — nothing changes there. `RLIMIT_AS` is
+ * deliberately NOT used: it counts reserved-but-uncommitted address space, and
+ * a V8 heap reserves gigabytes of it up front.
+ */
+
+const MiB = 1024 * 1024;
+
+/**
+ * Below this a cap starves ordinary tooling (git, pip, npm) rather than fencing
+ * a runaway script — a container that small is not worth fencing.
+ */
+export const CHILD_MEMORY_CAP_FLOOR_BYTES = 256 * MiB;
+
+/**
+ * cgroup v1 reports "no limit" as 2^63 rounded down to a page; anything in that
+ * neighbourhood is unlimited, not a real budget.
+ */
+const CGROUP_V1_UNLIMITED_BYTES = 2 ** 62;
+
+/**
+ * Where a container's own memory limit is readable, in preference order: the
+ * unified hierarchy (cgroup v2, every current Kubernetes node), then the
+ * legacy memory controller. A plain host has neither file at the root.
+ */
+export const CGROUP_MEMORY_LIMIT_FILES = [
+  "/sys/fs/cgroup/memory.max",
+  "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+] as const;
+
+/** Parse one cgroup limit file: bytes, or null for "no limit" / unreadable. */
+export function parseCgroupMemoryLimit(raw: string | null): number | null {
+  if (raw === null) return null;
+  const text = raw.trim();
+  if (text === "max") return null;
+  if (!/^\d+$/.test(text)) return null;
+  const bytes = Number(text);
+  if (!Number.isSafeInteger(bytes) || bytes <= 0) return null;
+  if (bytes >= CGROUP_V1_UNLIMITED_BYTES) return null;
+  return bytes;
+}
+
+/**
+ * The container's memory limit in bytes, or null when this process is not in
+ * a memory-limited container. Linux only — the cgroup files do not exist
+ * elsewhere, and neither does the kill semantics this guards against.
+ */
+export function readCgroupMemoryLimit(
+  read: (path: string) => string | null = readOrNull,
+  platform: NodeJS.Platform = process.platform,
+): number | null {
+  if (platform !== "linux") return null;
+  for (const path of CGROUP_MEMORY_LIMIT_FILES) {
+    const limit = parseCgroupMemoryLimit(read(path));
+    if (limit !== null) return limit;
+  }
+  return null;
+}
+
+function readOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The per-process cap for a given container limit: the limit minus the engine
+ * reserve, never below the floor. Null when there is no limit to derive from.
+ */
+export function childMemoryCapBytes(
+  limitBytes: number | null,
+  reserveBytes: number,
+): number | null {
+  if (limitBytes === null) return null;
+  return Math.max(CHILD_MEMORY_CAP_FLOOR_BYTES, limitBytes - reserveBytes);
+}
+
+/**
+ * The shell line that applies the cap to the current shell and everything it
+ * spawns. `ulimit -d` takes 1024-byte blocks. Errors are silenced: a hard limit
+ * already below the cap is stricter, not a failure, and the command must run.
+ */
+export function bashMemoryFencePrefix(capBytes: number): string {
+  return `ulimit -d ${Math.floor(capBytes / 1024)} 2>/dev/null`;
+}
+
+/**
+ * The wrapper the Claude CLI runs its Bash tool through when
+ * `CLAUDE_CODE_SHELL_PREFIX` names it: the CLI appends the whole command as
+ * ONE argument (verified against Claude Code 2.1), so `$1` is the command and
+ * the wrapper re-enters bash under the cap. `$BASH` is the interpreter running
+ * this script (always set inside a bash script), the same one the CLI chose.
+ */
+export function claudeShellFenceScript(capBytes: number): string {
+  return [
+    "#!/bin/bash",
+    "# Written by the Houston runtime (session/child-memory-fence.ts).",
+    "# Runs the Claude CLI's shell commands under a per-process memory cap.",
+    bashMemoryFencePrefix(capBytes),
+    'exec "$BASH" -c "$1"',
+    "",
+  ].join("\n");
+}
+
+/**
+ * Write the wrapper for `capBytes` under `dir` and return its absolute path.
+ * Rewritten on every call (cheap, and a cap change must never leave a stale
+ * script behind); mode 0755 so the CLI's shell can execute it.
+ */
+export function ensureClaudeShellFence(dir: string, capBytes: number): string {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "claude-shell-fence");
+  writeFileSync(path, claudeShellFenceScript(capBytes), "utf8");
+  chmodSync(path, 0o755);
+  return path;
+}
+
+let resolvedCap: number | null | undefined;
+let resolvedFencePath: string | null | undefined;
+
+/**
+ * This runtime's cap for model-spawned processes, decided once per process
+ * from the container limit and the configured engine reserve. Null outside a
+ * memory-limited container.
+ */
+export function resolveChildMemoryCap(): number | null {
+  if (resolvedCap === undefined)
+    resolvedCap = childMemoryCapBytes(
+      readCgroupMemoryLimit(),
+      config.engineMemoryReserveBytes,
+    );
+  return resolvedCap;
+}
+
+/**
+ * The absolute path of the Claude CLI shell wrapper for this runtime's cap,
+ * written into the runtime's data dir on first use. Null when there is no cap.
+ */
+export function claudeShellFencePath(): string | null {
+  if (resolvedFencePath === undefined) {
+    const cap = resolveChildMemoryCap();
+    resolvedFencePath =
+      cap === null
+        ? null
+        : ensureClaudeShellFence(join(config.dataDir, "bin"), cap);
+  }
+  return resolvedFencePath;
+}

--- a/packages/runtime/src/session/tools/scrubbed-bash.test.ts
+++ b/packages/runtime/src/session/tools/scrubbed-bash.test.ts
@@ -1,5 +1,10 @@
-import { expect, test } from "vitest";
-import { scrubbedBashEnv } from "./scrubbed-bash";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, test } from "vitest";
+import {
+  bashMemoryFenceOptions,
+  makeScrubbedBashTool,
+  scrubbedBashEnv,
+} from "./scrubbed-bash";
 
 /**
  * bash is where a leaked environment becomes an exploit: one `echo` prints
@@ -74,4 +79,60 @@ test("a variable with no value is left out rather than passed as undefined", () 
   expect(scrubbedBashEnv({ PATH: undefined, HOME: "/h" })).toEqual({
     HOME: "/h",
   });
+});
+
+describe("the memory fence", () => {
+  test("no cap adds no prefix, so the unfenced tool is unchanged", () => {
+    expect(bashMemoryFenceOptions(null)).toEqual({});
+  });
+
+  test("a cap becomes the ulimit prefix pi runs ahead of the command", () => {
+    expect(bashMemoryFenceOptions(768 * 1024 * 1024)).toEqual({
+      commandPrefix: "ulimit -d 786432 2>/dev/null",
+    });
+  });
+
+  // Runs a real shell: the fence only counts if it reaches the process that
+  // executes the model's command, not just the option bag. Linux only: macOS
+  // bash refuses to set RLIMIT_DATA at all (the fence is inert there, and no
+  // container limit exists to derive a cap from anyway).
+  test.skipIf(process.platform !== "linux")(
+    "the shell that runs the command sees the cap",
+    async () => {
+      // pi reads the session id/file off the context for its PI_* env vars.
+      const ctx = {
+        sessionManager: {
+          getSessionId: () => "test-session",
+          getSessionFile: () => undefined,
+        },
+      } as unknown as ExtensionContext;
+      const fenced = makeScrubbedBashTool(process.cwd(), {
+        memoryCapBytes: 768 * 1024 * 1024,
+      });
+      const out = await fenced.execute(
+        "call-1",
+        { command: "ulimit -d" },
+        new AbortController().signal,
+        undefined,
+        ctx,
+      );
+      expect(out.content[0]).toMatchObject({
+        text: expect.stringMatching(/^786432\b/),
+      });
+
+      const open = makeScrubbedBashTool(process.cwd(), {
+        memoryCapBytes: null,
+      });
+      const unfenced = await open.execute(
+        "call-2",
+        { command: "ulimit -d" },
+        new AbortController().signal,
+        undefined,
+        ctx,
+      );
+      expect(unfenced.content[0]).toMatchObject({
+        text: expect.stringMatching(/^unlimited\b/),
+      });
+    },
+  );
 });

--- a/packages/runtime/src/session/tools/scrubbed-bash.ts
+++ b/packages/runtime/src/session/tools/scrubbed-bash.ts
@@ -1,4 +1,8 @@
 import { createBashToolDefinition } from "@earendil-works/pi-coding-agent";
+import {
+  bashMemoryFencePrefix,
+  resolveChildMemoryCap,
+} from "../child-memory-fence";
 
 /**
  * The env allowlist for a model-directed bash child.
@@ -76,7 +80,23 @@ export function scrubbedBashEnv(
 }
 
 /**
- * A `bash` tool whose child process env is scrubbed to the allowlist above.
+ * The pi bash options that fence a command's memory: the cap is applied as a
+ * command prefix (pi runs `<prefix>\n<command>` in one shell), so the shell
+ * and every process it spawns inherit it. No cap → no prefix, byte-identical
+ * to the unfenced tool. See child-memory-fence.ts for why.
+ */
+export function bashMemoryFenceOptions(capBytes: number | null): {
+  commandPrefix?: string;
+} {
+  return capBytes === null
+    ? {}
+    : { commandPrefix: bashMemoryFencePrefix(capBytes) };
+}
+
+/**
+ * A `bash` tool whose child process env is scrubbed to the allowlist above,
+ * and whose memory is fenced by the container's limit (child-memory-fence.ts;
+ * `memoryCapBytes` overrides the resolved cap, null = no fence).
  * Registered as a custom tool under the name `bash`, so it SHADOWS pi's
  * built-in bash by name (the same shadow-by-name mechanism the clamped file
  * tools use). Every runtime that offers bash registers it — the long-lived
@@ -84,8 +104,16 @@ export function scrubbedBashEnv(
  * alike; a shell that can read the host credential is the same hole on all of
  * them.
  */
-export function makeScrubbedBashTool(cwd: string) {
+export function makeScrubbedBashTool(
+  cwd: string,
+  opts: { memoryCapBytes?: number | null } = {},
+) {
+  const cap =
+    opts.memoryCapBytes === undefined
+      ? resolveChildMemoryCap()
+      : opts.memoryCapBytes;
   return createBashToolDefinition(cwd, {
+    ...bashMemoryFenceOptions(cap),
     spawnHook: (context) => ({ ...context, env: scrubbedBashEnv() }),
   });
 }


### PR DESCRIPTION
## Root cause

"The turn ended unexpectedly" is the copy the host relay (`TURN_DIED_MESSAGE`) and the SDK's history settle stamp on a turn whose engine died mid-flight. Every case on 2026-09-09 was the engine pod being **OOM-killed**: the container has a 2Gi memory limit and `memory.oom.group=1`, so the moment any process in it crosses the limit the kernel kills the host, the runtime and the model's shell together, the pod restarts, and the running turn vanishes (`lastState.terminated.reason=OOMKilled`, exit 137).

The kernel's victim lists (Cloud Logging, node kernel messages) show three flavors:

- **A user workload.** The reporting agent (the CFO agent in the Kernel workspace, Claude backend) launched a Python data export that reached 1.05–1.14 GB on top of host 0.4 GB + runtime 0.4 GB + Claude CLI 0.2 GB. Killed at 14:27, 14:37 and 15:00 UTC; each kill is one "turn ended unexpectedly" in the chat.
- **Runtime bloat.** One pod restarted 87 times in 12 hours: a `shared`-mode routine conversation has grown to a 165 MB JSON (83 MB session), and the runtime loads all of it (1.0–1.5 GB resident). Separate follow-up, not fixed here.
- **The engine alone.** Two pods died at host 0.7–0.9 GB + runtime 0.5–0.9 GB + Claude CLI 0.5–0.6 GB with no user process at all. Needs the limit raised (cloud change, below).

Sentry never sees an OOM (SIGKILL), and the runtime log just stops, which is why this looked like a stream bug.

## The fix (this PR)

Inside a memory-limited container, the only per-process lever is a resource limit. The runtime now derives a **`RLIMIT_DATA` cap** (bash `ulimit -d`) from the container's cgroup limit minus an engine reserve (`HOUSTON_ENGINE_MEMORY_RESERVE_MB`, default 1280 MiB) and applies it to everything the model spawns:

- **pi's `bash` tool** via pi's `commandPrefix` (`ulimit -d <kb> 2>/dev/null` runs in the same shell, so every child inherits it).
- **the Claude CLI's Bash tool** via an on-disk wrapper handed to `CLAUDE_CODE_SHELL_PREFIX` (the CLI passes the whole command as one argument to the prefix, verified against Claude Code 2.1).

A script that outgrows the cap now fails **in place** (Python `MemoryError`, node `Buffer.alloc` throws, a runaway V8 heap aborts that one process) and the failure lands in the tool result, where the model can read it and change plan, instead of ending the conversation. No container limit (desktop, bare VM) means no cap and byte-identical behavior. `RLIMIT_AS` was rejected on purpose: V8 reserves ~22 GB of address space up front.

Verified on a real amd64 GKE node with the production engine image: under a 768 MiB cap Python raises `MemoryError` at 750 MB, node's `Buffer.alloc` throws at 700 MB, and the Claude CLI binary still starts and runs (it needs >384 MiB of its own, which is why the cap is applied to its *shell*, never to the CLI process).

New module: `packages/runtime/src/session/child-memory-fence.ts` (+ tests). Wiring in `tools/scrubbed-bash.ts` and `backends/claude/claude-env.ts` (+ tests).

## Companion cloud change (not in this repo)

The engine's own peak already exceeds 2Gi. Prepared on a local branch of the cloud repo (`fix/PRODUCT-1723-engine-memory-limit`): the engine container limit goes 2Gi → 3Gi, requests unchanged at 1Gi. With the fence, a 3Gi pod gives model-spawned processes a 1.75 GiB cap.

## Before the fix

1. On a hosted agent, ask it to run a script that allocates more than the pod has left, e.g. `python3 -c "b=[bytearray(50*1024*1024) for _ in range(60)]; input()"` (3 GB).
2. The pod is OOM-killed (`kubectl get pod -o jsonpath='{.status.containerStatuses[0].lastState.terminated.reason}'` → `OOMKilled`), and the chat shows "The turn ended unexpectedly" with the tool still marked as running.

## After the fix

1. Same request on an engine running this build. `ls <dataDir>/bin/claude-shell-fence` exists on a Claude-backend pod; a pi-backend `bash` call of `ulimit -d` prints the cap in KB (e.g. `786432` in a 2Gi pod).
2. The script ends with `MemoryError` in the tool result, the agent reports it and continues, and the pod's restart count does not move.
3. Off-container (desktop): `ulimit -d` from the agent still prints `unlimited`; nothing changed.

PRODUCT-1723
