### PR TITLE
fix(runtime): empty-refresh guard defers its unbound report past pi's boot credential pass (PRODUCT-1743)

### DIFF
--- a/packages/runtime/src/auth/empty-refresh-guard-binding.test.ts
+++ b/packages/runtime/src/auth/empty-refresh-guard-binding.test.ts
@@ -7,10 +7,13 @@ import { config } from "../config";
 /**
  * PRODUCT-1317's guard re-serves an expiring access-only entry through
  * serve.ts's sync. serve.ts binds that sync when it loads, and every runtime
- * loads it at boot (the turn start and the provider routes import it), so the
- * binding is in place before any refresh closure can fire. This suite pins the
- * three states: no-op off serve mode, bound once serve.ts loaded, and a loud
- * report (never a silent skip) if serve mode is on with nothing bound.
+ * loads it at boot (the turn start and the provider routes import it). pi's
+ * boot credential pass reads the store BEFORE that binding can exist
+ * (storage.ts's top-level await runs first, and serve.ts depends on it), so an
+ * unbound read is not a wiring fault by itself (PRODUCT-1743). This suite pins
+ * the states: no-op off serve mode, bound once serve.ts loaded, a report
+ * deferred past the bind grace when nothing ever binds, and a bind within the
+ * grace cancelling it.
  */
 
 config.dataDir = mkdtempSync(join(tmpdir(), "houston-erg-data-"));
@@ -20,9 +23,8 @@ config.dataDir = mkdtempSync(join(tmpdir(), "houston-erg-data-"));
 vi.mock("./serve-sync-run", () => ({ runServedSync: vi.fn(async () => []) }));
 
 const { runServedSync } = await import("./serve-sync-run");
-const { bindEmptyRefreshServeSync, runEmptyRefreshServeSync } = await import(
-  "./empty-refresh-guard"
-);
+const { BIND_GRACE_MS, bindEmptyRefreshServeSync, runEmptyRefreshServeSync } =
+  await import("./empty-refresh-guard");
 
 const serveMode = (on: boolean) => {
   config.controlPlaneUrl = on ? "http://control-plane.test" : "";
@@ -38,16 +40,48 @@ test("off serve mode the guard stays a true no-op", async () => {
   report.mockRestore();
 });
 
-test("in serve mode an unbound guard reports loudly instead of skipping", async () => {
+test("in serve mode an unbound read reports only once nothing has bound within the grace", async () => {
   serveMode(true);
   bindEmptyRefreshServeSync(null);
+  vi.useFakeTimers();
   const report = vi.spyOn(console, "error").mockImplementation(() => {});
-  await expect(runEmptyRefreshServeSync()).resolves.toBeUndefined();
-  expect(report).toHaveBeenCalledWith(
-    expect.stringContaining("no served sync is bound"),
-  );
-  report.mockRestore();
-  serveMode(false);
+  try {
+    // pi's boot pass: one read per provider, then availability checks, all
+    // before serve.ts could have bound. None of them reports on its own.
+    await runEmptyRefreshServeSync();
+    await runEmptyRefreshServeSync();
+    await runEmptyRefreshServeSync();
+    expect(report).not.toHaveBeenCalled();
+    expect(runServedSync).not.toHaveBeenCalled();
+
+    // A runtime that never loads serve.ts is the wiring fault: one report.
+    vi.advanceTimersByTime(BIND_GRACE_MS);
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(
+      expect.stringContaining("no served sync is bound"),
+    );
+  } finally {
+    report.mockRestore();
+    vi.useRealTimers();
+    serveMode(false);
+  }
+});
+
+test("serve.ts binding within the grace cancels the deferred report", async () => {
+  serveMode(true);
+  bindEmptyRefreshServeSync(null);
+  vi.useFakeTimers();
+  const report = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await runEmptyRefreshServeSync();
+    bindEmptyRefreshServeSync(async () => {});
+    vi.advanceTimersByTime(BIND_GRACE_MS * 2);
+    expect(report).not.toHaveBeenCalled();
+  } finally {
+    report.mockRestore();
+    vi.useRealTimers();
+    serveMode(false);
+  }
 });
 
 test("loading serve.ts binds the guard, and a store read re-serves through it", async () => {

--- a/packages/runtime/src/auth/empty-refresh-guard-boot.test.ts
+++ b/packages/runtime/src/auth/empty-refresh-guard-boot.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+import { config } from "../config";
+import { writeAuthFile } from "./auth-file";
+
+/**
+ * PRODUCT-1743 regression: pi's boot credential pass (`ModelRuntime.create`
+ * inside storage.ts's top-level await) reads every provider BEFORE any importer
+ * of storage.ts, serve.ts included, can have bound the guard's sync. A served
+ * access-only entry already inside pi's validity floor on that pass is the
+ * boot state of every recycled pod, not a wiring fault, and must not report.
+ */
+
+config.dataDir = mkdtempSync(join(tmpdir(), "houston-erg-boot-"));
+config.controlPlaneUrl = "http://control-plane.test";
+config.sandboxToken = "sbx-token";
+
+writeAuthFile(join(config.dataDir, "auth.json"), {
+  "openai-codex": {
+    type: "oauth",
+    access: "served-at",
+    refresh: "",
+    expires: Date.now() + 60_000,
+  },
+});
+
+test("booting storage.ts in serve mode with an expiring served entry never reports the guard as unbound", async () => {
+  const report = vi.spyOn(console, "error").mockImplementation(() => {});
+  await import("./storage");
+  expect(report).not.toHaveBeenCalledWith(
+    expect.stringContaining("no served sync is bound"),
+  );
+  report.mockRestore();
+});

--- a/packages/runtime/src/auth/empty-refresh-guard.ts
+++ b/packages/runtime/src/auth/empty-refresh-guard.ts
@@ -60,14 +60,28 @@ export function maskAccessOnly(
   return isAccessOnlyOAuth(cred) ? undefined : cred;
 }
 
-/** A sync standing in for serve.ts's own — tests drive the guard through it. */
-let serveSyncOverride: (() => Promise<void>) | null = null;
+/** serve.ts's non-throwing, single-flighted sync once it has loaded; tests bind their own. */
+let servedSync: (() => Promise<void>) | null = null;
 
-/** Test seam: run the guard against `fn`, or `null` to restore the real sync. */
+/**
+ * How long an unbound guard waits for serve.ts before calling the runtime
+ * mis-wired. Boot binds within the same module-evaluation pass as storage.ts
+ * (milliseconds); a runtime still unbound after this never loaded serve.ts.
+ */
+export const BIND_GRACE_MS = 15_000;
+
+/** A report deferred from a read that fired before anything was bound. */
+let pendingReport: ReturnType<typeof setTimeout> | null = null;
+
+/** Bind the served sync the guard re-serves through; `null` unbinds (tests). */
 export function bindEmptyRefreshServeSync(
   fn: (() => Promise<void>) | null,
 ): void {
-  serveSyncOverride = fn;
+  servedSync = fn;
+  if (fn && pendingReport) {
+    clearTimeout(pendingReport);
+    pendingReport = null;
+  }
 }
 
 /**
@@ -77,20 +91,33 @@ export function bindEmptyRefreshServeSync(
  * Not a static import: it would cycle (serve -> storage -> credential-store ->
  * this module), and a dynamic import closes that same cycle through the one
  * module with a top-level await (`storage.ts`), which the bundler cannot
- * order. The binding is safe because serve.ts is on every runtime's boot path
- * (the turn start and the provider routes import it), so it is in place
- * before any refresh closure can fire. Off serve mode there is nothing to
- * re-serve, so the guard is a genuine no-op there; in serve mode an unbound
- * guard is a wiring fault and says so loudly instead of letting pi POST
- * `refresh_token=""` (PRODUCT-1317).
+ * order. Off serve mode there is nothing to re-serve, so the guard is a
+ * genuine no-op there.
+ *
+ * In serve mode a read can legitimately arrive BEFORE the binding: pi's boot
+ * credential pass (`ModelRuntime.create` and the provider registrations that
+ * follow it, inside storage.ts's top-level await) reads every provider, and
+ * serve.ts depends on storage.ts, so it cannot have run yet. A recycled pod
+ * whose restored auth.json holds an access-only entry inside pi's validity
+ * floor lands here on every boot (PRODUCT-1743). Nothing needs re-serving on
+ * that pass: the turn start syncs before the first request and the `modify`
+ * mask still keeps `refresh_token=""` off the wire. So the report is deferred:
+ * serve.ts binding within the grace cancels it, and only a runtime that never
+ * loads serve.ts (the genuine wiring fault that would let pi POST an empty
+ * refresh token, PRODUCT-1317) says so, once.
  */
 export async function runEmptyRefreshServeSync(): Promise<void> {
-  if (serveSyncOverride) {
-    await serveSyncOverride();
+  if (servedSync) {
+    await servedSync();
     return;
   }
-  if (!serveModeOn()) return;
-  console.error(
-    "[empty-refresh-guard] serve mode is on but no served sync is bound; serve.ts did not load before a refresh fired",
-  );
+  if (!serveModeOn() || pendingReport) return;
+  pendingReport = setTimeout(() => {
+    pendingReport = null;
+    if (servedSync) return;
+    console.error(
+      "[empty-refresh-guard] serve mode is on but no served sync is bound; serve.ts never loaded after a refresh fired",
+    );
+  }, BIND_GRACE_MS);
+  pendingReport.unref();
 }


### PR DESCRIPTION
## Summary

Sentry HOUSTON-APP-5DP: `[empty-refresh-guard] serve mode is on but no served sync is bound; serve.ts did not load before a refresh fired`, three events in one second, 3s after an engine pod started. Linear: PRODUCT-1743.

**Root cause.** `storage.ts` builds pi's `ModelRuntime` with a top-level `await ModelRuntime.create(...)`. pi's create runs its boot credential pass (`refresh` + `getAvailable` + `checkAuth`, three reads per provider) through `HoustonAuthStore.read`, and `ensureQwenRuntimeProvider` fires one more `refresh` right after. `serve.ts` binds the guard's sync when it loads, but it depends on storage.ts (serve → serve-sync-run → providers → storage), so it cannot have evaluated before storage.ts's own top-level await finishes. Any recycled pod whose restored auth.json holds an access-only served entry inside pi's five-minute validity floor tripped the "wiring fault" report on every boot. Nothing was mis-wired: the turn start re-serves before the first request and the `modify` mask keeps `refresh_token=""` off the wire.

**Fix.** The guard treats an unbound read as that boot pass: it defers the report by a bind grace (15s, unref'd). serve.ts binding cancels it. A runtime that never loads serve.ts, the genuine wiring fault from PRODUCT-1317, still reports, once.

## Tests

- `empty-refresh-guard-boot.test.ts` (new): boots `storage.ts` in serve mode with an expiring served entry in auth.json and asserts no report. Fails on main with exactly three reports, matching production.
- `empty-refresh-guard-binding.test.ts`: unbound reads report only after the grace elapses with nothing bound; a bind within the grace cancels the report; loading serve.ts still binds and re-serves.

## Verify

Before (main):
```
cd packages/runtime && pnpm vitest run src/auth/empty-refresh-guard-boot.test.ts
```
fails with three `no served sync is bound` reports.

After (this branch): the same command passes, and
```
pnpm --filter @houston/runtime test -- src/auth
```
is green. In production, the HOUSTON-APP-5DP issue stops receiving events from pods running this build; a pod that never loaded serve.ts would still report once, 15s after its first guarded read.