### PR TITLE
fix(runtime): rotate oversized transcripts into archive segments (PRODUCT-1742)

### DIFF
--- a/packages/runtime/src/store/conversation-archive-cut.ts
+++ b/packages/runtime/src/store/conversation-archive-cut.ts
@@ -1,0 +1,56 @@
+import { rmSync } from "node:fs";
+import {
+  archiveDirFor,
+  readSegment,
+  segmentFileFor,
+  segments,
+  totalMessageCount,
+} from "./conversation-archive";
+import type { StoredConversation } from "./conversation-file";
+
+/**
+ * The destructive side of the archive (conversation-archive.ts): cutting a
+ * transcript back into a segment for edit-and-resend, and deleting the
+ * segments with their conversation.
+ */
+
+/**
+ * Edit-and-resend at a turn that lives in a segment: the segment's messages
+ * before that turn become the live tail, every segment from there on is
+ * deleted, and the index shrinks to what is left. Returns how many messages
+ * the cut removed, or null when no segment holds the turn.
+ */
+export function restoreArchivedTurn(
+  dir: string,
+  conv: StoredConversation,
+  turnId: string,
+): number | null {
+  const sizes = conv.archived?.segments ?? [];
+  for (let k = sizes.length; k >= 1; k--) {
+    const messages = readSegment(dir, conv.id, k);
+    const at = messages.findIndex((m) => m.turnId === turnId);
+    if (at === -1) continue;
+    const kept = sizes.slice(0, k - 1);
+    const keptCount = kept.reduce((sum, n) => sum + n, 0);
+    const removed = totalMessageCount(conv) - keptCount - at;
+    for (let n = k; n <= sizes.length; n++) {
+      const file = segmentFileFor(dir, conv.id, n);
+      rmSync(file, { force: true });
+      segments.delete(file);
+    }
+    conv.messages = messages.slice(0, at);
+    if (kept.length) conv.archived = { messages: keptCount, segments: kept };
+    else delete conv.archived;
+    return removed;
+  }
+  return null;
+}
+
+/**
+ * Drop every segment (the conversation is being deleted). The segment cache
+ * is small, so it is simply cleared rather than searched by prefix.
+ */
+export function removeArchive(dir: string, id: string): void {
+  segments.clear();
+  rmSync(archiveDirFor(dir, id), { recursive: true, force: true });
+}

--- a/packages/runtime/src/store/conversation-archive.test.ts
+++ b/packages/runtime/src/store/conversation-archive.test.ts
@@ -1,0 +1,261 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChatMessage } from "@houston/runtime-client";
+import { describe, expect, test } from "vitest";
+import {
+  ARCHIVE_TAIL_BYTES,
+  ARCHIVE_TRIGGER_BYTES,
+  archiveDirFor,
+  tailCutIndex,
+  totalMessageCount,
+} from "./conversation-archive";
+import {
+  appendAssistantMessageAt,
+  appendUserMessageAt,
+  deleteConversationAt,
+  getHistoryAt,
+  listConversationsAt,
+  loadConversation,
+  loadFullConversation,
+  type StoredConversation,
+} from "./conversation-file";
+import { truncateConversationMutationAt } from "./conversation-truncate";
+
+const freshDir = () => mkdtempSync(join(tmpdir(), "houston-archive-"));
+const KB = 1024;
+
+/** A turn of one user message and one assistant reply of ~`replyKb` KB. */
+function appendTurn(dir: string, id: string, n: number, replyKb: number) {
+  const turnId = `t${n}`;
+  appendUserMessageAt(dir, id, `question ${n}`, { turnId });
+  appendAssistantMessageAt(dir, id, `reply ${n} ${"x".repeat(replyKb * KB)}`, {
+    turnId,
+  });
+}
+
+/** Enough turns to push the live file past the rotation trigger. */
+function fillPastBudget(dir: string, id: string): void {
+  const turns = Math.ceil(ARCHIVE_TRIGGER_BYTES / (100 * KB)) + 2;
+  for (let n = 1; n <= turns; n++) appendTurn(dir, id, n, 100);
+}
+
+function liveFile(dir: string, id: string): StoredConversation {
+  return JSON.parse(
+    readFileSync(join(dir, `${id}.json`), "utf8"),
+  ) as StoredConversation;
+}
+
+describe("tailCutIndex", () => {
+  const msg = (role: "user" | "assistant", size: number): ChatMessage => ({
+    role,
+    content: "y".repeat(size),
+    ts: 1,
+  });
+
+  test("opens the tail at the user message of the newest turns that fit", () => {
+    const messages = [
+      msg("user", 10),
+      msg("assistant", 500),
+      msg("user", 10),
+      msg("assistant", 500),
+      msg("user", 10),
+      msg("assistant", 100),
+    ];
+    // Serialized, the last turn is ~185 bytes and the one before ~585. An 800
+    // byte tail holds both and opens at the user message at index 2; a 700
+    // byte tail holds only the last turn, so the middle one is archived whole.
+    expect(tailCutIndex(messages, 800)).toBe(2);
+    expect(tailCutIndex(messages, 700)).toBe(4);
+  });
+
+  test("keeps the newest turn whole even when it alone exceeds the tail", () => {
+    // Nothing fits, so the newest turn stays and nothing moves: a turn is
+    // never split, and the live file is never left empty.
+    const messages = [msg("user", 10), msg("assistant", 5000)];
+    expect(tailCutIndex(messages, 100)).toBe(0);
+    const two = [...messages, msg("user", 10), msg("assistant", 5000)];
+    expect(tailCutIndex(two, 100)).toBe(2);
+  });
+
+  test("cuts nothing when everything fits", () => {
+    expect(tailCutIndex([msg("user", 10), msg("assistant", 10)], 1000)).toBe(0);
+  });
+});
+
+describe("rotation", () => {
+  test("an append past the budget moves older turns into a segment and keeps the tail", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "r1");
+
+    const live = liveFile(dir, "r1");
+    // The tail plus whatever was appended after the rotating append.
+    expect(statSync(join(dir, "r1.json")).size).toBeLessThan(
+      ARCHIVE_TAIL_BYTES + 6 * 101 * KB,
+    );
+    expect(live.archived?.segments).toEqual([live.archived?.messages]);
+    expect(live.messages[0]?.role).toBe("user"); // never split a turn
+    expect(readdirSync(archiveDirFor(dir, "r1"))).toEqual(["1.json"]);
+
+    // The transcript is intact: every message, in order, across both files.
+    const full = loadFullConversation(dir, "r1");
+    expect(full?.archived).toBeUndefined();
+    const heads = full?.messages.map((m) =>
+      m.content.split(" ").slice(0, 2).join(" "),
+    );
+    expect(heads).toEqual(
+      Array.from({ length: (full?.messages.length ?? 0) / 2 }, (_, i) => [
+        `question ${i + 1}`,
+        `reply ${i + 1}`,
+      ]).flat(),
+    );
+  });
+
+  test("history paging is absolute across the segment boundary", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "r2");
+    const conv = loadConversation(dir, "r2");
+    if (!conv?.archived) throw new Error("expected a rotated conversation");
+    const total = totalMessageCount(conv);
+    const boundary = conv.archived.messages;
+
+    const all = getHistoryAt(dir, "r2");
+    expect(all?.totalMessages).toBe(total);
+    expect(all?.messages).toHaveLength(total);
+
+    // A page straddling the boundary: two from the segment, two from the tail.
+    const page = getHistoryAt(dir, "r2", { before: boundary + 2, limit: 4 });
+    expect(page?.offset).toBe(boundary - 2);
+    expect(page?.messages.map((m) => m.content.slice(0, 10))).toEqual(
+      all?.messages
+        .slice(boundary - 2, boundary + 2)
+        .map((m) => m.content.slice(0, 10)),
+    );
+
+    // The oldest page comes entirely from the segment.
+    const first = getHistoryAt(dir, "r2", { before: 3, limit: 3 });
+    expect(first?.messages.map((m) => m.content.slice(0, 10))).toEqual([
+      "question 1",
+      "reply 1 xx",
+      "question 2",
+    ]);
+  });
+
+  test("a second rotation adds segment 2 and the index accumulates", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "r3");
+    const after1 = liveFile(dir, "r3");
+    fillPastBudget(dir, "r3");
+    const after2 = liveFile(dir, "r3");
+
+    expect(after2.archived?.segments).toHaveLength(2);
+    expect(after2.archived?.segments[0]).toBe(after1.archived?.segments[0]);
+    expect(after2.archived?.messages).toBe(
+      (after2.archived?.segments ?? []).reduce((a, b) => a + b, 0),
+    );
+    expect(readdirSync(archiveDirFor(dir, "r3")).sort()).toEqual([
+      "1.json",
+      "2.json",
+    ]);
+    expect(getHistoryAt(dir, "r3")?.messages).toHaveLength(
+      totalMessageCount(after2),
+    );
+  });
+
+  test("the conversation list still sees one conversation, not its segments", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "r4");
+    expect(listConversationsAt(dir).map((c) => c.id)).toEqual(["r4"]);
+  });
+
+  test("a user append reports the ABSOLUTE expected count", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "r5");
+    const before = totalMessageCount(
+      loadConversation(dir, "r5") as StoredConversation,
+    );
+    const { expectedCount } = appendUserMessageAt(dir, "r5", "one more", {
+      turnId: "tail",
+    });
+    expect(expectedCount).toBe(before);
+  });
+});
+
+describe("edit-and-resend into a segment", () => {
+  test("restores the segment's earlier messages as the tail and drops the rest", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "e1");
+    const totalBefore = totalMessageCount(
+      loadConversation(dir, "e1") as StoredConversation,
+    );
+
+    // Turn 2 is deep in segment 1.
+    const cut = truncateConversationMutationAt(dir, "e1", "t2");
+    expect(cut?.removed).toBe(totalBefore - 2);
+
+    const conv = loadConversation(dir, "e1");
+    expect(conv?.archived).toBeUndefined();
+    expect(conv?.messages.map((m) => m.content.slice(0, 10))).toEqual([
+      "question 1",
+      "reply 1 xx",
+    ]);
+    expect(conv?.needsSessionReplay).toBe(true);
+    expect(existsSync(archiveDirFor(dir, "e1"))).toBe(true);
+    expect(readdirSync(archiveDirFor(dir, "e1"))).toEqual([]);
+  });
+
+  test("an unknown turn still writes nothing", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "e2");
+    expect(truncateConversationMutationAt(dir, "e2", "nope")).toBeNull();
+  });
+});
+
+describe("straggler and delete", () => {
+  test("an oversized file written outside save rotates on first load", () => {
+    const dir = freshDir();
+    const messages: ChatMessage[] = [];
+    for (let n = 1; n <= 100; n++) {
+      messages.push(
+        { role: "user", content: `q${n}`, ts: n, turnId: `t${n}` },
+        {
+          role: "assistant",
+          content: "z".repeat(100 * KB),
+          ts: n,
+          turnId: `t${n}`,
+        },
+      );
+    }
+    const conv: StoredConversation = {
+      id: "s1",
+      title: "old",
+      createdAt: 1,
+      updatedAt: 1,
+      messages,
+    };
+    writeFileSync(join(dir, "s1.json"), JSON.stringify(conv));
+
+    const loaded = loadConversation(dir, "s1");
+    expect(loaded?.archived).toBeDefined();
+    expect(statSync(join(dir, "s1.json")).size).toBeLessThan(
+      ARCHIVE_TAIL_BYTES + 128 * KB,
+    );
+    expect(getHistoryAt(dir, "s1")?.totalMessages).toBe(200);
+  });
+
+  test("deleting the conversation removes its segments", () => {
+    const dir = freshDir();
+    fillPastBudget(dir, "d1");
+    expect(existsSync(archiveDirFor(dir, "d1"))).toBe(true);
+    expect(deleteConversationAt(dir, "d1")).toBe(true);
+    expect(existsSync(archiveDirFor(dir, "d1"))).toBe(false);
+    expect(getHistoryAt(dir, "d1")).toBeNull();
+  });
+});

--- a/packages/runtime/src/store/conversation-archive.ts
+++ b/packages/runtime/src/store/conversation-archive.ts
@@ -1,0 +1,174 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ChatMessage } from "@houston/runtime-client";
+import { LruCache } from "../lru";
+import type { StoredConversation } from "./conversation-file";
+
+/**
+ * Transcript archiving: a conversation that never ends (a `shared` routine
+ * chat runs for months) keeps ONE live file that is re-parsed and re-written
+ * whole on every append. At 165 MB that cost the runtime over a gigabyte of
+ * resident memory per turn and OOM-killed its pod 87 times in a day.
+ *
+ * Past a size budget the live file keeps only the recent tail; everything
+ * older moves into immutable, numbered segment files beside it:
+ *
+ *   <dir>/<id>.json             the tail + `archived` (what the segments hold)
+ *   <dir>/<id>.archive/1.json   the oldest messages
+ *   <dir>/<id>.archive/2.json   ...
+ *
+ * Message indexes stay ABSOLUTE across the whole transcript (segments first,
+ * then the tail), so history paging, `totalMessages`, and edit-and-resend see
+ * the same conversation as before — a reader that only knows the live file
+ * (an older runtime, the parse cache) sees a valid, shorter one. Autocompact
+ * bounds the model's context, never storage; this bounds storage.
+ */
+
+const MiB = 1024 * 1024;
+
+/** Live file size past which an append rotates the older messages out. */
+export const ARCHIVE_TRIGGER_BYTES = 8 * MiB;
+
+/**
+ * What the live file keeps after a rotation. Comfortably above the replay
+ * preamble's budget (replay-transcript.ts, ~0.8 × a 200k window ≈ 640 KB of
+ * text), so a backend switch still carries the same recent history it would
+ * have carried from an un-rotated file.
+ */
+export const ARCHIVE_TAIL_BYTES = 2 * MiB;
+
+/** What the live file records about its segments (additive, optional). */
+export interface ArchiveIndex {
+  /** Messages held by every segment together — the tail's absolute offset. */
+  messages: number;
+  /** Message count per segment, in segment order (segment n = index n-1). */
+  segments: number[];
+}
+
+interface SegmentFile {
+  id: string;
+  segment: number;
+  messages: ChatMessage[];
+}
+
+export function archiveDirFor(dir: string, id: string): string {
+  return join(dir, `${encodeURIComponent(id)}.archive`);
+}
+
+export const segmentFileFor = (dir: string, id: string, n: number) =>
+  join(archiveDirFor(dir, id), `${n}.json`);
+
+export function archivedMessageCount(conv: StoredConversation): number {
+  return conv.archived?.messages ?? 0;
+}
+
+export function totalMessageCount(conv: StoredConversation): number {
+  return archivedMessageCount(conv) + conv.messages.length;
+}
+
+/**
+ * The index of the first message that STAYS in the live file when the tail
+ * must fit `tailBytes`: the newest messages that fit, opened at the user
+ * message of a turn so a turn is never split across files (a turn that only
+ * partly fits is archived whole). The newest turn always stays, even when it
+ * alone exceeds the budget. 0 means nothing would move.
+ */
+export function tailCutIndex(
+  messages: ChatMessage[],
+  tailBytes: number,
+): number {
+  let bytes = 0;
+  let fits = messages.length;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    bytes += JSON.stringify(messages[i]).length;
+    if (bytes > tailBytes) break;
+    fits = i;
+  }
+  if (fits === messages.length) {
+    // Nothing fits: keep the newest turn regardless.
+    const lastUser = messages.findLastIndex((m) => m.role === "user");
+    fits = lastUser === -1 ? Math.max(0, messages.length - 1) : lastUser;
+  }
+  // Open the tail at a turn boundary: the nearest user message at or after
+  // the byte cut. None at all means the fit index itself is the boundary.
+  for (let i = fits; i < messages.length; i++) {
+    if (messages[i]?.role === "user") return i;
+  }
+  return fits;
+}
+
+/**
+ * Move the messages before the tail into the next segment file and rewrite
+ * `conv` in place (the caller persists it). Returns whether anything moved.
+ * Segment first, live file second: a crash in between leaves a duplicate the
+ * next rotation overwrites (same segment number), never a hole.
+ */
+export function archiveOlderMessages(
+  dir: string,
+  conv: StoredConversation,
+  tailBytes: number = ARCHIVE_TAIL_BYTES,
+): boolean {
+  const cut = tailCutIndex(conv.messages, tailBytes);
+  if (cut <= 0) return false;
+  const prior = conv.archived ?? { messages: 0, segments: [] };
+  const n = prior.segments.length + 1;
+  const moved = conv.messages.slice(0, cut);
+  const file = segmentFileFor(dir, conv.id, n);
+  mkdirSync(archiveDirFor(dir, conv.id), { recursive: true });
+  const body: SegmentFile = { id: conv.id, segment: n, messages: moved };
+  writeFileSync(`${file}.tmp`, JSON.stringify(body));
+  renameSync(`${file}.tmp`, file);
+  segments.delete(file);
+  conv.messages = conv.messages.slice(cut);
+  conv.archived = {
+    messages: prior.messages + moved.length,
+    segments: [...prior.segments, moved.length],
+  };
+  return true;
+}
+
+/** Segments are immutable, so a parsed one is valid until it is deleted. */
+export const segments = new LruCache<string, ChatMessage[]>({ capacity: 8 });
+
+export function readSegment(dir: string, id: string, n: number): ChatMessage[] {
+  const file = segmentFileFor(dir, id, n);
+  const hit = segments.get(file);
+  if (hit) return hit;
+  let messages: ChatMessage[];
+  try {
+    messages = (JSON.parse(readFileSync(file, "utf8")) as SegmentFile).messages;
+  } catch (err) {
+    // A missing or corrupt segment shows as a gap in old history; the live
+    // conversation is unaffected, so log loudly and keep serving.
+    console.error(`[conversations] archive segment unreadable: ${file}`, err);
+    messages = [];
+  }
+  segments.set(file, messages);
+  return messages;
+}
+
+/** Messages [start, end) by ABSOLUTE index across segments and the tail. */
+export function sliceTranscript(
+  dir: string,
+  conv: StoredConversation,
+  start: number,
+  end: number,
+): ChatMessage[] {
+  const out: ChatMessage[] = [];
+  let offset = 0;
+  const sizes = conv.archived?.segments ?? [];
+  for (let i = 0; i < sizes.length; i++) {
+    const size = sizes[i] ?? 0;
+    const lo = Math.max(start, offset);
+    const hi = Math.min(end, offset + size);
+    if (lo < hi)
+      out.push(
+        ...readSegment(dir, conv.id, i + 1).slice(lo - offset, hi - offset),
+      );
+    offset += size;
+  }
+  const lo = Math.max(start, offset);
+  const hi = Math.min(end, offset + conv.messages.length);
+  if (lo < hi) out.push(...conv.messages.slice(lo - offset, hi - offset));
+  return out;
+}

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -3,10 +3,18 @@ import {
   mkdirSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import type { ChatMessage } from "@houston/runtime-client";
+import {
+  ARCHIVE_TRIGGER_BYTES,
+  type ArchiveIndex,
+  archiveOlderMessages,
+  totalMessageCount,
+} from "./conversation-archive";
+import { removeArchive } from "./conversation-archive-cut";
 import type { UserMessageMeta } from "./conversation-message-meta";
 import {
   dropParsedFile,
@@ -23,6 +31,7 @@ export {
   getHistoryAt,
   type HistoryWindow,
   listConversationsAt,
+  loadFullConversation,
 } from "./conversation-queries";
 
 /**
@@ -55,6 +64,13 @@ export type StoredConversation = {
    * the compacted history.
    */
   claudeCompaction?: CompactionCheckpoint;
+  /**
+   * Present once older messages were rotated into segment files beside this
+   * one (`conversation-archive.ts`): `messages` is then only the recent tail,
+   * and this records what the segments hold. Absent on every conversation
+   * that never outgrew the live-file budget — byte-identical to before.
+   */
+  archived?: ArchiveIndex;
 };
 
 /** A compaction summary waiting to be carried into the next prompt. */
@@ -78,7 +94,22 @@ export function loadConversation(
   dir: string,
   id: string,
 ): StoredConversation | null {
-  return readParsedFile(fileFor(dir, id));
+  const f = fileFor(dir, id);
+  const conv = readParsedFile(f);
+  // A transcript that outgrew the budget BEFORE rotation existed (or was
+  // written by a writer that bypasses save) rotates on its first load, so a
+  // pod that was dying on it heals itself at boot: one last whole parse, then
+  // never again.
+  if (conv && liveFileSize(f) > ARCHIVE_TRIGGER_BYTES) save(dir, conv);
+  return conv;
+}
+
+function liveFileSize(f: string): number {
+  try {
+    return statSync(f).size;
+  } catch {
+    return 0;
+  }
 }
 
 /**
@@ -94,7 +125,12 @@ function save(dir: string, conv: StoredConversation) {
   mkdirSync(dir, { recursive: true });
   const f = fileFor(dir, conv.id);
   const tmp = `${f}.tmp`;
-  writeFileSync(tmp, JSON.stringify(conv));
+  let json = JSON.stringify(conv);
+  // Past the budget, rotate the older messages out (mutates `conv`, which is
+  // also the cached object) and write the tail that remains.
+  if (json.length > ARCHIVE_TRIGGER_BYTES && archiveOlderMessages(dir, conv))
+    json = JSON.stringify(conv);
+  writeFileSync(tmp, json);
   renameSync(tmp, f); // atomic swap; never leaves a half-written file
   stampParsedFile(f, conv);
 }
@@ -113,7 +149,9 @@ export function appendUserMessageAt(
     updatedAt: now,
     messages: [],
   };
-  const expectedCount = conv.messages.length;
+  // Absolute, segments included: the transcript shadow compares it against
+  // the remote copy's whole count, not the live tail.
+  const expectedCount = totalMessageCount(conv);
   const needsSessionReplay = conv.needsSessionReplay === true;
   // Stamp the author (C5) only when a token identified one — a single-user /
   // local turn omits the field entirely, keeping the stored record
@@ -157,6 +195,7 @@ export function renameConversationMutationAt(
 export function deleteConversationAt(dir: string, id: string): boolean {
   const f = fileFor(dir, id);
   dropParsedFile(f);
+  removeArchive(dir, id);
   if (!existsSync(f)) return false;
   rmSync(f);
   return true;

--- a/packages/runtime/src/store/conversation-queries.ts
+++ b/packages/runtime/src/store/conversation-queries.ts
@@ -4,7 +4,8 @@ import type {
   ConversationHistory,
   ConversationSummary,
 } from "@houston/runtime-client";
-import { loadConversation } from "./conversation-file";
+import { sliceTranscript, totalMessageCount } from "./conversation-archive";
+import { loadConversation, type StoredConversation } from "./conversation-file";
 import { readParsedFile } from "./conversation-parse-cache";
 
 /**
@@ -31,14 +32,16 @@ export function getHistoryAt(
 ): ConversationHistory | null {
   const conv = loadConversation(dir, id);
   if (!conv) return null;
-  const total = conv.messages.length;
+  // Indexes are absolute across the archive segments and the live tail
+  // (conversation-archive.ts), so a page before the tail reads a segment.
+  const total = totalMessageCount(conv);
   const end = Math.min(Math.max(window.before ?? total, 0), total);
   const start =
     window.limit === undefined ? 0 : Math.max(0, end - window.limit);
   return {
     id: conv.id,
     title: conv.title,
-    messages: conv.messages.slice(start, end),
+    messages: sliceTranscript(dir, conv, start, end),
     offset: start,
     totalMessages: total,
   };
@@ -61,4 +64,22 @@ export function listConversationsAt(dir: string): ConversationSummary[] {
     });
   }
   return out.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * The whole transcript, segments included, as one conversation object — the
+ * shape a reader that must see everything (the transcript shadow's repair)
+ * expects. `archived` is dropped: the result IS the full message list.
+ */
+export function loadFullConversation(
+  dir: string,
+  id: string,
+): StoredConversation | null {
+  const conv = loadConversation(dir, id);
+  if (!conv?.archived) return conv;
+  const { archived: _, ...rest } = conv;
+  return {
+    ...rest,
+    messages: sliceTranscript(dir, conv, 0, totalMessageCount(conv)),
+  };
 }

--- a/packages/runtime/src/store/conversation-truncate.ts
+++ b/packages/runtime/src/store/conversation-truncate.ts
@@ -1,3 +1,4 @@
+import { restoreArchivedTurn } from "./conversation-archive-cut";
 import { loadConversation, saveConversation } from "./conversation-file";
 
 /**
@@ -23,9 +24,17 @@ export function truncateConversationMutationAt(
   const conv = loadConversation(dir, id);
   if (!conv) return null;
   const at = conv.messages.findIndex((m) => m.turnId === turnId);
-  if (at === -1) return null;
-  const removed = conv.messages.length - at;
-  conv.messages = conv.messages.slice(0, at);
+  let removed: number;
+  if (at === -1) {
+    // Not in the live tail: the turn may sit in an archive segment, in which
+    // case the segment's earlier messages become the tail again.
+    const restored = restoreArchivedTurn(dir, conv, turnId);
+    if (restored === null) return null;
+    removed = restored;
+  } else {
+    removed = conv.messages.length - at;
+    conv.messages = conv.messages.slice(0, at);
+  }
   delete conv.claudeCompaction;
   conv.needsSessionReplay = true;
   conv.updatedAt = Date.now();

--- a/packages/runtime/src/store/conversations.ts
+++ b/packages/runtime/src/store/conversations.ts
@@ -13,7 +13,7 @@ import {
   getHistoryAt,
   type HistoryWindow,
   listConversationsAt,
-  loadConversation,
+  loadFullConversation,
   renameConversationMutationAt,
   type UserMessageMeta,
 } from "./conversation-file";
@@ -117,7 +117,9 @@ const shadow =
           config.controlPlaneUrl,
           config.sandboxToken,
         ),
-        (conversationId) => loadConversation(dir, conversationId),
+        // A repair replaces the remote document whole, so it must carry the
+        // archived segments too, not just the live tail.
+        (conversationId) => loadFullConversation(dir, conversationId),
       )
     : undefined;
 const store = createConversationStore(dir, shadow);

--- a/packages/runtime/src/turn/turn-filesystem-scope.ts
+++ b/packages/runtime/src/turn/turn-filesystem-scope.ts
@@ -13,11 +13,19 @@ export function claimedTurnIncludes(
     "conversations",
     `${encodeURIComponent(conversationId)}.json`,
   );
+  // The transcript's archive segments (store/conversation-archive.ts) belong
+  // to the same turn as its live file.
+  const archive = posix.join(
+    dataRel,
+    "conversations",
+    `${encodeURIComponent(conversationId)}.archive/`,
+  );
   const session = posix.join(dataRel, "sessions", conversationId);
   const activity = turnActivityKey(workspaceRel);
   const runs = turnRoutineRunsKey(workspaceRel);
   return (relativePath) =>
     relativePath === conversation ||
+    relativePath.startsWith(archive) ||
     turnSessionScopeIncludes(session, relativePath) ||
     relativePath === activity ||
     relativePath === runs ||

--- a/packages/runtime/src/turn/turn-filesystem.test.ts
+++ b/packages/runtime/src/turn/turn-filesystem.test.ts
@@ -317,6 +317,13 @@ test("the eager path reports the store's generation capability even when the fil
   expect(plain.generationAware).toBe(false);
 });
 
+test("a claim covers the conversation's archive segments", () => {
+  const include = claimedTurnIncludes("data", "workspace", "c1");
+  expect(include("data/conversations/c1.archive/1.json")).toBe(true);
+  expect(include("data/conversations/c1.archive/2.json")).toBe(true);
+  expect(include("data/conversations/c2.archive/1.json")).toBe(false);
+});
+
 test("a claim syncs only durable Claude conversation state", () => {
   const include = claimedTurnIncludes("data", "workspace", "c1");
   const claude = "data/sessions/c1/claude";


### PR DESCRIPTION
## Root cause

A `shared`-mode routine keeps one conversation forever. Its transcript, `conversations/<id>.json`, is appended with a read-modify-write of the whole file, and the parse cache keeps the parsed object resident. One prod routine (running since 2026-08-01) had reached 165 MB, its runtime sat at 1.0 to 1.5 GB, and the pod was OOM-killed 87 times in 12 hours. Autocompact is not the fix: it bounds the model's context (summarize + reseed at 93% window fill) and never shrinks storage.

## The fix

`store/conversation-archive.ts`: past an 8 MiB live file, an append moves the messages older than a ~2 MiB tail into immutable, numbered segment files beside it:

```
conversations/<id>.json             tail + `archived: { messages, segments[] }`
conversations/<id>.archive/1.json   oldest messages
conversations/<id>.archive/2.json   ...
```

- Indexes stay **absolute** across segments and tail, so `getHistoryAt` (HOU-819 windowing) pages older history out of the segments, `totalMessages` is unchanged, and the chat shows exactly what it showed before. The tail always opens at a user message, so a turn is never split, and the newest turn always stays.
- Edit-and-resend at a turn that lives in a segment restores the segment's earlier messages as the tail and drops the later segments (`conversation-archive-cut.ts`).
- The transcript shadow's `repair` (which replaces the remote document whole) now snapshots the full transcript, segments included, so the control-plane copy never shrinks.
- A pooled turn's object scope covers `<id>.archive/` alongside the live file.
- **Stragglers heal themselves**: a file that outgrew the budget before this existed (or was written by a writer that bypasses `save`) rotates on its first load. One last whole parse, then never again. That is what fixes the crash-looping pod without anyone touching its routine.
- Delete removes the segments. `listConversations` never sees them (the archive is a directory, not a `.json`).
- Nothing changes for a conversation under 8 MiB: no `archived` field, byte-identical file. Routines keep their chat mode and their history.

Not in this PR, tracked on the issue as the second half: rotating the pi session JSONL after a compaction (pi's `SessionManager` loads the whole file on open). The transcript is the dominant cost; the session file for the same routine is 83 MB and worth its own change.

## Before

Seed a conversation past 8 MiB (or copy the affected routine's file to a staging pod). Each turn re-parses and re-serializes the whole file; runtime VmRSS during a turn tracks the file size several times over; the pod OOMs at the limit.

## After

Same conversation: after the next append the live file is ~2 MiB, `<id>.archive/1.json` holds the rest, `GET .../messages?before=&limit=` returns the same messages for every page, `totalMessages` is unchanged, and runtime VmRSS during a turn drops to the tail's cost. `pnpm --filter @houston/runtime test` covers rotation, paging across the boundary, a second rotation, edit-and-resend into a segment, straggler rotation on load, delete, and the pooled-turn scope.

PRODUCT-1742
