### PR TITLE
fix(runtime): honest restart line and one Sentry event for a turn the engine died on (PRODUCT-1740)

### DIFF
--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -416,6 +416,30 @@ export interface ChatMessage {
    * finish. Absent on turns that ran to completion.
    */
   stopped?: true;
+  /**
+   * Set on the assistant message the engine writes at boot for a turn it found
+   * still in flight from its previous life: the process died mid-turn (a pod
+   * OOM-killed, the desktop force-quit) and never persisted a reply. The
+   * runtime cannot stamp it as the turn ends (there is no process left), so the
+   * boot settle writes it, and the SDK renders the authored restart line from
+   * it, both live (settle-from-history) and on a reload. `tool` names what was
+   * running when the process died, when the engine had recorded one.
+   */
+  interrupted?: TurnInterruption;
+}
+
+/**
+ * Why a turn ended without the runtime finishing it. One cause today; a
+ * discriminated field rather than a boolean so the next cause (a drain
+ * deadline, a host-initiated kill) is a value, not another flag.
+ */
+export type TurnInterruptionCause = "engine_restart";
+
+/** How a turn was cut short (see {@link ChatMessage.interrupted}). */
+export interface TurnInterruption {
+  cause: TurnInterruptionCause;
+  /** The tool running when the engine died, when one was recorded. */
+  tool?: string;
 }
 
 /** The most @mentions one message may carry; the rest are dropped. */

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -1083,3 +1083,49 @@ test("two different requests raise two cards even when they read alike", async (
     steps.map((s) => (s.kind === "question" ? s.requestId : null)),
   ).toEqual(["req-a", "req-b"]);
 });
+
+// ── The in-flight marker (turn-inflight-marker.ts) ──────────────────────────
+// Written with the user message, named after the running tool, gone on every
+// in-process end — so a marker found at boot is unambiguously a turn the
+// previous process died on (settle-interrupted-turns.ts).
+
+const { readInflightMarker } = await import("./turn-inflight-marker");
+const { config } = await import("../config");
+
+test("the in-flight marker lives from the user message to the turn's end and names the running tool", async () => {
+  const id = "exec-inflight-clean";
+  const seen: Array<ReturnType<typeof readInflightMarker>> = [];
+  const conv = fakeConv((emit) => {
+    seen.push(readInflightMarker(config.dataDir, id));
+    emit({ type: "tool_start", data: { name: "bash", args: { cmd: "ls" } } });
+    seen.push(readInflightMarker(config.dataDir, id));
+    emit({
+      type: "tool_end",
+      data: { name: "bash", isError: false, content: "ok" },
+    });
+    emit({ type: "text", data: "done" });
+  });
+  const recorded = recordUserTurn(conv, id, "turn-inflight", "run it");
+  expect(readInflightMarker(config.dataDir, id)).toMatchObject({
+    conversationId: id,
+    turnId: "turn-inflight",
+  });
+  await execTurn(conv, id, "turn-inflight", "run it", recorded);
+  expect(seen[0]).toMatchObject({ turnId: "turn-inflight" });
+  expect(seen[0]?.tool).toBeUndefined();
+  expect(seen[1]?.tool).toBe("bash");
+  expect(readInflightMarker(config.dataDir, id)).toBeNull();
+});
+
+test("a thrown turn clears the in-flight marker too", async () => {
+  const id = "exec-inflight-thrown";
+  const conv = fakeConv(() => {}, {
+    setModel: () => {
+      throw new Error("boom");
+    },
+  });
+  const recorded = recordUserTurn(conv, id, "turn-thrown", "go");
+  expect(readInflightMarker(config.dataDir, id)).not.toBeNull();
+  await execTurn(conv, id, "turn-thrown", "go", recorded);
+  expect(readInflightMarker(config.dataDir, id)).toBeNull();
+});

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -50,6 +50,7 @@ import {
 import { needsAutocompact } from "./autocompact";
 import { runAutocompact } from "./autocompact-guard";
 import { publish } from "./bus";
+import { resolveChildMemoryCap } from "./child-memory-fence";
 import { evictClaudeSessionOnRevokedToken } from "./claude-token-guard";
 import {
   type Conversation,
@@ -73,6 +74,11 @@ import { reportMissionSettle } from "./mission-settle";
 import { switchNeedsCompaction } from "./provider-switch";
 import { renderReplayPreamble, replayCharBudget } from "./replay-transcript";
 import { createStallWatchdog } from "./stall-watchdog";
+import {
+  clearInflightMarker,
+  noteInflightTool,
+  writeInflightMarker,
+} from "./turn-inflight-marker";
 import { runWithTurnMode, type TurnModeRef } from "./turn-mode-context";
 import { runWithTurnModel } from "./turn-model-context";
 
@@ -148,6 +154,16 @@ export function recordUserTurn(
   // names as plain text inside `text`, so this only travels so a reader can map
   // "@Name" back to a person. Persisted AND published, exactly like `author`.
   appendUserMessage(id, text, { author, turnId, displayText, mentions });
+  // The turn is now in flight on disk (turn-inflight-marker.ts): cleared by
+  // execTurn's finally on every in-process end, so a marker found at the next
+  // boot is a turn this process died on — the boot settle answers it. Written
+  // right after the user message so the store sync ships the two together.
+  writeInflightMarker(config.dataDir, {
+    conversationId: id,
+    turnId,
+    startedAt: Date.now(),
+    fenced: resolveChildMemoryCap() !== null,
+  });
   publish(id, {
     type: "user",
     data: { content: text, ts: Date.now(), nonce, author, mentions },
@@ -245,9 +261,18 @@ export async function execTurn(
         interaction.finish.noteAssistantText(wire.data);
       } else if (wire.type === "thinking") thinkingText += wire.data;
       else if (wire.type === "usage") usage = wire.data;
-      else if (wire.type === "tool_start")
+      else if (wire.type === "tool_start") {
         tools.push({ name: wire.data.name, input: wire.data.args });
-      else if (wire.type === "tool_end") {
+        // Name the running tool on the in-flight marker: a restart during a
+        // shell command is the OOM shape, and the boot report says so. Inside
+        // the backend's emit loop, so a disk fault here degrades the report
+        // (breadcrumb), never the turn.
+        try {
+          noteInflightTool(config.dataDir, id, wire.data.name);
+        } catch (error) {
+          console.warn("[turn] in-flight marker tool note failed:", error);
+        }
+      } else if (wire.type === "tool_end") {
         const t = tools[tools.length - 1];
         if (t) {
           t.isError = wire.data.isError;
@@ -827,6 +852,9 @@ export async function execTurn(
     reportMissionSettle(id, "error", null);
   } finally {
     conv.turnId = undefined;
+    // Every in-process end of the turn — clean, failed, stopped, thrown —
+    // passes here, so a marker that outlives this process is unambiguous.
+    clearInflightMarker(config.dataDir, id);
     // Retire the live-mode ref with the turn: a Mode-pill switch between turns
     // has nothing to apply to (the next turn's pin carries it instead).
     conv.liveMode = undefined;

--- a/packages/runtime/src/session/settle-interrupted-turns.test.ts
+++ b/packages/runtime/src/session/settle-interrupted-turns.test.ts
@@ -1,0 +1,159 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  EngineRestartedMidTurnError,
+  fenceBypassed,
+  settleInterruptedTurns,
+} from "./settle-interrupted-turns";
+import {
+  listInflightMarkers,
+  writeInflightMarker,
+} from "./turn-inflight-marker";
+
+function seed() {
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-settle-"));
+  const conversations = join(dataDir, "conversations");
+  mkdirSync(conversations, { recursive: true });
+  const write = (id: string, messages: unknown[]) =>
+    writeFileSync(
+      join(conversations, `${encodeURIComponent(id)}.json`),
+      JSON.stringify({
+        id,
+        title: id,
+        createdAt: 1,
+        updatedAt: 1,
+        messages,
+      }),
+    );
+  const read = (id: string) =>
+    JSON.parse(
+      readFileSync(
+        join(conversations, `${encodeURIComponent(id)}.json`),
+        "utf8",
+      ),
+    ) as { messages: Record<string, unknown>[] };
+  return { dataDir, write, read };
+}
+
+describe("settleInterruptedTurns", () => {
+  it("writes the interrupted reply for the dead turn, reports once, clears the marker", () => {
+    const { dataDir, write, read } = seed();
+    write("chat", [
+      { role: "user", content: "export it", ts: 1, turnId: "t-9" },
+    ]);
+    writeInflightMarker(dataDir, {
+      conversationId: "chat",
+      turnId: "t-9",
+      startedAt: 10_000,
+      tool: "bash",
+      fenced: true,
+    });
+    const report = vi.fn();
+    const settleMission = vi.fn();
+    const settled = settleInterruptedTurns({
+      dataDir,
+      report,
+      settleMission,
+      now: () => 73_000,
+    });
+
+    expect(settled.map((m) => m.turnId)).toEqual(["t-9"]);
+    const last = read("chat").messages.at(-1);
+    expect(last).toMatchObject({
+      role: "assistant",
+      content: "",
+      turnId: "t-9",
+      interrupted: { cause: "engine_restart", tool: "bash" },
+    });
+    expect(settleMission).toHaveBeenCalledWith("chat");
+    expect(report).toHaveBeenCalledTimes(1);
+    const error = report.mock.calls[0]?.[0] as EngineRestartedMidTurnError;
+    expect(error).toBeInstanceOf(EngineRestartedMidTurnError);
+    expect(error.name).toBe("EngineRestartedMidTurnError");
+    expect(error.ranForMs).toBe(63_000);
+    expect(error.message).toContain("conversation=chat");
+    expect(error.message).toContain("turn=t-9");
+    expect(error.message).toContain("ran=63s");
+    expect(error.message).toContain("tool=bash");
+    expect(error.message).toContain("fenced=true");
+    expect(error.message).toContain("memory fence");
+    expect(listInflightMarkers(dataDir)).toEqual([]);
+  });
+
+  it("a marker without a tool settles without one, and the report names no fence bypass", () => {
+    const { dataDir, write, read } = seed();
+    write("idle", [{ role: "user", content: "hi", ts: 1, turnId: "t-1" }]);
+    writeInflightMarker(dataDir, {
+      conversationId: "idle",
+      turnId: "t-1",
+      startedAt: 0,
+      fenced: true,
+    });
+    const report = vi.fn();
+    settleInterruptedTurns({ dataDir, report, settleMission: () => {} });
+    const last = read("idle").messages.at(-1);
+    expect(last?.interrupted).toEqual({ cause: "engine_restart" });
+    const error = report.mock.calls[0]?.[0] as EngineRestartedMidTurnError;
+    expect(error.message).toContain("tool=none");
+    expect(error.message).not.toContain("memory fence");
+  });
+
+  it("a marker whose conversation is gone still clears and reports", () => {
+    const { dataDir } = seed();
+    writeInflightMarker(dataDir, {
+      conversationId: "deleted",
+      turnId: "t-d",
+      startedAt: 0,
+      fenced: false,
+    });
+    const report = vi.fn();
+    const settled = settleInterruptedTurns({
+      dataDir,
+      report,
+      settleMission: () => {},
+    });
+    expect(settled).toHaveLength(1);
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(listInflightMarkers(dataDir)).toEqual([]);
+  });
+
+  it("a quiet boot settles nothing and reports nothing", () => {
+    const { dataDir } = seed();
+    const report = vi.fn();
+    expect(
+      settleInterruptedTurns({ dataDir, report, settleMission: () => {} }),
+    ).toEqual([]);
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it("a second boot after the settle is quiet (idempotent)", () => {
+    const { dataDir, write, read } = seed();
+    write("once", [{ role: "user", content: "go", ts: 1, turnId: "t-once" }]);
+    writeInflightMarker(dataDir, {
+      conversationId: "once",
+      turnId: "t-once",
+      startedAt: 0,
+      fenced: false,
+    });
+    const report = vi.fn();
+    settleInterruptedTurns({ dataDir, report, settleMission: () => {} });
+    settleInterruptedTurns({ dataDir, report, settleMission: () => {} });
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(
+      read("once").messages.filter((m) => m.interrupted !== undefined),
+    ).toHaveLength(1);
+  });
+});
+
+describe("fenceBypassed", () => {
+  const base = { conversationId: "c", turnId: "t", startedAt: 0 };
+  it("is a shell tool under the fence, nothing else", () => {
+    expect(fenceBypassed({ ...base, fenced: true, tool: "bash" })).toBe(true);
+    expect(fenceBypassed({ ...base, fenced: true, tool: "Bash" })).toBe(true);
+    expect(fenceBypassed({ ...base, fenced: false, tool: "bash" })).toBe(false);
+    expect(fenceBypassed({ ...base, fenced: true, tool: "read" })).toBe(false);
+    expect(fenceBypassed({ ...base, fenced: true })).toBe(false);
+  });
+});

--- a/packages/runtime/src/session/settle-interrupted-turns.ts
+++ b/packages/runtime/src/session/settle-interrupted-turns.ts
@@ -1,0 +1,110 @@
+import { join } from "node:path";
+import { appendAssistantMessageAt } from "../store/conversation-file";
+import { reportMissionSettle } from "./mission-settle";
+import {
+  clearInflightMarker,
+  type InflightTurnMarker,
+  listInflightMarkers,
+} from "./turn-inflight-marker";
+
+/**
+ * Boot-time settle of the turns the previous process died on (see
+ * turn-inflight-marker.ts). For each survivor: persist the reply the dead
+ * process never wrote — empty content, `interrupted` set — so a client that
+ * reconnects (settle-from-history) or reloads (history replay) renders the
+ * authored restart line instead of the generic dead-turn copy; report the
+ * restart once, with the marker's fields, so Sentry can count them fleet-wide;
+ * then drop the marker so the next boot is quiet. Runs BEFORE the server
+ * listens: a client that reconnects the instant the engine is back must find
+ * the reply already on disk.
+ *
+ * Cause inference: a marker survives only an UNCLEAN exit — every in-process
+ * end of a turn clears it, and a drained shutdown lets the turn end first. So
+ * "marker present at boot" IS "the process was killed mid-turn"; on a managed
+ * pod that is the group OOM kill or an involuntary eviction.
+ */
+
+/**
+ * The name Sentry titles the issue by — one issue for every restart, the
+ * marker's fields in the message and extras. Never merged into a generic
+ * `[turn]` bucket: the count is the point.
+ */
+export class EngineRestartedMidTurnError extends Error {
+  constructor(
+    readonly marker: InflightTurnMarker,
+    readonly ranForMs: number,
+  ) {
+    super(
+      `engine restarted mid-turn: conversation=${marker.conversationId} turn=${marker.turnId} ran=${Math.round(ranForMs / 1000)}s tool=${marker.tool ?? "none"} fenced=${marker.fenced}${fenceBypassed(marker) ? " (bash ran under the memory fence and the engine still died)" : ""}`,
+    );
+    this.name = "EngineRestartedMidTurnError";
+  }
+}
+
+/**
+ * Whether the fence should have caught this: a shell tool was running and the
+ * cap was on. Any other survivor (no tool, a non-shell tool, no fence) is a
+ * kill the fence never claimed to prevent.
+ */
+export function fenceBypassed(marker: InflightTurnMarker): boolean {
+  return marker.fenced && marker.tool !== undefined && isShellTool(marker.tool);
+}
+
+// pi registers its shell as `bash`; the Claude CLI names its tool `Bash`.
+const SHELL_TOOLS = new Set(["bash", "Bash"]);
+
+function isShellTool(name: string): boolean {
+  return SHELL_TOOLS.has(name);
+}
+
+export interface SettleInterruptedTurnsOptions {
+  dataDir: string;
+  /** Test seam; defaults to the console error the Sentry capture feeds on. */
+  report?: (error: EngineRestartedMidTurnError) => void;
+  /** Test seam; defaults to the control-plane mission settle. */
+  settleMission?: (conversationId: string) => void;
+  now?: () => number;
+}
+
+/** Returns the settled markers (the report count), in directory order. */
+export function settleInterruptedTurns(
+  opts: SettleInterruptedTurnsOptions,
+): InflightTurnMarker[] {
+  const report =
+    opts.report ??
+    ((error: EngineRestartedMidTurnError) =>
+      console.error("[turn] engine restarted mid-turn", error));
+  const settleMission =
+    opts.settleMission ??
+    ((conversationId: string) =>
+      reportMissionSettle(conversationId, "error", null));
+  const now = opts.now ?? Date.now;
+  const conversationsDir = join(opts.dataDir, "conversations");
+  const settled: InflightTurnMarker[] = [];
+  for (const marker of listInflightMarkers(opts.dataDir)) {
+    // The reply first, the marker last: a crash between the two re-settles
+    // (a second `interrupted` reply) rather than losing the settle. A missing
+    // conversation (deleted while the turn ran) has nothing to settle into;
+    // appendAssistantMessageAt is a no-op on it and the marker still clears.
+    appendAssistantMessageAt(conversationsDir, marker.conversationId, "", {
+      interrupted: {
+        cause: "engine_restart",
+        ...(marker.tool !== undefined ? { tool: marker.tool } : {}),
+      },
+      turnId: marker.turnId,
+    });
+    // An agent-started mission has no client to settle its card from the
+    // reply; the runtime reports its terminal state exactly as a thrown turn
+    // does (mission-settle.ts). Fire-and-forget there, never boot-fatal here.
+    settleMission(marker.conversationId);
+    report(
+      new EngineRestartedMidTurnError(
+        marker,
+        Math.max(0, now() - marker.startedAt),
+      ),
+    );
+    clearInflightMarker(opts.dataDir, marker.conversationId);
+    settled.push(marker);
+  }
+  return settled;
+}

--- a/packages/runtime/src/session/turn-inflight-marker.test.ts
+++ b/packages/runtime/src/session/turn-inflight-marker.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  clearInflightMarker,
+  inflightDir,
+  listInflightMarkers,
+  noteInflightTool,
+  readInflightMarker,
+  writeInflightMarker,
+} from "./turn-inflight-marker";
+
+const fresh = () => mkdtempSync(join(tmpdir(), "houston-inflight-"));
+
+describe("turn in-flight marker", () => {
+  it("round-trips a marker and clears it", () => {
+    const dataDir = fresh();
+    writeInflightMarker(dataDir, {
+      conversationId: "chat/one",
+      turnId: "t-1",
+      startedAt: 1_000,
+      fenced: true,
+    });
+    expect(readInflightMarker(dataDir, "chat/one")).toEqual({
+      conversationId: "chat/one",
+      turnId: "t-1",
+      startedAt: 1_000,
+      fenced: true,
+    });
+    // The id is encoded into the file name (a slash must not nest a dir).
+    expect(readdirSync(inflightDir(dataDir))).toEqual(["chat%2Fone.json"]);
+    clearInflightMarker(dataDir, "chat/one");
+    expect(readInflightMarker(dataDir, "chat/one")).toBeNull();
+    expect(listInflightMarkers(dataDir)).toEqual([]);
+  });
+
+  it("clearing a marker that never existed is a no-op", () => {
+    const dataDir = fresh();
+    expect(() => clearInflightMarker(dataDir, "nope")).not.toThrow();
+    expect(existsSync(inflightDir(dataDir))).toBe(false);
+  });
+
+  it("records the running tool, and never resurrects a cleared marker", () => {
+    const dataDir = fresh();
+    writeInflightMarker(dataDir, {
+      conversationId: "c",
+      turnId: "t",
+      startedAt: 5,
+      fenced: false,
+    });
+    noteInflightTool(dataDir, "c", "bash");
+    expect(readInflightMarker(dataDir, "c")?.tool).toBe("bash");
+    // A tool_end frame racing the turn's end: the marker is already gone, and
+    // the late tool note must not bring the turn back as in-flight.
+    clearInflightMarker(dataDir, "c");
+    noteInflightTool(dataDir, "c", "bash");
+    expect(readInflightMarker(dataDir, "c")).toBeNull();
+  });
+
+  it("lists every valid marker and drops unparseable files from disk", () => {
+    const dataDir = fresh();
+    writeInflightMarker(dataDir, {
+      conversationId: "b",
+      turnId: "t-b",
+      startedAt: 2,
+      fenced: false,
+    });
+    writeInflightMarker(dataDir, {
+      conversationId: "a",
+      turnId: "t-a",
+      startedAt: 1,
+      tool: "Bash",
+      fenced: true,
+    });
+    writeFileSync(join(inflightDir(dataDir), "junk.json"), "{not json");
+    writeFileSync(
+      join(inflightDir(dataDir), "shape.json"),
+      JSON.stringify({ conversationId: 1 }),
+    );
+    writeFileSync(join(inflightDir(dataDir), "notes.txt"), "ignored");
+    expect(listInflightMarkers(dataDir)).toEqual([
+      {
+        conversationId: "a",
+        turnId: "t-a",
+        startedAt: 1,
+        tool: "Bash",
+        fenced: true,
+      },
+      { conversationId: "b", turnId: "t-b", startedAt: 2, fenced: false },
+    ]);
+    expect(readdirSync(inflightDir(dataDir)).sort()).toEqual([
+      "a.json",
+      "b.json",
+      "notes.txt",
+    ]);
+  });
+
+  it("an absent directory lists as empty", () => {
+    expect(listInflightMarkers(fresh())).toEqual([]);
+  });
+});

--- a/packages/runtime/src/session/turn-inflight-marker.ts
+++ b/packages/runtime/src/session/turn-inflight-marker.ts
@@ -1,0 +1,148 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The "turn in flight" marker: one small file per conversation, written the
+ * moment a turn is accepted and removed when it ends — by ANY path (clean
+ * done, provider error, user stop, a thrown turn). A marker that survives into
+ * the next boot is therefore the one trace of a turn the previous process died
+ * on: a pod OOM-killed mid-turn (one cgroup, group kill, SIGKILL leaves no
+ * process to report), the desktop force-quit. The boot settle
+ * (settle-interrupted-turns.ts) reads survivors, writes the honest reply the
+ * dead process never could, and reports the restart — the only way the fleet
+ * count of these ever reaches Sentry.
+ *
+ * Lives under the runtime's data dir, beside `conversations/`, so the managed
+ * pod's store sync carries it to the object store with the transcript: a
+ * marker that never left the pod would die with it and there would be nothing
+ * to find. Own directory rather than a sibling of the conversation file: the
+ * conversation lister treats every `*.json` under `conversations/` as a
+ * transcript.
+ */
+
+export interface InflightTurnMarker {
+  conversationId: string;
+  turnId: string;
+  /** Epoch ms the turn was accepted (the user message persisted). */
+  startedAt: number;
+  /** The tool running when the marker was last updated, when one started. */
+  tool?: string;
+  /**
+   * Whether model-spawned processes ran under the child memory fence
+   * (child-memory-fence.ts). A survivor with a running bash tool AND the fence
+   * up is a kill the fence should have prevented — the report names it.
+   */
+  fenced: boolean;
+}
+
+export const INFLIGHT_DIR = join("turns", "inflight");
+
+export function inflightDir(dataDir: string): string {
+  return join(dataDir, INFLIGHT_DIR);
+}
+
+const fileFor = (dataDir: string, conversationId: string) =>
+  join(inflightDir(dataDir), `${encodeURIComponent(conversationId)}.json`);
+
+/** Write (or replace) the marker for `marker.conversationId`. Atomic swap. */
+export function writeInflightMarker(
+  dataDir: string,
+  marker: InflightTurnMarker,
+): void {
+  const dir = inflightDir(dataDir);
+  mkdirSync(dir, { recursive: true });
+  const file = fileFor(dataDir, marker.conversationId);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify(marker));
+  renameSync(tmp, file);
+}
+
+/**
+ * Record the tool that just started on the running turn. A marker that is
+ * gone (the turn ended between the frame and this write) is left gone: the
+ * update must never resurrect a settled turn as in-flight.
+ */
+export function noteInflightTool(
+  dataDir: string,
+  conversationId: string,
+  tool: string,
+): void {
+  const current = readInflightMarker(dataDir, conversationId);
+  if (!current) return;
+  writeInflightMarker(dataDir, { ...current, tool });
+}
+
+export function clearInflightMarker(
+  dataDir: string,
+  conversationId: string,
+): void {
+  rmSync(fileFor(dataDir, conversationId), { force: true });
+}
+
+export function readInflightMarker(
+  dataDir: string,
+  conversationId: string,
+): InflightTurnMarker | null {
+  return parseMarker(readOrNull(fileFor(dataDir, conversationId)));
+}
+
+/**
+ * Every marker on disk — at boot, every one of them is a turn the previous
+ * process died on. A file that does not parse as a marker is dropped from the
+ * listing AND from disk: it can never be settled, and leaving it would make
+ * every boot re-report the same junk.
+ */
+export function listInflightMarkers(dataDir: string): InflightTurnMarker[] {
+  const dir = inflightDir(dataDir);
+  if (!existsSync(dir)) return [];
+  const out: InflightTurnMarker[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    if (!name.endsWith(".json")) continue;
+    const file = join(dir, name);
+    const marker = parseMarker(readOrNull(file));
+    if (marker) out.push(marker);
+    else rmSync(file, { force: true });
+  }
+  return out;
+}
+
+function parseMarker(raw: string | null): InflightTurnMarker | null {
+  if (raw === null) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (value === null || typeof value !== "object") return null;
+  const m = value as Partial<InflightTurnMarker>;
+  if (
+    typeof m.conversationId !== "string" ||
+    typeof m.turnId !== "string" ||
+    typeof m.startedAt !== "number"
+  )
+    return null;
+  return {
+    conversationId: m.conversationId,
+    turnId: m.turnId,
+    startedAt: m.startedAt,
+    ...(typeof m.tool === "string" ? { tool: m.tool } : {}),
+    fenced: m.fenced === true,
+  };
+}
+
+function readOrNull(file: string): string | null {
+  try {
+    return readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/packages/runtime/src/store/conversation-append-assistant.ts
+++ b/packages/runtime/src/store/conversation-append-assistant.ts
@@ -39,6 +39,7 @@ export function appendAssistantMessageAt(
     fileChanges: meta.fileChanges,
     pendingInteraction: meta.pendingInteraction,
     stopped: meta.stopped,
+    interrupted: meta.interrupted,
     turnId: meta.turnId,
   });
   conv.updatedAt = Date.now();

--- a/packages/runtime/src/store/conversation-message-meta.ts
+++ b/packages/runtime/src/store/conversation-message-meta.ts
@@ -54,6 +54,12 @@ export interface AssistantMessageMeta {
    * turns.
    */
   stopped?: true;
+  /**
+   * Set by the boot settle (session/settle-interrupted-turns.ts) on the reply
+   * it writes for a turn the previous process died on. Never set by a running
+   * turn — a turn that ends in-process has a real terminal shape instead.
+   */
+  interrupted?: ChatMessage["interrupted"];
   /** The turn's wire id (`WireFrame.turnId`) — same as the user message's. */
   turnId?: string;
 }

--- a/packages/runtime/src/transport/server.ts
+++ b/packages/runtime/src/transport/server.ts
@@ -7,6 +7,7 @@ import {
 } from "../session/acting-context";
 import { anyTurnRunning } from "../session/bus";
 import { isDraining } from "../session/drain";
+import { settleInterruptedTurns } from "../session/settle-interrupted-turns";
 import { handleAnonymizeRoute } from "./anonymize-route";
 import { handleConversationRoute } from "./conversation-routes";
 import { applyCors } from "./cors";
@@ -75,6 +76,16 @@ export function createRuntimeServer() {
 }
 
 export function startServer() {
+  // Turns the previous process died on (a pod OOM-killed mid-turn, the desktop
+  // force-quit) get their honest reply BEFORE anything can read history: a
+  // client reconnecting the instant this runtime is back settles from it.
+  // Never boot-fatal — a settle that throws must not turn one lost turn into
+  // an engine that will not start (it logs; the marker stays for next boot).
+  try {
+    settleInterruptedTurns({ dataDir: config.dataDir });
+  } catch (error) {
+    console.error("[turn] settling interrupted turns failed:", error);
+  }
   // Warm the anthropic shared-dir credential probe so the turn-time sync path
   // (`activeProvider`) sees a connected credential even before the first
   // /auth/status poll. Fire-and-forget; failures self-log (never connected).

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -161,6 +161,7 @@ export {
   conversationScope,
   type DecodedAttachmentText,
   decodeAttachmentText,
+  ENGINE_RESTART_MESSAGE,
   type FeedAuthor,
   type FeedFrame,
   type FeedItemVM,

--- a/packages/sdk/src/modules/turns/history.test.ts
+++ b/packages/sdk/src/modules/turns/history.test.ts
@@ -299,6 +299,34 @@ describe("historyToFeed", () => {
     });
   });
 
+  it("replays the engine-restart line for a persisted interrupted turn", () => {
+    const feed = historyToFeed([
+      { role: "user", content: "export it", ts: 1, turnId: "t-1" },
+      {
+        role: "assistant",
+        content: "",
+        ts: 2,
+        turnId: "t-1",
+        interrupted: { cause: "engine_restart", tool: "bash" },
+      },
+    ]);
+    expect(feed).toEqual([
+      {
+        feed_type: "user_message",
+        data: "export it",
+        author: undefined,
+        ts: 1,
+        turnId: "t-1",
+      },
+      {
+        feed_type: "system_message",
+        data: "Your agent had to restart. Say continue and it will pick up where it left off.",
+        ts: 2,
+        turnId: "t-1",
+      },
+    ]);
+  });
+
   it("omits the stop line for a turn that ran to completion (no regression)", () => {
     const feed = historyToFeed([
       { role: "user", content: "do it", ts: 1 },

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -13,7 +13,7 @@
  */
 
 import type { ChatMessage } from "@houston/runtime-client";
-import { STOPPED_BY_USER } from "./turn-errors";
+import { ENGINE_RESTART_MESSAGE, STOPPED_BY_USER } from "./turn-errors";
 import type { FeedAuthor, FeedMention } from "./vm-output";
 
 /**
@@ -186,6 +186,17 @@ export function historyToFeed(
       out.push({
         feed_type: "system_message",
         data: STOPPED_BY_USER,
+        ts,
+        ...turn,
+      });
+    }
+    // A turn the engine died on (`interrupted`, written by the runtime's boot
+    // settle): the same authored restart line the lost-terminal settle shows,
+    // so a reload reads exactly what the user saw when the engine came back.
+    if (m.interrupted) {
+      out.push({
+        feed_type: "system_message",
+        data: ENGINE_RESTART_MESSAGE,
         ts,
         ...turn,
       });

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -169,6 +169,7 @@ export {
   streamKey,
 } from "./stream-registry";
 export {
+  ENGINE_RESTART_MESSAGE,
   isEngineWakingRejection,
   isNotConnectedError,
   isStoppedByUser,

--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -1,6 +1,6 @@
 import { isPendingInteraction } from "@houston/protocol";
 import type { ChatMessage } from "@houston/runtime-client";
-import { STOPPED_BY_USER } from "./turn-errors";
+import { ENGINE_RESTART_MESSAGE, STOPPED_BY_USER } from "./turn-errors";
 import {
   finishErr,
   finishOk,
@@ -102,6 +102,15 @@ function adoptReply(
   // so this precedes the adopt below.
   if (reply.stopped) {
     finishErr(s, STOPPED_BY_USER);
+    return;
+  }
+  // A turn the ENGINE died on: the runtime's boot settle wrote this reply in
+  // place of the one the dead process never persisted. Same body as the dead-
+  // turn settle above (`finishErr` → system line + `error` status), with the
+  // authored restart copy instead of the generic one — the client's own
+  // detection never sees this shape, only a reload after the engine is back.
+  if (reply.interrupted) {
+    finishErr(s, ENGINE_RESTART_MESSAGE);
     return;
   }
   s.text = reply.content;

--- a/packages/sdk/src/modules/turns/turn-errors.ts
+++ b/packages/sdk/src/modules/turns/turn-errors.ts
@@ -116,6 +116,16 @@ export function isNotConnectedError(message: string): boolean {
 export const STOPPED_BY_USER = "Stopped by user";
 
 /**
+ * The line for a turn the ENGINE died on (a pod OOM-killed mid-turn, the
+ * desktop force-quit): the runtime's boot settle stamps the dead turn's reply
+ * `interrupted` (`ChatMessage.interrupted`), and both the lost-terminal settle
+ * and the history replay render this from it. Product voice: the user's next
+ * move is in the copy, and nothing technical (no "process", "pod", "memory").
+ */
+export const ENGINE_RESTART_MESSAGE =
+  "Your agent had to restart. Say continue and it will pick up where it left off.";
+
+/**
  * Whether a turn's terminal error is the user pressing Stop — the verbatim
  * message the runtime (and the control plane's relay) emit on a cancel. This is
  * an intentional, handled stop, not a turn failure, so the UI shows the message

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -2,6 +2,7 @@ import type { ChatMessage } from "@houston/runtime-client";
 import { expect, test } from "vitest";
 import type { FeedOutput, PendingInteraction } from "./feed-output";
 import { settleFromHistory, TURN_DIED_MESSAGE } from "./settle-from-history";
+import { ENGINE_RESTART_MESSAGE } from "./turn-errors";
 import {
   finishErr,
   finishOk,
@@ -326,6 +327,34 @@ test("a stopped reply with an (illegal) pendingInteraction: stopped wins, no car
     data: "Stopped by user",
     turnId: "t-1",
   });
+});
+
+test("an `interrupted` reply for our turnId settles as the ENGINE RESTART error, never a completed render", () => {
+  const { s, items, statuses } = run(
+    [
+      { role: "user", content: "export it", ts: 1, turnId: "t-1" },
+      {
+        role: "assistant",
+        content: "",
+        ts: 2,
+        turnId: "t-1",
+        interrupted: { cause: "engine_restart", tool: "bash" },
+      },
+    ],
+    "t-1",
+    { streamed: "half a repl" },
+  );
+  expect(s.settled).toBe(true);
+  expect(s.terminal).toBe("error");
+  // The reply's turnId is adopted first, so the settle push carries it.
+  expect(items).toContainEqual({
+    feed_type: "system_message",
+    data: ENGINE_RESTART_MESSAGE,
+    turnId: "t-1",
+  });
+  expect(items.some((i) => i.feed_type === "final_result")).toBe(false);
+  expect(items.some((i) => i.feed_type === "provider_error")).toBe(false);
+  expect(statuses).toEqual([["error", ENGINE_RESTART_MESSAGE]]);
 });
 
 test("our user message with NO assistant reply for our turnId settles as the dead-turn ERROR", () => {


### PR DESCRIPTION
## Summary

PRODUCT-1740, Part 1 (detect the restart, settle honestly, report it). Part 2 (one-shot auto-resume) is gated on this shipping and is not in this PR.

**Root cause.** When the engine pod is OOM-killed mid-turn (one cgroup, group kill, exit 137) or the desktop is force-quit, no process is left to end the turn. The relay snapshot is in-memory, so the dead-pump reaper has nothing to heal after a restart. The client resyncs, finds no reply for its turn id, and prints the generic dead-turn copy. Sentry never sees the kill.

**Where the fix lives.** The issue points at `dispatchTurn` / `TurnRelay`. That path is the per-turn `TurnChannel`, which nothing constructs; every deployment (desktop and pod) proxies turns to the runtime process, whose `execTurn` owns the turn. The marker lives there.

**The change.**
- `packages/runtime/src/session/turn-inflight-marker.ts`: one marker file per conversation under `<dataDir>/turns/inflight/`, written with the user message, updated with the running tool on `tool_start`, removed in `execTurn`'s `finally` on every in-process end. It sits beside the transcript so the managed pod's store sync ships it to the object store.
- `packages/runtime/src/session/settle-interrupted-turns.ts`: runs in `startServer` before listen. For each surviving marker it appends the reply the dead process never wrote (`interrupted: { cause: "engine_restart", tool }`, same turn id), reports the mission terminal state like a thrown turn, logs one `EngineRestartedMidTurnError` (conversation id, turn id, run time, tool, whether the child memory fence was up, and an explicit "bash ran under the fence and the engine still died" when it should have held), then clears the marker. Idempotent across boots.
- Protocol: `ChatMessage.interrupted?: TurnInterruption` (additive).
- SDK: `settleFromHistory` finishes an `interrupted` reply with the authored `ENGINE_RESTART_MESSAGE` ("Your agent had to restart. Say continue and it will pick up where it left off.") instead of the generic copy; `historyToFeed` replays the same line after a reload.

## Before

1. Open a chat and ask the agent to run a long shell command (a sleep, or an export that grows memory).
2. While the tool is running, kill the engine: `kubectl delete pod` on the engine pod, or on the desktop kill the `houston-engine` process.
3. Once the engine is back, the chat shows "The turn ended unexpectedly". Nothing about the kill reaches Sentry; the pod log simply stops.

## After

1. Same steps 1 and 2.
2. Once the engine is back, the chat shows "Your agent had to restart. Say continue and it will pick up where it left off." A reload of the conversation shows the same line in place.
3. The runtime's boot log carries one `[turn] engine restarted mid-turn` error naming the conversation and turn ids, the run time, the tool that was running, and `fenced=true|false`. On a Sentry-enabled engine that is one `EngineRestartedMidTurnError` event.
4. Boot again without a kill: no reply is added, nothing is logged.

## Verification run

- `pnpm check` clean; `pnpm -r typecheck` clean.
- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test`: host 2216 passed, runtime 2056 passed, domain 248 passed.
- `packages/sdk` vitest: 474 passed. `packages/protocol` vitest: 37 passed.
- New tests: marker round-trip and junk handling, boot settle (reply shape, report fields, missing conversation, idempotent second boot), `execTurn` marker lifecycle on a clean and a thrown turn, SDK settle and history replay of an `interrupted` reply.
