### PR TITLE
fix(runtime): log pi's auto-retry so a healed Codex WebSocket drop no longer reads as a dead turn (PRODUCT-1739)

### DIFF
--- a/packages/runtime/src/ai/provider-error-log.ts
+++ b/packages/runtime/src/ai/provider-error-log.ts
@@ -92,3 +92,44 @@ export function logProviderError(
   if (expected) console.warn(line);
   else console.error(line);
 }
+
+/**
+ * pi's own auto-retry of a transient provider failure (a dropped Codex
+ * WebSocket, a 5xx, an overloaded 529). The failed attempt already logged its
+ * `[provider_error]` line, but without these the log reads as a dead turn:
+ * every retried failure looks identical to one that reached the user as a
+ * card. `start` records the re-issue, `recovered` the clean attempt that
+ * followed, `failed` the budget running out or a Stop during the backoff (the card
+ * that follows names the same text). Always a warning: a retry is an expected state.
+ */
+export function logProviderRetry(
+  event:
+    | {
+        type: "auto_retry_start";
+        attempt: number;
+        maxAttempts: number;
+        delayMs: number;
+        errorMessage: string;
+      }
+    | {
+        type: "auto_retry_end";
+        success: boolean;
+        attempt: number;
+        finalError?: string;
+      },
+): void {
+  if (event.type === "auto_retry_start") {
+    console.warn(
+      `[provider_retry] attempt=${event.attempt}/${event.maxAttempts} ` +
+        `delay_ms=${event.delayMs} :: ${event.errorMessage}`,
+    );
+    return;
+  }
+  if (event.success) {
+    console.warn(`[provider_retry] recovered attempt=${event.attempt}`);
+    return;
+  }
+  console.warn(
+    `[provider_retry] failed attempt=${event.attempt} :: ${event.finalError ?? "unknown"}`,
+  );
+}

--- a/packages/runtime/src/backends/pi/codex-websocket-retry.test.ts
+++ b/packages/runtime/src/backends/pi/codex-websocket-retry.test.ts
@@ -1,0 +1,179 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type AssistantMessage,
+  fauxAssistantMessage,
+  fauxProvider,
+  isRetryableAssistantError,
+} from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import type { WireEvent } from "@houston/runtime-client";
+import { expect, test, vi } from "vitest";
+import { HoustonAuthStore } from "../../auth/credential-store";
+import { PiSession } from "./session";
+
+/**
+ * Codex (ChatGPT OAuth) streams over a WebSocket. When that socket dies
+ * mid-turn with no close frame — an abnormal 1006 during a long reasoning
+ * stretch — pi-ai's transport rethrows it (it only falls back to SSE when the
+ * failure lands BEFORE the first event) and the turn ends as an assistant
+ * message with errorMessage `WebSocket closed 1006`. Nothing about that
+ * response can be resumed (the Codex backend rejects `store: true`, so there
+ * is no server-side response to pick back up), which is why the official
+ * Codex CLI answers a mid-stream drop the same way pi does: re-issue the whole
+ * request with the conversation intact, a bounded number of times, and only
+ * then fail the turn.
+ *
+ * pi owns that retry (`websocket.?closed` is in its retryable pattern), and
+ * Houston's wire translator holds the errored turn_end until `agent_settled`
+ * so a healed retry never paints a card. These tests pin the whole chain on a
+ * REAL pi AgentSession over the scripted faux provider: a pi bump that drops
+ * the pattern, or a translator change that flushes the held error early,
+ * fails here rather than as a red card in production.
+ */
+
+const WEBSOCKET_CLOSED_1006 = "WebSocket closed 1006";
+
+function socketClosed(code = 1006): AssistantMessage {
+  return fauxAssistantMessage("", {
+    stopReason: "error",
+    errorMessage: `WebSocket closed ${code}`,
+  });
+}
+
+/**
+ * A real pi AgentSession over the faux provider (scripted responses, no
+ * network), built the way chat.ts builds one and wrapped in PiSession. Retry
+ * backoff is zeroed so the exhausted-retries case runs in milliseconds; the
+ * retry COUNT stays pi's default so the test pins the real policy.
+ */
+async function fauxSession(responses: AssistantMessage[]) {
+  const cwd = mkdtempSync(join(tmpdir(), "houston-codex-ws-retry-"));
+  const faux = fauxProvider({
+    provider: "faux",
+    api: "faux",
+    models: [
+      { id: "faux-1", name: "Faux 1", contextWindow: 200000, maxTokens: 8192 },
+    ],
+  });
+  faux.setResponses(responses);
+  const authStorage = new HoustonAuthStore(join(cwd, "auth.json"));
+  authStorage.set("faux", { type: "api_key", key: "faux-key" });
+  const modelRuntime = await ModelRuntime.create({
+    credentials: authStorage,
+    modelsPath: join(cwd, "models.json"),
+  });
+  modelRuntime.registerNativeProvider(faux.provider);
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir: cwd,
+    modelRuntime,
+    model: faux.getModel() as never,
+    sessionManager: SessionManager.inMemory(),
+    settingsManager: SettingsManager.inMemory({ retry: { baseDelayMs: 0 } }),
+    tools: [],
+    customTools: [],
+  });
+  const wrapped = new PiSession(session);
+  const events: WireEvent[] = [];
+  wrapped.subscribe((e) => events.push(e));
+  return { faux, session: wrapped, events };
+}
+
+const providerErrors = (events: WireEvent[]) =>
+  events.filter(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+
+test("pi-ai's retryable predicate covers every Codex WebSocket close code seen in the wild", () => {
+  // 1006 abnormal closure, 1000 server closed mid-turn, 1012 service restart.
+  for (const code of [1006, 1000, 1012]) {
+    expect(isRetryableAssistantError(socketClosed(code))).toBe(true);
+  }
+  // The connect-phase failure text and the idle watchdog's text as well.
+  for (const message of [
+    "WebSocket error",
+    "WebSocket connect timeout after 15000ms",
+    "WebSocket idle timeout after 300000ms",
+  ]) {
+    expect(
+      isRetryableAssistantError(
+        fauxAssistantMessage("", {
+          stopReason: "error",
+          errorMessage: message,
+        }),
+      ),
+    ).toBe(true);
+  }
+});
+
+test("a mid-turn 'WebSocket closed 1006' is retried inside the same prompt and the healed turn reaches the chat clean", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const { faux, session, events } = await fauxSession([
+      socketClosed(),
+      fauxAssistantMessage("Recovered answer", { stopReason: "stop" }),
+    ]);
+    await session.prompt("hello");
+    // Two provider requests: the dropped stream and its re-issue.
+    expect(faux.state.callCount).toBe(2);
+    // No card: the held error was dropped by the clean turn.
+    expect(providerErrors(events)).toEqual([]);
+    expect(
+      events
+        .filter(
+          (e): e is Extract<WireEvent, { type: "text" }> => e.type === "text",
+        )
+        .map((e) => e.data)
+        .join(""),
+    ).toBe("Recovered answer");
+    // The dropped attempt and its re-issue are both visible in runtime.log.
+    const lines = warn.mock.calls.map((c) => String(c[0]));
+    expect(lines).toContainEqual(
+      expect.stringMatching(
+        /^\[provider_retry\] attempt=1\/3 delay_ms=0 :: WebSocket closed 1006$/,
+      ),
+    );
+    expect(lines).toContainEqual(
+      expect.stringMatching(/^\[provider_retry\] recovered attempt=1$/),
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test("a 1006 on every attempt exhausts pi's retry budget and surfaces ONE provider_internal card", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    // pi's default budget is 3 retries: the first attempt plus three more.
+    const { faux, session, events } = await fauxSession([
+      socketClosed(),
+      socketClosed(),
+      socketClosed(),
+      socketClosed(),
+    ]);
+    await session.prompt("hello");
+    expect(faux.state.callCount).toBe(4);
+    const errors = providerErrors(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.data).toMatchObject({
+      kind: "provider_internal",
+      message: WEBSOCKET_CLOSED_1006,
+    });
+    const lines = warn.mock.calls.map((c) => String(c[0]));
+    expect(lines).toContainEqual(
+      expect.stringMatching(
+        /^\[provider_retry\] failed attempt=3 :: WebSocket closed 1006$/,
+      ),
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -6,7 +6,10 @@ import {
   type WireEvent,
 } from "@houston/runtime-client";
 import { classifyProviderError } from "../../ai/provider-error";
-import { logProviderError } from "../../ai/provider-error-log";
+import {
+  logProviderError,
+  logProviderRetry,
+} from "../../ai/provider-error-log";
 import { canonicalPinProvider } from "../../ai/providers";
 import {
   noteAuthFailure,
@@ -264,6 +267,10 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
       const usage = msg && "usage" in msg ? normalizeUsage(msg.usage) : null;
       return usage ? { type: "usage", data: usage } : null;
     }
+    case "auto_retry_start":
+    case "auto_retry_end":
+      logProviderRetry(e);
+      return null;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

Linear: PRODUCT-1739

A user reported long Codex (`openai-codex`, `gpt-5.6-sol`) turns that "stay thinking" and then show an error. The agent's `runtime.log` had one `[provider_error] … WebSocket closed 1006` line per incident, which read as the socket drop ending the turn.

The persisted pi session files for that agent tell a different story. Every one of the four `WebSocket closed 1006` entries is followed by a clean assistant message a few seconds to a few minutes later with no user message in between, and the Houston transcripts for those conversations carry no error marker at all:

| drop | next assistant message |
|---|---|
| 2026-08-06 15:29:39 | 15:30:33 (`stop`) |
| 2026-08-18 14:37:31 | 14:42:15 (tool call, then `stop`) |
| 2026-08-21 14:01:11 | 14:01:30 (tool call) |
| 2026-09-07 16:46:45 | 16:46:54 (`stop`) |

That is pi's own auto-retry: `websocket.?closed` has been in pi-ai's retryable pattern since 0.83 (every incident above ran with it), pi re-issues the request inside the same `prompt()` up to three times, and Houston's wire translator holds the errored `turn_end` until `agent_settled`, so a healed retry never paints a card. Resuming the broken response itself is not possible (the Codex backend rejects `store: true`, so there is no server-side response to pick back up), and the official Codex CLI answers a mid-stream drop the same way: re-issue the whole request, then fall back to SSE. pi already does both. The engine runs on Node, whose built-in WebSocket answers server pings but cannot send its own, so a client keepalive is not available either.

What was actually wrong is observability: the failed attempt logs `[provider_error]`, and nothing logs the retry, so a healed drop is indistinguishable in `runtime.log` from a turn that died with a card. That is exactly what misled the triage here.

## Changes

- `provider-error-log.ts`: `logProviderRetry` writes `[provider_retry] attempt=N/M delay_ms=… :: <error>` when pi schedules a retry, `[provider_retry] recovered attempt=N` when the retried attempt completes, and `[provider_retry] failed attempt=N :: <error>` when the budget runs out. All warnings: a retry is an expected state.
- `wire.ts`: `toWire` routes pi's `auto_retry_start` / `auto_retry_end` events through it (still no wire frame).
- `codex-websocket-retry.test.ts`: drives a REAL pi AgentSession over the faux provider through `PiSession` with a scripted `WebSocket closed 1006`, and pins that (a) the predicate covers 1006 / 1000 / 1012 and the connect / idle timeout texts, (b) one drop is retried inside the prompt and the healed turn reaches the chat with no `provider_error`, with both log lines present, (c) four drops exhaust the budget and surface exactly one `provider_internal` card. A pi bump that drops the pattern, or a translator change that flushes the held error early, fails here.

## Before

Pin an agent to `openai-codex` / `gpt-5.6-sol` and run a long tool-heavy task until a socket drop lands (or replay the faux test without this branch's log lines). `runtime.log` shows only:

```
[provider_error] provider=openai-codex model=gpt-5.6-sol status=? kind=provider_internal :: WebSocket closed 1006
```

and nothing says whether the turn recovered.

## After

Same drop:

```
[provider_error] provider=openai-codex model=gpt-5.6-sol status=? kind=provider_internal :: WebSocket closed 1006
[provider_retry] attempt=1/3 delay_ms=2000 :: WebSocket closed 1006
[provider_retry] recovered attempt=1
```

and the chat shows the completed answer, no card.

```
pnpm --filter @houston/runtime vitest run src/backends/pi/codex-websocket-retry.test.ts src/backends/pi/malformed-retry.test.ts src/backends/pi/wire.test.ts
```

## Verification

- `pnpm check` clean; `pnpm typecheck` clean (pre-commit).
- runtime: `src/backends/pi` + `src/ai/provider-error-log` suites: 49 tests pass.

## What this does not settle

The user's "error naming OpenAI" did not come from these drops. The only other provider failure in that agent's log is a July Anthropic spend-limit card. The visible effect of a drop is extra "thinking" time while pi re-runs the request (up to ~5 minutes in the 08-18 case); if the user is seeing a card, it needs a fresh report with the time so the transcript can be matched.
