### PR TITLE
fix(store): route offline catalog reads to the quiet connectivity class (PRODUCT-1735)

### DIFF
--- a/app/src/hooks/use-update-checker.ts
+++ b/app/src/hooks/use-update-checker.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { currentAppVersion } from "../lib/app-version";
-import { showUpdateCheckStuckToast } from "../lib/error-toast";
+import { showUpdateCheckStuckToast } from "../lib/update-check-toast";
 import {
   nextCheckFailureStreak,
   shouldRecheckOnFocus,

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -4,6 +4,7 @@ import { isAgentWarmingRefusal } from "./agent-warming-refusal";
 import { analytics, classifyAnalyticsError } from "./analytics";
 import { createBurstGate } from "./error-burst";
 import i18n from "./i18n";
+import { classifyQuietError } from "./quiet-error-class";
 import { reportQuietError } from "./quiet-error-report";
 import {
   captureException as sentryCapture,
@@ -67,52 +68,6 @@ export function showConnectivityErrorToast(
     title: i18n.t("shell:errorToast.offlineTitle"),
     description,
     variant: "info",
-  });
-}
-
-/**
- * Surface a client whose update checks keep failing (PRODUCT-1386). The
- * forced updater is fail-open — a check failure only console.warns — so a
- * client that can NEVER reach the release feed (a proxy or region block
- * between it and GitHub) would strand on an old build invisibly, with no
- * server-side floor to catch it since the 426 gate was retired
- * (PRODUCT-1144). The checker calls this once per failure streak, after
- * `UPDATE_CHECK_STUCK_THRESHOLD` consecutive failures:
- *  - one informational toast pointing at the manual download, so the user
- *    can act;
- *  - a dedicated `update_check_failed` analytics event (its own name, not
- *    `app_error_shown`, so a fleet-staleness dashboard can count stuck
- *    clients directly);
- *  - a Sentry capture, so stranded clients get an issue with a user count —
- *    this also surfaces any leaked staging QA build, whose no-op updater
- *    endpoint 404s every check by design.
- */
-export function showUpdateCheckStuckToast(
-  message: string,
-  consecutiveFailures: number,
-  currentVersion: string,
-): void {
-  const command = "update_check";
-  console.error(
-    `[toast:${command}] ${consecutiveFailures} consecutive check failures: ${message}`,
-  );
-  useUIStore.getState().addToast({
-    title: i18n.t("shell:errorToast.updateStuckTitle"),
-    description: i18n.t("shell:errorToast.updateStuckDescription"),
-    variant: "info",
-  });
-  analytics.track("update_check_failed", {
-    source: command,
-    consecutive_failures: consecutiveFailures,
-    from_version: currentVersion,
-    error_kind: classifyAnalyticsError(message),
-  });
-  if (sentrySuppressedInDev) return;
-  void sentryCapture(createSentryReportError(command, message), {
-    source: command,
-    error_kind: classifyAnalyticsError(message),
-  }).catch((flushErr: unknown) => {
-    console.error("[sentry] failed to flush captured error", flushErr);
   });
 }
 
@@ -199,6 +154,26 @@ export function showErrorToast(
     console.debug(`[toast:${command}] write blocked while the agent warms up`);
     return;
   }
+  // The quiet classes (PRODUCT-1735) — the same gate the engine-call layer,
+  // `reportError` and the global handlers run. A caller that hands a raw
+  // query error here (the store screens: an anonymous catalog read that
+  // never passes through `call()`) used to capture an offline device as a
+  // per-user bug. Each class keeps its own informational surface and its ONE
+  // fingerprinted warning; the bridge class has an inline surface already.
+  switch (classifyQuietError(originalError)) {
+    case "offline":
+      showConnectivityErrorToast(command, message, originalError);
+      return;
+    case "engine_waking":
+      showEngineWakingToast(command, message, originalError);
+      return;
+    case "bridge_unsupported":
+      console.error(`[toast:${command}] ${message}`);
+      reportQuietError("bridge_unsupported", command, message, originalError);
+      return;
+    case null:
+      break;
+  }
 
   // With no toast left, this line is the failure's only trace on the user's
   // machine — guarantee it here rather than trusting each caller to log.
@@ -227,12 +202,4 @@ export function showErrorToast(
   }).catch((flushErr: unknown) => {
     console.error("[sentry] failed to flush captured error", flushErr);
   });
-}
-
-export function raiseJavascriptSentrySmokeTest(): never {
-  return raiseJavascriptSentrySmokeTestLeaf();
-}
-
-function raiseJavascriptSentrySmokeTestLeaf(): never {
-  throw new Error(`sentry-js-stack-smoke-${Date.now()}`);
 }

--- a/app/src/lib/quiet-error-class.ts
+++ b/app/src/lib/quiet-error-class.ts
@@ -52,7 +52,9 @@ export interface QuietErrorDetails {
  * carries the raw text as its message, the runtime client's `EngineError`
  * keeps the raw text on `body`) — the searchable payload the Sentry event
  * exists to carry. A transport `TypeError` has no status and its message IS
- * the diagnostic.
+ * the diagnostic; a status-0 wrapper around one (the store client's
+ * `StoreApiError`) reads the same way, since `0` is "no response", not an
+ * HTTP status, and its `body` is the thrown error itself.
  */
 export function quietErrorDetails(err: unknown): QuietErrorDetails {
   if (!(err instanceof Error)) return { status: null, body: null };
@@ -61,10 +63,15 @@ export function quietErrorDetails(err: unknown): QuietErrorDetails {
   const rawBody =
     typeof body === "string"
       ? body
-      : body !== null && body !== undefined
-        ? JSON.stringify(body)
-        : err.message;
-  return { status: typeof status === "number" ? status : null, body: rawBody };
+      : body instanceof Error
+        ? body.message
+        : body !== null && body !== undefined
+          ? JSON.stringify(body)
+          : err.message;
+  return {
+    status: typeof status === "number" && status > 0 ? status : null,
+    body: rawBody,
+  };
 }
 
 /**

--- a/app/src/lib/sentry-smoke.ts
+++ b/app/src/lib/sentry-smoke.ts
@@ -1,5 +1,5 @@
 import { useUIStore } from "../stores/ui";
-import { raiseJavascriptSentrySmokeTest, showErrorToast } from "./error-toast";
+import { showErrorToast } from "./error-toast";
 import i18n from "./i18n";
 import { osTriggerNativeSentrySmokeTest } from "./os-bridge";
 import { sentrySuppressedInDev } from "./sentry";
@@ -58,6 +58,14 @@ function triggerNativeSmokeTest(): Promise<void> {
       const message = error instanceof Error ? error.message : String(error);
       showErrorToast("sentry_native_smoke_failed", message, error);
     });
+}
+
+function raiseJavascriptSentrySmokeTest(): never {
+  return raiseJavascriptSentrySmokeTestLeaf();
+}
+
+function raiseJavascriptSentrySmokeTestLeaf(): never {
+  throw new Error(`sentry-js-stack-smoke-${Date.now()}`);
 }
 
 declare global {

--- a/app/src/lib/update-check-toast.ts
+++ b/app/src/lib/update-check-toast.ts
@@ -1,0 +1,54 @@
+import { useUIStore } from "../stores/ui";
+import { analytics, classifyAnalyticsError } from "./analytics";
+import i18n from "./i18n";
+import {
+  captureException as sentryCapture,
+  sentrySuppressedInDev,
+} from "./sentry";
+import { createSentryReportError } from "./sentry-report-error";
+
+/**
+ * Surface a client whose update checks keep failing (PRODUCT-1386). The
+ * forced updater is fail-open — a check failure only console.warns — so a
+ * client that can NEVER reach the release feed (a proxy or region block
+ * between it and GitHub) would strand on an old build invisibly, with no
+ * server-side floor to catch it since the 426 gate was retired
+ * (PRODUCT-1144). The checker calls this once per failure streak, after
+ * `UPDATE_CHECK_STUCK_THRESHOLD` consecutive failures:
+ *  - one informational toast pointing at the manual download, so the user
+ *    can act;
+ *  - a dedicated `update_check_failed` analytics event (its own name, not
+ *    `app_error_shown`, so a fleet-staleness dashboard can count stuck
+ *    clients directly);
+ *  - a Sentry capture, so stranded clients get an issue with a user count —
+ *    this also surfaces any leaked staging QA build, whose no-op updater
+ *    endpoint 404s every check by design.
+ */
+export function showUpdateCheckStuckToast(
+  message: string,
+  consecutiveFailures: number,
+  currentVersion: string,
+): void {
+  const command = "update_check";
+  console.error(
+    `[toast:${command}] ${consecutiveFailures} consecutive check failures: ${message}`,
+  );
+  useUIStore.getState().addToast({
+    title: i18n.t("shell:errorToast.updateStuckTitle"),
+    description: i18n.t("shell:errorToast.updateStuckDescription"),
+    variant: "info",
+  });
+  analytics.track("update_check_failed", {
+    source: command,
+    consecutive_failures: consecutiveFailures,
+    from_version: currentVersion,
+    error_kind: classifyAnalyticsError(message),
+  });
+  if (sentrySuppressedInDev) return;
+  void sentryCapture(createSentryReportError(command, message), {
+    source: command,
+    error_kind: classifyAnalyticsError(message),
+  }).catch((flushErr: unknown) => {
+    console.error("[sentry] failed to flush captured error", flushErr);
+  });
+}

--- a/app/tests/network-transport-error.test.ts
+++ b/app/tests/network-transport-error.test.ts
@@ -85,6 +85,35 @@ describe("isNetworkTransportError", () => {
     );
   });
 
+  // PRODUCT-1735: the Agent Store client wraps a thrown fetch in a status-0
+  // StoreApiError that keeps the transport TypeError as its `cause`. That
+  // wrapper IS the offline drop; one level of cause is unwrapped, no more.
+  it("unwraps one level of `cause` around a transport failure", () => {
+    const wrapped = new Error("Failed to fetch", {
+      cause: new TypeError("Failed to fetch"),
+    });
+    strictEqual(isNetworkTransportError(wrapped), true);
+    strictEqual(
+      isNetworkTransportError(
+        new Error("outer", {
+          cause: new TypeError("undefined is not a function"),
+        }),
+      ),
+      false,
+    );
+    strictEqual(
+      isNetworkTransportError(new Error("outer", { cause: wrapped })),
+      false,
+      "a two-deep chain is not unwrapped",
+    );
+    strictEqual(
+      isNetworkTransportError(
+        new Error("Load failed", { cause: "Load failed" }),
+      ),
+      false,
+    );
+  });
+
   it("requires the TypeError shape — same message on other errors stays a bug", () => {
     strictEqual(isNetworkTransportError(new Error("Load failed")), false);
     strictEqual(isNetworkTransportError("Load failed"), false);

--- a/app/tests/quiet-error-class.test.ts
+++ b/app/tests/quiet-error-class.test.ts
@@ -1,5 +1,6 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
+import { StoreApiError } from "../../packages/agentstore-client/src/errors.ts";
 import {
   agentKeyOf,
   classifyQuietError,
@@ -41,6 +42,30 @@ describe("classifyQuietError", () => {
       null,
     );
     strictEqual(classifyQuietError(new TypeError("x is not a function")), null);
+  });
+
+  // PRODUCT-1735: the Agent Store client's status-0 wrapper around a thrown
+  // fetch is the offline class; a real gateway status from the store stays a
+  // bug (a store 5xx is ours to fix).
+  it("names the offline class for the store client's network-failure wrapper", () => {
+    const offline = new StoreApiError(
+      0,
+      "Failed to fetch",
+      null,
+      new TypeError("Failed to fetch"),
+    );
+    strictEqual(classifyQuietError(offline), "offline");
+    strictEqual(
+      classifyQuietError(
+        new StoreApiError(
+          502,
+          "Gateway request failed (502).",
+          null,
+          "Bad Gateway",
+        ),
+      ),
+      null,
+    );
   });
 
   // PRODUCT-1717: a gateway without the local-model bridge answers every
@@ -133,6 +158,15 @@ describe("quietErrorDetails", () => {
         }),
       ),
       { status: 502, body: raw },
+    );
+  });
+
+  it("reads the store client's status-0 wrapper as a transport drop", () => {
+    deepStrictEqual(
+      quietErrorDetails(
+        new StoreApiError(0, "Load failed", null, new TypeError("Load failed")),
+      ),
+      { status: null, body: "Load failed" },
     );
   });
 

--- a/app/tests/store-offline-quiet.test.ts
+++ b/app/tests/store-offline-quiet.test.ts
@@ -1,0 +1,61 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+// PRODUCT-1735 (HOUSTON-APP-54J / 55K): the store screens hand their raw
+// TanStack query error to `showErrorToast`, and an anonymous catalog read
+// never passes through `call()` — so the engine-call layer's quiet-class
+// gate never saw it, and 36 users browsing the store offline were captured as
+// "store browse fetch failed" bugs. `showErrorToast` is the last reporting
+// surface without the gate; this pins it in, ahead of the per-event capture.
+//
+// Asserted against the source: `error-toast` pulls i18n and the Zustand
+// store, neither of which loads under this suite's runner (same constraint as
+// error-toast-not-shown.test.ts).
+
+const read = (rel: string): string =>
+  readFileSync(join(import.meta.dirname, rel), "utf8");
+
+describe("showErrorToast routes the quiet classes to their own surfaces", () => {
+  const source = read("../src/lib/error-toast.ts");
+  const body = source.slice(source.indexOf("export function showErrorToast("));
+
+  it("classifies before the per-event Sentry capture", () => {
+    ok(source.includes('from "./quiet-error-class"'));
+    const guard = body.indexOf("classifyQuietError(originalError)");
+    const capture = body.indexOf("sentryCapture(");
+    ok(guard !== -1, "showErrorToast must classify quiet errors");
+    ok(capture !== -1, "every other failure keeps its per-event capture");
+    ok(guard < capture, "the quiet guard must run before the capture");
+  });
+
+  it("keeps each class on its existing informational surface", () => {
+    ok(
+      body.includes(
+        "showConnectivityErrorToast(command, message, originalError)",
+      ),
+    );
+    ok(body.includes("showEngineWakingToast(command, message, originalError)"));
+    ok(body.includes('reportQuietError("bridge_unsupported"'));
+  });
+});
+
+describe("the store screens report through the gated surface", () => {
+  for (const [rel, command] of [
+    ["../src/components/store-view/store-browse.tsx", "store_browse"],
+    ["../src/components/store-view/store-detail-pane.tsx", "store_detail"],
+    [
+      "../src/components/store-view/creator/creator-profile-pane.tsx",
+      "store_creator",
+    ],
+  ]) {
+    it(`${command} uses showErrorToast`, () => {
+      const source = read(rel);
+      ok(
+        source.includes(`showErrorToast(\n        "${command}"`) ||
+          source.includes(`showErrorToast("${command}"`),
+      );
+    });
+  }
+});

--- a/packages/agentstore-client/src/client.test.ts
+++ b/packages/agentstore-client/src/client.test.ts
@@ -221,6 +221,7 @@ describe("AgentStoreClient — error mapping", () => {
     expect(err).toBeInstanceOf(StoreApiError);
     expect(err.status).toBe(0);
     expect(err.body).toBe(cause);
+    expect(err.cause).toBe(cause);
     expect(err.message).toBe("Failed to fetch");
   });
 

--- a/packages/agentstore-client/src/errors.ts
+++ b/packages/agentstore-client/src/errors.ts
@@ -16,6 +16,9 @@ export class StoreApiError extends Error {
   /**
    * The response payload as observed: the parsed JSON object when the body was
    * JSON, the raw text otherwise, or the thrown error on a network failure.
+   * A network failure's thrown error is ALSO the standard `cause`, so a
+   * classifier that unwraps `Error.cause` (the app's offline gate) sees the
+   * transport `TypeError` instead of reporting an offline device as a bug.
    */
   readonly body: unknown;
 
@@ -25,7 +28,7 @@ export class StoreApiError extends Error {
     code: string | null,
     body: unknown,
   ) {
-    super(message);
+    super(message, body instanceof Error ? { cause: body } : undefined);
     this.name = "StoreApiError";
     this.status = status;
     this.code = code;

--- a/packages/web/src/engine-adapter/network-transport-error.ts
+++ b/packages/web/src/engine-adapter/network-transport-error.ts
@@ -33,7 +33,19 @@ const TRANSPORT_MESSAGE =
  * (HOU-1085: a sleep-wake burst fails every live gateway query at once with
  * WebKit's "Load failed"). These are an expected, explainable environment
  * state — surfaced as a connectivity toast, never the red bug pair + Sentry.
+ *
+ * A wrapper that kept the thrown transport error as its standard `cause`
+ * (the Agent Store client's status-0 `StoreApiError`) is the same failure:
+ * one level of `cause` is unwrapped, never more, so a wrapper chain cannot
+ * loop and a coding-bug wrapper stays a bug.
  */
 export function isNetworkTransportError(err: unknown): boolean {
+  return (
+    isTransportTypeError(err) ||
+    (err instanceof Error && isTransportTypeError(err.cause))
+  );
+}
+
+function isTransportTypeError(err: unknown): boolean {
   return err instanceof TypeError && TRANSPORT_MESSAGE.test(err.message);
 }


### PR DESCRIPTION
## Summary

PRODUCT-1735

Browsing the Agent Store while offline captured as a Houston bug: `store_browse: store browse fetch failed` (36 users since August) and `store_detail: store detail fetch failed`. The device had no network (every gateway request in the same second had no status code), the gateway calls were classified as the `offline` quiet class, but the store reads were not.

### Root cause

The store screens hand their raw TanStack query error straight to `showErrorToast`. An anonymous catalog read never passes through the engine-call layer (`call()` in `tauri.ts`), and `showErrorToast` was the one reporting surface with no quiet-class gate, so the transport `TypeError("Failed to fetch")` went to the per-event Sentry capture.

The Linear diagnosis pointed at `StoreApiError` hiding the cause. That is true at the client layer, but both adapters (`ui/engine-client/src/store-catalog.ts`, `packages/web/src/engine-adapter/portable-store.ts`) already re-raise the status-0 cause unwrapped; the app saw the bare `TypeError` and still reported it.

### Fix

- `showErrorToast` runs `classifyQuietError` before the per-event capture: `offline` goes to the deduped connectivity toast, `engine_waking` to the waking toast, `bridge_unsupported` to its low-noise capture. Each keeps its ONE fingerprinted Sentry warning. Every other error keeps the per-event capture, so a store 5xx is still loud.
- `isNetworkTransportError` unwraps one level of `Error.cause`, and `StoreApiError` keeps a status-0 thrown fetch on `cause`, so a consumer that does not unwrap the wrapper still classifies as offline.
- `quietErrorDetails` reads a status-0 wrapper as a transport drop (no HTTP status, body = the thrown message) instead of `status: 0, body: "{}"`.
- `showUpdateCheckStuckToast` moves to `app/src/lib/update-check-toast.ts` and the Sentry smoke raisers into `sentry-smoke.ts`, to keep `error-toast.ts` within the file limit. No behavior change there.

The store screens already render their inline "could not be reached" state, so no screen change is needed.

### Before

1. Open the desktop app, go to the Store.
2. Cut the network (Wi-Fi off), then reload the Store screen (or open an agent's detail).
3. Sentry receives a new `store_browse` / `store_detail` error event tagged `error_kind: network`, with no `quiet_class` tag.

### After

1. Same steps.
2. The user sees the single "Houston, connection lost" info toast and the store's inline retry state.
3. Sentry receives at most one burst-collapsed warning in the fixed `offline` issue (`quiet_class: offline`, `source: store_browse`), no new per-user issue.
4. Regression guard: a store 5xx (stub the gateway to answer 502) still captures as a `store_browse` error event.

### Tests

- `app/tests/store-offline-quiet.test.ts`: `showErrorToast` classifies before capture and routes each class to its existing surface; the three store screens report through it.
- `app/tests/network-transport-error.test.ts`: one-level `cause` unwrap, coding-bug and two-deep chains stay bugs.
- `app/tests/quiet-error-class.test.ts`: a status-0 `StoreApiError` is `offline` with transport-drop details; a 502 from the store is not quiet.
- `packages/agentstore-client/src/client.test.ts`: the network failure's `cause`.

`pnpm check`, `cd app && pnpm test` (4207 pass), `pnpm --filter @houston/agentstore-client test`, `cd app && pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck` all pass.
