### PR TITLE
fix(runtime): map engine stack frames on demand instead of --enable-source-maps (PRODUCT-1744)

### DIFF
--- a/packages/runtime-client/package.json
+++ b/packages/runtime-client/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260607.1",
+    "esbuild": "0.25.12",
     "typescript": "6.0.3",
     "vitest": "3.2.6"
   },

--- a/packages/runtime-client/src/sentry/client.ts
+++ b/packages/runtime-client/src/sentry/client.ts
@@ -19,6 +19,7 @@ import {
   resolveEngineSentryConfig,
 } from "./activation";
 import { addSourceContext, trimReporterFrames } from "./frames";
+import { createBundleFrameMapper, defaultBundlePath } from "./map-frames";
 
 /** Levels as the engine's loggers name them (observability/logging.ts). */
 export type LogCaptureLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
@@ -158,11 +159,20 @@ export function initEngineSentry(
   }
 }
 
+export interface EngineSentryOptions {
+  /**
+   * The esbuild bundle whose frames get source-mapped on demand; defaults to
+   * the running entry (see map-frames.ts). Tests point it at a fixture.
+   */
+  bundlePath?: string;
+}
+
 /** Exported for tests (inject a capturing transport). Use initEngineSentry. */
 export function createEngineSentry(
   engineProcess: EngineProcess,
   config: EngineSentryConfig,
   transport: (options: BaseTransportOptions) => Transport,
+  options: EngineSentryOptions = {},
 ): EngineSentry {
   const stackParser = createStackParser(nodeStackLineParser());
   const client = new ServerRuntimeClient({
@@ -209,8 +219,13 @@ export function createEngineSentry(
       Date.now() - process.uptime() * 1000,
     ).toISOString(),
   });
-  // Order matters: trim the reporter's plumbing frames first, then inline the
-  // source lines around what remains (no file reads for dropped frames).
+  // Order matters: map bundle offsets to `.ts` locations first (the next two
+  // key on mapped filenames), trim the reporter's plumbing frames, then
+  // inline the source lines around what remains (no file reads for dropped
+  // frames).
+  scope.addEventProcessor(
+    createBundleFrameMapper(options.bundlePath ?? defaultBundlePath()),
+  );
   scope.addEventProcessor(trimReporterFrames);
   scope.addEventProcessor(addSourceContext);
   client.init();

--- a/packages/runtime-client/src/sentry/frames.ts
+++ b/packages/runtime-client/src/sentry/frames.ts
@@ -15,8 +15,8 @@ import type { Event, StackFrame } from "@sentry/core";
  * Trailing frames from these files are popped so the innermost frame is the
  * code that actually logged. Filename-based: both production stacks are
  * source-mapped back to the original `.ts` paths (the sidecar's embedded bun
- * sourcemap, the pod's `--enable-source-maps`); an unmapped stack just stays
- * untrimmed.
+ * sourcemap; the pod bundles' sibling `.map`, applied per event by
+ * map-frames.ts); an unmapped stack just stays untrimmed.
  */
 const REPORTER_FRAME =
   /(?:sentry[/\\](?:client|console-capture))\.(?:m?[jt]s)$|(?:observability[/\\]logging)\.(?:m?[jt]s)$/;
@@ -28,7 +28,8 @@ function isReporterFrame(frame: StackFrame): boolean {
 /** Exception values and thread values both carry an optional stacktrace. */
 type StackHolder = { stacktrace?: { frames?: StackFrame[] } };
 
-function stackHolders(event: Event): StackHolder[] {
+/** Every frame list an event can carry, in one pass. */
+export function stackHolders(event: Event): StackHolder[] {
   return [...(event.exception?.values ?? []), ...(event.threads?.values ?? [])];
 }
 

--- a/packages/runtime-client/src/sentry/index.ts
+++ b/packages/runtime-client/src/sentry/index.ts
@@ -9,6 +9,7 @@ export {
 export {
   createEngineSentry,
   type EngineSentry,
+  type EngineSentryOptions,
   initEngineSentry,
   type LogCaptureLevel,
 } from "./client";

--- a/packages/runtime-client/src/sentry/map-frames.test.ts
+++ b/packages/runtime-client/src/sentry/map-frames.test.ts
@@ -1,0 +1,152 @@
+import { rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import type { Event } from "@sentry/core";
+import { createTransport } from "@sentry/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { EngineSentryConfig } from "./activation";
+import { createEngineSentry, type EngineSentry } from "./client";
+import { defaultBundlePath } from "./map-frames";
+import {
+  buildFixtureBundle,
+  type FixtureBundle,
+  LOG_LINE,
+  THROW_LINE,
+} from "./source-map.fixture";
+
+interface Fixture {
+  throwFromFixture(): never;
+  logFromFixture(sentry: EngineSentry): void;
+}
+
+const CONFIG: EngineSentryConfig = {
+  dsn: "https://key@o1.ingest.sentry.io/1",
+  environment: "production",
+  release: "engine-pod@abc",
+  deployment: "managed-cloud",
+  tags: {},
+};
+
+function testSentry(bundlePath: string): {
+  sentry: EngineSentry;
+  events: Event[];
+} {
+  const events: Event[] = [];
+  const sentry = createEngineSentry(
+    "host",
+    CONFIG,
+    (options) =>
+      createTransport(options, async (request) => {
+        const lines = (request.body as string).split("\n");
+        for (let i = 1; i < lines.length; i += 2) {
+          if (JSON.parse(lines[i] ?? "{}").type === "event") {
+            events.push(JSON.parse(lines[i + 1] ?? "{}"));
+          }
+        }
+        return { statusCode: 200 };
+      }),
+    { bundlePath },
+  );
+  return { sentry, events };
+}
+
+let fixture: FixtureBundle;
+let mod: Fixture;
+
+beforeAll(async () => {
+  fixture = await buildFixtureBundle();
+  mod = createRequire(import.meta.url)(fixture.bundlePath) as Fixture;
+});
+
+afterAll(() => {
+  rmSync(fixture.dir, { recursive: true, force: true });
+});
+
+function thrown(): Error {
+  try {
+    mod.throwFromFixture();
+  } catch (err) {
+    return err as Error;
+  }
+  throw new Error("fixture did not throw");
+}
+
+describe("bundle frame mapping", () => {
+  it("the fixture's raw stack points at the bundle (the harness does not map it)", () => {
+    expect(thrown().stack).toContain(`${fixture.bundlePath}:`);
+    expect(thrown().stack).not.toContain("site.ts");
+  });
+
+  it("exception frames map to the original .ts file, line and column, with context", async () => {
+    const { sentry, events } = testSentry(fixture.bundlePath);
+    sentry.captureException(thrown());
+    await sentry.flush();
+
+    const frames = events[0]?.exception?.values?.[0]?.stacktrace?.frames ?? [];
+    const top = frames[frames.length - 1];
+    expect(top?.filename).toBe(fixture.sitePath);
+    expect(top?.lineno).toBe(THROW_LINE);
+    // V8 reports the `new`: 1-based column 9 in the generated
+    // `  throw new Error(`, 13 in the over-indented original. Anything else
+    // is a 0/1-based slip or a lost segment offset.
+    expect(top?.colno).toBe(13);
+    expect(top?.in_app).toBe(true);
+    expect(top?.context_line).toContain('throw new Error("fixture boom")');
+    expect(top?.pre_context?.length).toBeGreaterThan(0);
+    // No frame is left at the bundle path; the test's own frame is untouched.
+    expect(frames.every((f) => f.filename !== fixture.bundlePath)).toBe(true);
+    expect(
+      frames.some((f) => /map-frames\.test\.ts$/.test(f.filename ?? "")),
+    ).toBe(true);
+  });
+
+  it("a bare-string ERROR logged from the bundle trims the mapped reporter frame", async () => {
+    // Stack: client.ts (captureLog) ← logging.ts (bundle) ← site.ts (bundle).
+    // logging.ts only reads as a reporter frame AFTER mapping; without it the
+    // event's top frame would be the log helper instead of the log site.
+    const { sentry, events } = testSentry(fixture.bundlePath);
+    mod.logFromFixture(sentry);
+    await sentry.flush();
+
+    expect(events[0]?.message).toBe("fixture log site");
+    const frames = events[0]?.threads?.values?.[0]?.stacktrace?.frames ?? [];
+    const site = frames[frames.length - 1];
+    expect(site?.filename).toBe(fixture.sitePath);
+    expect(site?.lineno).toBe(LOG_LINE);
+    expect(site?.context_line).toContain('emit(sentry, "fixture log site")');
+    expect(frames.some((f) => f.filename === fixture.loggingPath)).toBe(false);
+  });
+
+  it("repeated sites hit the position cache (one event, one scan, same answer)", async () => {
+    const { sentry, events } = testSentry(fixture.bundlePath);
+    sentry.captureException(thrown());
+    sentry.captureException(thrown());
+    await sentry.flush();
+    const tops = events.map((e) => {
+      const frames = e.exception?.values?.[0]?.stacktrace?.frames ?? [];
+      return frames[frames.length - 1];
+    });
+    expect(tops[1]).toMatchObject({
+      filename: fixture.sitePath,
+      lineno: THROW_LINE,
+      colno: 13,
+    });
+  });
+
+  it("no map beside the bundle → frames stay at bundle offsets, nothing throws", async () => {
+    const { sentry, events } = testSentry(`${fixture.dir}/nowhere/main.mjs`);
+    sentry.captureException(thrown());
+    await sentry.flush();
+    const frames = events[0]?.exception?.values?.[0]?.stacktrace?.frames ?? [];
+    expect(frames[frames.length - 1]?.filename).toBe(fixture.bundlePath);
+  });
+
+  it("defaultBundlePath: the resolved argv[1] on Node, nothing under Bun", () => {
+    expect(defaultBundlePath(["node", "dist/host/main.mjs"], {} as never)).toBe(
+      `${process.cwd()}/dist/host/main.mjs`,
+    );
+    expect(
+      defaultBundlePath(["bun", "/$bunfs/root/main"], { bun: "1.2" } as never),
+    ).toBeUndefined();
+    expect(defaultBundlePath(["node"], {} as never)).toBeUndefined();
+  });
+});

--- a/packages/runtime-client/src/sentry/map-frames.ts
+++ b/packages/runtime-client/src/sentry/map-frames.ts
@@ -1,0 +1,98 @@
+import { resolve } from "node:path";
+import type { Event, StackFrame } from "@sentry/core";
+import { stackHolders } from "./frames";
+import {
+  BundleSourceMap,
+  type GeneratedPosition,
+  type OriginalPosition,
+} from "./source-map";
+
+/**
+ * Event processor that rewrites frames pointing at the running esbuild bundle
+ * (`dist/<host|runtime>/main.mjs`) to their original `.ts` file, line and
+ * column, using the sibling `.map` — loaded on the first event that needs it,
+ * never at boot. Node itself runs WITHOUT `--enable-source-maps` (see
+ * source-map.ts for the memory reason), so this is the only place bundle
+ * offsets become source locations. It runs before `trimReporterFrames` and
+ * `addSourceContext`, which both key on the mapped filenames.
+ *
+ * A missing or unparsable map leaves frames at their bundle offsets; nothing
+ * here throws.
+ */
+
+/**
+ * The bundle this process is running, if it is one: Node resolves argv[1] to
+ * an absolute path, which is exactly what V8 prints in `file://` stack frames
+ * (Sentry's node parser strips the scheme). The Bun-compiled desktop sidecar
+ * maps its own frames from its embedded sourcemap, and dev runs execute `.ts`
+ * sources directly — neither has a `.map` sibling, so the mapper stays idle.
+ */
+export function defaultBundlePath(
+  argv: readonly string[] = process.argv,
+  versions: NodeJS.ProcessVersions = process.versions,
+): string | undefined {
+  if (versions.bun) return undefined;
+  const entry = argv[1];
+  return entry ? resolve(entry) : undefined;
+}
+
+/** Log sites repeat; positions are cached by generated line:column. */
+const CACHE_LIMIT = 512;
+
+function frameKey(frame: StackFrame): string {
+  return `${frame.lineno}:${frame.colno}`;
+}
+
+function applyPosition(frame: StackFrame, position: OriginalPosition): void {
+  frame.filename = position.file;
+  frame.lineno = position.line;
+  frame.colno = position.column + 1;
+  // The bundle path itself reads as in-app; a frame that maps back into a
+  // bundled dependency is not, and Sentry greys it out accordingly.
+  frame.in_app = !position.file.includes("node_modules/");
+}
+
+export function createBundleFrameMapper(
+  bundlePath: string | undefined,
+): <E extends Event>(event: E) => E {
+  /** undefined = not loaded yet; null = tried and unavailable. */
+  let map: BundleSourceMap | null | undefined;
+  const cache = new Map<string, OriginalPosition | null>();
+
+  const isBundleFrame = (frame: StackFrame): boolean =>
+    frame.filename === bundlePath && !!frame.lineno && !!frame.colno;
+
+  return function mapBundleFrames<E extends Event>(event: E): E {
+    if (!bundlePath) return event;
+    const frames = stackHolders(event)
+      .flatMap((holder) => holder.stacktrace?.frames ?? [])
+      .filter(isBundleFrame);
+    if (frames.length === 0) return event;
+    if (map === undefined) map = BundleSourceMap.load(bundlePath) ?? null;
+    if (map === null) return event;
+
+    const pending = new Map<string, GeneratedPosition>();
+    for (const frame of frames) {
+      const key = frameKey(frame);
+      if (!cache.has(key) && !pending.has(key)) {
+        pending.set(key, {
+          line: frame.lineno as number,
+          column: (frame.colno as number) - 1,
+        });
+      }
+    }
+    if (pending.size > 0) {
+      if (cache.size + pending.size > CACHE_LIMIT) cache.clear();
+      const keys = [...pending.keys()];
+      const positions = map.lookup([...pending.values()]);
+      for (let i = 0; i < keys.length; i++) {
+        cache.set(keys[i] as string, positions[i] ?? null);
+      }
+    }
+    for (const frame of frames) {
+      const position = cache.get(frameKey(frame));
+      if (position) applyPosition(frame, position);
+    }
+    return event;
+  };
+}

--- a/packages/runtime-client/src/sentry/mappings-scan.ts
+++ b/packages/runtime-client/src/sentry/mappings-scan.ts
@@ -1,0 +1,169 @@
+/**
+ * The per-lookup walk over a v3 `mappings` string (see source-map.ts for why
+ * the map is not decoded up front). Reads segments one VLQ at a time with a
+ * scalar cursor: no array per segment, nothing retained between calls.
+ */
+
+/** A generated-code location as V8 reports it, minus one on the column. */
+export interface GeneratedPosition {
+  /** 1-based. */
+  line: number;
+  /** 0-based. */
+  column: number;
+}
+
+export interface OriginalPosition {
+  /** Absolute path of the original source file. */
+  file: string;
+  /** 1-based. */
+  line: number;
+  /** 0-based. */
+  column: number;
+}
+
+const SEMICOLON = 59;
+const COMMA = 44;
+
+/** Base64 digit → value, -1 for anything that is not a VLQ character. */
+const VLQ_DIGIT = (() => {
+  const table = new Int8Array(128).fill(-1);
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  for (let i = 0; i < alphabet.length; i++) {
+    table[alphabet.charCodeAt(i)] = i;
+  }
+  return table;
+})();
+
+class Cursor {
+  pos = 0;
+  constructor(private readonly encoded: string) {}
+
+  get done(): boolean {
+    return this.pos >= this.encoded.length;
+  }
+
+  peek(): number {
+    return this.encoded.charCodeAt(this.pos);
+  }
+
+  atSegmentEnd(): boolean {
+    if (this.done) return true;
+    const char = this.peek();
+    return char === COMMA || char === SEMICOLON;
+  }
+
+  readVlq(): number {
+    let value = 0;
+    let shift = 0;
+    let digit: number;
+    do {
+      if (this.done || shift > 30) throw new RangeError("malformed VLQ");
+      digit = VLQ_DIGIT[this.encoded.charCodeAt(this.pos++)] ?? -1;
+      if (digit < 0) throw new RangeError("malformed VLQ");
+      value += (digit & 31) << shift;
+      shift += 5;
+    } while (digit & 32);
+    return value & 1 ? -(value >>> 1) : value >>> 1;
+  }
+}
+
+function compareNeedles(
+  needles: readonly GeneratedPosition[],
+  a: number,
+  b: number,
+): number {
+  const x = needles[a] as GeneratedPosition;
+  const y = needles[b] as GeneratedPosition;
+  return x.line - y.line || x.column - y.column;
+}
+
+/**
+ * Original position for each needle, or undefined where the map has no
+ * segment at or before it. Same rule as Node's own `SourceMap.findOrigin`
+ * (what `--enable-source-maps` applied to stack traces): the greatest segment
+ * at or before the needle, in map order across lines, with the needle's
+ * distance from that segment carried over. For unminified output that lands
+ * on the exact token (segments start at statements; V8 reports the `new`
+ * inside one); a needle on a line with no segments of its own inherits the
+ * previous line's source and an offset. One scan serves the whole batch, so
+ * an event's frames cost one pass however many there are. A malformed
+ * `mappings` string ends the scan early and leaves the rest unmapped.
+ */
+export function scanMappings(
+  encoded: string,
+  sources: readonly (string | null)[],
+  needles: readonly GeneratedPosition[],
+): (OriginalPosition | undefined)[] {
+  const found: (OriginalPosition | undefined)[] = new Array(
+    needles.length,
+  ).fill(undefined);
+  const order = needles
+    .map((_, index) => index)
+    .sort((a, b) => compareNeedles(needles, a, b));
+  const cursor = new Cursor(encoded);
+  let line = 1;
+  let next = 0;
+  let source = 0;
+  let sourceLine = 0;
+  let sourceColumn = 0;
+  // The last segment with a source, as scalars: no per-segment allocation.
+  let lastGeneratedLine = 0;
+  let lastGeneratedColumn = 0;
+  let lastSource = -1;
+  let lastSourceLine = 0;
+  let lastSourceColumn = 0;
+  const resolve = (index: number): void => {
+    const file = lastSource < 0 ? null : sources[lastSource];
+    if (!file) return;
+    const needle = needles[index] as GeneratedPosition;
+    found[index] = {
+      file,
+      line: lastSourceLine + 1 + (needle.line - lastGeneratedLine),
+      column: Math.max(
+        0,
+        lastSourceColumn + (needle.column - lastGeneratedColumn),
+      ),
+    };
+  };
+  try {
+    while (!cursor.done && next < order.length) {
+      let generated = 0;
+      while (!cursor.done) {
+        const char = cursor.peek();
+        if (char === SEMICOLON) {
+          cursor.pos++;
+          break;
+        }
+        if (char === COMMA) {
+          cursor.pos++;
+          continue;
+        }
+        generated += cursor.readVlq();
+        if (cursor.atSegmentEnd()) continue;
+        source += cursor.readVlq();
+        sourceLine += cursor.readVlq();
+        sourceColumn += cursor.readVlq();
+        if (!cursor.atSegmentEnd()) cursor.readVlq();
+        // Every needle before this segment resolves against the previous.
+        while (next < order.length) {
+          const needle = needles[order[next] as number] as GeneratedPosition;
+          if (needle.line > line) break;
+          if (needle.line === line && needle.column >= generated) break;
+          resolve(order[next] as number);
+          next++;
+        }
+        lastGeneratedLine = line;
+        lastGeneratedColumn = generated;
+        lastSource = source;
+        lastSourceLine = sourceLine;
+        lastSourceColumn = sourceColumn;
+      }
+      line++;
+    }
+    for (; next < order.length; next++) resolve(order[next] as number);
+  } catch {
+    // Malformed VLQ: whatever was resolved before it stands.
+  }
+  return found;
+}

--- a/packages/runtime-client/src/sentry/source-map.fixture.ts
+++ b/packages/runtime-client/src/sentry/source-map.fixture.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build } from "esbuild";
+
+/**
+ * Test-only: a two-file TypeScript program bundled the way selfhost/bundle.mjs
+ * bundles the engine (external `.map`, no `sourcesContent`), so the mapper is
+ * exercised against real esbuild output rather than a hand-written map.
+ *
+ * `throwFromFixture` is over-indented on purpose: the generated column then
+ * differs from the original one, which is what catches a 0/1-based mix-up.
+ * `logFromFixture` routes through an `observability/logging.ts` so the
+ * reporter-frame trim has a mapped frame to pop.
+ *
+ * Emitted as CommonJS and loaded through Node's own `require`: vitest never
+ * sees the file, so nothing but the mapper under test can rewrite its frames.
+ */
+export const SITE_SOURCE = `import { emit } from "../observability/logging";
+export function throwFromFixture(): never {
+      throw new Error("fixture boom");
+}
+export function logFromFixture(sentry: { captureLog(level: "ERROR", values: unknown[]): void }): void {
+  emit(sentry, "fixture log site");
+}
+`;
+/** 1-based line of the \`throw\` in SITE_SOURCE. */
+export const THROW_LINE = 3;
+/** 1-based line of the \`emit(...)\` call in SITE_SOURCE. */
+export const LOG_LINE = 6;
+
+const LOGGING_SOURCE = `export function emit(sentry: { captureLog(level: "ERROR", values: unknown[]): void }, message: string): void {
+  sentry.captureLog("ERROR", [message]);
+}
+`;
+
+export interface FixtureBundle {
+  dir: string;
+  bundlePath: string;
+  mapPath: string;
+  sitePath: string;
+  loggingPath: string;
+}
+
+export async function buildFixtureBundle(): Promise<FixtureBundle> {
+  // realpath: esbuild writes `sources` relative to the REAL outdir, and macOS
+  // symlinks /var → /private/var.
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), "houston-sourcemap-"));
+  const sitePath = join(dir, "src", "app", "site.ts");
+  const loggingPath = join(dir, "src", "observability", "logging.ts");
+  mkdirSync(join(dir, "src", "app"), { recursive: true });
+  mkdirSync(join(dir, "src", "observability"), { recursive: true });
+  writeFileSync(sitePath, SITE_SOURCE);
+  writeFileSync(loggingPath, LOGGING_SOURCE);
+  const bundlePath = join(dir, "dist", "main.cjs");
+  await build({
+    entryPoints: [sitePath],
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    outfile: bundlePath,
+    sourcemap: "external",
+    sourcesContent: false,
+    logLevel: "silent",
+  });
+  return {
+    dir,
+    bundlePath,
+    mapPath: `${bundlePath}.map`,
+    sitePath,
+    loggingPath,
+  };
+}

--- a/packages/runtime-client/src/sentry/source-map.test.ts
+++ b/packages/runtime-client/src/sentry/source-map.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { SourceMap } from "node:module";
+import { dirname, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { BundleSourceMap, type GeneratedPosition } from "./source-map";
+import { buildFixtureBundle, type FixtureBundle } from "./source-map.fixture";
+
+let fixture: FixtureBundle;
+
+beforeAll(async () => {
+  fixture = await buildFixtureBundle();
+});
+
+afterAll(() => {
+  rmSync(fixture.dir, { recursive: true, force: true });
+});
+
+describe("BundleSourceMap", () => {
+  it("agrees with Node's own SourceMap.findOrigin on every generated position", () => {
+    // Node's decoder is what `--enable-source-maps` used to apply to stack
+    // traces; the streaming scan must give the same answer for every line
+    // and column of the bundle (including positions past the last segment
+    // of a line and on lines without segments, where Node extrapolates), or
+    // the mapped frames would silently drift from what pods reported before.
+    const map = BundleSourceMap.load(fixture.bundlePath);
+    expect(map).toBeDefined();
+    const oracle = new SourceMap(
+      JSON.parse(readFileSync(fixture.mapPath, "utf8")),
+    );
+    const lineCount = readFileSync(fixture.bundlePath, "utf8").split(
+      "\n",
+    ).length;
+    const needles: GeneratedPosition[] = [];
+    for (let line = 1; line <= lineCount; line++) {
+      for (const column of [0, 1, 2, 5, 6, 8, 12, 40]) {
+        needles.push({ line, column });
+      }
+    }
+    // Shuffle so the batch scan's sort-by-line is exercised too.
+    needles.sort(() => Math.random() - 0.5);
+    const found = (map as BundleSourceMap).lookup(needles);
+    let mapped = 0;
+    needles.forEach((needle, i) => {
+      const expected = oracle.findOrigin(needle.line, needle.column + 1);
+      const actual = found[i];
+      if (!("fileName" in expected)) {
+        expect(actual, `${needle.line}:${needle.column}`).toBeUndefined();
+        return;
+      }
+      mapped++;
+      expect(actual, `${needle.line}:${needle.column}`).toEqual({
+        file: resolve(dirname(fixture.mapPath), expected.fileName),
+        line: expected.lineNumber,
+        // Node lets a cross-line extrapolation go negative; the mapper clamps.
+        column: Math.max(0, expected.columnNumber - 1),
+      });
+    });
+    expect(mapped).toBeGreaterThan(10);
+    expect(found.some((p) => p?.file === fixture.sitePath)).toBe(true);
+    expect(found.some((p) => p?.file === fixture.loggingPath)).toBe(true);
+  });
+
+  it("needles before the first segment are unmapped; later ones extrapolate", () => {
+    // ";AAAA": no segment on generated line 1, one at line 2 col 0 → source
+    // 0 line 1 col 0. Node's rule carries the distance from the last segment
+    // over, so line 4 col 5 lands on source line 3 col 5.
+    const bundle = `${fixture.dir}/sparse.mjs`;
+    writeFileSync(
+      `${bundle}.map`,
+      JSON.stringify({ version: 3, sources: ["src/a.ts"], mappings: ";AAAA" }),
+    );
+    const map = BundleSourceMap.load(bundle) as BundleSourceMap;
+    expect(
+      map.lookup([
+        { line: 1, column: 0 },
+        { line: 2, column: 0 },
+        { line: 4, column: 5 },
+      ]),
+    ).toEqual([
+      undefined,
+      { file: `${fixture.dir}/src/a.ts`, line: 1, column: 0 },
+      { file: `${fixture.dir}/src/a.ts`, line: 3, column: 5 },
+    ]);
+    expect(map.lookup([])).toEqual([]);
+  });
+
+  it("load: missing map → undefined, never a throw", () => {
+    expect(BundleSourceMap.load("/nonexistent/main.mjs")).toBeUndefined();
+  });
+
+  it("load: a file that is not a v3 map → undefined", () => {
+    const bundle = `${fixture.dir}/notamap.mjs`;
+    writeFileSync(`${bundle}.map`, '{"version":2,"mappings":"AAAA"}');
+    expect(BundleSourceMap.load(bundle)).toBeUndefined();
+    writeFileSync(`${bundle}.map`, "{ this is not json");
+    expect(BundleSourceMap.load(bundle)).toBeUndefined();
+  });
+
+  it("lookup: a malformed mappings string keeps what was resolved before it", () => {
+    // Line 1 has two valid segments (col 0 → src line 1, col 1 → src line
+    // 2); line 2 is garbage. The needle between the two segments resolved
+    // before the scan hit the corruption and stands; the one on line 2 is
+    // left alone rather than guessed.
+    const bundle = `${fixture.dir}/broken.mjs`;
+    writeFileSync(
+      `${bundle}.map`,
+      JSON.stringify({
+        version: 3,
+        sources: ["src/ok.ts"],
+        mappings: "AAAA,CACA;!!!!",
+      }),
+    );
+    const map = BundleSourceMap.load(bundle) as BundleSourceMap;
+    expect(
+      map.lookup([
+        { line: 1, column: 0 },
+        { line: 2, column: 0 },
+      ]),
+    ).toEqual([
+      { file: `${fixture.dir}/src/ok.ts`, line: 1, column: 0 },
+      undefined,
+    ]);
+  });
+});

--- a/packages/runtime-client/src/sentry/source-map.ts
+++ b/packages/runtime-client/src/sentry/source-map.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type GeneratedPosition,
+  type OriginalPosition,
+  scanMappings,
+} from "./mappings-scan";
+
+export type { GeneratedPosition, OriginalPosition } from "./mappings-scan";
+
+/**
+ * On-demand reader for the `.map` esbuild writes beside each engine bundle
+ * (`dist/<host|runtime>/main.mjs.map`), used by the Sentry reporter to turn
+ * bundle offsets back into `.ts` locations (see map-frames.ts).
+ *
+ * Why neither `node --enable-source-maps` nor a decoder library: both decode
+ * EVERY segment of the map into JS arrays up front and keep them for the life
+ * of the process. Measured on the Node 22 image against the production maps
+ * (mappings only): +163 MB RSS on the host and +200 MB on the runtime, the
+ * same whether Node or `@jridgewell/trace-mapping` did the decoding. Errors
+ * are rare, so this keeps only the `mappings` string (6-8 MB) plus the
+ * resolved source paths and walks the string per lookup — a linear VLQ scan
+ * (~30 ms for a position near the end of the runtime bundle) that allocates
+ * nothing per segment. Total retained cost is ~25 MB per process.
+ */
+
+interface EncodedSourceMap {
+  version: 3;
+  sources: (string | null)[];
+  sourceRoot?: string;
+  mappings: string;
+}
+
+function isEncodedSourceMap(value: unknown): value is EncodedSourceMap {
+  if (typeof value !== "object" || value === null) return false;
+  const map = value as Partial<EncodedSourceMap>;
+  return (
+    map.version === 3 &&
+    typeof map.mappings === "string" &&
+    Array.isArray(map.sources)
+  );
+}
+
+function resolveSource(
+  mapDir: string,
+  sourceRoot: string | undefined,
+  source: string,
+): string {
+  if (source.startsWith("file://")) return fileURLToPath(source);
+  if (isAbsolute(source)) return source;
+  return resolve(mapDir, sourceRoot ?? "", source);
+}
+
+const MAPPINGS_KEY = '"mappings":"';
+
+/**
+ * Byte range of the `mappings` string value inside a compact (esbuild-style)
+ * map, or undefined for anything else — a pretty-printed map, or a value
+ * with an escape in it — which then takes the plain `JSON.parse` path.
+ * VLQ mappings are base64 plus `,` and `;`, so the first `"` after the
+ * opening one closes the value unless a `\` precedes it.
+ */
+function splitMappings(
+  raw: Buffer,
+): { start: number; end: number } | undefined {
+  const key = raw.indexOf(MAPPINGS_KEY);
+  if (key < 0) return undefined;
+  const start = key + MAPPINGS_KEY.length;
+  const end = raw.indexOf('"', start);
+  if (end < 0) return undefined;
+  const backslash = raw.indexOf("\\", start);
+  if (backslash >= 0 && backslash < end) return undefined;
+  return { start, end };
+}
+
+export class BundleSourceMap {
+  private readonly mappings: string;
+  private readonly sources: readonly (string | null)[];
+  private constructor(mappings: string, sources: readonly (string | null)[]) {
+    this.mappings = mappings;
+    this.sources = sources;
+  }
+
+  /**
+   * Read `<bundlePath>.map`. Returns undefined when the file is missing,
+   * unreadable, or not a v3 map — a crash reporter must never throw.
+   *
+   * The `mappings` value is sliced straight out of the file bytes rather
+   * than parsed: `JSON.parse` over the whole 6-8 MB map builds a graph V8
+   * frees but keeps as resident heap, ~30 MB of RSS for one call. Only the
+   * small remainder (version, sources, names) goes through the parser.
+   */
+  static load(bundlePath: string): BundleSourceMap | undefined {
+    const mapPath = `${bundlePath}.map`;
+    try {
+      const raw = readFileSync(mapPath);
+      const split = splitMappings(raw);
+      // `start` sits after the opening quote and `end` on the closing one,
+      // so head + tail is the same document with an empty `mappings`.
+      const parsed: unknown = JSON.parse(
+        split
+          ? raw.toString("utf8", 0, split.start) +
+              raw.toString("utf8", split.end)
+          : raw.toString("utf8"),
+      );
+      if (!isEncodedSourceMap(parsed)) return undefined;
+      const mappings = split
+        ? raw.toString("latin1", split.start, split.end)
+        : parsed.mappings;
+      const mapDir = dirname(mapPath);
+      const sources = parsed.sources.map((source) =>
+        source === null
+          ? null
+          : resolveSource(mapDir, parsed.sourceRoot, source),
+      );
+      return new BundleSourceMap(mappings, sources);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** See `scanMappings`: one pass per batch, Node's `findOrigin` rule. */
+  lookup(
+    needles: readonly GeneratedPosition[],
+  ): (OriginalPosition | undefined)[] {
+    return scanMappings(this.mappings, this.sources, needles);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260607.1
         version: 7.0.0-dev.20260607.1
+      esbuild:
+        specifier: 0.25.12
+        version: 0.25.12
       typescript:
         specifier: 6.0.3
         version: 6.0.3

--- a/selfhost/Dockerfile
+++ b/selfhost/Dockerfile
@@ -101,7 +101,7 @@ ENV NODE_ENV=production \
     HOUSTON_HOME=/data \
     HOUSTON_HOST_BIND=0.0.0.0 \
     HOUSTON_HOST_PORT=4318 \
-    HOUSTON_RUNTIME_COMMAND="node --enable-source-maps /app/dist/runtime/main.mjs"
+    HOUSTON_RUNTIME_COMMAND="node /app/dist/runtime/main.mjs"
 # HOUSTON_HOST_TOKEN is deliberately NOT defaulted: an unset token would leave the
 # host open to anyone who can reach the port. docker-compose.yml requires it.
 
@@ -115,10 +115,19 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
 
 # Exec form → node is PID 1 and gets SIGTERM from `docker stop`; local/main.ts
 # handles it (stops the scheduler/watcher and kills spawned runtimes).
-# --enable-source-maps applies the bundle's .map so stack traces (incl. Sentry
-# events) show original TS locations. Set per-command, not NODE_OPTIONS, so it
-# never leaks into node processes the agent's own bash tool runs.
-CMD ["node", "--enable-source-maps", "dist/host/main.mjs"]
+#
+# Deliberately NO --enable-source-maps (here or in HOUSTON_RUNTIME_COMMAND):
+# node decodes the whole .map into memory on the first stack trace and keeps
+# it — measured at +163 MB RSS on the host and +200 MB on the runtime, the
+# largest fixed cost of both processes. The maps still ship beside the bundles
+# and the Sentry reporter applies them per event, on demand
+# (packages/runtime-client/src/sentry/map-frames.ts), so Sentry keeps `.ts`
+# frames and code context. Stack traces in the logs show bundle offsets; map
+# one offline with the same map node would have used:
+#   node -e 'const {SourceMap}=require("node:module");const m=new SourceMap(
+#     JSON.parse(require("fs").readFileSync("/app/dist/host/main.mjs.map","utf8")));
+#     console.log(m.findOrigin(LINE, COLUMN))'
+CMD ["node", "dist/host/main.mjs"]
 
 FROM host-base AS engine-pod
 

--- a/selfhost/bundle.mjs
+++ b/selfhost/bundle.mjs
@@ -47,9 +47,10 @@ const shared = {
   banner,
   plugins: [externalNodeModules],
   logLevel: "info",
-  // External .map next to each bundle; node runs with --enable-source-maps
-  // (see the Dockerfile) so stack traces — and the Sentry events built from
-  // them — point at the original TS files instead of bundle offsets.
+  // External .map next to each bundle. Node does NOT load it (no
+  // --enable-source-maps, see the Dockerfile); the Sentry reporter reads it
+  // on demand so events point at the original TS files instead of bundle
+  // offsets.
   sourcemap: true,
 };
 


### PR DESCRIPTION
Fixes PRODUCT-1744.

## Root cause

Both engine processes (`dist/host/main.mjs` as PID 1 and every `dist/runtime/main.mjs` it spawns) ran under `node --enable-source-maps`. Node reads the whole `.map` at module load and, on the first stack trace that passes through the bundle, decodes every segment of `mappings` into JS arrays and keeps them for the life of the process. Sentry's `attachStacktrace` builds an Error for every logged error, so that happens within minutes of boot on every pod. The map only matters when an error event is built.

Measured on `node:22-bookworm-slim` against the production maps with `sourcesContent` stripped (the shape #1533 ships), RSS after the first stack trace:

| | no map | `--enable-source-maps` | `@jridgewell/trace-mapping` | this PR |
|--|--|--|--|--|
| host | 44 MB | 207 MB | 208 MB | 86 MB |
| runtime | 44 MB | 244 MB | 251 MB | 89 MB |

The ticket suggested `@jridgewell/trace-mapping`; it retains exactly as much as Node because it also decodes every segment into arrays, so it is not used.

## Fix

- `selfhost/Dockerfile`: the flag is gone from `CMD` and from `HOUSTON_RUNTIME_COMMAND`. The comment documents why and gives a one-liner (`node:module` `SourceMap.findOrigin`) to map a logged bundle offset offline. Log stack traces now show bundle offsets, as the ticket accepts.
- `packages/runtime-client/src/sentry/map-frames.ts`: a Sentry event processor, installed ahead of `trimReporterFrames` and `addSourceContext`, rewrites frames whose filename is the running bundle (`process.argv[1]`; never under Bun, where the sidecar has its own embedded map) to the original `.ts` path, line and column, and sets `in_app` false for frames that map into `node_modules`. The map is loaded on the first event that needs it, never at boot. Missing or unparsable maps leave frames untouched; nothing throws.
- `source-map.ts` + `mappings-scan.ts`: the map keeps only the `mappings` string (sliced straight out of the file bytes rather than `JSON.parse`-ing the whole document, which left ~30 MB of freed heap resident) and the resolved source paths. Each event does one streaming VLQ pass for all of its frames, ~22-30 ms for positions near the end of the runtime bundle, allocating nothing per segment, with a small position cache for repeated log sites. Lookup semantics are Node's own `findOrigin` (greatest segment at or before the position, offset carried over), so frames land exactly where `--enable-source-maps` put them.
- Reporter-frame trimming and on-disk source context are unchanged and still work: the mapper runs first, so `logging.ts` frames trim and `context_line` reads from the copied `packages/*` sources.

## Tests

- `source-map.test.ts` builds a two-file fixture with esbuild (external map, no `sourcesContent`) and checks the scan against Node's `SourceMap.findOrigin` for every line of the bundle at eight columns each, plus missing / non-v3 / malformed maps.
- `map-frames.test.ts` loads the fixture through Node's `require` (so vitest cannot map it first), throws from it and logs from it, and asserts the top frame is the `.ts` file at the right line and column, that the mapped `observability/logging.ts` frame is trimmed, that `context_line` is populated, that the cache path gives the same answer, and that a bundle without a map is left alone.

`pnpm check`, `pnpm -r typecheck`, `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain --filter @houston/runtime-client test` all green.

## Before

1. `docker build -t houston-engine --target engine-pod -f selfhost/Dockerfile .` from `main`, run it, `kubectl exec` / `docker exec` in and read `VmRSS` of PID 1 and the runtime child after the first logged error: roughly 447 MB / 258 MB (2026-09-09 fleet numbers, pre-#1533).
2. Reproducer without a pod: a two-line `.mjs` whose `//# sourceMappingURL=` points at `dist/host/main.mjs.map`, run with `node --enable-source-maps`, print `process.memoryUsage().rss` before and after `new Error().stack`: +163 MB (host map) / +200 MB (runtime map) on Node 22.

## After

1. Same image from this branch: `ps -o rss` on PID 1 and the runtime after an error event stays within ~45 MB of a process that never touched the map, instead of +163 / +200 MB.
2. Trigger an error on a staging pod (or `pnpm dev:staging`) and open the Sentry event: frames show `packages/host/src/...ts` / `packages/runtime/src/...ts` paths with code context, and the top frame of a logged error is the log site, not `observability/logging.ts`.
3. `pnpm --filter @houston/runtime-client test` passes the two new suites.

## Notes

- Pairs with #1533 (`sourcesContent: false`): with the full 28-35 MB maps the one-time load still parses the inlined sources transiently. Merge order does not matter for correctness.
- The cloud repo's pool-worker manifest still launches the runtime with `--enable-source-maps`; that is a separate change.
