### PR TITLE
fix(sdk): coalesce store notifications per task so a frame burst cannot trip React #185 (PRODUCT-1738)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260607.1",
     "esbuild": "0.25.12",
+    "jsdom": "29.1.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "typescript": "6.0.3",

--- a/packages/sdk/src/react/use-sdk-snapshot.burst.test.ts
+++ b/packages/sdk/src/react/use-sdk-snapshot.burst.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { createElement, useEffect, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ScopeStore } from "../store";
+import { useSdkSnapshot } from "./use-sdk-snapshot";
+
+/**
+ * The synthetic turn burst behind "Maximum update depth exceeded" (React
+ * #185): a stream hands the conversation VM one frame per microtask, and a
+ * subscriber whose passive effect mirrors the snapshot into local state — the
+ * everyday "derive state from the feed" shape — leaves default-lane work
+ * pending after each sync commit. Notified per publish, React counted 50+ of
+ * those commits as one nested chain and threw into `ScopeStore.publish`, which
+ * failed the turn. The binding must coalesce the burst into one render.
+ */
+
+// Real scheduling, not `act()`: the bug is precisely about how React batches
+// (or fails to batch) outside a test-controlled flush.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = false;
+
+const BURST = 120;
+
+function Probe({
+  store,
+  onRender,
+}: {
+  store: ScopeStore;
+  onRender: () => void;
+}) {
+  const snapshot = useSdkSnapshot<{ n: number }>(store, "conversation/x");
+  const [mirror, setMirror] = useState(0);
+  onRender();
+  useEffect(() => {
+    if (snapshot) setMirror(snapshot.n);
+  }, [snapshot]);
+  return createElement("output", null, `${snapshot?.n ?? "none"}/${mirror}`);
+}
+
+function settle(ms = 20): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("useSdkSnapshot under a microtask-gapped publish burst", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+  });
+  afterEach(() => {
+    root.unmount();
+    host.remove();
+  });
+
+  it("publishes every frame without tripping React's nested-update limit", async () => {
+    const store = new ScopeStore();
+    let renders = 0;
+    root = createRoot(host);
+    root.render(
+      createElement(Probe, {
+        store,
+        onRender: () => {
+          renders++;
+        },
+      }),
+    );
+    await settle();
+    const rendersBefore = renders;
+
+    // Each frame's publish is separated from the next by a microtask only —
+    // exactly how the SSE reader (`await onEvent(frame)`) drains a chunk.
+    for (let n = 1; n <= BURST; n++) {
+      store.publish("conversation/x", { n });
+      await Promise.resolve();
+    }
+    await settle();
+
+    // The publisher was never thrown into: the last frame landed and rendered.
+    expect(store.getSnapshot("conversation/x")).toEqual({ n: BURST });
+    expect(host.innerHTML).toBe(`<output>${BURST}/${BURST}</output>`);
+    // One coalesced notification (plus the mirror effect's own commit), not one
+    // sync render per frame.
+    expect(renders - rendersBefore).toBeLessThanOrEqual(4);
+  });
+});

--- a/packages/sdk/src/react/use-sdk-snapshot.test.ts
+++ b/packages/sdk/src/react/use-sdk-snapshot.test.ts
@@ -37,25 +37,55 @@ describe("snapshotStoreAdapter", () => {
     expect(adapter.getSnapshot()).toBe(second);
   });
 
-  it("notifies React's zero-arg callback on every publish to the scope", () => {
+  it("coalesces a burst of publishes into one React notification per task", async () => {
     const store = new ScopeStore();
     const adapter = snapshotStoreAdapter(store, "connection");
     const onStoreChange = vi.fn();
     const unsubscribe = adapter.subscribe(onStoreChange);
 
+    // A stream delivers frames with only microtask gaps between them: React
+    // must hear about the whole burst once, after the task settles — never
+    // once per publish (that is the nested-update chain React aborts, #185).
+    for (let i = 0; i < 60; i++) {
+      store.publish("connection", { online: i % 2 === 0 });
+      await Promise.resolve();
+    }
+    expect(onStoreChange).not.toHaveBeenCalled();
+    await nextTask();
+    expect(onStoreChange).toHaveBeenCalledTimes(1);
+
+    // A publish in a later task is its own notification.
     store.publish("connection", { online: true });
-    store.publish("connection", { online: false });
+    await nextTask();
     expect(onStoreChange).toHaveBeenCalledTimes(2);
 
     // A publish to an unrelated scope must not wake this subscriber.
     store.publish("agents", []);
+    await nextTask();
     expect(onStoreChange).toHaveBeenCalledTimes(2);
 
     unsubscribe();
-    store.publish("connection", { online: true });
+    store.publish("connection", { online: false });
+    await nextTask();
     expect(onStoreChange).toHaveBeenCalledTimes(2);
   });
+
+  it("drops a notification still in flight when React unsubscribes first", async () => {
+    const store = new ScopeStore();
+    const adapter = snapshotStoreAdapter(store, "connection");
+    const onStoreChange = vi.fn();
+    const unsubscribe = adapter.subscribe(onStoreChange);
+    store.publish("connection", { online: true });
+    unsubscribe();
+    await nextTask();
+    expect(onStoreChange).not.toHaveBeenCalled();
+  });
 });
+
+/** Resolve after the pending macrotasks (the adapter's deferred notify) ran. */
+function nextTask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 1));
+}
 
 describe("useSdkSnapshot (server render)", () => {
   it("renders undefined for an unpublished scope", () => {

--- a/packages/sdk/src/react/use-sdk-snapshot.ts
+++ b/packages/sdk/src/react/use-sdk-snapshot.ts
@@ -25,6 +25,20 @@ export interface SnapshotStoreAdapter<T> {
  * Build the external-store adapter that binds `scope` to `source`'s reactive
  * store. Framework-agnostic on purpose: the hook wraps it, tests drive it
  * directly.
+ *
+ * **One React notification per task, not per publish.** `useSyncExternalStore`
+ * answers every `onStoreChange` with a SYNC-lane render, and React 19 counts
+ * consecutive sync commits that leave other work pending (a passive effect's
+ * setState is default-lane work) as one nested-update chain — it never resets
+ * until a task boundary lets that work commit. A turn stream delivers frames
+ * with only microtask gaps (`await onEvent(frame)` per SSE frame, and a
+ * reconnect replay hands over dozens in one chunk), so notifying per publish
+ * runs 50+ sync commits inside one task and React throws "Maximum update
+ * depth exceeded" (#185) INTO the publisher — failing the turn. Deferring the
+ * notification to a macrotask coalesces the burst into one render; a
+ * microtask would not (it interleaves with the stream's own microtasks).
+ * `getSnapshot` stays synchronous, so any render in between already reads the
+ * latest value — the deferral only delays React learning it changed.
  */
 export function snapshotStoreAdapter<T>(
   source: SnapshotSource,
@@ -34,7 +48,22 @@ export function snapshotStoreAdapter<T>(
     // `useSyncExternalStore` hands us a zero-arg `onStoreChange`; the store's
     // subscriber receives the snapshot too, which we intentionally ignore —
     // React re-reads through `getSnapshot`.
-    subscribe: (onStoreChange) => source.subscribe(scope, onStoreChange),
+    subscribe: (onStoreChange) => {
+      let scheduled = false;
+      let live = true;
+      const unsubscribe = source.subscribe(scope, () => {
+        if (scheduled) return;
+        scheduled = true;
+        setTimeout(() => {
+          scheduled = false;
+          if (live) onStoreChange();
+        }, 0);
+      });
+      return () => {
+        live = false;
+        unsubscribe();
+      };
+    },
     getSnapshot: () => source.getSnapshot(scope) as T | undefined,
   };
 }

--- a/packages/sdk/src/store.test.ts
+++ b/packages/sdk/src/store.test.ts
@@ -116,6 +116,63 @@ describe("ScopeStore re-entrancy", () => {
   });
 });
 
+describe("ScopeStore listener isolation", () => {
+  it("a throwing subscriber neither unwinds publish nor starves its siblings", () => {
+    const deferred: Array<() => void> = [];
+    const spy = vi
+      .spyOn(globalThis, "queueMicrotask")
+      .mockImplementation((cb) => {
+        deferred.push(cb as () => void);
+      });
+    try {
+      const store = new ScopeStore();
+      const boom = new Error("Maximum update depth exceeded");
+      const sibling = vi.fn();
+      store.subscribe("conversation/a", () => {
+        throw boom;
+      });
+      store.subscribe("conversation/a", sibling);
+
+      // The publisher (the turn machinery mid-frame) must never see the error.
+      expect(() => store.publish("conversation/a", { n: 1 })).not.toThrow();
+      expect(store.getSnapshot("conversation/a")).toEqual({ n: 1 });
+      expect(sibling).toHaveBeenCalledWith({ n: 1 });
+
+      // …but it is not swallowed: it resurfaces on its own microtask, where
+      // the host's uncaught-error handler reports it.
+      expect(deferred).toHaveLength(1);
+      expect(() => deferred[0]?.()).toThrow(boom);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("a throwing event listener neither unwinds emitEvent nor starves its siblings", () => {
+    const deferred: Array<() => void> = [];
+    const spy = vi
+      .spyOn(globalThis, "queueMicrotask")
+      .mockImplementation((cb) => {
+        deferred.push(cb as () => void);
+      });
+    try {
+      const store = new ScopeStore();
+      const boom = new Error("listener bug");
+      const sibling = vi.fn();
+      store.onEvent(() => {
+        throw boom;
+      });
+      store.onEvent(sibling);
+      const event: SdkEvent = { type: "turn/started" };
+      expect(() => store.emitEvent(event)).not.toThrow();
+      expect(sibling).toHaveBeenCalledWith(event);
+      expect(deferred).toHaveLength(1);
+      expect(() => deferred[0]?.()).toThrow(boom);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe("ScopeStore events", () => {
   it("broadcasts events to all listeners and supports unsubscribe", () => {
     const store = new ScopeStore();

--- a/packages/sdk/src/store.ts
+++ b/packages/sdk/src/store.ts
@@ -43,6 +43,12 @@ export type EventListener = (event: SdkEvent) => void;
  * iteration. A listener removed during a `publish` is not observed on the
  * *next* publish; whether it still receives the in-flight notification is
  * unspecified (it is iterating a snapshot taken before it was removed).
+ *
+ * **Listener isolation.** A throwing listener never reaches the publisher or
+ * its sibling listeners: the snapshot is already stored, every other listener
+ * still runs, and the error is rethrown on its own microtask so it surfaces on
+ * the host's uncaught-error path (log + Sentry) instead of aborting the turn
+ * machinery mid-frame. A UI binding's failure is never the data flow's.
  */
 export class ScopeStore {
   private readonly snapshots = new Map<string, unknown>();
@@ -79,7 +85,13 @@ export class ScopeStore {
     this.snapshots.set(scope, snapshot);
     const subs = this.subscribers.get(scope);
     if (!subs || subs.size === 0) return;
-    for (const listener of [...subs]) listener(snapshot);
+    for (const listener of [...subs]) {
+      try {
+        listener(snapshot);
+      } catch (err) {
+        rethrowAsync(err);
+      }
+    }
   }
 
   /**
@@ -106,7 +118,13 @@ export class ScopeStore {
   /** Broadcast `event` to every global event listener. */
   emitEvent(event: SdkEvent): void {
     if (this.eventListeners.size === 0) return;
-    for (const listener of [...this.eventListeners]) listener(event);
+    for (const listener of [...this.eventListeners]) {
+      try {
+        listener(event);
+      } catch (err) {
+        rethrowAsync(err);
+      }
+    }
   }
 
   /**
@@ -119,4 +137,15 @@ export class ScopeStore {
       this.eventListeners.delete(cb);
     };
   }
+}
+
+/**
+ * Surface a listener's exception without unwinding through the notifier: a
+ * fresh microtask throws it, which lands on the process's uncaught-error
+ * handler (`window.onerror` in a browser) — reported, never swallowed.
+ */
+function rethrowAsync(err: unknown): void {
+  queueMicrotask(() => {
+    throw err;
+  });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,6 +626,9 @@ importers:
       esbuild:
         specifier: 0.25.12
         version: 0.25.12
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       react:
         specifier: 19.2.7
         version: 19.2.7


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1738: `unhandled_rejection: Maximum update depth exceeded` (React #185) thrown from `ScopeStore.publish` while a feed item is pushed.

### Root cause

- `useSyncExternalStore` answers every `onStoreChange` with a **sync-lane** render. React 19.2 counts consecutive sync commits that leave blocking-lane work pending (a passive effect's `setState` is default-lane work) as one nested-update chain, and that counter only resets once a task boundary lets the pending work commit. Each `getRootForUpdatedFiber` call checks the counter and throws #185 past 50.
- The SSE reader delivers frames with **microtask gaps only** (`await onEvent(frame)` in `packages/runtime-client/src/sse-read.ts`), so one chunk carrying 50+ frames (a reconnect replay with `?after=`, a tool-heavy turn on a machine that fell behind) produced 50+ sync commits inside one task. The 52nd publish threw #185 into the publisher, the frame handler error failed the turn ("Something went wrong"), and the failure settle's own publish threw again as an unhandled rejection. The sibling issue HOUSTON-APP-57V (a zustand `setDraftText` on a keystroke throwing #185 during a feed burst) is the same counter tripped from another store.
- Microtask batching in `MultiplexFeedOutput` would not help: it interleaves with the stream's own microtasks.

### Fix

- `snapshotStoreAdapter` (`packages/sdk/src/react/use-sdk-snapshot.ts`) defers React's `onStoreChange` to a macrotask and coalesces a burst into one notification. `getSnapshot` stays synchronous, so any render in between already reads the latest snapshot.
- `ScopeStore.publish` / `emitEvent` isolate a throwing listener: siblings still run, the publisher never unwinds, and the error is rethrown on its own microtask so the host's uncaught-error path (log, PostHog, Sentry) still reports it. A UI binding's failure never aborts the turn machinery mid-frame.

### Tests

- `packages/sdk/src/react/use-sdk-snapshot.burst.test.ts` (jsdom + real react-dom root): 120 publishes with microtask gaps and a derived-state effect. On the old adapter it fails with #185 after ~52 frames and 119 renders; now every frame lands with at most a handful of renders.
- `use-sdk-snapshot.test.ts`: coalescing contract and unsubscribe-before-notify.
- `store.test.ts`: listener isolation for `publish` and `emitEvent`.

`jsdom` added as an sdk devDependency (already in the lockfile via agentstore).

### Verify

Before (main):
```
cd packages/sdk && git show <this-branch>:packages/sdk/src/react/use-sdk-snapshot.burst.test.ts > src/react/burst.test.ts && pnpm vitest run src/react/burst.test.ts
```
Fails with `Maximum update depth exceeded` and `expected 119 to be less than or equal to 4`.

After:
```
pnpm --filter @houston/sdk test
pnpm check && pnpm --filter @houston/sdk typecheck && pnpm --filter houston-web typecheck && (cd app && pnpm tsgo --noEmit)
```
All pass. In the app: open a long tool-heavy chat, kill the connection mid-turn and let it reconnect (replay burst), or run a turn on a slow machine; the chat keeps streaming and no "Something went wrong" card appears. Sentry HOUSTON-APP-572 should stay quiet for two releases.
