### PR TITLE
fix(shell): the launch update check is one per process, not one per mount (PRODUCT-1752)

### DIFF
--- a/app/src/hooks/use-update-machine.ts
+++ b/app/src/hooks/use-update-machine.ts
@@ -11,6 +11,7 @@ import {
   type DownloadTally,
   EMPTY_DOWNLOAD_TALLY,
 } from "../lib/update-download-progress";
+import { claimLaunchCheck } from "../lib/update-launch-claim";
 import {
   shouldReportDownloadFailure,
   type UpdateCheckOutcome,
@@ -45,7 +46,6 @@ export function useUpdateMachine() {
   const statusRef = useRef<UpdateStatus>(status);
   const busyRef = useRef(false);
   const appPathRef = useRef<string | null>(null);
-  const firstCheckRef = useRef(true);
   const reportedDownloadFailureRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -56,10 +56,12 @@ export function useUpdateMachine() {
     outcome: UpdateCheckOutcome;
     message?: string;
   }> => {
-    // The first check of a run is the launch check: the user just opened the
-    // app and hasn't started working. Everything after is mid-session.
-    const origin: UpdateOrigin = firstCheckRef.current ? "launch" : "poll";
-    firstCheckRef.current = false;
+    // The first check of the PROCESS is the launch check: the user just
+    // opened the app and hasn't started working. Everything after is
+    // mid-session. Claimed outside React on purpose: this hook is remounted
+    // with <App/> on every identity change, and a per-mount flag would
+    // re-run the launch-time install on a user mid-task.
+    const origin: UpdateOrigin = claimLaunchCheck();
     if (busyRef.current || updateCheckBlocked(statusRef.current)) {
       return { outcome: "skipped" };
     }

--- a/app/src/lib/update-launch-claim.ts
+++ b/app/src/lib/update-launch-claim.ts
@@ -1,0 +1,43 @@
+import type { UpdateOrigin } from "./update-policy";
+
+/**
+ * Which update check is THE launch check: the first one this app process
+ * runs, and only that one.
+ *
+ * The updater hook is mounted inside `<App/>`, which React remounts as a
+ * matter of course: `IdentityKeyedApp` keys it by the signed-in uid and swaps
+ * in the splash while the session query is pending, so a session reset, a
+ * re-login or a signed-out gap all tear the tree down and build it again. A
+ * per-mount "first check" flag calls the first check after ANY of those a
+ * launch check, and a release the poll had just found mid-session (or finds a
+ * second later) lands behind the upgrading overlay: the install-now path the
+ * background policy exists to keep away from a working user.
+ *
+ * The claim therefore lives outside React: at module scope, which survives a
+ * remount, and in `sessionStorage`, which survives a webview reload. Neither
+ * outlives the process (a new app launch starts a fresh session), so the
+ * launch check is exactly one check per launch.
+ */
+const STORAGE_KEY = "houston.updater.launch-check-claimed";
+let claimedInMemory = false;
+
+function storage(): Storage | null {
+  return typeof sessionStorage === "undefined" ? null : sessionStorage;
+}
+
+/** Hands the launch origin to the first caller of this process and the
+ *  mid-session origin to every caller after it. */
+export function claimLaunchCheck(): UpdateOrigin {
+  const store = storage();
+  if (claimedInMemory || store?.getItem(STORAGE_KEY) === "1") return "poll";
+  claimedInMemory = true;
+  store?.setItem(STORAGE_KEY, "1");
+  return "launch";
+}
+
+/** Forgets the claim (memory and session), so a test starts as a fresh
+ *  process. */
+export function resetLaunchCheckClaimForTests(): void {
+  claimedInMemory = false;
+  storage()?.removeItem(STORAGE_KEY);
+}

--- a/app/src/lib/update-policy.ts
+++ b/app/src/lib/update-policy.ts
@@ -7,7 +7,10 @@
  * - `launch` — the launch check found it. Nothing is running yet, so the
  *   install runs right away behind a calm "upgrading Houston" overlay and the
  *   app relaunches into the new version. This is what keeps the fleet fresh:
- *   every update lands on the next app open at the latest.
+ *   every update lands on the next app open at the latest. The launch check
+ *   is the first check of the app PROCESS (`update-launch-claim.ts`), never
+ *   the first check of a hook mount: React remounts the updater with
+ *   `<App/>` on every identity change, and that must not re-arm it.
  * - `poll` — a background re-check found it mid-session. The release
  *   downloads silently; nothing is shown until it is on disk. Then a small
  *   "Restart to update" pill sits in the window corner and the user restarts

--- a/app/tests/update-launch-claim.test.ts
+++ b/app/tests/update-launch-claim.test.ts
@@ -1,0 +1,76 @@
+import { strictEqual } from "node:assert";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  claimLaunchCheck,
+  resetLaunchCheckClaimForTests,
+} from "../src/lib/update-launch-claim.ts";
+
+/** A `sessionStorage` stand-in: the node runner has none, and the claim must
+ *  behave the same with and without one. */
+function installSessionStorage(): Map<string, string> {
+  const backing = new Map<string, string>();
+  const fake = {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      backing.set(key, value);
+    },
+    removeItem: (key: string) => {
+      backing.delete(key);
+    },
+  };
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: fake,
+    configurable: true,
+    writable: true,
+  });
+  return backing;
+}
+
+function uninstallSessionStorage(): void {
+  Reflect.deleteProperty(globalThis, "sessionStorage");
+}
+
+// The launch check is the first check of the PROCESS. The hook that runs it
+// is remounted with <App/> on every identity change, so "first check since
+// mount" would turn a mid-session find into a launch-time install.
+describe("claimLaunchCheck", () => {
+  beforeEach(() => {
+    uninstallSessionStorage();
+    resetLaunchCheckClaimForTests();
+  });
+  afterEach(() => {
+    resetLaunchCheckClaimForTests();
+    uninstallSessionStorage();
+  });
+
+  it("hands the first check of a process the launch origin", () => {
+    strictEqual(claimLaunchCheck(), "launch");
+  });
+
+  it("calls every later check mid-session, a remount of the hook included", () => {
+    strictEqual(claimLaunchCheck(), "launch");
+    // The hook's own state is gone after a remount; the claim is not.
+    strictEqual(claimLaunchCheck(), "poll");
+    strictEqual(claimLaunchCheck(), "poll");
+  });
+
+  it("records the claim in sessionStorage so a webview reload stays mid-session", () => {
+    const backing = installSessionStorage();
+    strictEqual(claimLaunchCheck(), "launch");
+    strictEqual(backing.get("houston.updater.launch-check-claimed"), "1");
+  });
+
+  it("honours a claim left by the previous page of the same session", () => {
+    const backing = installSessionStorage();
+    // A reload drops module state but keeps the session; the claim must hold.
+    backing.set("houston.updater.launch-check-claimed", "1");
+    strictEqual(claimLaunchCheck(), "poll");
+  });
+
+  it("starts over for a fresh process", () => {
+    installSessionStorage();
+    strictEqual(claimLaunchCheck(), "launch");
+    resetLaunchCheckClaimForTests();
+    strictEqual(claimLaunchCheck(), "launch");
+  });
+});


### PR DESCRIPTION
## Summary

PRODUCT-1752. A cloud desktop app on 0.6.20 showed the full-screen "Actualizando Houston" overlay for the 0.6.21 release instead of downloading it in the background and offering the "Restart to update" pill.

**Root cause.** `useUpdateMachine` decided "launch check vs mid-session check" with a `useRef` inside the hook, so the first check after *any* mount of the hook counted as the launch check. The hook lives inside `<App/>`, which is remounted on every identity change (`IdentityKeyedApp` keys it by uid and renders the splash while the session query is pending). In today's frontend log the poll found 0.6.21 seconds after the manifest went live, then `<App/>` remounted (the session-events listener, a mount-only effect of `<App/>`, re-registered), and the fresh hook ran a "launch" check that found the same release and installed it behind the overlay, on top of a working session.

**Fix.** The launch claim lives outside React: a module-level flag (survives a remount) mirrored in `sessionStorage` (survives a webview reload). Neither outlives the process, so exactly one check per app launch is the launch check. Everything after downloads silently and ends in the restart pill, as the policy intends. A genuine fresh launch after a publish still shows the overlay, by design.

## Verification

Before the fix (0.6.20, or `main` without this PR):
1. Run the packaged cloud app while a newer `cloud-v*` release is published.
2. Trigger an `<App/>` remount after the poll has found the release: sign out and back in, or force a session reset (any `resetForIdentityChange()` path).
3. The upgrading overlay appears and the install starts, killing the running session.

After the fix:
1. Same setup. After the remount the check runs again with the mid-session origin: nothing is shown while the download runs, then the "Restart to update" pill appears in the top strip. No overlay, no forced relaunch.
2. Quit and reopen the app: the launch check shows the overlay and installs, as before.

Unit tests: `app/tests/update-launch-claim.test.ts` covers first-call launch origin, every later call (a remount) being mid-session, the `sessionStorage` mirror, and a fresh-process reset.

Checks run: `pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (4218 pass), `pnpm --filter houston-web typecheck`.
