### PR TITLE
fix(usage): settle a rate-limit window whose reset has passed

### DIFF
--- a/app/src/components/ai-hub/connected-providers-strip.tsx
+++ b/app/src/components/ai-hub/connected-providers-strip.tsx
@@ -11,6 +11,7 @@ import {
   matchUsageToProviders,
   type UsageFetchState,
 } from "./provider-usage-model";
+import { formatReadingAge } from "./provider-usage-window";
 
 /**
  * How many connected accounts the strip previews at rest.
@@ -66,7 +67,7 @@ export function ConnectedProvidersStrip({
   searching: boolean;
   onOpen: (provider: ProviderInfo) => void;
 }) {
-  const { t } = useTranslation("aiHub");
+  const { t, i18n } = useTranslation("aiHub");
   const [expanded, setExpanded] = useState(false);
   // The strip's MOUNT is not the gate: this list means "the user's accounts",
   // which by design includes the ones whose probe could not be confirmed, and
@@ -76,7 +77,12 @@ export function ConnectedProvidersStrip({
     () => hasConfirmedAccount(providers, connectionState),
     [providers, connectionState],
   );
-  const { data: usageRows, isLoading, isError } = useProviderUsage(enabled);
+  const {
+    data: usageRows,
+    isLoading,
+    isError,
+    dataUpdatedAt,
+  } = useProviderUsage(enabled);
   // TanStack keeps the last good `data` through a failed BACKGROUND refetch, so
   // a single blip must not blank every meter on the strip: the rows only fall
   // back to the honest error note when there is nothing to show at all.
@@ -85,6 +91,13 @@ export function ConnectedProvidersStrip({
     : isError && !usageRows
       ? "error"
       : "ready";
+  // ...but a retained reading is not a live one. While the refetch keeps
+  // failing (an asleep pod, the device offline) the meters would otherwise
+  // present hours-old numbers as current, so the strip dates them.
+  const staleReadingAge =
+    isError && usageRows
+      ? formatReadingAge(dataUpdatedAt, i18n.language)
+      : null;
 
   // A live query shows every match; at rest the strip caps its rows so a full
   // strip never pushes the discovery tabs below the fold.
@@ -118,6 +131,11 @@ export function ConnectedProvidersStrip({
         <CatalogShowMore onClick={() => setExpanded(true)}>
           {t("search.showAll", { count: providers.length })}
         </CatalogShowMore>
+      )}
+      {staleReadingAge && (
+        <p className="mt-2 text-xs text-ink-muted" role="status">
+          {t("providerUsage.staleReading", { when: staleReadingAge })}
+        </p>
       )}
     </div>
   );

--- a/app/src/components/ai-hub/provider-usage-meters.tsx
+++ b/app/src/components/ai-hub/provider-usage-meters.tsx
@@ -11,6 +11,7 @@ import {
   formatTokensAmount,
   type UsageSlot,
 } from "./provider-usage-model";
+import { settleUsageWindow } from "./provider-usage-window";
 
 type Translate = (key: string, options?: Record<string, unknown>) => string;
 
@@ -140,7 +141,7 @@ function MeteredTokens({
 }
 
 function UsageWindowBar({
-  window: w,
+  window,
   locale,
   t,
 }: {
@@ -148,6 +149,9 @@ function UsageWindowBar({
   locale: string;
   t: Translate;
 }) {
+  // A reading ages on screen between polls: a window whose reset passed since
+  // the last fetch has rolled over and reads 0%, not its last percentage.
+  const w = settleUsageWindow(window);
   const percent = Math.round(w.usedPercent);
   const when = formatResetWhen(w.resetsAt, locale);
   return (

--- a/app/src/components/ai-hub/provider-usage-window.ts
+++ b/app/src/components/ai-hub/provider-usage-window.ts
@@ -1,0 +1,41 @@
+import type { ProviderUsageWindow } from "@houston-ai/engine-client";
+
+/**
+ * Render-time settling of ONE rate-limit window on the AI Models hub's
+ * Connected strip. The engine already settles a window the provider reports
+ * past its own reset (`packages/runtime/src/ai/usage/types.ts`), but a reading
+ * AGES on screen: the strip polls every five minutes, keeps the last reading
+ * through a failed refetch, and the hub stays mounted while hidden. A 5h window
+ * whose reset instant passed since the last successful fetch has rolled over
+ * (the next request opens a fresh one at 0%), so the bar must not keep drawing
+ * the percentage of a window that no longer exists next to no reset note. Pure
+ * so it unit-tests under node:test (app/tests/ai-hub-usage-window.test.ts).
+ */
+export function settleUsageWindow(
+  window: ProviderUsageWindow,
+  now: number = Date.now(),
+): ProviderUsageWindow {
+  if (window.resetsAt === null) return window;
+  const resetAt = Date.parse(window.resetsAt);
+  if (Number.isNaN(resetAt) || resetAt > now) return window;
+  return { ...window, usedPercent: 0, resetsAt: null };
+}
+
+/**
+ * A localized "3 hours ago" phrase for when the strip's retained reading was
+ * fetched, so a reading the poll could not refresh is dated instead of shown
+ * as live. Null for a junk instant (the note then omits its age).
+ */
+export function formatReadingAge(
+  fetchedAt: number,
+  locale: string,
+  now: number = Date.now(),
+): string | null {
+  if (!Number.isFinite(fetchedAt) || fetchedAt <= 0) return null;
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "always" });
+  const minutes = Math.max(1, Math.round((now - fetchedAt) / 60_000));
+  if (minutes < 60) return rtf.format(-minutes, "minute");
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return rtf.format(-hours, "hour");
+  return rtf.format(-Math.round(hours / 24), "day");
+}

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -156,7 +156,8 @@
     "noData": "This account reports no limits right now.",
     "notMeteredYet": "No usage yet. Houston will start measuring with your next message.",
     "reconnect": "Sign in again to see this account's usage.",
-    "error": "Couldn't load usage right now. Try again in a moment."
+    "error": "Couldn't load usage right now. Try again in a moment.",
+    "staleReading": "Couldn't refresh usage. Showing the reading from {{when}}."
   },
   "timeWorked": {
     "range": {

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -156,7 +156,8 @@
     "noData": "Esta cuenta no reporta límites por ahora.",
     "notMeteredYet": "Aún no hay uso. Houston empezará a medir con tu próximo mensaje.",
     "reconnect": "Inicia sesión de nuevo para ver el uso de esta cuenta.",
-    "error": "No pudimos cargar el uso. Intenta de nuevo en un momento."
+    "error": "No pudimos cargar el uso. Intenta de nuevo en un momento.",
+    "staleReading": "No pudimos actualizar el uso. Mostramos la lectura de {{when}}."
   },
   "timeWorked": {
     "range": {

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -156,7 +156,8 @@
     "noData": "Esta conta não reporta limites no momento.",
     "notMeteredYet": "Ainda não há uso. A Houston vai começar a medir com a sua próxima mensagem.",
     "reconnect": "Entre novamente para ver o uso desta conta.",
-    "error": "Não foi possível carregar o uso. Tente de novo em instantes."
+    "error": "Não foi possível carregar o uso. Tente de novo em instantes.",
+    "staleReading": "Não foi possível atualizar o uso. Mostrando a leitura de {{when}}."
   },
   "timeWorked": {
     "range": {

--- a/app/tests/ai-hub-usage-window.test.ts
+++ b/app/tests/ai-hub-usage-window.test.ts
@@ -1,0 +1,67 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { ProviderUsageWindow } from "@houston-ai/engine-client";
+import {
+  formatReadingAge,
+  settleUsageWindow,
+} from "../src/components/ai-hub/provider-usage-window.ts";
+
+describe("settleUsageWindow", () => {
+  const now = Date.parse("2026-09-10T13:46:00Z");
+  const live: ProviderUsageWindow = {
+    id: "session",
+    usedPercent: 49,
+    resetsAt: "2026-09-10T18:40:00Z",
+    windowMinutes: 300,
+  };
+
+  it("keeps a live window as the engine reported it", () => {
+    strictEqual(settleUsageWindow(live, now), live);
+  });
+
+  it("keeps a window with no reset instant, and one with a junk instant", () => {
+    const noReset = { ...live, resetsAt: null };
+    strictEqual(settleUsageWindow(noReset, now), noReset);
+    const junk = { ...live, resetsAt: "garbage" };
+    strictEqual(settleUsageWindow(junk, now), junk);
+  });
+
+  it("draws a window whose reset has passed as empty, not as its last percent", () => {
+    // The stuck strip: "49% used" with no reset note, hours after the 5h window
+    // reset. The reset note was already omitted for a past instant; the bar and
+    // percent must roll over with it.
+    deepStrictEqual(
+      settleUsageWindow({ ...live, resetsAt: "2026-09-10T07:00:00Z" }, now),
+      { id: "session", usedPercent: 0, resetsAt: null, windowMinutes: 300 },
+    );
+    deepStrictEqual(
+      settleUsageWindow({ ...live, resetsAt: "2026-09-10T13:46:00Z" }, now),
+      { id: "session", usedPercent: 0, resetsAt: null, windowMinutes: 300 },
+    );
+  });
+});
+
+describe("formatReadingAge", () => {
+  const now = Date.parse("2026-09-10T13:46:00Z");
+
+  it("localizes the age at minute/hour/day granularity", () => {
+    strictEqual(
+      formatReadingAge(Date.parse("2026-09-10T13:40:00Z"), "en", now),
+      "6 minutes ago",
+    );
+    strictEqual(
+      formatReadingAge(Date.parse("2026-09-10T08:46:00Z"), "en", now),
+      "5 hours ago",
+    );
+    strictEqual(
+      formatReadingAge(Date.parse("2026-09-07T13:46:00Z"), "en", now),
+      "3 days ago",
+    );
+  });
+
+  it("never says 0 minutes, and answers null for a junk instant", () => {
+    strictEqual(formatReadingAge(now, "en", now), "1 minute ago");
+    strictEqual(formatReadingAge(0, "en", now), null);
+    strictEqual(formatReadingAge(Number.NaN, "en", now), null);
+  });
+});

--- a/packages/runtime/src/ai/usage/anthropic.ts
+++ b/packages/runtime/src/ai/usage/anthropic.ts
@@ -10,6 +10,7 @@ import {
   clampPercent,
   type ProviderUsage,
   type ProviderUsageWindow,
+  settleWindow,
 } from "./types";
 
 /**
@@ -118,10 +119,14 @@ function toWindow(
   };
 }
 
-/** Fetch the connected Claude account's usage windows. */
+/**
+ * Fetch the connected Claude account's usage windows. A window the API still
+ * reports past its own reset is settled to empty (`settleWindow`).
+ */
 export async function fetchAnthropicUsage(
   fetchImpl: typeof fetch = fetch,
   resolveToken: () => Promise<string | null> = resolveAnthropicToken,
+  now: () => number = Date.now,
 ): Promise<ProviderUsage> {
   const provider = "anthropic";
   const token = await resolveToken();
@@ -155,11 +160,13 @@ export async function fetchAnthropicUsage(
     toWindow("session", body.five_hour, 300),
     toWindow("week", body.seven_day, 10_080),
     toWindow("week_opus", body.seven_day_opus, 10_080),
-  ].filter((w): w is ProviderUsageWindow => w !== null);
+  ]
+    .filter((w): w is ProviderUsageWindow => w !== null)
+    .map((w) => settleWindow(w, now()));
   return {
     provider,
     status: "ok",
     windows,
-    fetchedAt: new Date().toISOString(),
+    fetchedAt: new Date(now()).toISOString(),
   };
 }

--- a/packages/runtime/src/ai/usage/codex.ts
+++ b/packages/runtime/src/ai/usage/codex.ts
@@ -4,6 +4,7 @@ import {
   epochSecondsToIso,
   type ProviderUsage,
   type ProviderUsageWindow,
+  settleWindow,
 } from "./types";
 
 /**
@@ -52,10 +53,14 @@ function toWindow(
   };
 }
 
-/** Fetch the connected Codex account's rate-limit windows. */
+/**
+ * Fetch the connected Codex account's rate-limit windows. A window the API
+ * still reports past its own reset is settled to empty (`settleWindow`).
+ */
 export async function fetchCodexUsage(
   fetchImpl: typeof fetch = fetch,
   store: Pick<KeyStore, "get" | "getApiKey"> = keyStore,
+  now: () => number = Date.now,
 ): Promise<ProviderUsage> {
   const provider = "openai-codex";
   // getApiKey auto-refreshes the OAuth token under the store's serialized
@@ -96,7 +101,9 @@ export async function fetchCodexUsage(
   const windows = [
     toWindow(body.rate_limit?.primary_window, "session"),
     toWindow(body.rate_limit?.secondary_window, "week"),
-  ].filter((w): w is ProviderUsageWindow => w !== null);
+  ]
+    .filter((w): w is ProviderUsageWindow => w !== null)
+    .map((w) => settleWindow(w, now()));
   return {
     provider,
     status: "ok",
@@ -104,6 +111,6 @@ export async function fetchCodexUsage(
     ...(typeof body.plan_type === "string" && body.plan_type
       ? { plan: body.plan_type }
       : {}),
-    fetchedAt: new Date().toISOString(),
+    fetchedAt: new Date(now()).toISOString(),
   };
 }

--- a/packages/runtime/src/ai/usage/types.ts
+++ b/packages/runtime/src/ai/usage/types.ts
@@ -6,6 +6,8 @@
  * fetcher normalizes provider payloads with.
  */
 
+import type { ProviderUsageWindow } from "@houston/runtime-client";
+
 export type {
   ProviderUsage,
   ProviderUsageCredits,
@@ -26,4 +28,24 @@ export function epochSecondsToIso(value: unknown): string | null {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0)
     return null;
   return new Date(value * 1000).toISOString();
+}
+
+/**
+ * A window whose reset instant has already passed has ROLLED OVER: the next
+ * request opens a fresh window at 0%, so the utilization the provider still
+ * reports for it describes a window that no longer exists. Both subscription
+ * usage APIs keep answering with the previous window until the account makes
+ * another request, and the strip drew that as "49% used" / "100% used" with
+ * no reset note, hours after both windows had reset. Report the window as
+ * empty with no reset scheduled instead (Claude's own /usage and CodexBar
+ * both drop an elapsed window rather than draw it).
+ */
+export function settleWindow(
+  window: ProviderUsageWindow,
+  now: number,
+): ProviderUsageWindow {
+  if (window.resetsAt === null) return window;
+  const resetAt = Date.parse(window.resetsAt);
+  if (Number.isNaN(resetAt) || resetAt > now) return window;
+  return { ...window, usedPercent: 0, resetsAt: null };
 }

--- a/packages/runtime/src/ai/usage/usage.test.ts
+++ b/packages/runtime/src/ai/usage/usage.test.ts
@@ -4,7 +4,7 @@ import { fetchCodexUsage } from "./codex";
 import { fetchCopilotUsage } from "./copilot";
 import { fetchDeepSeekUsage, fetchOpenRouterUsage } from "./credits";
 import { listProviderUsage } from "./index";
-import { clampPercent, epochSecondsToIso } from "./types";
+import { clampPercent, epochSecondsToIso, settleWindow } from "./types";
 
 function jsonResponse(body: unknown, status = 200): typeof fetch {
   return async () =>
@@ -15,6 +15,8 @@ function jsonResponse(body: unknown, status = 200): typeof fetch {
 }
 
 const someToken = async () => "tok-123";
+/** A clock BEFORE every fixture's reset instant, so live windows stay live. */
+const beforeFixtures = () => Date.parse("2026-07-01T00:00:00Z");
 
 describe("fetchAnthropicUsage", () => {
   it("maps the five_hour / seven_day / opus blocks to windows", async () => {
@@ -25,6 +27,7 @@ describe("fetchAnthropicUsage", () => {
         seven_day_opus: null,
       }),
       someToken,
+      beforeFixtures,
     );
     expect(row.status).toBe("ok");
     expect(row.windows).toEqual([
@@ -58,6 +61,31 @@ describe("fetchAnthropicUsage", () => {
     const row = await fetchAnthropicUsage(jsonResponse({}, 500), someToken);
     expect(row.status).toBe("error");
     expect(row.message).toContain("500");
+  });
+
+  it("settles a window the API still reports past its own reset", async () => {
+    // The stuck-strip shape: hours after the 5h window reset, the API keeps
+    // answering with the previous window (49%, a reset instant in the past)
+    // until the account's next request. The weekly lane is still live.
+    const now = Date.parse("2026-09-10T13:46:00Z");
+    const row = await fetchAnthropicUsage(
+      jsonResponse({
+        five_hour: { utilization: 49, resets_at: "2026-09-10T07:00:00Z" },
+        seven_day: { utilization: 65, resets_at: "2026-09-11T00:00:00Z" },
+      }),
+      someToken,
+      () => now,
+    );
+    expect(row.windows).toEqual([
+      { id: "session", usedPercent: 0, resetsAt: null, windowMinutes: 300 },
+      {
+        id: "week",
+        usedPercent: 65,
+        resetsAt: "2026-09-11T00:00:00Z",
+        windowMinutes: 10_080,
+      },
+    ]);
+    expect(row.fetchedAt).toBe(new Date(now).toISOString());
   });
 });
 
@@ -98,7 +126,7 @@ describe("fetchCodexUsage", () => {
         { status: 200 },
       );
     };
-    const row = await fetchCodexUsage(fetchImpl, store);
+    const row = await fetchCodexUsage(fetchImpl, store, beforeFixtures);
     expect(sawAccountHeader).toBe(true);
     expect(row.status).toBe("ok");
     expect(row.plan).toBe("pro");
@@ -115,6 +143,76 @@ describe("fetchCodexUsage", () => {
       getApiKey: async () => undefined,
     });
     expect(row.status).toBe("unauthenticated");
+  });
+
+  it("settles an exhausted session window whose reset has passed", async () => {
+    // "100% used" with a reset instant behind us is the previous window; the
+    // next request opens a fresh one, so the honest reading is empty.
+    const now = 1_784_100_000_000;
+    const row = await fetchCodexUsage(
+      jsonResponse({
+        rate_limit: {
+          primary_window: {
+            used_percent: 100,
+            reset_at: 1_784_000_000,
+            limit_window_seconds: 18_000,
+          },
+          secondary_window: {
+            used_percent: 20,
+            reset_at: 1_784_500_000,
+            limit_window_seconds: 604_800,
+          },
+        },
+      }),
+      store,
+      () => now,
+    );
+    expect(row.windows).toEqual([
+      { id: "session", usedPercent: 0, resetsAt: null, windowMinutes: 300 },
+      {
+        id: "week",
+        usedPercent: 20,
+        resetsAt: new Date(1_784_500_000 * 1000).toISOString(),
+        windowMinutes: 10_080,
+      },
+    ]);
+  });
+});
+
+describe("settleWindow", () => {
+  const now = Date.parse("2026-09-10T12:00:00Z");
+  const live = {
+    id: "session" as const,
+    usedPercent: 49,
+    resetsAt: "2026-09-10T15:00:00Z",
+  };
+
+  it("leaves a live window, a window with no reset, and junk alone", () => {
+    expect(settleWindow(live, now)).toBe(live);
+    const noReset = { ...live, resetsAt: null };
+    expect(settleWindow(noReset, now)).toBe(noReset);
+    const junk = { ...live, resetsAt: "garbage" };
+    expect(settleWindow(junk, now)).toBe(junk);
+  });
+
+  it("empties a window at and after its reset instant", () => {
+    const atReset = { ...live, resetsAt: "2026-09-10T12:00:00Z" };
+    expect(settleWindow(atReset, now)).toEqual({
+      id: "session",
+      usedPercent: 0,
+      resetsAt: null,
+    });
+    const past = {
+      ...live,
+      resetsAt: "2026-09-10T07:00:00Z",
+      windowMinutes: 300,
+    };
+    expect(settleWindow(past, now)).toEqual({
+      id: "session",
+      usedPercent: 0,
+      resetsAt: null,
+      windowMinutes: 300,
+    });
   });
 });
 


### PR DESCRIPTION
Closes [PRODUCT-1753](https://linear.app/houston-ai/issue/PRODUCT-1753)

## What the user saw

A WhatsApp report (2026-09-10 08:46): the AI Models hub's Connected strip had been "stuck since yesterday". Anthropic read **Session limit 49% used** with no reset note; OpenAI read **Session limit 100% used** with no reset note. At the same minute the Claude app showed the 5h limit at **0%** and the Codex app showed a fresh 5h window at 2% used (resets 13:43). Both weekly rows matched the provider apps exactly.

## Why

The missing reset note is the tell: `formatResetWhen` already omits the note for a `resetsAt` in the past, but the bar and "% used" beside it still rendered the window's last `usedPercent`. A 5h window whose reset instant has passed has rolled over (the next request opens a fresh one at 0%), so drawing its previous percentage is wrong however it got there. Two paths put one on screen:

1. Neither `fetchAnthropicUsage` nor `fetchCodexUsage` looked at `resets_at` / `reset_at`; a payload still carrying the previous window went through verbatim. CodexBar (same two endpoints) drops a window whose `resetsAt <= now` (`ClaudeSwapAccountProjection.unexpiredWindow`) and treats already-elapsed reset metadata as a stale post-reset snapshot.
2. A reading ages on screen: the strip polls every 5 minutes, keeps the last reading through a failed refetch by design, and the hub stays mounted while hidden. A probe against an asleep pod answers 503 inside the client's 10s retry budget, so the poll fails and the old numbers stay up with nothing saying they are old.

Verified today against both live APIs with my own credentials that the fetchers and mapping are right for a live window; the bug only shows once a window's reset has elapsed, which was exactly the reporter's state.

## Fix

- **runtime**: `settleWindow` in `packages/runtime/src/ai/usage/types.ts`; both fetchers map their windows through it with an injectable clock. A window at or past its reset becomes `usedPercent: 0, resetsAt: null`. Weekly lanes and windows with no reset are untouched.
- **app**: `settleUsageWindow` (new `provider-usage-window.ts`) applies the same rule at render time in `UsageWindowBar`.
- **app**: when a background refetch fails and the strip is showing a retained reading, a muted line under the strip dates it ("Couldn't refresh usage. Showing the reading from 5 hours ago."), en/es/pt.

## Tests

- `usage.test.ts`: rolled-over five_hour / primary_window settle to 0% with no reset while the weekly lane stays live; `settleWindow` edge cases (at-reset, past, junk, null). Existing fixtures now pin a clock before their July reset instants.
- `app/tests/ai-hub-usage-window.test.ts`: `settleUsageWindow` + `formatReadingAge`.

`pnpm check`, runtime vitest (244 files), `app tsgo`, `app pnpm test` (4218), `check-locales` all green.
