### PR TITLE
fix(host): type skills.sh timeouts and cancel abandoned community searches (PRODUCT-1728)

### DIFF
--- a/app/src/components/agent/use-skill-surface-labels.ts
+++ b/app/src/components/agent/use-skill-surface-labels.ts
@@ -96,6 +96,7 @@ export function useSkillMarketplaceSectionLabels(): SkillMarketplaceSectionLabel
     noResults: (query: string) => t("store.noResults", { query }),
     searchRateLimited: t("store.searchRateLimited"),
     searchOffline: t("store.searchOffline"),
+    searchSlow: t("store.searchSlow"),
     searchGeneric: t("store.searchGeneric"),
     typeToSearch: t("store.typeToSearch"),
     minQuery: t("store.minQuery"),

--- a/app/src/lib/skill-search-expected-state.ts
+++ b/app/src/lib/skill-search-expected-state.ts
@@ -1,0 +1,23 @@
+/**
+ * A community skill search that failed for a reason outside Houston: skills.sh
+ * took longer than the host's budget (`upstream_timeout`), could not be reached
+ * at all (`offline`), or is rate limiting (`rate_limited`). The marketplace
+ * renders each one inline with its own copy (`searchErrorPhase`), so the
+ * engine-call layer logs it and stops there: no red toast, no Sentry issue.
+ * skills.sh being slow was the third most frequent "error" on 0.6.17 to 0.6.20
+ * (PRODUCT-1728) and nothing in Houston had broken.
+ *
+ * `upstream_error` is NOT here on purpose: a real 500 or an unparseable body
+ * from skills.sh is a fault we want to hear about, and it stays loud.
+ *
+ * Dependency-free (the typed `kind` is read here, not via `@houston-ai/skills`,
+ * whose root barrel the app's node:test runner cannot load) so it is testable
+ * directly (app/tests/skill-search-expected-state.test.ts).
+ */
+export function isExpectedSkillSearchError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("kind" in err)) return false;
+  const kind = (err as { kind?: unknown }).kind;
+  return (
+    kind === "upstream_timeout" || kind === "offline" || kind === "rate_limited"
+  );
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -76,6 +76,7 @@ import { toDisplayProviderIdOrNull } from "./provider-overrides";
 import { normalizeLegacyModel } from "./providers";
 import { healStaleRosterFromError } from "./roster-heal";
 import { isSharedSkillsUnconfiguredError } from "./shared-skills-availability";
+import { isExpectedSkillSearchError } from "./skill-search-expected-state";
 import { isStaleAttachmentError } from "./stale-attachment";
 import {
   isLastOwnerError,
@@ -874,7 +875,9 @@ export const tauriSkills = {
           }),
         ),
       undefined,
-      { toast: false },
+      // skills.sh slow / unreachable / rate limiting is upstream weather the
+      // grid renders inline (PRODUCT-1728); a real upstream error stays loud.
+      { toast: false, silence: isExpectedSkillSearchError },
     ),
   previewCommunity: (
     agentPath: string,

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -63,6 +63,7 @@
     "noResults": "No skills found for \"{{query}}\"",
     "searchRateLimited": "Skills.sh is busy right now. Wait a moment and try again.",
     "searchOffline": "Couldn't reach Skills.sh. Check your internet and try again.",
+    "searchSlow": "Skill search is slow right now. Try again in a moment.",
     "searchGeneric": "Skill search hit a snag. Wait a moment and try again.",
     "typeToSearch": "Type to search for skills",
     "minQuery": "Type at least 2 characters to search",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -63,6 +63,7 @@
     "noResults": "No se encontraron skills para \"{{query}}\"",
     "searchRateLimited": "Skills.sh está ocupado ahora mismo. Espera un momento e inténtalo de nuevo.",
     "searchOffline": "No se pudo conectar con Skills.sh. Revisa tu internet e inténtalo de nuevo.",
+    "searchSlow": "La búsqueda de skills está lenta ahora mismo. Inténtalo de nuevo en un momento.",
     "searchGeneric": "La búsqueda tuvo un problema. Espera un momento e inténtalo de nuevo.",
     "typeToSearch": "Escribe para buscar skills",
     "minQuery": "Escribe al menos 2 caracteres para buscar",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -63,6 +63,7 @@
     "noResults": "Nenhum skill encontrado para \"{{query}}\"",
     "searchRateLimited": "O Skills.sh está ocupado agora. Aguarde um momento e tente de novo.",
     "searchOffline": "Não conseguimos acessar o Skills.sh. Verifique sua internet e tente de novo.",
+    "searchSlow": "A busca de skills está lenta agora. Tente de novo em instantes.",
     "searchGeneric": "A busca teve um problema. Aguarde um momento e tente de novo.",
     "typeToSearch": "Digite para buscar skills",
     "minQuery": "Digite pelo menos 2 caracteres para buscar",

--- a/app/tests/skill-search-expected-state.test.ts
+++ b/app/tests/skill-search-expected-state.test.ts
@@ -1,0 +1,57 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { HoustonEngineError } from "../../packages/web/src/engine-adapter/client/errors.ts";
+import { isExpectedSkillSearchError } from "../src/lib/skill-search-expected-state.ts";
+
+/** The engine-client's error exposes `kind` from `error.details.kind`. */
+function engineClientError(kind: string): Error {
+  return Object.assign(new Error(`engine error (${kind})`), {
+    name: "HoustonEngineError",
+    status: 504,
+    kind,
+  });
+}
+
+describe("isExpectedSkillSearchError (PRODUCT-1728)", () => {
+  it("treats a skills.sh timeout as expected on the web adapter's shape", () => {
+    const err = new HoustonEngineError(504, {
+      error: {
+        code: "UNAVAILABLE",
+        message: "skills.sh search timed out after 10000ms",
+        kind: "upstream_timeout",
+        details: { kind: "upstream_timeout" },
+      },
+    });
+    strictEqual(isExpectedSkillSearchError(err), true);
+  });
+
+  it("treats a skills.sh timeout as expected on the engine-client's shape", () => {
+    strictEqual(
+      isExpectedSkillSearchError(engineClientError("upstream_timeout")),
+      true,
+    );
+  });
+
+  it("treats offline and rate limiting as expected upstream weather", () => {
+    strictEqual(isExpectedSkillSearchError(engineClientError("offline")), true);
+    strictEqual(
+      isExpectedSkillSearchError(engineClientError("rate_limited")),
+      true,
+    );
+  });
+
+  it("keeps a real skills.sh error loud", () => {
+    strictEqual(
+      isExpectedSkillSearchError(engineClientError("upstream_error")),
+      false,
+    );
+  });
+
+  it("keeps untyped failures loud", () => {
+    strictEqual(isExpectedSkillSearchError(new Error("boom")), false);
+    strictEqual(
+      isExpectedSkillSearchError(new TypeError("fetch failed")),
+      false,
+    );
+  });
+});

--- a/packages/host/src/routes/client-abort.ts
+++ b/packages/host/src/routes/client-abort.ts
@@ -1,0 +1,27 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/**
+ * A signal that fires when the client goes away before the response is sent —
+ * the browser aborted its fetch (a superseded typed search), the tab closed,
+ * the tunnel dropped. Routes that fan out to a slow upstream thread it into
+ * that fetch so abandoned work is cancelled instead of running to its timeout
+ * (PRODUCT-1728: three searches per keystroke burst, each holding the
+ * skills.sh slot for the full 10 s).
+ *
+ * Node fires "close" on the ServerResponse, bun on the IncomingMessage; listen
+ * on both so it works under either runtime (same pairing as proxy/route.ts).
+ * "close" also follows a normally completed response, so the signal aborts
+ * after every request — harmless, since nothing is pending by then. Callers
+ * that catch a failure must check `signal.aborted` FIRST: a client that hung
+ * up has no response to receive, and its abort reason is not a route error.
+ */
+export function clientAbortSignal(
+  req: IncomingMessage,
+  res: ServerResponse,
+): AbortSignal {
+  const controller = new AbortController();
+  const onClose = () => controller.abort();
+  res.once("close", onClose);
+  req.once("close", onClose);
+  return controller.signal;
+}

--- a/packages/host/src/routes/skills-directory.test.ts
+++ b/packages/host/src/routes/skills-directory.test.ts
@@ -7,8 +7,39 @@ import { handleSkillsDirectory } from "./skills-directory";
  * calls while browsing: /v1/skills/community/{search,popular} + repo/list.
  */
 
-const outbound: typeof fetch = async (input) => {
+/** What the fake skills.sh saw on its latest search, for abort checks. An
+ *  object holder: a bare `let` assigned only inside the fetch closure narrows
+ *  to `never` at the assertion sites. */
+const upstream: { signal: AbortSignal | null | undefined; hang: boolean } = {
+  signal: undefined,
+  hang: false,
+};
+
+const outbound: typeof fetch = async (input, init) => {
   const url = String(input);
+  if (url.startsWith("https://skills.sh/api/search")) {
+    upstream.signal = init?.signal;
+    if (upstream.hang) {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(init.signal?.reason),
+        );
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        skills: [
+          {
+            id: "owner/repo/research",
+            skillId: "research",
+            name: "research",
+            installs: 5,
+            source: "owner/repo",
+          },
+        ],
+      }),
+    );
+  }
   if (url === "https://api.github.com/repos/owner/repo")
     return new Response("{}");
   if (url.includes("git/trees/HEAD"))
@@ -100,6 +131,46 @@ test("typed errors expose kind at both shapes the two clients read", async () =>
   };
   expect(body.error.kind).toBe("invalid_repo_source");
   expect(body.error.details.kind).toBe("invalid_repo_source");
+});
+
+test("community search answers a completed request normally", async () => {
+  // Guards the client-abort signal against firing early: under node the
+  // request's own "close" must not abort the upstream fetch of a live request
+  // (an early abort would reject the fetch and this would not be a 200). The
+  // signal DOES abort once the response completes, so it is not asserted.
+  const res = await fetch(`${base}/v1/skills/community/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query: "research" }),
+  });
+  expect(res.status).toBe(200);
+  const skills = (await res.json()) as Array<{ skillId: string }>;
+  expect(skills[0]?.skillId).toBe("research");
+});
+
+test("a client that abandons its search cancels the skills.sh fetch (PRODUCT-1728)", async () => {
+  // Object.assign: a direct property assignment narrows `signal` to
+  // `undefined` for the rest of the test and the `.aborted` reads below.
+  Object.assign(upstream, { hang: true, signal: undefined });
+  const controller = new AbortController();
+  const pending = fetch(`${base}/v1/skills/community/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query: "abandoned typing" }),
+    signal: controller.signal,
+  });
+  // The directory spaces outbound requests; wait until the upstream is in flight.
+  for (let i = 0; i < 200 && !upstream.signal; i++) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  expect(upstream.signal?.aborted).toBe(false);
+  controller.abort();
+  await expect(pending).rejects.toThrow();
+  for (let i = 0; i < 100 && !upstream.signal?.aborted; i++) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  expect(upstream.signal?.aborted).toBe(true);
+  upstream.hang = false;
 });
 
 test("non-marketplace paths fall through; GET answers 405", async () => {

--- a/packages/host/src/routes/skills-directory.ts
+++ b/packages/host/src/routes/skills-directory.ts
@@ -3,6 +3,7 @@ import { CommunityDirectory } from "../skills/community";
 import { listSkillsFromRepo } from "../skills/github";
 import { PreviewDirectory } from "../skills/preview";
 import { SkillRemoteError } from "../skills/remote-error";
+import { clientAbortSignal } from "./client-abort";
 import { json, readJson } from "./http";
 
 /**
@@ -66,20 +67,27 @@ export async function communitySearchAction(
     json(res, 400, { error: "missing 'query'" });
     return;
   }
+  // The client's own cancellation rides into the skills.sh fetch: a search the
+  // user already typed past is dropped upstream, not run to its timeout.
+  const signal = clientAbortSignal(req, res);
   try {
-    json(res, 200, await directory.search(body.query, { fetchImpl }));
+    json(res, 200, await directory.search(body.query, { fetchImpl, signal }));
   } catch (err) {
+    if (signal.aborted) return;
     failSkill(res, err);
   }
 }
 
 export async function communityPopularAction(
+  req: IncomingMessage,
   res: ServerResponse,
   fetchImpl?: typeof fetch,
 ): Promise<void> {
+  const signal = clientAbortSignal(req, res);
   try {
-    json(res, 200, await directory.popular({ fetchImpl }));
+    json(res, 200, await directory.popular({ fetchImpl, signal }));
   } catch (err) {
+    if (signal.aborted) return;
     failSkill(res, err);
   }
 }
@@ -144,7 +152,7 @@ export async function handleSkillsDirectory(
   if (route === "community/search")
     await communitySearchAction(req, res, deps.fetchImpl);
   else if (route === "community/popular")
-    await communityPopularAction(res, deps.fetchImpl);
+    await communityPopularAction(req, res, deps.fetchImpl);
   else if (route === "community/preview")
     await communityPreviewAction(req, res, deps.fetchImpl ?? fetch);
   else await repoListAction(req, res, deps.fetchImpl ?? fetch);

--- a/packages/host/src/routes/skills-remote.ts
+++ b/packages/host/src/routes/skills-remote.ts
@@ -54,7 +54,7 @@ export async function handleSkillsRemote(
     return true;
   }
   if (family === "community" && action === "popular") {
-    await communityPopularAction(res, fetchImpl);
+    await communityPopularAction(req, res, fetchImpl);
     return true;
   }
   if (family === "community" && action === "preview") {

--- a/packages/host/src/routes/skills-sandbox-search.ts
+++ b/packages/host/src/routes/skills-sandbox-search.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { clientAbortSignal } from "./client-abort";
 import { json, readJson } from "./http";
 import {
   communityDirectory,
@@ -68,17 +69,20 @@ export async function searchAction(
     json(res, 400, { error: "missing 'queries'" });
     return;
   }
+  const signal = clientAbortSignal(req, res);
   try {
     const result = await searchCommunitySkills(
       {
         directory: deps.directory ?? communityDirectory,
         previews: deps.previews ?? previewDirectory,
         fetchImpl,
+        signal,
       },
       queries,
     );
     json(res, 200, result);
   } catch (err) {
+    if (signal.aborted) return;
     failSkill(res, err);
   }
 }

--- a/packages/host/src/routes/skills-sandbox.test.ts
+++ b/packages/host/src/routes/skills-sandbox.test.ts
@@ -80,6 +80,8 @@ function fakeReq(body: unknown, headers: Record<string, string>) {
   const buf = Buffer.from(JSON.stringify(body));
   return {
     headers,
+    // The route arms a client-gone signal on the pair (client-abort.ts).
+    once() {},
     async *[Symbol.asyncIterator]() {
       if (buf.byteLength) yield buf;
     },
@@ -90,6 +92,7 @@ function fakeReq(body: unknown, headers: Record<string, string>) {
 function fakeRes() {
   const captured: { status: number; body: unknown } = { status: 0, body: null };
   const res = {
+    once() {},
     writeHead(status: number) {
       captured.status = status;
       return res;

--- a/packages/host/src/skills/community-fetch.ts
+++ b/packages/host/src/skills/community-fetch.ts
@@ -1,0 +1,83 @@
+import type { CommunitySkill } from "@houston/protocol";
+import { SkillRemoteError } from "./remote-error";
+
+export interface CommunityFetchArgs {
+  endpoint: string;
+  query: string;
+  fetchImpl: typeof fetch;
+  /** The caller's cancellation (the host route's client-gone signal). */
+  signal: AbortSignal | null;
+  /** Per-attempt budget for one skills.sh round-trip. */
+  timeoutMs: number;
+  retryDelayMs: number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+/**
+ * One skills.sh search round-trip. Retries once after a delay on HTTP 429.
+ *
+ * The caller's signal rides INTO the upstream fetch, joined with the request
+ * budget: a superseded search (the user typed again, the host route saw the
+ * client hang up) cancels its skills.sh request instead of running to the
+ * 10 s timeout and holding the outbound slot (PRODUCT-1728). Every failure is
+ * typed by cause — the caller's own cancellation rethrows its reason, the
+ * budget expiring is `upstream_timeout`, a transport drop is `offline`, and an
+ * answer we cannot use is `upstream_error` — so the client can tell expected
+ * weather from a real fault.
+ */
+export async function fetchCommunitySearch(
+  args: CommunityFetchArgs,
+): Promise<CommunitySkill[]> {
+  const { endpoint, query, fetchImpl, signal: caller, timeoutMs } = args;
+  for (let attempt = 0; ; attempt++) {
+    const budget = AbortSignal.timeout(timeoutMs);
+    const signal = caller ? AbortSignal.any([budget, caller]) : budget;
+    let res: Response;
+    try {
+      res = await fetchImpl(`${endpoint}?q=${encodeURIComponent(query)}`, {
+        headers: { "User-Agent": "houston-skills/1.0" },
+        signal,
+      });
+    } catch (err) {
+      if (caller?.aborted) throw caller.reason ?? err;
+      if (budget.aborted) {
+        console.warn(
+          `[host-skills] skills.sh search timed out after ${timeoutMs}ms`,
+        );
+        throw new SkillRemoteError(
+          "upstream_timeout",
+          `skills.sh search timed out after ${timeoutMs}ms`,
+        );
+      }
+      throw new SkillRemoteError(
+        "offline",
+        `skills.sh search failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (res.status === 429 && attempt === 0) {
+      await args.sleep(args.retryDelayMs);
+      continue;
+    }
+    if (res.status === 429) {
+      throw new SkillRemoteError(
+        "rate_limited",
+        "skills.sh rate limit hit, wait a moment and try again",
+      );
+    }
+    if (!res.ok) {
+      throw new SkillRemoteError(
+        "upstream_error",
+        `Skills search failed (${res.status})`,
+      );
+    }
+
+    const body = (await res.json().catch(() => null)) as {
+      skills?: unknown;
+    } | null;
+    if (!body || !Array.isArray(body.skills)) {
+      throw new SkillRemoteError("upstream_error", "Failed to parse results");
+    }
+    return body.skills as CommunitySkill[];
+  }
+}

--- a/packages/host/src/skills/community.ts
+++ b/packages/host/src/skills/community.ts
@@ -1,5 +1,5 @@
 import type { CommunitySkill } from "@houston/protocol";
-import { SkillRemoteError } from "./remote-error";
+import { fetchCommunitySearch } from "./community-fetch";
 
 /**
  * skills.sh community directory client. The host owns the resilience the KB
@@ -15,7 +15,8 @@ const SEARCH_FRESH_TTL_MS = 10 * 60_000;
 const SEARCH_STALE_TTL_MS = 24 * 60 * 60_000;
 const SEARCH_MIN_INTERVAL_MS = 750;
 /** Upper bound on one skills.sh round-trip. A wedged upstream must surface as
- *  the typed offline error, never hang the host route (or a test) open. */
+ *  the typed `upstream_timeout` error, never hang the host route (or a test)
+ *  open. */
 const SEARCH_REQUEST_TIMEOUT_MS = 10_000;
 
 /**
@@ -100,7 +101,7 @@ export class CommunityDirectory {
 
     await this.waitForRequestSlot();
     try {
-      const skills = await this.fetchSearch(trimmed, opts.fetchImpl);
+      const skills = await this.fetchSearch(trimmed, opts);
       this.entries.set(key, { skills, fetchedAt: this.now() });
       return skills;
     } catch (err) {
@@ -124,10 +125,11 @@ export class CommunityDirectory {
 
     await this.waitForRequestSlot();
     try {
-      const skills = await this.fetchSearch(POPULAR_SEED, opts.fetchImpl);
+      const skills = await this.fetchSearch(POPULAR_SEED, opts);
       this.popularEntry = { skills, fetchedAt: this.now() };
       return skills.slice(0, POPULAR_LIMIT);
     } catch (err) {
+      if (opts.signal?.aborted) throw opts.signal.reason ?? err;
       const stale = this.popularEntry;
       if (stale && this.now() - stale.fetchedAt <= this.staleTtlMs) {
         console.warn(
@@ -147,52 +149,19 @@ export class CommunityDirectory {
     if (target > now) await this.sleep(target - now);
   }
 
-  /** One search round-trip. Retries once after a delay on HTTP 429. */
-  private async fetchSearch(
+  /** One search round-trip, typed by cause (see `community-fetch.ts`). */
+  private fetchSearch(
     query: string,
-    fetchOverride?: typeof fetch,
+    opts: CommunitySearchOptions,
   ): Promise<CommunitySkill[]> {
-    for (let attempt = 0; ; attempt++) {
-      let res: Response;
-      try {
-        res = await (fetchOverride ?? this.fetchImpl)(
-          `${this.endpoint}?q=${encodeURIComponent(query)}`,
-          {
-            headers: { "User-Agent": "houston-skills/1.0" },
-            signal: AbortSignal.timeout(this.requestTimeoutMs),
-          },
-        );
-      } catch (err) {
-        throw new SkillRemoteError(
-          "offline",
-          `skills.sh search failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      if (res.status === 429 && attempt === 0) {
-        await this.sleep(this.retryDelayMs);
-        continue;
-      }
-      if (res.status === 429) {
-        throw new SkillRemoteError(
-          "rate_limited",
-          "skills.sh rate limit hit, wait a moment and try again",
-        );
-      }
-      if (!res.ok) {
-        throw new SkillRemoteError(
-          "offline",
-          `Skills search failed (${res.status})`,
-        );
-      }
-
-      const body = (await res.json().catch(() => null)) as {
-        skills?: unknown;
-      } | null;
-      if (!body || !Array.isArray(body.skills)) {
-        throw new SkillRemoteError("offline", "Failed to parse results");
-      }
-      return body.skills as CommunitySkill[];
-    }
+    return fetchCommunitySearch({
+      endpoint: this.endpoint,
+      query,
+      fetchImpl: opts.fetchImpl ?? this.fetchImpl,
+      signal: opts.signal ?? null,
+      timeoutMs: this.requestTimeoutMs,
+      retryDelayMs: this.retryDelayMs,
+      sleep: this.sleep,
+    });
   }
 }

--- a/packages/host/src/skills/remote-error.ts
+++ b/packages/host/src/skills/remote-error.ts
@@ -1,13 +1,21 @@
 /**
  * Typed failures for the community/repo skill routes. `kind` is the stable
  * machine-readable tag the frontend matches on to render plain-English copy —
- * keep the values in sync with `ui/skills/src/skill-error-kinds.ts` (the same
- * taxonomy the legacy Rust engine emits, so both engines read identically).
+ * keep the values in sync with `ui/skills/src/skill-error-kinds.ts`.
  */
 
 export type SkillRemoteErrorKind =
   | "rate_limited"
+  /** The upstream never answered: a transport failure on the way out. */
   | "offline"
+  /** The upstream did not answer within the request budget (PRODUCT-1728).
+   *  Its own state, not `offline`: the copy differs ("slow", not "check your
+   *  internet") and the client treats it as expected weather. */
+  | "upstream_timeout"
+  /** The upstream answered, but with a non-OK status or an unparseable body.
+   *  Kept apart from the transport kinds so a real skills.sh 500 (or a schema
+   *  change) stays loud in Sentry while slowness and outages stay quiet. */
+  | "upstream_error"
   | "skill_not_in_repo"
   | "invalid_repo_source"
   | "repo_private"
@@ -19,6 +27,8 @@ export type SkillRemoteErrorKind =
 const HTTP_STATUS: Record<SkillRemoteErrorKind, number> = {
   rate_limited: 429,
   offline: 503,
+  upstream_timeout: 504,
+  upstream_error: 502,
   skill_not_in_repo: 404,
   invalid_repo_source: 400,
   repo_private: 403,

--- a/packages/host/src/skills/remote.test.ts
+++ b/packages/host/src/skills/remote.test.ts
@@ -172,6 +172,59 @@ test("community search never turns cancellation into a stale-cache success", asy
   ).rejects.toThrow("search cancelled");
 });
 
+test("community search threads the caller's signal into the upstream fetch", async () => {
+  const clock = fakeClock();
+  const controller = new AbortController();
+  let upstreamSignal: AbortSignal | null | undefined;
+  const hangingFetch: typeof fetch = (_input, init) =>
+    new Promise((_resolve, reject) => {
+      upstreamSignal = init?.signal;
+      init?.signal?.addEventListener("abort", () =>
+        reject(init.signal?.reason),
+      );
+    });
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    fetchImpl: hangingFetch,
+  });
+  const pending = dir.search("writing", { signal: controller.signal });
+  await new Promise((r) => setTimeout(r, 0));
+  expect(upstreamSignal?.aborted).toBe(false);
+  controller.abort(new Error("client hung up"));
+  await expect(pending).rejects.toThrow("client hung up");
+  expect(upstreamSignal?.aborted).toBe(true);
+});
+
+test("community search keeps a real skills.sh 500 apart from the transport kinds", async () => {
+  const clock = fakeClock();
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    fetchImpl: fakeFetch(() => new Response("boom", { status: 500 })),
+  });
+  const err = await dir.search("writing").catch((e) => e);
+  expect(err).toBeInstanceOf(SkillRemoteError);
+  expect((err as SkillRemoteError).kind).toBe("upstream_error");
+  expect((err as SkillRemoteError).httpStatus).toBe(502);
+});
+
+test("community search maps a transport failure to offline", async () => {
+  const clock = fakeClock();
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    fetchImpl: async () => {
+      throw new TypeError("fetch failed");
+    },
+  });
+  const err = await dir.search("writing").catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("offline");
+});
+
 test("community search maps a persistent 429 to rate_limited when no cache", async () => {
   const clock = fakeClock();
   const dir = new CommunityDirectory({
@@ -399,7 +452,7 @@ test("installCommunitySkill surfaces skill_not_in_repo when nothing matches", as
   expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
 });
 
-test("a wedged skills.sh surfaces the typed offline error instead of hanging", async () => {
+test("a wedged skills.sh surfaces the typed upstream_timeout error instead of hanging", async () => {
   const hanging: typeof fetch = (_input, init) =>
     new Promise((_resolve, reject) => {
       init?.signal?.addEventListener("abort", () =>
@@ -412,7 +465,8 @@ test("a wedged skills.sh surfaces the typed offline error instead of hanging", a
     minIntervalMs: 0,
   });
   const err = await dir.search("research").catch((e) => e);
-  expect((err as SkillRemoteError).kind).toBe("offline");
+  expect((err as SkillRemoteError).kind).toBe("upstream_timeout");
+  expect((err as SkillRemoteError).httpStatus).toBe(504);
 });
 
 test("popular threads a request-scoped fetch and never touches global fetch", async () => {

--- a/ui/skills/src/skill-error-kinds.ts
+++ b/ui/skills/src/skill-error-kinds.ts
@@ -1,15 +1,18 @@
 /**
- * Stable machine-readable error kinds emitted by the engine for
- * skill-related routes. UI matches on these to render plain-English
- * copy without parsing error message strings.
+ * Stable machine-readable error kinds emitted by the host for skill-related
+ * routes. UI matches on these to render plain-English copy without parsing
+ * error message strings.
  *
- * Source of truth: `engine/houston-engine-core/src/skills.rs` — keep
- * the union below in sync with the `SkillError` → `CoreError::Labeled`
- * mapping there.
+ * Source of truth: `packages/host/src/skills/remote-error.ts` — keep the
+ * union below in sync with `SkillRemoteErrorKind` there.
  */
 export type SkillErrorKind =
   | "rate_limited"
   | "offline"
+  /** Skills.sh took longer than the host's request budget. */
+  | "upstream_timeout"
+  /** Skills.sh answered with a non-OK status or an unusable body. */
+  | "upstream_error"
   | "already_installed"
   | "skill_not_found"
   | "skill_not_in_repo"

--- a/ui/skills/src/skill-marketplace-grid-model.ts
+++ b/ui/skills/src/skill-marketplace-grid-model.ts
@@ -44,6 +44,7 @@ const DEFAULT_LABELS: Required<Omit<SkillMarketplaceGridLabels, "card">> = {
   searchRateLimited:
     "Skills.sh is busy right now. Wait a moment and try again.",
   searchOffline: "Couldn't reach Skills.sh. Check your internet and try again.",
+  searchSlow: "Skill search is slow right now. Try again in a moment.",
   searchGeneric: "Skill search hit a snag. Wait a moment and try again.",
   typeToSearch: "Type to search for skills",
   minQuery: "Type at least 2 characters to search",

--- a/ui/skills/src/skill-marketplace-grid-parts.tsx
+++ b/ui/skills/src/skill-marketplace-grid-parts.tsx
@@ -140,7 +140,9 @@ export function MarketplaceBody({
         ? l.searchRateLimited
         : phase.reason === "offline"
           ? l.searchOffline
-          : l.searchGeneric;
+          : phase.reason === "slow"
+            ? l.searchSlow
+            : l.searchGeneric;
     return <MutedNotice icon>{message}</MutedNotice>;
   }
   if (phase.kind === "idle") {

--- a/ui/skills/src/skill-marketplace-grid.tsx
+++ b/ui/skills/src/skill-marketplace-grid.tsx
@@ -44,7 +44,7 @@ export type SkillMarketplacePhase =
   | { kind: "no-results"; query: string }
   | {
       kind: "search-error";
-      reason: "rate_limited" | "offline" | "generic";
+      reason: "rate_limited" | "offline" | "slow" | "generic";
       query: string;
     };
 
@@ -58,6 +58,8 @@ export interface SkillMarketplaceGridLabels {
   noResults?: (query: string) => string;
   searchRateLimited?: string;
   searchOffline?: string;
+  /** Skills.sh took too long to answer: try again, nothing to fix locally. */
+  searchSlow?: string;
   searchGeneric?: string;
   typeToSearch?: string;
   minQuery?: string;

--- a/ui/skills/src/skill-marketplace-section-labels.ts
+++ b/ui/skills/src/skill-marketplace-section-labels.ts
@@ -52,6 +52,7 @@ export const DEFAULT_SKILL_MARKETPLACE_SECTION_LABELS: Required<SkillMarketplace
       "Skills.sh is busy right now. Wait a moment and try again.",
     searchOffline:
       "Couldn't reach Skills.sh. Check your internet and try again.",
+    searchSlow: "Skill search is slow right now. Try again in a moment.",
     searchGeneric: "Skill search hit a snag. Wait a moment and try again.",
     typeToSearch: "Type to search for skills",
     minQuery: "Type at least 2 characters to search",

--- a/ui/skills/src/skill-marketplace-state-model.ts
+++ b/ui/skills/src/skill-marketplace-state-model.ts
@@ -50,7 +50,9 @@ export function resultsPhase(
 /**
  * A failed search. Returns `null` when the failure is an abort (a superseded
  * request), so the caller leaves the current phase untouched instead of
- * flashing an error for a request it deliberately cancelled.
+ * flashing an error for a request it deliberately cancelled. A skills.sh
+ * timeout is its own "slow" reason: the remedy is to retry, not to check the
+ * connection (PRODUCT-1728).
  */
 export function searchErrorPhase(
   err: unknown,
@@ -58,12 +60,14 @@ export function searchErrorPhase(
 ): SkillMarketplacePhase | null {
   const cls = classifySkillError(err);
   if (cls === "aborted") return null;
-  const reason: "rate_limited" | "offline" | "generic" =
+  const reason: "rate_limited" | "offline" | "slow" | "generic" =
     cls === "rate_limited" || cls === "github_rate_limited"
       ? "rate_limited"
       : cls === "offline"
         ? "offline"
-        : "generic";
+        : cls === "upstream_timeout"
+          ? "slow"
+          : "generic";
   return { kind: "search-error", reason, query };
 }
 

--- a/ui/skills/tests/skill-marketplace-state.test.ts
+++ b/ui/skills/tests/skill-marketplace-state.test.ts
@@ -77,6 +77,20 @@ describe("searchErrorPhase", () => {
       query: "sdr",
     });
   });
+  it("maps a skills.sh timeout to the slow reason, not offline", () => {
+    assert.deepEqual(searchErrorPhase({ kind: "upstream_timeout" }, "sdr"), {
+      kind: "search-error",
+      reason: "slow",
+      query: "sdr",
+    });
+  });
+  it("keeps a skills.sh upstream error on the generic reason", () => {
+    assert.deepEqual(searchErrorPhase({ kind: "upstream_error" }, "sdr"), {
+      kind: "search-error",
+      reason: "generic",
+      query: "sdr",
+    });
+  });
   it("maps anything else to the generic reason", () => {
     assert.deepEqual(searchErrorPhase(new Error("boom"), "sdr"), {
       kind: "search-error",


### PR DESCRIPTION
## Summary

PRODUCT-1728. Community skill search reported skills.sh slowness as a Houston bug: 18 Sentry events / 15 users on 0.6.17 to 0.6.20 (HOUSTON-APP-5CQ, -5CZ).

**Root cause**
- `packages/host/src/skills/community.ts` typed every fetch failure, including the 10 s `AbortSignal.timeout`, as `offline` (503). The client's `search_community_skills` call treated that 503 as unexpected: Sentry + `app_error_shown` on every slow upstream answer.
- The caller's `AbortSignal` never reached the skills.sh fetch. Each keystroke's superseded search ran to the full 10 s timeout and held the global outbound slot, so the third search in a burst was the one that timed out (the breadcrumb pattern in the ticket).

**Fix**
- Host: `upstream_timeout` (504) when the request budget expires, `upstream_error` (502) for a non-OK or unparseable upstream answer, `offline` (503) reserved for transport failures. The round trip moved to `community-fetch.ts`; the caller's signal is joined with the timeout and passed to `fetch`.
- Host: `client-abort.ts` arms a client-gone signal (`res`/`req` close, same pairing as `proxy/route.ts`) on search, popular and the agent's `find_skills` route, so an abandoned request cancels its upstream fetch. Per-query caching (10 min fresh / 24 h stale) already existed and is unchanged.
- ui/skills: new `slow` search-error reason with its own copy, mapped from `upstream_timeout`.
- app: `search_community_skills` silences `upstream_timeout` / `offline` / `rate_limited` (the grid renders each inline with authored copy, logged locally, no toast, no Sentry). `upstream_error` stays loud. New `store.searchSlow` in en/es/pt.

Not done: a shorter first-byte timeout with a retry (item 3 in the ticket). A retry after a 10 s wait doubles the worst case; with abort propagation the long wait only happens for a query the user is still waiting on.

## Tests
- `remote.test.ts`: caller signal reaches the upstream fetch and abort rethrows the caller's reason; timeout is `upstream_timeout`/504; 500 is `upstream_error`/502; transport failure is `offline`.
- `skills-directory.test.ts`: a completed request still answers 200 (the close signal must not fire early under node); a client that aborts its fetch cancels the skills.sh fetch.
- `ui/skills` state model: `upstream_timeout` renders the slow state, `upstream_error` the generic one.
- `app/tests/skill-search-expected-state.test.ts`: both `HoustonEngineError` shapes classify as expected; `upstream_error` and untyped errors stay loud.

## Verify

Before (main): run `pnpm dev`, open an agent's Skills page, and point the host at a hanging skills.sh (e.g. add `127.0.0.1 skills.sh` to `/etc/hosts` with nothing listening on 443, or throttle the network). Type a query. After ~10 s the grid shows "Couldn't reach Skills.sh. Check your internet", the frontend log shows `[engine:search_community_skills] ... skills.sh search failed: The operation was aborted due to timeout`, and a Sentry event / `app_error_shown` fires. In the host pane, typing several characters produces one upstream request per keystroke burst that each run the full 10 s.

After (this branch): same setup. The grid shows "Skill search is slow right now. Try again in a moment." The frontend log still records the failure; no Sentry capture, no `app_error_shown`. The host answers 504 with `kind: "upstream_timeout"`. Typing past a query cancels the previous upstream fetch immediately (the host log no longer shows a `[host-skills] skills.sh search timed out` line for superseded queries).

Checks run: `pnpm check`, host/runtime/domain vitest, `cd app && pnpm test && pnpm tsgo --noEmit && pnpm check-locales`, `pnpm typecheck`, `pnpm check:boundaries`, `pnpm check:parity`. `ui/showcase` "matches a fresh run of the generator" fails on main too (stale `usage.gen.json`, unrelated).