### PR TITLE
fix(shell): resume release downloads across dropped streams (PRODUCT-1727)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
  "houston-local-model-bridge",
  "keyring",
  "log",
+ "minisign-verify",
  "notify-rust",
  "objc2",
  "objc2-app-kit",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -35,6 +35,10 @@ tauri-plugin-notification = "2"
 # navigator.clipboard.readText is permission-gated and flaky across platforms).
 arboard = "3"
 tauri-plugin-updater = "2"
+# The shell downloads releases itself (resume + backoff; src/commands/
+# update_fetch.rs) and verifies them against the updater pubkey the way the
+# plugin does. Same crate + version the plugin pulls in.
+minisign-verify = "0.2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-sentry = "0.5"
 sentry = "0.42"
@@ -120,6 +124,9 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Securit
 tauri-winrt-notification = "0.7"
 
 [dev-dependencies]
+# `start_paused` in the resumable-download tests: the backoff sleeps between
+# resume attempts auto-advance instead of running on the wall clock.
+tokio = { version = "1", features = ["full", "test-util"] }
 # `log::error!(target: ...)` in sentry_filter tests: drives the real
 # log → tracing bridge the way Tauri plugins and rustls do in production.
 log = "0.4"

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -10,6 +10,9 @@ pub mod portable;
 pub mod save_file;
 pub mod terminal;
 pub mod update;
+mod update_failure;
+mod update_fetch;
+pub mod update_stage;
 
 /// Expand a leading `~` to the user's home directory.
 ///

--- a/app/src-tauri/src/commands/update_failure.rs
+++ b/app/src-tauri/src/commands/update_failure.rs
@@ -1,0 +1,56 @@
+//! The wire shapes of the shell's resumable release download
+//! (`update_fetch.rs`): the progress events and the typed failure the
+//! frontend classifies (`app/src/lib/update-download-failure.ts`).
+
+use serde::Serialize;
+
+/// Mirrors the plugin's `DownloadEvent` so the frontend's progress fold
+/// (`update-download-progress.ts`) reads both shapes unchanged.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "event", content = "data")]
+pub enum DownloadEvent {
+    #[serde(rename_all = "camelCase")]
+    Started {
+        content_length: Option<u64>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Progress {
+        chunk_length: usize,
+    },
+    Finished,
+}
+
+/// Why a download gave up. `Network` is the transport-shaped class (connect,
+/// TLS, timeout, a body cut mid-stream): expected on a bad link, retried here
+/// and reported quietly by the frontend. Everything else is a bug.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DownloadFailureKind {
+    Network,
+    Http,
+    Signature,
+    Other,
+}
+
+/// The failure the frontend receives: the class, the message of the LAST
+/// attempt, and where the stream stopped, so Sentry shows the byte position.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DownloadFailure {
+    pub kind: DownloadFailureKind,
+    pub message: String,
+    pub received: u64,
+    pub total: Option<u64>,
+    pub attempts: u32,
+}
+
+impl DownloadFailure {
+    pub fn other(message: impl Into<String>) -> Self {
+        Self {
+            kind: DownloadFailureKind::Other,
+            message: message.into(),
+            received: 0,
+            total: None,
+            attempts: 0,
+        }
+    }
+}

--- a/app/src-tauri/src/commands/update_fetch.rs
+++ b/app/src-tauri/src/commands/update_fetch.rs
@@ -1,0 +1,174 @@
+//! Resumable release download (PRODUCT-1727).
+//!
+//! `tauri-plugin-updater` fetches a release in ONE streamed request with no
+//! retry: a 300 MB `Houston.app.tar.gz` on a flaky link dies mid-body as
+//! "error decoding response body" and the whole download starts over on the
+//! next poll. This loop keeps the bytes it already has and asks the server
+//! for the rest with a `Range` header (GitHub release assets answer 206),
+//! backing off between attempts. A server that ignores the range (answers
+//! 200) restarts the buffer, so the caller's progress tally is reset by a
+//! fresh `Started` event. Pure over a `reqwest::Client` so the tests can run
+//! it against a local socket.
+
+pub use super::update_failure::{DownloadEvent, DownloadFailure, DownloadFailureKind};
+use futures_util::StreamExt;
+use reqwest::header::{HeaderMap, RANGE};
+use reqwest::{Client, StatusCode, Url};
+use std::time::Duration;
+
+/// Attempts per download: the first request plus three resumes.
+pub const DOWNLOAD_ATTEMPTS: u32 = 4;
+
+/// Backoff before resume attempt `attempt` (1-based, the retries only).
+pub fn retry_delay(attempt: u32) -> Duration {
+    Duration::from_secs(3u64.pow(attempt.saturating_sub(1)))
+}
+
+fn classify(err: &reqwest::Error) -> DownloadFailureKind {
+    if err.is_connect() || err.is_timeout() || err.is_request() || err.is_body() || err.is_decode()
+    {
+        DownloadFailureKind::Network
+    } else {
+        DownloadFailureKind::Other
+    }
+}
+
+fn failure(
+    kind: DownloadFailureKind,
+    message: String,
+    received: usize,
+    total: Option<u64>,
+) -> DownloadFailure {
+    DownloadFailure {
+        kind,
+        message,
+        received: received as u64,
+        total,
+        attempts: 0,
+    }
+}
+
+enum AttemptOutcome {
+    Done,
+    Retry(DownloadFailure),
+}
+
+/// Stream `url` into `buffer`, resuming from its current length. Emits
+/// `Started` on a fresh (or restarted) body and `Progress` per chunk.
+async fn attempt(
+    client: &Client,
+    url: &Url,
+    headers: &HeaderMap,
+    buffer: &mut Vec<u8>,
+    total: &mut Option<u64>,
+    on_event: &mut (dyn FnMut(DownloadEvent) + Send),
+) -> Result<AttemptOutcome, DownloadFailure> {
+    let mut request = client.get(url.clone()).headers(headers.clone());
+    let resuming = !buffer.is_empty();
+    if resuming {
+        request = request.header(RANGE, format!("bytes={}-", buffer.len()));
+    }
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(err) => {
+            return Ok(AttemptOutcome::Retry(failure(
+                classify(&err),
+                err.to_string(),
+                buffer.len(),
+                *total,
+            )))
+        }
+    };
+    match response.status() {
+        StatusCode::PARTIAL_CONTENT if resuming => {}
+        StatusCode::OK => {
+            // A fresh body, or a server that ignored the range: start over.
+            buffer.clear();
+            *total = response.content_length();
+            on_event(DownloadEvent::Started {
+                content_length: *total,
+            });
+        }
+        status => {
+            return Err(failure(
+                DownloadFailureKind::Http,
+                format!("Download request failed with status: {status}"),
+                buffer.len(),
+                *total,
+            ))
+        }
+    }
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(chunk) => {
+                on_event(DownloadEvent::Progress {
+                    chunk_length: chunk.len(),
+                });
+                buffer.extend_from_slice(&chunk);
+            }
+            Err(err) => {
+                return Ok(AttemptOutcome::Retry(failure(
+                    classify(&err),
+                    err.to_string(),
+                    buffer.len(),
+                    *total,
+                )))
+            }
+        }
+    }
+    if let Some(total) = *total {
+        if (buffer.len() as u64) < total {
+            // The server closed the stream early without an error frame.
+            return Ok(AttemptOutcome::Retry(failure(
+                DownloadFailureKind::Network,
+                format!("stream ended at {} of {total} bytes", buffer.len()),
+                buffer.len(),
+                Some(total),
+            )));
+        }
+    }
+    Ok(AttemptOutcome::Done)
+}
+
+/// Download `url` in full, resuming across up to `DOWNLOAD_ATTEMPTS` tries.
+/// A non-network failure (an HTTP status) is final on the first sight.
+pub async fn fetch_with_resume(
+    client: &Client,
+    url: &Url,
+    headers: &HeaderMap,
+    mut on_event: impl FnMut(DownloadEvent) + Send,
+) -> Result<Vec<u8>, DownloadFailure> {
+    let mut buffer = Vec::new();
+    let mut total = None;
+    let mut last: Option<DownloadFailure> = None;
+    for attempt_no in 1..=DOWNLOAD_ATTEMPTS {
+        if attempt_no > 1 {
+            tokio::time::sleep(retry_delay(attempt_no - 1)).await;
+        }
+        match attempt(client, url, headers, &mut buffer, &mut total, &mut on_event).await? {
+            AttemptOutcome::Done => {
+                on_event(DownloadEvent::Finished);
+                return Ok(buffer);
+            }
+            AttemptOutcome::Retry(mut failure) => {
+                failure.attempts = attempt_no;
+                tracing::warn!(
+                    "[updater] download attempt {attempt_no}/{DOWNLOAD_ATTEMPTS} stopped at {}/{} bytes: {}",
+                    failure.received,
+                    failure.total.map_or("?".to_string(), |t| t.to_string()),
+                    failure.message
+                );
+                if failure.kind != DownloadFailureKind::Network {
+                    return Err(failure);
+                }
+                last = Some(failure);
+            }
+        }
+    }
+    Err(last.unwrap_or_else(|| DownloadFailure::other("download made no attempt")))
+}
+
+#[cfg(test)]
+#[path = "update_fetch_tests.rs"]
+mod tests;

--- a/app/src-tauri/src/commands/update_fetch_tests.rs
+++ b/app/src-tauri/src/commands/update_fetch_tests.rs
@@ -1,0 +1,194 @@
+//! `fetch_with_resume` against a scripted HTTP/1.1 server on a local socket:
+//! each connection follows the next step of a script (serve the whole body,
+//! cut it after N bytes, ignore the range, answer a status), and records the
+//! `Range` header it was asked for.
+
+use super::{
+    fetch_with_resume, retry_delay, DownloadEvent, DownloadFailureKind, DOWNLOAD_ATTEMPTS,
+};
+use reqwest::header::HeaderMap;
+use reqwest::{Client, Url};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+#[derive(Clone, Copy)]
+enum Step {
+    /// Honour the range (206) or serve everything (200), then cut the
+    /// connection after `cut` body bytes (`None` = serve it all).
+    Serve {
+        cut: Option<usize>,
+    },
+    /// Answer 200 with the FULL body even when a range was asked for.
+    IgnoreRange,
+    Status(u16),
+}
+
+struct Script {
+    steps: Vec<Step>,
+    ranges: Vec<Option<String>>,
+}
+
+fn body() -> Vec<u8> {
+    (0..20_000u32).map(|i| (i % 251) as u8).collect()
+}
+
+async fn serve(script: Arc<Mutex<Script>>) -> Url {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = Url::parse(&format!("http://{}/asset", listener.local_addr().unwrap())).unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut head = Vec::new();
+            let mut byte = [0u8; 1];
+            while !head.ends_with(b"\r\n\r\n") {
+                if socket.read(&mut byte).await.unwrap() == 0 {
+                    break;
+                }
+                head.push(byte[0]);
+            }
+            let head = String::from_utf8_lossy(&head).to_string();
+            // reqwest sends header names lowercased.
+            let range = head.lines().find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("range: bytes=")
+                    .map(|r| r.trim_end_matches('-').to_string())
+            });
+            let step = {
+                let mut script = script.lock().unwrap();
+                script.ranges.push(range.clone());
+                if script.steps.is_empty() {
+                    Step::Serve { cut: None }
+                } else {
+                    script.steps.remove(0)
+                }
+            };
+            let full = body();
+            let (status, from, cut) = match step {
+                Step::Serve { cut } => {
+                    let from = range
+                        .as_deref()
+                        .and_then(|r| r.parse::<usize>().ok())
+                        .unwrap_or(0);
+                    (if from > 0 { 206 } else { 200 }, from, cut)
+                }
+                Step::IgnoreRange => (200, 0, None),
+                Step::Status(code) => (code, 0, Some(0)),
+            };
+            let payload = &full[from..];
+            let mut response = format!(
+                "HTTP/1.1 {status} X\r\nContent-Length: {}\r\nConnection: close\r\n",
+                payload.len()
+            );
+            if status == 206 {
+                response.push_str(&format!(
+                    "Content-Range: bytes {from}-{}/{}\r\n",
+                    full.len() - 1,
+                    full.len()
+                ));
+            }
+            response.push_str("\r\n");
+            socket.write_all(response.as_bytes()).await.unwrap();
+            let sent = cut.map_or(payload, |n| &payload[..n.min(payload.len())]);
+            socket.write_all(sent).await.unwrap();
+            socket.flush().await.unwrap();
+            drop(socket);
+        }
+    });
+    url
+}
+
+async fn run(
+    steps: Vec<Step>,
+) -> (
+    Result<Vec<u8>, super::DownloadFailure>,
+    Vec<DownloadEvent>,
+    Vec<Option<String>>,
+) {
+    let script = Arc::new(Mutex::new(Script {
+        steps,
+        ranges: Vec::new(),
+    }));
+    let url = serve(script.clone()).await;
+    let client = Client::builder().build().unwrap();
+    let mut events = Vec::new();
+    let result = fetch_with_resume(&client, &url, &HeaderMap::new(), |e| events.push(e)).await;
+    let ranges = script.lock().unwrap().ranges.clone();
+    (result, events, ranges)
+}
+
+fn started(events: &[DownloadEvent]) -> usize {
+    events
+        .iter()
+        .filter(|e| matches!(e, DownloadEvent::Started { .. }))
+        .count()
+}
+
+#[tokio::test(start_paused = true)]
+async fn resumes_twice_then_completes() {
+    let steps = vec![
+        Step::Serve { cut: Some(5_000) },
+        Step::Serve { cut: Some(7_000) },
+        Step::Serve { cut: None },
+    ];
+    let (result, events, ranges) = run(steps).await;
+    assert_eq!(result.unwrap(), body());
+    assert_eq!(
+        ranges,
+        vec![None, Some("5000".into()), Some("12000".into())]
+    );
+    assert_eq!(started(&events), 1, "a resume never resets the tally");
+    assert_eq!(events.last(), Some(&DownloadEvent::Finished));
+    let progressed: usize = events
+        .iter()
+        .filter_map(|e| match e {
+            DownloadEvent::Progress { chunk_length } => Some(*chunk_length),
+            _ => None,
+        })
+        .sum();
+    assert_eq!(progressed, body().len());
+}
+
+#[tokio::test(start_paused = true)]
+async fn restarts_when_the_server_ignores_the_range() {
+    let (result, events, ranges) =
+        run(vec![Step::Serve { cut: Some(3_000) }, Step::IgnoreRange]).await;
+    assert_eq!(result.unwrap(), body());
+    assert_eq!(ranges, vec![None, Some("3000".into())]);
+    assert_eq!(
+        started(&events),
+        2,
+        "a 200 on a ranged request restarts the tally"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn gives_up_after_the_attempt_budget_with_the_byte_position() {
+    let steps = (0..DOWNLOAD_ATTEMPTS)
+        .map(|_| Step::Serve { cut: Some(1_000) })
+        .collect();
+    let (result, _, ranges) = run(steps).await;
+    let failure = result.unwrap_err();
+    assert_eq!(failure.kind, DownloadFailureKind::Network);
+    assert_eq!(failure.attempts, DOWNLOAD_ATTEMPTS);
+    assert_eq!(failure.received, 1_000 * DOWNLOAD_ATTEMPTS as u64);
+    assert_eq!(failure.total, Some(body().len() as u64));
+    assert_eq!(ranges.len() as u32, DOWNLOAD_ATTEMPTS);
+}
+
+#[tokio::test(start_paused = true)]
+async fn an_http_status_is_final_on_first_sight() {
+    let (result, _, ranges) = run(vec![Step::Status(404)]).await;
+    let failure = result.unwrap_err();
+    assert_eq!(failure.kind, DownloadFailureKind::Http);
+    assert!(failure.message.contains("404"), "{}", failure.message);
+    assert_eq!(ranges.len(), 1, "no retry for a status answer");
+}
+
+#[test]
+fn backoff_grows_per_retry() {
+    assert_eq!(retry_delay(1), Duration::from_secs(1));
+    assert_eq!(retry_delay(2), Duration::from_secs(3));
+    assert_eq!(retry_delay(3), Duration::from_secs(9));
+}

--- a/app/src-tauri/src/commands/update_stage.rs
+++ b/app/src-tauri/src/commands/update_stage.rs
@@ -1,0 +1,164 @@
+//! The shell's own download + install commands over the updater plugin's
+//! `Update` resource (PRODUCT-1727). `check()` stays with the plugin; the
+//! download runs through `update_fetch` (resume + backoff, which the plugin's
+//! single-shot request lacks), the bytes are verified against the release
+//! signature exactly as the plugin would, then staged in the resource table
+//! until the frontend asks for the install.
+
+use super::update_failure::{DownloadFailure, DownloadFailureKind};
+use super::update_fetch::{fetch_with_resume, DownloadEvent};
+use minisign_verify::{PublicKey, Signature};
+use reqwest::header::{HeaderValue, ACCEPT};
+use std::time::Duration;
+use tauri::ipc::Channel;
+use tauri::{Manager, Resource, ResourceId, Runtime, Webview};
+use tauri_plugin_updater::Update;
+
+/// A silent stall reads as a failure after this long, so it can be resumed
+/// instead of hanging the download for the rest of the session.
+const READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The verified release bytes, waiting for `install_update`.
+struct StagedUpdate(Vec<u8>);
+impl Resource for StagedUpdate {}
+
+fn client_for(update: &Update) -> Result<reqwest::Client, DownloadFailure> {
+    let mut builder = reqwest::Client::builder()
+        .user_agent(format!("houston-app/{}", env!("CARGO_PKG_VERSION")))
+        .read_timeout(READ_TIMEOUT);
+    if let Some(timeout) = update.timeout {
+        builder = builder.timeout(timeout);
+    }
+    if update.no_proxy {
+        builder = builder.no_proxy();
+    } else if let Some(ref proxy) = update.proxy {
+        let proxy = reqwest::Proxy::all(proxy.as_str())
+            .map_err(|e| DownloadFailure::other(format!("invalid updater proxy: {e}")))?;
+        builder = builder.proxy(proxy);
+    }
+    builder
+        .build()
+        .map_err(|e| DownloadFailure::other(format!("build download client: {e}")))
+}
+
+/// The plugin's minisign check, on the same pubkey it reads from
+/// `tauri.conf.json` (`plugins.updater.pubkey`).
+fn verify_signature(data: &[u8], release_signature: &str, pubkey_b64: &str) -> Result<(), String> {
+    use base64::Engine;
+    let decode = |value: &str| {
+        base64::engine::general_purpose::STANDARD
+            .decode(value)
+            .map_err(|e| e.to_string())
+            .and_then(|bytes| String::from_utf8(bytes).map_err(|e| e.to_string()))
+    };
+    let public_key = PublicKey::decode(&decode(pubkey_b64)?).map_err(|e| e.to_string())?;
+    let signature = Signature::decode(&decode(release_signature)?).map_err(|e| e.to_string())?;
+    public_key
+        .verify(data, &signature, true)
+        .map_err(|e| e.to_string())
+}
+
+fn updater_pubkey<R: Runtime>(webview: &Webview<R>) -> Result<String, DownloadFailure> {
+    webview
+        .config()
+        .plugins
+        .0
+        .get("updater")
+        .and_then(|cfg| cfg.get("pubkey"))
+        .and_then(|key| key.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| DownloadFailure::other("updater pubkey missing from tauri.conf.json"))
+}
+
+fn take_update<R: Runtime>(
+    webview: &Webview<R>,
+    rid: ResourceId,
+) -> Result<Update, DownloadFailure> {
+    let update = webview
+        .resources_table()
+        .get::<Update>(rid)
+        .map_err(|e| DownloadFailure::other(format!("update resource {rid} is gone: {e}")))?;
+    Ok((*update).clone())
+}
+
+/// Download the release the plugin's `check()` found (`rid` is its `Update`
+/// resource), resuming across drops, verify its signature, and stage the
+/// bytes. Resolves with the staged resource id for `install_update`.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn download_update<R: Runtime>(
+    webview: Webview<R>,
+    rid: ResourceId,
+    on_event: Channel<DownloadEvent>,
+) -> Result<ResourceId, DownloadFailure> {
+    let update = take_update(&webview, rid)?;
+    let pubkey = updater_pubkey(&webview)?;
+    let client = client_for(&update)?;
+    let mut headers = update.headers.clone();
+    if !headers.contains_key(ACCEPT) {
+        headers.insert(ACCEPT, HeaderValue::from_static("application/octet-stream"));
+    }
+    let bytes = fetch_with_resume(&client, &update.download_url, &headers, |event| {
+        // Progress callback with no UI thread: a closed channel only means
+        // the webview went away mid-download, and the result still returns.
+        if let Err(e) = on_event.send(event) {
+            tracing::warn!("[updater] progress channel closed: {e}");
+        }
+    })
+    .await?;
+    if let Err(message) = verify_signature(&bytes, &update.signature, &pubkey) {
+        return Err(DownloadFailure {
+            kind: DownloadFailureKind::Signature,
+            message: format!("release signature did not verify: {message}"),
+            received: bytes.len() as u64,
+            total: Some(bytes.len() as u64),
+            attempts: 0,
+        });
+    }
+    Ok(webview.resources_table().add(StagedUpdate(bytes)))
+}
+
+/// Install the staged bytes through the plugin's installer (bundle swap on
+/// macOS; msiexec hand-off + process exit on Windows).
+#[tauri::command(rename_all = "snake_case")]
+pub async fn install_update<R: Runtime>(
+    webview: Webview<R>,
+    rid: ResourceId,
+    bytes_rid: ResourceId,
+) -> Result<(), String> {
+    let update = take_update(&webview, rid).map_err(|e| e.message)?;
+    let staged = webview
+        .resources_table()
+        .get::<StagedUpdate>(bytes_rid)
+        .map_err(|e| format!("staged update {bytes_rid} is gone: {e}"))?;
+    update.install(&staged.0).map_err(|e| e.to_string())?;
+    // Windows never reaches here (the installer hand-off exits the process);
+    // on macOS the bytes are on disk now and the buffer can go.
+    webview
+        .resources_table()
+        .close(bytes_rid)
+        .map_err(|e| format!("release staged buffer: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verify_signature;
+
+    const PUBKEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJDQTdCMzc1MURERDRFQkQKUldTOVR0MGRkYk9uTEE4SUNnNElWZzVEN3QvcFQzczl6Y2NTMUpLSXJYZkxyK2g5azk4UHpRdmcK";
+
+    #[test]
+    fn rejects_a_signature_that_does_not_verify() {
+        // Minisign-shaped text that is not a signature over these bytes.
+        let signature = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            "untrusted comment: signature from tauri secret key\nRUS9Tt0ddbOnLNz8OJ/uxxZ7Z2XCvOfOPq+3pf+F4v2tGZJ5EbFqGhRp1yfy/LjrnNmnQ/4DUfL1x6jOSK2E1c1aILtmv0BYWQY=\ntrusted comment: timestamp:1\nO/A8d4Gk1e3G4pVUQFLHwQ4YwjQ8G9x8qz6uJ3+2OMZbjqPjVtKk8jsY0Y3tmBh8gQ7hFbHDd6i5a4Jj+8XCDQ==\n",
+        );
+        assert!(verify_signature(b"not the release", &signature, PUBKEY).is_err());
+    }
+
+    #[test]
+    fn rejects_a_signature_that_is_not_minisign() {
+        let signature =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, "garbage");
+        assert!(verify_signature(b"bytes", &signature, PUBKEY).is_err());
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -477,6 +477,10 @@ pub fn run() {
             commands::save_file::save_download,
             commands::update::current_app_bundle_path,
             commands::update::relaunch_app_from_path,
+            // Resumable release download + staged install over the updater
+            // plugin's `Update` resource (PRODUCT-1727).
+            commands::update_stage::download_update,
+            commands::update_stage::install_update,
             // Hidden Sentry smoke command for native stack verification.
             commands::diagnostics::sentry_native_stack_smoke_test,
             // Logging (writes to local log files).

--- a/app/src/hooks/use-update-machine.ts
+++ b/app/src/hooks/use-update-machine.ts
@@ -4,6 +4,8 @@ import { analytics } from "../lib/analytics";
 import { reportError } from "../lib/error-report";
 import {
   osCurrentAppBundlePath,
+  osDownloadUpdate,
+  osInstallUpdate,
   osRelaunchAppFromPath,
 } from "../lib/os-bridge";
 import {
@@ -11,6 +13,7 @@ import {
   type DownloadTally,
   EMPTY_DOWNLOAD_TALLY,
 } from "../lib/update-download-progress";
+import { reportUpdateDownloadFailure } from "../lib/update-download-report";
 import {
   shouldReportDownloadFailure,
   type UpdateCheckOutcome,
@@ -26,6 +29,7 @@ import {
 export type { InstallSource, UpdateInfo, UpdateStatus };
 
 type AvailableUpdate = NonNullable<Awaited<ReturnType<typeof check>>>;
+type CheckResult = { outcome: UpdateCheckOutcome; message?: string };
 
 /**
  * The updater state machine: check → available → downloading → downloaded →
@@ -36,7 +40,9 @@ type AvailableUpdate = NonNullable<Awaited<ReturnType<typeof check>>>;
  * Download and install are two steps on purpose: the release downloads in
  * the background while the user keeps working, and the install (msiexec
  * hand-off + process exit on Windows, bundle swap on macOS) runs only when
- * something explicitly asks for it.
+ * something explicitly asks for it. Both are the shell's own commands over
+ * the plugin's `Update` resource: the plugin's single-shot download died
+ * mid-stream on a 300 MB asset with no resume (PRODUCT-1727).
  */
 export function useUpdateMachine() {
   const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
@@ -45,6 +51,8 @@ export function useUpdateMachine() {
   const statusRef = useRef<UpdateStatus>(status);
   const busyRef = useRef(false);
   const appPathRef = useRef<string | null>(null);
+  // Staged release bytes (a shell resource id) once a download landed.
+  const bytesRidRef = useRef<number | null>(null);
   const firstCheckRef = useRef(true);
   const reportedDownloadFailureRef = useRef<string | null>(null);
 
@@ -52,10 +60,7 @@ export function useUpdateMachine() {
     statusRef.current = status;
   }, [status]);
 
-  const runCheck = useCallback(async (): Promise<{
-    outcome: UpdateCheckOutcome;
-    message?: string;
-  }> => {
+  const runCheck = useCallback(async (): Promise<CheckResult> => {
     // The first check of a run is the launch check: the user just opened the
     // app and hasn't started working. Everything after is mid-session.
     const origin: UpdateOrigin = firstCheckRef.current ? "launch" : "poll";
@@ -79,8 +84,7 @@ export function useUpdateMachine() {
       };
       updateRef.current = update;
       infoRef.current = info;
-      // `update_offered` fires on the first sighting of a version only, so a
-      // recheck (or a retried download) doesn't double-count.
+      // `update_offered` fires on the first sighting of a version only.
       const previous = statusRef.current;
       if (previous.state === "idle" || previous.info.version !== info.version) {
         analytics.track("update_offered", {
@@ -91,9 +95,8 @@ export function useUpdateMachine() {
       setStatus({ state: "available", info });
       return { outcome: "found" };
     } catch (error) {
-      // Fail-open by design: the staging QA flavor's updater endpoint 404s
-      // forever and a launch must never block on the release feed. The
-      // checker counts these to surface a client whose checks NEVER succeed.
+      // Fail-open by design: a launch must never block on the release feed.
+      // The checker counts these to surface a client that NEVER succeeds.
       console.warn("[updater] check failed", error);
       return {
         outcome: "failed",
@@ -102,9 +105,9 @@ export function useUpdateMachine() {
     }
   }, []);
 
-  /** Fetch the release into the updater's buffer; true once it can be
-   *  installed. A failure is reported (once per version), never shown: the
-   *  next check finds the release again and the download re-runs. */
+  /** Fetch the release into the shell's staging buffer; true once it can
+   *  be installed. A failure is reported (once per version), never shown:
+   *  the next check finds the release again and the download re-runs. */
   const download = useCallback(async (): Promise<boolean> => {
     const update = updateRef.current;
     const info = infoRef.current;
@@ -115,7 +118,7 @@ export function useUpdateMachine() {
     let tally: DownloadTally = EMPTY_DOWNLOAD_TALLY;
     try {
       setStatus({ state: "downloading", info, progress: null });
-      await update.download((event) => {
+      bytesRidRef.current = await osDownloadUpdate(update.rid, (event) => {
         const next = applyDownloadEvent(tally, event);
         tally = next.tally;
         setStatus({ state: "downloading", info, progress: next.progress });
@@ -132,7 +135,7 @@ export function useUpdateMachine() {
       const reported = reportedDownloadFailureRef.current;
       if (shouldReportDownloadFailure(reported, info.version)) {
         reportedDownloadFailureRef.current = info.version;
-        reportError("update_download", `download of ${info.version}`, error);
+        reportUpdateDownloadFailure(info.version, error);
       }
       setStatus({ state: "error", info, phase: "download" });
       return false;
@@ -164,7 +167,8 @@ export function useUpdateMachine() {
         return;
       const update = updateRef.current;
       const info = infoRef.current;
-      if (!update || !info) return;
+      const bytesRid = bytesRidRef.current;
+      if (!update || !info || bytesRid === null) return;
 
       busyRef.current = true;
       analytics.track("update_accepted", {
@@ -176,7 +180,8 @@ export function useUpdateMachine() {
         // Captured BEFORE the install: on macOS the install moves the bundle.
         appPathRef.current = await osCurrentAppBundlePath();
         setStatus({ state: "installing", info });
-        await update.install();
+        await osInstallUpdate(update.rid, bytesRid);
+        bytesRidRef.current = null;
       } catch (error) {
         console.error("[updater] install failed", error);
         reportError("update_install", `install of ${info.version}`, error);

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -19,13 +19,14 @@
 
 import type { LocalBridgeDevice, LocalBridgeIdentity } from "@houston/protocol";
 import type { LocalBridgeJournal, LocalBridgeNativePort } from "@houston/sdk";
-import { invoke, isTauri } from "@tauri-apps/api/core";
+import { Channel, invoke, isTauri } from "@tauri-apps/api/core";
 import {
   type Event,
   emit,
   listen,
   type UnlistenFn,
 } from "@tauri-apps/api/event";
+import type { DownloadEvent } from "@tauri-apps/plugin-updater";
 import type {
   DictationModelProgress,
   DictationModelStatus,
@@ -309,6 +310,27 @@ export function osOpenFile(
 /** Resolve the app bundle/executable path before updater install moves it. */
 export function osCurrentAppBundlePath(): Promise<string> {
   return invoke<string>("current_app_bundle_path");
+}
+
+/** Download the release the updater plugin's `check()` found, through the
+ * shell's own resumable client (retry with backoff, `Range` resume across a
+ * dropped stream), verify its signature, and stage the bytes. `rid` is the
+ * plugin's `Update` resource id. Progress arrives in the plugin's own event
+ * shape. Resolves with the staged-bytes resource id for `osInstallUpdate`;
+ * rejects with the shell's typed failure (`update-download-failure.ts`). */
+export function osDownloadUpdate(
+  rid: number,
+  onEvent: (event: DownloadEvent) => void,
+): Promise<number> {
+  const channel = new Channel<DownloadEvent>();
+  channel.onmessage = onEvent;
+  return invoke<number>("download_update", { rid, on_event: channel });
+}
+
+/** Install a release staged by `osDownloadUpdate`. On Windows the installer
+ * hand-off exits this process, so the promise never settles there. */
+export function osInstallUpdate(rid: number, bytesRid: number): Promise<void> {
+  return invoke<void>("install_update", { rid, bytes_rid: bytesRid });
 }
 
 /** Relaunch the installed app from a path captured before update install. */

--- a/app/src/lib/update-check-toast.ts
+++ b/app/src/lib/update-check-toast.ts
@@ -1,11 +1,13 @@
 import { useUIStore } from "../stores/ui";
 import { analytics, classifyAnalyticsError } from "./analytics";
 import i18n from "./i18n";
+import { reportQuietError } from "./quiet-error-report";
 import {
   captureException as sentryCapture,
   sentrySuppressedInDev,
 } from "./sentry";
 import { createSentryReportError } from "./sentry-report-error";
+import { isUpdateNetworkFailure } from "./update-download-failure";
 
 /**
  * Surface a client whose update checks keep failing (PRODUCT-1386). The
@@ -22,7 +24,11 @@ import { createSentryReportError } from "./sentry-report-error";
  *    clients directly);
  *  - a Sentry capture, so stranded clients get an issue with a user count —
  *    this also surfaces any leaked staging QA build, whose no-op updater
- *    endpoint 404s every check by design.
+ *    endpoint 404s every check by design. A network-shaped failure (the
+ *    request never got an answer: offline, DNS, a proxy that drops GitHub)
+ *    is the quiet `offline` class instead (PRODUCT-1727): the toast and the
+ *    analytics event still fire, but Sentry gets one burst-collapsed warning
+ *    in the class's fingerprinted issue, never a per-user error.
  */
 export function showUpdateCheckStuckToast(
   message: string,
@@ -45,6 +51,10 @@ export function showUpdateCheckStuckToast(
     error_kind: classifyAnalyticsError(message),
   });
   if (sentrySuppressedInDev) return;
+  if (isUpdateNetworkFailure(message)) {
+    reportQuietError("offline", command, message, new Error(message));
+    return;
+  }
   void sentryCapture(createSentryReportError(command, message), {
     source: command,
     error_kind: classifyAnalyticsError(message),

--- a/app/src/lib/update-download-failure.ts
+++ b/app/src/lib/update-download-failure.ts
@@ -1,0 +1,102 @@
+// The typed failure the shell's resumable release download rejects with
+// (app/src-tauri/src/commands/update_failure.rs), and the two classifiers the
+// updater's reporting paths need. Dependency-free so it is node-testable
+// directly (app/tests/update-download-failure.test.ts).
+
+export type UpdateDownloadFailureKind =
+  | "network"
+  | "http"
+  | "signature"
+  | "other";
+
+/** What the shell reports when a release download gives up: the class, the
+ *  last attempt's message, and where the stream stopped. */
+export interface UpdateDownloadFailure {
+  kind: UpdateDownloadFailureKind;
+  message: string;
+  received: number;
+  total: number | null;
+  attempts: number;
+}
+
+/** The failure as an `Error`, so the reporting paths carry the byte position
+ *  in the message and the class on the instance. */
+export class UpdateDownloadError extends Error {
+  readonly kind: UpdateDownloadFailureKind;
+  readonly received: number;
+  readonly total: number | null;
+  readonly attempts: number;
+
+  constructor(failure: UpdateDownloadFailure) {
+    super(describeDownloadFailure(failure));
+    this.name = "UpdateDownloadError";
+    this.kind = failure.kind;
+    this.received = failure.received;
+    this.total = failure.total;
+    this.attempts = failure.attempts;
+  }
+}
+
+const KINDS: ReadonlySet<string> = new Set([
+  "network",
+  "http",
+  "signature",
+  "other",
+]);
+
+/**
+ * Read the shell's rejection into an `UpdateDownloadError`. Anything else
+ * (a plain string from an older command, a thrown `Error`) is wrapped as
+ * `other` so the caller never has to branch on the raw shape.
+ */
+export function toUpdateDownloadError(err: unknown): UpdateDownloadError {
+  if (err instanceof UpdateDownloadError) return err;
+  if (err !== null && typeof err === "object" && "kind" in err) {
+    const raw = err as Record<string, unknown>;
+    const kind = typeof raw.kind === "string" && KINDS.has(raw.kind);
+    if (kind && typeof raw.message === "string") {
+      return new UpdateDownloadError({
+        kind: raw.kind as UpdateDownloadFailureKind,
+        message: raw.message,
+        received: typeof raw.received === "number" ? raw.received : 0,
+        total: typeof raw.total === "number" ? raw.total : null,
+        attempts: typeof raw.attempts === "number" ? raw.attempts : 0,
+      });
+    }
+  }
+  return new UpdateDownloadError({
+    kind: "other",
+    message: err instanceof Error ? err.message : String(err),
+    received: 0,
+    total: null,
+    attempts: 0,
+  });
+}
+
+/** "stopped at 123456789/315000000 bytes after 4 attempts: error decoding
+ *  response body": the Sentry title says where a download died. */
+export function describeDownloadFailure(
+  failure: UpdateDownloadFailure,
+): string {
+  const total = failure.total === null ? "?" : String(failure.total);
+  const attempts =
+    failure.attempts > 0 ? ` after ${failure.attempts} attempts` : "";
+  return `stopped at ${failure.received}/${total} bytes${attempts}: ${failure.message}`;
+}
+
+/**
+ * The messages `reqwest` (the updater plugin's HTTP client) surfaces for a
+ * transport-level failure of the release-feed check: the request never got a
+ * response, or the body was cut mid-stream. These are the device offline or
+ * a proxy/DNS between it and GitHub, the same class as `isNetworkTransportError`
+ * on the browser side; they report as the quiet `offline` class, never as a
+ * bug per event. A 404 or a malformed manifest ("Could not fetch a valid
+ * release JSON") is NOT matched: that shape is how a leaked staging build
+ * surfaces itself.
+ */
+const NETWORK_SHAPED =
+  /error sending request|error decoding response body|dns error|connection (reset|refused|closed|aborted)|operation timed out|timed out|network is unreachable|no route to host|tls handshake|certificate|broken pipe|unexpected eof|incomplete message/i;
+
+export function isUpdateNetworkFailure(message: string): boolean {
+  return NETWORK_SHAPED.test(message);
+}

--- a/app/src/lib/update-download-report.ts
+++ b/app/src/lib/update-download-report.ts
@@ -1,0 +1,26 @@
+import { reportError } from "./error-report";
+import { reportQuietError } from "./quiet-error-report";
+import { toUpdateDownloadError } from "./update-download-failure";
+
+/**
+ * Report a failed release download (PRODUCT-1727). The shell already retried
+ * and resumed it; what reaches here is the LAST attempt, with the byte
+ * position in the message. A `network` failure is the device's link, not a
+ * bug: it captures as the quiet `offline` class (one fingerprinted warning
+ * issue, burst-collapsed), the way every other transport drop does. Any other
+ * class (an HTTP status, a signature that did not verify, a missing resource)
+ * is a real error and files as one.
+ */
+export function reportUpdateDownloadFailure(
+  version: string,
+  err: unknown,
+): void {
+  const error = toUpdateDownloadError(err);
+  const command = "update_download";
+  const message = `download of ${version} ${error.message}`;
+  if (error.kind === "network") {
+    reportQuietError("offline", command, message, error);
+    return;
+  }
+  reportError(command, message, error);
+}

--- a/app/tests/update-download-failure.test.ts
+++ b/app/tests/update-download-failure.test.ts
@@ -1,0 +1,99 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  describeDownloadFailure,
+  isUpdateNetworkFailure,
+  toUpdateDownloadError,
+  UpdateDownloadError,
+} from "../src/lib/update-download-failure.ts";
+
+// PRODUCT-1727: the shell's resumable download rejects with a typed failure;
+// the frontend routes `network` to the quiet offline class and everything
+// else to a real report, with the byte position in the message either way.
+describe("toUpdateDownloadError", () => {
+  it("reads the shell's typed rejection", () => {
+    const error = toUpdateDownloadError({
+      kind: "network",
+      message: "error decoding response body",
+      received: 123_456_789,
+      total: 315_000_000,
+      attempts: 4,
+    });
+    strictEqual(error instanceof UpdateDownloadError, true);
+    strictEqual(error.kind, "network");
+    strictEqual(error.received, 123_456_789);
+    strictEqual(
+      error.message,
+      "stopped at 123456789/315000000 bytes after 4 attempts: error decoding response body",
+    );
+  });
+
+  it("wraps an untyped rejection as `other`", () => {
+    const error = toUpdateDownloadError("update resource 3 is gone");
+    strictEqual(error.kind, "other");
+    strictEqual(error.received, 0);
+    strictEqual(
+      error.message,
+      "stopped at 0/? bytes: update resource 3 is gone",
+    );
+  });
+
+  it("refuses an unknown kind rather than trusting it", () => {
+    const error = toUpdateDownloadError({ kind: "weird", message: "x" });
+    strictEqual(error.kind, "other");
+  });
+
+  it("returns an existing UpdateDownloadError as is", () => {
+    const error = new UpdateDownloadError({
+      kind: "signature",
+      message: "bad",
+      received: 10,
+      total: 10,
+      attempts: 0,
+    });
+    strictEqual(toUpdateDownloadError(error), error);
+  });
+});
+
+describe("describeDownloadFailure", () => {
+  it("omits the attempt count when nothing was attempted", () => {
+    strictEqual(
+      describeDownloadFailure({
+        kind: "http",
+        message: "Download request failed with status: 404",
+        received: 0,
+        total: null,
+        attempts: 0,
+      }),
+      "stopped at 0/? bytes: Download request failed with status: 404",
+    );
+  });
+});
+
+// The release-feed check's reqwest messages: transport failures are the
+// device's link, a 404 / bad manifest is a leaked staging build and must
+// keep filing as a bug.
+describe("isUpdateNetworkFailure", () => {
+  it("matches reqwest's transport shapes", () => {
+    for (const message of [
+      "error sending request for url (https://github.com/gethouston/houston/releases/latest/download/latest.json)",
+      "error decoding response body",
+      "dns error: failed to lookup address information",
+      "Connection reset by peer (os error 54)",
+      "operation timed out",
+      "tls handshake eof",
+    ]) {
+      strictEqual(isUpdateNetworkFailure(message), true, message);
+    }
+  });
+
+  it("leaves a manifest or status failure as a bug", () => {
+    for (const message of [
+      "Could not fetch a valid release JSON from the remote",
+      "Download request failed with status: 404 Not Found",
+      "Update.install called before Update.download",
+    ]) {
+      strictEqual(isUpdateNetworkFailure(message), false, message);
+    }
+  });
+});

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -27,6 +27,19 @@ export function isTauri(): boolean {
 
 type InvokeArgs = Record<string, unknown> | Uint8Array | undefined;
 
+/** Mirror of `@tauri-apps/api`'s `Channel`: a native command's progress
+ * stream. The web build never invokes a command that takes one (the
+ * updater's download is desktop-only), so it only has to type-check. */
+export class Channel<T = unknown> {
+  onmessage: (response: T) => void = () => {};
+  constructor(onmessage?: (response: T) => void) {
+    if (onmessage) this.onmessage = onmessage;
+  }
+  toJSON(): string {
+    return "__CHANNEL__:web";
+  }
+}
+
 /** Mirror of `@tauri-apps/api`'s InvokeOptions (headers ride the raw-payload
  * IPC on desktop). The web shim has no native IPC, so they're ignored. */
 type InvokeOptions = { headers?: Record<string, string> };
@@ -289,6 +302,10 @@ export async function invoke<T = unknown>(
     case "open_file":
     case "current_app_bundle_path":
     case "relaunch_app_from_path":
+    // The shell's resumable release download + staged install; the web tab has
+    // no bundle to update and the updater shim's check() never finds one.
+    case "download_update":
+    case "install_update":
     case "sentry_native_stack_smoke_test":
       return notAvailable(cmd);
 

--- a/packages/web/src/shims/tauri-plugin-updater.ts
+++ b/packages/web/src/shims/tauri-plugin-updater.ts
@@ -19,6 +19,9 @@ export type DownloadEvent =
   | { event: "Finished"; data: Record<string, never> };
 
 export interface Update {
+  /** The plugin's `Update` resource id; the desktop's own download and
+   *  install commands take it (os-bridge `osDownloadUpdate`). */
+  rid: number;
   currentVersion: string;
   version: string;
   body?: string;


### PR DESCRIPTION
## Summary

PRODUCT-1727. Release downloads of 0.6.18 / 0.6.20 failed mid-stream for 14 users in two days (HOUSTON-APP-5CY: `error decoding response body`, `error sending request for url`).

**Root cause.** `tauri-plugin-updater` fetches a release in ONE streamed `reqwest` request, buffers it, and verifies. There is no retry and no resume, so a dropped connection anywhere in a 290 MB `Houston.app.tar.gz` (the macOS artifact is universal, so it carries both architectures' sidecars) or a 170 MB MSI throws the whole download away, and the frontend filed it as a bug per user.

**Fix.** The shell owns the download and the staged install over the plugin's `Update` resource (`check()` stays with the plugin):

- `download_update` (`app/src-tauri/src/commands/update_fetch.rs` + `update_stage.rs`): up to 4 attempts with 1s / 3s / 9s backoff, `Range: bytes=<received>-` resume (GitHub assets answer 206; a 200 on a ranged request restarts the tally with a fresh `Started` event), a 60s read timeout so a silent stall resumes instead of hanging, and the same minisign verification the plugin runs against the `tauri.conf.json` pubkey. Progress rides the plugin's own `DownloadEvent` shape, so the tally fold is unchanged.
- `install_update` hands the verified bytes to the plugin's installer (bundle swap on macOS, msiexec hand-off on Windows).
- The rejection is typed (`update-download-failure.ts`): `network` failures carry the byte position (`stopped at 123456789/315000000 bytes after 4 attempts: ...`) and report as the quiet `offline` class (one fingerprinted warning issue, burst-collapsed); `http` / `signature` / `other` still file as bugs.
- Release-feed check failures that are transport-shaped take the same quiet path after the 3-failure streak; the stuck-client toast and `update_check_failed` analytics event still fire. A 404 / malformed manifest (the leaked-staging-build signature) still files as an error.

Not in this PR: a "could not download, we will retry" pill state (PRODUCT-1719) and the 5DE unpack failure (one user).

## Tests

- Rust (`update_fetch_tests.rs`, scripted HTTP server on a local socket): resume twice then complete with the right `Range` headers and a single `Started`; restart when the server ignores the range; give up after the attempt budget with the byte position; an HTTP status is final on first sight; backoff values. Signature rejection tests in `update_stage.rs`.
- Node (`app/tests/update-download-failure.test.ts`): typed-rejection parsing, message shape, and the check-failure network classifier (transport shapes match, manifest/status shapes do not).

`cargo test` (221 pass), `cd app && pnpm test` (4225 pass), `pnpm check`, `cd app && pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck` (shim parity) all green.

## Verification

**Before (reproduce on `main`):** run a packaged build from an older version with a link that drops mid-stream (e.g. Network Link Conditioner "Very Bad Network", or toggle Wi-Fi off for a few seconds while the pill is downloading). The frontend log shows `[updater] download failed ... error decoding response body`, Sentry gets an `update_download` error event, and the next poll starts the download from byte 0.

**After (this branch):** same setup. The backend log shows `[updater] download attempt 1/4 stopped at N/T bytes: ...` followed by a resumed attempt with a `Range` header; the download completes and the restart pill appears. If all four attempts fail, the frontend log carries `stopped at N/T bytes after 4 attempts`, and Sentry receives only a warning in the `offline` quiet-class issue (tag `quiet_class:offline`, `source:update_download`), never a new `update_download` error issue. With the release feed unreachable (DNS blocked for github.com), three consecutive checks still show the "updates can't reach you" toast, but the Sentry event lands in the `offline` issue instead of `update_check`.
