### PR TITLE
fix(chat): re-issue the mission board row while the agent's pod wakes (PRODUCT-1736)

### DIFF
--- a/app/src/lib/create-mission-now.ts
+++ b/app/src/lib/create-mission-now.ts
@@ -23,20 +23,15 @@
  * status writes match the row by session key once it has landed.
  */
 
-import { isAgentGoneError } from "./agent-gone";
 import { analytics } from "./analytics";
 import type {
   CreateMissionAgent,
   CreateMissionOptions,
   CreateMissionResult,
 } from "./create-mission";
-import { getEngine } from "./engine";
-import { showErrorToast } from "./error-toast";
-import i18n from "./i18n";
 import { logger } from "./logger";
-import { missionRowInput } from "./mission-row";
+import { landMissionRow } from "./mission-row-landing";
 import { fallbackMissionTitle, refreshMissionTitle } from "./mission-title";
-import { healStaleRosterFromError } from "./roster-heal";
 import { showSendFailedToast } from "./send-error-toast";
 import { tauriActivity, tauriChat } from "./tauri";
 
@@ -48,49 +43,6 @@ export interface MissionIdentity {
   description: string;
   /** Source text for the async AI title pass; absent = keep `title`. */
   titleText?: string;
-}
-
-/**
- * Land the board row through the host's single id-honoring POST. Resolves the
- * landed id (differs from ours only under version skew — an engine predating
- * client-supplied ids assigned its own, so its row is stamped with our session
- * key to keep the card opening this chat), or null after toasting: losing the
- * card must never lose the message.
- */
-async function landMissionRow(
-  agent: CreateMissionAgent,
-  opts: CreateMissionOptions,
-  mission: MissionIdentity,
-): Promise<string | null> {
-  try {
-    const created = await tauriActivity.createWithId(
-      agent.folderPath,
-      missionRowInput(mission, opts),
-    );
-    if (created.id !== mission.conversationId) {
-      await getEngine().updateActivity(agent.folderPath, created.id, {
-        session_key: mission.sessionKey,
-      });
-    }
-    return created.id;
-  } catch (e) {
-    // The agent vanished under the send (deleted/unshared elsewhere): an
-    // expected roster-stale state, healed like the warming flush does — not a
-    // bug toast the user can't act on.
-    if (isAgentGoneError(e)) {
-      healStaleRosterFromError(e);
-      return null;
-    }
-    showErrorToast(
-      "create_mission_now",
-      "mission row create/update failed",
-      e,
-      {
-        userMessage: i18n.t("chat:errors.missionRowFailed"),
-      },
-    );
-    return null;
-  }
 }
 
 /**

--- a/app/src/lib/mission-row-landing.ts
+++ b/app/src/lib/mission-row-landing.ts
@@ -1,0 +1,84 @@
+/**
+ * The board-row half of an optimistic mission create (`create-mission-now.ts`):
+ * one id-honoring POST, re-issued while the agent's pod is still waking.
+ */
+
+import { isAgentGoneError } from "./agent-gone";
+import type {
+  CreateMissionAgent,
+  CreateMissionOptions,
+} from "./create-mission";
+import type { MissionIdentity } from "./create-mission-now";
+import { getEngine } from "./engine";
+import { isEngineWakingError } from "./engine-waking-error";
+import { showErrorToast } from "./error-toast";
+import i18n from "./i18n";
+import { logger } from "./logger";
+import { missionRowInput } from "./mission-row";
+import { healStaleRosterFromError } from "./roster-heal";
+import { surfaceEngineError, tauriActivity } from "./tauri";
+import { MISSION_ROW_WAKING_RETRY_MS, retryWhileWaking } from "./waking-retry";
+
+/**
+ * Land the board row through the host's single id-honoring POST. Resolves the
+ * landed id (differs from ours only under version skew — an engine predating
+ * client-supplied ids assigned its own, so its row is stamped with our session
+ * key to keep the card opening this chat), or null after toasting: losing the
+ * card must never lose the message.
+ */
+export async function landMissionRow(
+  agent: CreateMissionAgent,
+  opts: CreateMissionOptions,
+  mission: MissionIdentity,
+): Promise<string | null> {
+  const input = missionRowInput(mission, opts);
+  try {
+    // The POST rides the gateway's wake hold; when that hold gives up on a
+    // stalled control plane it answers the waking 503, and the pod answers a
+    // little later (PRODUCT-1736). Re-issue along the SDK send's ladder
+    // rather than dropping the card. Attempts run with the engine-call
+    // surface deferred (`createWithIdAttempt`): one ladder is one failure,
+    // reported once below, never once per rung.
+    const created = await retryWhileWaking(
+      () => tauriActivity.createWithIdAttempt(agent.folderPath, input),
+      MISSION_ROW_WAKING_RETRY_MS,
+      {
+        isWaking: isEngineWakingError,
+        sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+        onRetry: (err, delayMs) =>
+          logger.warn(
+            `[create-mission-now] board row refused while the agent wakes; retrying in ${delayMs}ms: ${err}`,
+          ),
+      },
+    );
+    if (created.id !== mission.conversationId) {
+      await getEngine().updateActivity(agent.folderPath, created.id, {
+        session_key: mission.sessionKey,
+      });
+    }
+    return created.id;
+  } catch (e) {
+    // The deferred engine-call surface for the final attempt: the log line,
+    // the quiet class or the capture, exactly as `createWithId` would have.
+    await surfaceEngineError("create_activity", e, undefined, {
+      toast: false,
+      silence: isAgentGoneError,
+    });
+    // The agent vanished under the send (deleted/unshared elsewhere): an
+    // expected roster-stale state, healed like the warming flush does — not a
+    // bug toast the user can't act on.
+    if (isAgentGoneError(e)) {
+      healStaleRosterFromError(e);
+      return null;
+    }
+    showErrorToast(
+      "create_mission_now",
+      "mission row create/update failed",
+      e,
+      {
+        userMessage: i18n.t("chat:errors.missionRowFailed"),
+      },
+    );
+    return null;
+  }
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -186,7 +186,7 @@ export async function surfaceEngineError(
   label: string,
   err: unknown,
   context?: Record<string, unknown>,
-  options?: Pick<EngineCallOptions, "silence">,
+  options?: Pick<EngineCallOptions, "silence" | "toast">,
 ): Promise<void> {
   await surfaceError(label, err, context, options);
 }
@@ -1510,6 +1510,18 @@ export const tauriActivity = {
       // roster-stale state, not a Houston bug. Both callers catch it: the
       // flush heals + aborts, the mission path keeps its own toast.
       { toast: false, silence: isAgentGoneError },
+    ),
+  /**
+   * `createWithId` for ONE rung of a retry ladder: the log tail records the
+   * attempt, nothing else surfaces. The caller hands the final error to
+   * `surfaceEngineError` (`create-mission-now.ts`, PRODUCT-1736).
+   */
+  createWithIdAttempt: (agentPath: string, input: EngineNewActivity) =>
+    call(
+      "create_activity",
+      () => getEngine().createActivity(agentPath, input),
+      undefined,
+      { surface: false },
     ),
   update: (
     agentPath: string,

--- a/app/src/lib/waking-retry.ts
+++ b/app/src/lib/waking-retry.ts
@@ -1,0 +1,60 @@
+/**
+ * Re-run a write the gateway refused because the agent's pod is not there
+ * yet (PRODUCT-1736).
+ *
+ * A hosted write against a pod mid-wake can come back as the waking 503 even
+ * after the gateway held it for its whole wake budget: the control plane it
+ * asked to wake the pod stalled (a replica restarting under a roll, or wedged
+ * behind its own dependencies), and the pod answers seconds to minutes later.
+ * The SDK's turn send already walks a delay ladder on exactly this refusal
+ * (`turn-stream.ts` resendWhileWaking); this is the same ladder for the
+ * board-row write the mission flow fires next to the send, so a card is not
+ * lost to a wake that merely ran long. Any other refusal, an exhausted ladder,
+ * or a pod that never answers surfaces the LAST error to the caller, which
+ * owns the one report.
+ *
+ * Pure so `node --test` covers it (app/tests/waking-retry.test.ts): the
+ * classifier and the clock are injected.
+ */
+
+export interface WakingRetryDeps {
+  /** The waking classifier (`isEngineWakingError` in the app). */
+  isWaking: (err: unknown) => boolean;
+  sleep: (ms: number) => Promise<void>;
+  /** Observability hook: fires before each pause, with the refusal it follows. */
+  onRetry?: (err: unknown, delayMs: number) => void;
+}
+
+/**
+ * Pauses before the second, third and fourth attempt. Each attempt itself
+ * rides the gateway's own wake hold, so the ladder is deliberately short: it
+ * bridges the gap between one hold giving up and the pod answering, it does
+ * not replace the hold.
+ */
+export const MISSION_ROW_WAKING_RETRY_MS: readonly number[] = [
+  5_000, 15_000, 30_000,
+];
+
+export async function retryWhileWaking<T>(
+  attempt: () => Promise<T>,
+  delaysMs: readonly number[],
+  deps: WakingRetryDeps,
+): Promise<T> {
+  let last: unknown;
+  try {
+    return await attempt();
+  } catch (e) {
+    last = e;
+  }
+  for (const delayMs of delaysMs) {
+    if (!deps.isWaking(last)) throw last;
+    deps.onRetry?.(last, delayMs);
+    await deps.sleep(delayMs);
+    try {
+      return await attempt();
+    } catch (e) {
+      last = e;
+    }
+  }
+  throw last;
+}

--- a/app/tests/engine-waking-error.test.ts
+++ b/app/tests/engine-waking-error.test.ts
@@ -337,6 +337,45 @@ function activitiesHttpError(status: number, body: string): Error {
   return err;
 }
 
+// PRODUCT-1736 (HOUSTON-APP-5CJ/5CF): the gateway's wake hold gave up on a
+// control plane that never answered its ensure-awake, and the 503 it minted
+// carries the cpclient transport error as detail — with Go's sorted map keys
+// putting "detail" BEFORE "error". The body is the wake 503 and must classify
+// quiet through both shapes a mission-row write can throw.
+const CPCLIENT_ENSURE_AWAKE_503 =
+  '{"detail":"cpclient: POST /internal/v1/agents/b095cb5c018ca652/82a19c02c0bd0c5b:ensure-awake: Post \\"http://control-plane.houston-gateway.svc.cluster.local:8081/internal/v1/agents/b095cb5c018ca652/82a19c02c0bd0c5b:ensure-awake\\": context deadline exceeded","error":"engine unavailable"}';
+
+describe("isEngineWakingError (control-plane stall body, PRODUCT-1736)", () => {
+  it("classifies the cpclient deadline 503 quiet on the SDK activity shape", () => {
+    strictEqual(
+      isEngineWakingError(activitiesHttpError(503, CPCLIENT_ENSURE_AWAKE_503)),
+      true,
+    );
+  });
+
+  it("classifies the same answer quiet on the engine-adapter shape", () => {
+    // `HoustonEngineError` keeps the parsed reason in its message; the
+    // cpclient detail lives on `body` and must not change the verdict.
+    const err = engineError(503, "engine unavailable") as Error & {
+      body: unknown;
+    };
+    err.body = JSON.parse(CPCLIENT_ENSURE_AWAKE_503);
+    strictEqual(isEngineWakingError(err), true);
+  });
+
+  it("never lets the cpclient detail promote another reason", () => {
+    strictEqual(
+      isEngineWakingError(
+        activitiesHttpError(
+          503,
+          '{"detail":"cpclient: POST /internal/v1/agents/o/a:ensure-awake: context deadline exceeded","error":"no cluster configured"}',
+        ),
+      ),
+      false,
+    );
+  });
+});
+
 // HOUSTON-APP-51X: a mission created against a pod mid-roll answered the
 // proxy-failed 502 through the SDK activities module, which carries the body
 // exactly like the agents module but was not in the classifier's name list.

--- a/app/tests/mission-row.test.ts
+++ b/app/tests/mission-row.test.ts
@@ -60,10 +60,15 @@ describe("both mission creation paths route their row through it", () => {
     readFileSync(new URL(`../src/lib/${file}`, import.meta.url), "utf8");
 
   it("the optimistic create posts the shared row payload", () => {
+    // The row write lives in its own module since the waking-retry ladder
+    // (PRODUCT-1736); the payload is built once and re-posted per rung.
+    const landing = source("mission-row-landing.ts");
     strictEqual(
-      /createWithId\(\s*agent\.folderPath,\s*missionRowInput\(/.test(
-        source("create-mission-now.ts"),
-      ),
+      /const input = missionRowInput\(mission, opts\)/.test(landing),
+      true,
+    );
+    strictEqual(
+      /createWithIdAttempt\(agent\.folderPath, input\)/.test(landing),
       true,
     );
   });

--- a/app/tests/waking-retry.test.ts
+++ b/app/tests/waking-retry.test.ts
@@ -1,0 +1,132 @@
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  MISSION_ROW_WAKING_RETRY_MS,
+  retryWhileWaking,
+} from "../src/lib/waking-retry.ts";
+
+// PRODUCT-1736: a board-row write refused with the waking 503 (the gateway's
+// wake hold gave up on a stalled control plane) is re-issued along a short
+// ladder instead of dropping the card; every other refusal surfaces at once.
+
+class Waking extends Error {}
+
+function harness() {
+  const slept: number[] = [];
+  const retried: number[] = [];
+  return {
+    slept,
+    retried,
+    deps: {
+      isWaking: (err: unknown) => err instanceof Waking,
+      sleep: async (ms: number) => {
+        slept.push(ms);
+      },
+      onRetry: (_err: unknown, delayMs: number) => {
+        retried.push(delayMs);
+      },
+    },
+  };
+}
+
+describe("retryWhileWaking", () => {
+  it("returns the first attempt's value without sleeping", async () => {
+    const h = harness();
+    const value = await retryWhileWaking(async () => "row-1", [5, 15], h.deps);
+    strictEqual(value, "row-1");
+    deepStrictEqual(h.slept, []);
+  });
+
+  it("walks the ladder while the pod is waking, then lands", async () => {
+    const h = harness();
+    let calls = 0;
+    const value = await retryWhileWaking(
+      async () => {
+        calls += 1;
+        if (calls < 3) throw new Waking("engine unavailable");
+        return "row-1";
+      },
+      [5, 15, 30],
+      h.deps,
+    );
+    strictEqual(value, "row-1");
+    strictEqual(calls, 3);
+    deepStrictEqual(h.slept, [5, 15]);
+    deepStrictEqual(h.retried, [5, 15]);
+  });
+
+  it("surfaces the last waking refusal once the ladder is spent", async () => {
+    const h = harness();
+    let calls = 0;
+    await rejects(
+      retryWhileWaking(
+        async () => {
+          calls += 1;
+          throw new Waking(`attempt ${calls}`);
+        },
+        [5, 15],
+        h.deps,
+      ),
+      (err: unknown) => err instanceof Waking && err.message === "attempt 3",
+    );
+    deepStrictEqual(h.slept, [5, 15]);
+  });
+
+  it("never retries a refusal that is not a wake", async () => {
+    const h = harness();
+    let calls = 0;
+    await rejects(
+      retryWhileWaking(
+        async () => {
+          calls += 1;
+          throw new Error("agent not found");
+        },
+        [5, 15],
+        h.deps,
+      ),
+      /agent not found/,
+    );
+    strictEqual(calls, 1);
+    deepStrictEqual(h.slept, []);
+  });
+
+  it("stops the ladder the moment a retry fails for another reason", async () => {
+    const h = harness();
+    let calls = 0;
+    await rejects(
+      retryWhileWaking(
+        async () => {
+          calls += 1;
+          if (calls === 1) throw new Waking("engine unavailable");
+          throw new Error("store unavailable");
+        },
+        [5, 15, 30],
+        h.deps,
+      ),
+      /store unavailable/,
+    );
+    strictEqual(calls, 2);
+    deepStrictEqual(h.slept, [5]);
+  });
+
+  it("with no ladder is a single attempt", async () => {
+    const h = harness();
+    await rejects(
+      retryWhileWaking(
+        async () => {
+          throw new Waking("engine unavailable");
+        },
+        [],
+        h.deps,
+      ),
+      Waking,
+    );
+    deepStrictEqual(h.slept, []);
+  });
+
+  it("ships a short ladder: three pauses under a minute in total", () => {
+    strictEqual(MISSION_ROW_WAKING_RETRY_MS.length, 3);
+    const total = MISSION_ROW_WAKING_RETRY_MS.reduce((a, b) => a + b, 0);
+    strictEqual(total <= 60_000, true);
+  });
+});


### PR DESCRIPTION
PRODUCT-1736

## Root cause

A mission created while the control plane stalled (HOUSTON-APP-5CJ / 5CF) came back as the waking 503 once the gateway's wake hold gave up: body `{"detail":"cpclient: POST …:ensure-awake … context deadline exceeded","error":"engine unavailable"}`. The waking classifier already reads that body as `engine_waking` (the `create_activity` layer filed it in the quiet 5CE bucket), and the leak into a bug report was `showErrorToast("create_mission_now", …)` not running the quiet gate, which PR #1534 fixed (0.6.21, merged after the last 5CJ event). What was still wrong: the board row was dropped for good on that first refusal, while the send itself walked the SDK's waking ladder and landed.

The server half (per-attempt bound + retry in cpclient, a real `/readyz`) is gethouston/cloud#354.

## Fix

- `app/src/lib/waking-retry.ts`: pure `retryWhileWaking` ladder (injected classifier + clock), `MISSION_ROW_WAKING_RETRY_MS = [5s, 15s, 30s]`, mirroring the SDK send's `resendWhileWaking`.
- `app/src/lib/mission-row-landing.ts` (extracted from `create-mission-now.ts` to stay under the file limit): the row POST re-issues on a waking refusal through a surface-deferred `tauriActivity.createWithIdAttempt`, then hands the final error to `surfaceEngineError` once, so one stalled wake is one quiet report, never one per rung. Any other refusal surfaces at once; agent-gone still heals the roster.
- `surfaceEngineError` accepts `toast` so the deferred surface matches `createWithId`'s exactly.

## Tests

- `app/tests/waking-retry.test.ts`: first-try success, ladder walk then land, ladder spent surfaces the last refusal, non-wake never retried, a non-wake mid-ladder stops it, empty ladder, ladder under a minute.
- `app/tests/engine-waking-error.test.ts`: the exact Sentry body (Go's sorted keys put `detail` before `error`) classifies quiet on both the SDK activity shape and the engine-adapter shape; the cpclient detail never promotes another reason.
- `app/tests/mission-row.test.ts` updated for the extracted module.
- `pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (4228 pass) green.

## Before

1. On the hosted profile, make the gateway's ensure-awake fail after its hold (pause a control-plane replica, or point `CP_URL` at a blackhole) and send a message to an asleep agent.
2. After the hold the frontend log shows `[toast:create_activity] {"detail":"cpclient: …","error":"engine unavailable"}` then `[toast:create_mission_now] mission row create/update failed`. The message lands once the pod answers, but the board never shows a card for it.

## After

1. Same setup, then unpause the control plane within ~50s.
2. The log shows `[create-mission-now] board row refused while the agent wakes; retrying in 5000ms` (then 15000, 30000 as needed) and the card appears on the board once the pod answers. Sentry receives at most one `engine_waking` warning for the episode, no `create_mission_now` issue.
3. Delete the agent from another device mid-send: the row write stops at once and the roster heals, no retry ladder.