### PR TITLE
fix(shell): probe Win32 window creation before tao asserts on it (PRODUCT-1726)

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -113,7 +113,7 @@ notify-rust = "4.11"
 # DPAPI binds the ciphertext to the Windows user account so a copied
 # file is useless to another user. See `src/auth.rs` storage module.
 [target."cfg(target_os = \"windows\")".dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_Shell"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_Security_Cryptography", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_LibraryLoader", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 # Same reason as notify-rust on Linux, but notify-rust's action handling is
 # XDG/D-Bus-only — on Windows we use the WinRT toast's `on_activated` callback
 # to catch the click. This is the crate notify-rust uses under the hood.

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -28,6 +28,10 @@ mod sentry_filter;
 mod shell_env;
 mod store_deep_link;
 mod window_focus;
+// Pure decision logic compiles and tests everywhere; only the Win32 probe
+// and dialog are Windows-only.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+mod window_preflight;
 mod windows_icon_repair;
 
 use engine_supervisor::{
@@ -256,6 +260,12 @@ pub fn run() {
     // here onwards, including engine subprocess spawn logs and plugin setup.
     logging::init(&houston);
     redirection_guard::report_after_logging_init();
+
+    // Windows: tao's event loop asserts (a bare panic, no error code) when
+    // the session cannot create a window. Probe the same calls first so a
+    // broken session ends in a Sentry event that names the Win32 error and
+    // a dialog the user can act on, instead of a silent crash (PRODUCT-1726).
+    window_preflight::ensure_window_creation_works();
 
     let mut builder = tauri::Builder::default();
 

--- a/app/src-tauri/src/window_preflight/mod.rs
+++ b/app/src-tauri/src/window_preflight/mod.rs
@@ -1,0 +1,243 @@
+//! Refuse to reach tao's start-up assert when Windows cannot create a
+//! window (PRODUCT-1726).
+//!
+//! tao's `EventLoop::new` registers a window class, creates a hidden
+//! message-target window and attaches a comctl32 subclass to it, then
+//! `assert!`s on the subclass result. On a machine where any of those calls
+//! fails, the process dies with `assertion failed: subclass_result.as_bool()`
+//! before a single window exists: the user clicks the icon, nothing appears,
+//! and the only trace is a panic that carries no Win32 error code (Sentry
+//! HOUSTON-APP-4RG: two machines, every event a retry of the one before).
+//! Nothing Houston does precedes that call, so the shell cannot repair the
+//! session; it can stop short of the assert. This module runs the same three
+//! calls on a throwaway window first. A failure is retried briefly (a session
+//! still settling after logon or an update-launched relaunch recovers), then
+//! reported with the failing call and `GetLastError` so the next event names
+//! the cause, shown to the user as a plain-language dialog with the remedy
+//! that covers every known cause (close apps or restart), and the process
+//! exits cleanly.
+//!
+//! Decision logic is pure and unit-tested on every host; only the Win32
+//! calls are `cfg(windows)`.
+
+use std::time::Duration;
+
+/// Which of tao's three start-up calls the probe could not complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Step {
+    RegisterClass,
+    CreateWindow,
+    Subclass,
+}
+
+impl Step {
+    /// The Win32 entry point, as it reads in Microsoft's documentation, for
+    /// the log line and the support hint in the dialog.
+    pub fn win32_call(self) -> &'static str {
+        match self {
+            Step::RegisterClass => "RegisterClassExW",
+            Step::CreateWindow => "CreateWindowExW",
+            Step::Subclass => "SetWindowSubclass",
+        }
+    }
+}
+
+/// One failed probe: the step and the `GetLastError` it left behind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Failure {
+    pub step: Step,
+    pub code: u32,
+}
+
+/// Pause before each retry. Five attempts over roughly 2.5 seconds: long
+/// enough for a settling session, short enough that a user whose session is
+/// truly out of resources sees the dialog rather than a hung launch.
+const RETRY_DELAYS_MS: [u64; 4] = [200, 400, 800, 1200];
+
+/// How long to wait before the next attempt after `failed_attempts`
+/// failures, `None` once the attempts are used up.
+fn retry_delay(failed_attempts: usize) -> Option<Duration> {
+    failed_attempts
+        .checked_sub(1)
+        .and_then(|i| RETRY_DELAYS_MS.get(i))
+        .map(|ms| Duration::from_millis(*ms))
+}
+
+/// `ERROR_NOT_ENOUGH_MEMORY`, `ERROR_OUTOFMEMORY`, `ERROR_NO_SYSTEM_RESOURCES`:
+/// the session's desktop heap or atom table is full, which only closing apps
+/// or a restart clears.
+fn is_resource_exhaustion(code: u32) -> bool {
+    matches!(code, 8 | 14 | 1450)
+}
+
+const DIALOG_TITLE: &str = "Houston can't open";
+
+/// Debug builds honour `HOUSTON_FORCE_WINDOW_PREFLIGHT_FAIL=<win32 code>` so
+/// the report and dialog path can be exercised with `pnpm tauri dev` on a
+/// healthy machine (the DMG guard's pattern). Release builds ignore it.
+const FORCE_FAIL_ENV: &str = "HOUSTON_FORCE_WINDOW_PREFLIGHT_FAIL";
+
+fn forced_failure(raw: Option<&str>) -> Option<Failure> {
+    let code = raw?.trim().parse().ok()?;
+    Some(Failure {
+        step: Step::CreateWindow,
+        code,
+    })
+}
+
+/// Plain-language dialog body. The error code and call are the one technical
+/// detail kept, so support can match a report to the Sentry event.
+fn dialog_body(failure: &Failure) -> String {
+    let detail = format!("error {} in {}", failure.code, failure.step.win32_call());
+    if is_resource_exhaustion(failure.code) {
+        format!(
+            "Windows has run out of the resources it needs to open a new window, \
+             so Houston can't start right now.\n\n\
+             Close a few apps or restart your computer, then open Houston again.\n\n\
+             ({detail})"
+        )
+    } else {
+        format!(
+            "Windows refused to create Houston's window, so Houston can't start right now.\n\n\
+             Restart your computer, then open Houston again. If this keeps happening, \
+             contact support and mention {detail}."
+        )
+    }
+}
+
+/// Probe window creation before the Tauri builder runs. Returns normally when
+/// Windows can create and subclass a window (always, off Windows); otherwise
+/// reports, shows the dialog and exits the process.
+pub fn ensure_window_creation_works() {
+    #[cfg(target_os = "windows")]
+    {
+        let forced = cfg!(debug_assertions)
+            .then(|| forced_failure(std::env::var(FORCE_FAIL_ENV).ok().as_deref()))
+            .flatten();
+        let mut failed_attempts = 0;
+        loop {
+            match forced.map(Err).unwrap_or_else(win::probe) {
+                Ok(()) => {
+                    if failed_attempts > 0 {
+                        tracing::warn!(
+                            attempts = failed_attempts + 1,
+                            "[window-preflight] window creation recovered after retrying"
+                        );
+                    }
+                    return;
+                }
+                Err(failure) => {
+                    failed_attempts += 1;
+                    let Some(delay) = retry_delay(failed_attempts) else {
+                        fail_closed(failure, failed_attempts);
+                    };
+                    tracing::warn!(
+                        call = failure.step.win32_call(),
+                        code = failure.code,
+                        attempt = failed_attempts,
+                        "[window-preflight] window creation failed; retrying"
+                    );
+                    std::thread::sleep(delay);
+                }
+            }
+        }
+    }
+}
+
+/// Report the persistent failure (the ERROR record becomes the Sentry event
+/// that finally carries the Win32 code), flush it so a process exit does not
+/// drop it, tell the user, and exit without the panic.
+#[cfg(target_os = "windows")]
+fn fail_closed(failure: Failure, attempts: usize) -> ! {
+    tracing::error!(
+        call = failure.step.win32_call(),
+        code = failure.code,
+        attempts,
+        "[window-preflight] Windows cannot create Houston's window; exiting before the event loop asserts"
+    );
+    if let Some(client) = sentry::Hub::current().client() {
+        client.flush(Some(Duration::from_secs(3)));
+    }
+    win::show_dialog(DIALOG_TITLE, &dialog_body(&failure));
+    std::process::exit(1)
+}
+
+#[cfg(target_os = "windows")]
+mod win;
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        dialog_body, forced_failure, is_resource_exhaustion, retry_delay, Failure, Step,
+        DIALOG_TITLE,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn retries_five_times_over_about_two_and_a_half_seconds() {
+        let delays: Vec<Duration> = (1..).map_while(retry_delay).collect();
+        assert_eq!(delays.len(), 4, "four retries after the first attempt");
+        assert!(delays.windows(2).all(|pair| pair[0] < pair[1]), "backs off");
+        let total: Duration = delays.iter().sum();
+        assert!(total <= Duration::from_secs(3), "total {total:?}");
+        assert_eq!(retry_delay(0), None, "no delay before the first attempt");
+    }
+
+    #[test]
+    fn forced_failure_needs_a_numeric_code() {
+        assert_eq!(forced_failure(None), None);
+        assert_eq!(forced_failure(Some("")), None);
+        assert_eq!(forced_failure(Some("nope")), None);
+        assert_eq!(
+            forced_failure(Some(" 1450 ")),
+            Some(Failure {
+                step: Step::CreateWindow,
+                code: 1450,
+            })
+        );
+    }
+
+    #[test]
+    fn exhaustion_codes_are_the_three_out_of_resources_errors() {
+        for code in [8, 14, 1450] {
+            assert!(is_resource_exhaustion(code), "{code}");
+        }
+        for code in [0, 5, 1407, 1410] {
+            assert!(!is_resource_exhaustion(code), "{code}");
+        }
+    }
+
+    #[test]
+    fn exhaustion_dialog_tells_the_user_to_close_apps_or_restart() {
+        let body = dialog_body(&Failure {
+            step: Step::CreateWindow,
+            code: 8,
+        });
+        assert!(body.contains("Close a few apps or restart your computer"));
+        assert!(body.contains("error 8 in CreateWindowExW"));
+    }
+
+    #[test]
+    fn other_failures_point_at_support_with_the_code() {
+        let body = dialog_body(&Failure {
+            step: Step::Subclass,
+            code: 1407,
+        });
+        assert!(body.contains("contact support"));
+        assert!(body.contains("error 1407 in SetWindowSubclass"));
+    }
+
+    #[test]
+    fn copy_never_leaks_internals() {
+        for step in [Step::RegisterClass, Step::CreateWindow, Step::Subclass] {
+            let body = dialog_body(&Failure { step, code: 1450 });
+            for banned in ["tao", "panic", "assert", "HWND", "event loop"] {
+                assert!(!body.contains(banned), "{banned:?} in {body:?}");
+            }
+        }
+        assert!(
+            !DIALOG_TITLE.contains('\u{2014}'),
+            "no em dash in user copy"
+        );
+    }
+}

--- a/app/src-tauri/src/window_preflight/win.rs
+++ b/app/src-tauri/src/window_preflight/win.rs
@@ -1,0 +1,133 @@
+//! The Win32 half of the start-up window probe: register a class, create
+//! a hidden window with tao's exact extended styles, subclass it, tear it
+//! down, and the native dialog shown when that keeps failing.
+
+use super::{Failure, Step};
+use std::ptr::{null, null_mut};
+use windows_sys::Win32::Foundation::{
+    GetLastError, SetLastError, ERROR_CLASS_ALREADY_EXISTS, HINSTANCE, HWND, LPARAM, LRESULT,
+    WPARAM,
+};
+use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows_sys::Win32::UI::Shell::{DefSubclassProc, RemoveWindowSubclass, SetWindowSubclass};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, DestroyWindow, MessageBoxW, RegisterClassExW,
+    UnregisterClassW, MB_ICONERROR, MB_OK, MB_SETFOREGROUND, MB_TOPMOST, WNDCLASSEXW,
+    WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_OVERLAPPED,
+};
+
+/// Distinct from tao's "Tao Thread Event Target" so the two never collide.
+const CLASS_NAME: &str = "Houston Window Preflight";
+const SUBCLASS_ID: usize = 1;
+
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, w: WPARAM, l: LPARAM) -> LRESULT {
+    DefWindowProcW(hwnd, msg, w, l)
+}
+
+unsafe extern "system" fn subclass_proc(
+    hwnd: HWND,
+    msg: u32,
+    w: WPARAM,
+    l: LPARAM,
+    _id: usize,
+    _data: usize,
+) -> LRESULT {
+    DefSubclassProc(hwnd, msg, w, l)
+}
+
+/// Register a class, create a hidden window with exactly the extended
+/// styles tao gives its message-target window, subclass it, then tear
+/// everything down. Every resource is released on every path so a retry
+/// starts clean.
+pub(super) fn probe() -> Result<(), Failure> {
+    let class_name = wide(CLASS_NAME);
+    // SAFETY: plain Win32 calls on a class this module owns; the name
+    // buffer outlives every use and the class is unregistered before it
+    // is dropped.
+    unsafe {
+        let instance: HINSTANCE = GetModuleHandleW(null());
+        let class = WNDCLASSEXW {
+            cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+            style: 0,
+            lpfnWndProc: Some(wnd_proc),
+            cbClsExtra: 0,
+            cbWndExtra: 0,
+            hInstance: instance,
+            hIcon: null_mut(),
+            hCursor: null_mut(),
+            hbrBackground: null_mut(),
+            lpszMenuName: null(),
+            lpszClassName: class_name.as_ptr(),
+            hIconSm: null_mut(),
+        };
+        // A class left behind by an earlier attempt whose window would not
+        // die is still ours: probe through it rather than fail on it.
+        SetLastError(0);
+        if RegisterClassExW(&class) == 0 && GetLastError() != ERROR_CLASS_ALREADY_EXISTS {
+            return Err(failure(Step::RegisterClass));
+        }
+        let result = probe_window(class_name.as_ptr(), instance);
+        UnregisterClassW(class_name.as_ptr(), instance);
+        result
+    }
+}
+
+unsafe fn probe_window(class_name: *const u16, instance: HINSTANCE) -> Result<(), Failure> {
+    SetLastError(0);
+    let window = CreateWindowExW(
+        WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW,
+        class_name,
+        null(),
+        WS_OVERLAPPED,
+        0,
+        0,
+        0,
+        0,
+        null_mut(),
+        null_mut(),
+        instance,
+        null(),
+    );
+    if window.is_null() {
+        return Err(failure(Step::CreateWindow));
+    }
+    // comctl32 documents only FALSE on failure, so clear the thread's error
+    // first: a stale code from an earlier call must not pose as the cause.
+    SetLastError(0);
+    let result = if SetWindowSubclass(window, Some(subclass_proc), SUBCLASS_ID, 0) != 0 {
+        RemoveWindowSubclass(window, Some(subclass_proc), SUBCLASS_ID);
+        Ok(())
+    } else {
+        Err(failure(Step::Subclass))
+    };
+    DestroyWindow(window);
+    result
+}
+
+unsafe fn failure(step: Step) -> Failure {
+    Failure {
+        step,
+        code: GetLastError(),
+    }
+}
+
+/// Native message box; the only UI this process will ever show. Its own
+/// window creation can fail for the same reason, in which case the
+/// Sentry event and log line already sent are all that remains.
+pub(super) fn show_dialog(title: &str, body: &str) {
+    let title = wide(title);
+    let body = wide(body);
+    // SAFETY: both buffers are NUL-terminated and outlive the call.
+    unsafe {
+        MessageBoxW(
+            null_mut(),
+            body.as_ptr(),
+            title.as_ptr(),
+            MB_OK | MB_ICONERROR | MB_SETFOREGROUND | MB_TOPMOST,
+        );
+    }
+}


### PR DESCRIPTION
Fixes PRODUCT-1726.

## Root cause

The panic `assertion failed: subclass_result.as_bool()` is tao 0.35.3 `EventLoop::new` → `subclass_event_target_window` (`src/platform_impl/windows/event_loop.rs:709`), reached from `tauri::Builder::build` at `lib.rs:538`. It fires before any Houston plugin or setup code runs, so neither the update relaunch nor the Redirection Guard relaunch can be the cause (the 0.6.17 events also predate the guard, and 0.6.17 shipped no crate bumps).

tao's `create_event_target_window` returns a null `HWND` when `CreateWindowExW` fails and then asserts on `SetWindowSubclass`, so the panic never carries the Win32 error. The 18 events are two machines (one Windows 11 21H2 laptop accounts for 16), each cluster a user re-clicking the icon minutes apart with nothing appearing. That shape is a session that cannot create windows (desktop heap or atom table exhaustion is the classic cause), not a Houston code path, and the shell cannot repair it.

## Fix

A Windows start-up preflight (`app/src-tauri/src/window_preflight/`) runs right after logging init and before the Tauri builder. It performs tao's three calls on a throwaway window (register a class, `CreateWindowExW` with tao's exact extended styles, `SetWindowSubclass`), tears everything down, and:

- retries five times over about 2.6 s so a session that is still settling recovers;
- on persistent failure logs `[window-preflight]` at ERROR with the failing call and `GetLastError` (becomes the Sentry event that finally names the cause), flushes Sentry, shows a native dialog with a plain-language remedy (close apps or restart), and exits cleanly instead of panicking.

Debug builds honour `HOUSTON_FORCE_WINDOW_PREFLIGHT_FAIL=<win32 code>` so the report and dialog path can be exercised on a healthy machine (same pattern as the DMG guard). Pure decision logic (retry schedule, code classification, copy, override parsing) is unit-tested on every host.

## Verification

Before (0.6.17 / 0.6.18 on an affected machine):
1. Launch Houston from the Start menu or the desktop icon.
2. Nothing appears, no dialog. Sentry HOUSTON-APP-4RG receives `panic: assertion failed: subclass_result.as_bool()` with no Win32 code, one per click.

After:
1. Healthy Windows machine: launch normally. The app opens as before; `backend.log` has no `[window-preflight]` line (the probe takes under a millisecond).
2. Forced failure on a Windows dev box: `HOUSTON_FORCE_WINDOW_PREFLIGHT_FAIL=8 pnpm tauri dev`. After ~2.6 s a native "Houston can't open" dialog appears telling the user to close apps or restart; `backend.log` shows four `[window-preflight] window creation failed; retrying` WARN lines then one ERROR line with `call=CreateWindowExW code=8 attempts=5`; the process exits with code 1 and no panic. With `SENTRY_SEND_IN_DEV=1` the ERROR line lands in Sentry as an event carrying `call` and `code`.
3. On the affected machines, the next launch produces that Sentry event instead of the panic bucket entry, and the `code` field says why Windows refuses the window.

Checks run: `cargo check`, `cargo test` (shell crate, 218 tests), `cargo check --target x86_64-pc-windows-gnu -p houston-app` (Win32 half compiled for Windows), `rustfmt --check` on the new files.
