### PR TITLE
fix(providers): keep API-key rejections out of Sentry, name the huggingface/google remedy (PRODUCT-1730)

### DIFF
--- a/app/src/components/shell/provider-api-key-dialog.tsx
+++ b/app/src/components/shell/provider-api-key-dialog.tsx
@@ -10,10 +10,12 @@ import {
 import { ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { analytics } from "../../lib/analytics";
 import {
-  type ApiKeyConnectReason,
   apiKeyConnectReason,
+  isApiKeyUserRejection,
 } from "../../lib/api-key-connect-error";
+import { apiKeyReasonCopyKey } from "../../lib/api-key-reason-copy";
 import { isOrgAdminRequiredError } from "../../lib/org-admin-required-error";
 import { API_KEY_ENDPOINT_PROVIDERS } from "../../lib/provider-overrides";
 import type { ProviderInfo } from "../../lib/providers";
@@ -45,35 +47,6 @@ function verifyFailureDetail(err: unknown): string {
 interface Props {
   provider: ProviderInfo | null;
   onClose: () => void;
-}
-
-/** Verification verdicts (from the engine's typed `reason`) → inline copy. */
-const REASON_COPY: Record<
-  ApiKeyConnectReason,
-  | "apiKey.errorInvalidKey"
-  | "apiKey.errorKeyRestricted"
-  | "apiKey.errorProviderUnavailable"
-> = {
-  invalid_key: "apiKey.errorInvalidKey",
-  key_restricted: "apiKey.errorKeyRestricted",
-  provider_unavailable: "apiKey.errorProviderUnavailable",
-};
-
-/**
- * NVIDIA's `key_restricted` is an ACCOUNT gate, not key settings: NVIDIA has
- * to enable "Public API Endpoints" on the account's org, so the generic
- * "create a new key" remedy would send users in circles (HOU-890).
- */
-function reasonCopyKey(providerId: string, reason: ApiKeyConnectReason) {
-  if (providerId === "nvidia" && reason === "key_restricted")
-    return "apiKey.errorNvidiaAccountGated" as const;
-  // Bedrock's console lists keys by NAME ("BedrockAPIKey-xxxx-at-<account>")
-  // and reveals the VALUE only once at generation, so a rejected key is
-  // usually the name pasted in place of the value (PRODUCT-1477) — say so
-  // instead of the generic "check it and paste it again".
-  if (providerId === "amazon-bedrock" && reason === "invalid_key")
-    return "apiKey.errorBedrockInvalidKey" as const;
-  return REASON_COPY[reason];
 }
 
 export function ProviderApiKeyDialog({ provider, onClose }: Props) {
@@ -131,7 +104,9 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
       // actionable copy. A reason-less failure (transport error, older host)
       // shows the host's REAL sentence instead of generic copy, which turned
       // every provider-QA failure into an undiagnosable "failed to connect".
-      // Sentry capture already happened in the tauri call wrapper.
+      // The tauri call wrapper already captured anything that is not a
+      // user-fixable verdict; those are counted here instead so the provider
+      // mix that confuses users stays visible without filing Sentry bugs.
       const reason = apiKeyConnectReason(err);
       if (isOrgAdminRequiredError(err)) {
         // A plain member on the org-level (pre-agent) connect: the gateway
@@ -139,8 +114,14 @@ export function ProviderApiKeyDialog({ provider, onClose }: Props) {
         // `setApiKey` silences it so nothing else surfaces.
         setError(t("apiKey.errorOrgAdminRequired"));
       } else if (reason) {
+        if (isApiKeyUserRejection(err)) {
+          analytics.track("provider_key_rejected", {
+            provider: provider.id,
+            error_kind: reason,
+          });
+        }
         setError(
-          t(reasonCopyKey(provider.id, reason), { name: provider.name }),
+          t(apiKeyReasonCopyKey(provider.id, reason), { name: provider.name }),
         );
       } else {
         const detail = verifyFailureDetail(err);

--- a/app/src/components/shell/provider-api-key-guide.tsx
+++ b/app/src/components/shell/provider-api-key-guide.tsx
@@ -8,9 +8,16 @@ import { useTranslation } from "react-i18next";
  * build.nvidia.com key flow never shows, so without these steps users mint
  * keys that fail on every chat model. Amazon Bedrock second (PRODUCT-1477):
  * the console shows a generated key's VALUE exactly once and afterwards lists
- * only its name, which users then paste as the key.
+ * only its name, which users then paste as the key. Hugging Face third
+ * (PRODUCT-1730): a fine-grained token without "Make calls to Inference
+ * Providers" authenticates but is refused on every model.
  */
 const GUIDES = {
+  huggingface: [
+    "apiKey.guide.huggingface1",
+    "apiKey.guide.huggingface2",
+    "apiKey.guide.huggingface3",
+  ],
   nvidia: [
     "apiKey.guide.nvidia1",
     "apiKey.guide.nvidia2",

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -120,6 +120,10 @@ export type AnalyticsEventName =
   | "workspace_created"
   | "provider_configured"
   | "provider_not_configured"
+  // A pasted API key the provider refused with a user-fixable verdict
+  // (`error_kind`: invalid_key | key_restricted). Counted, never a Sentry
+  // error: it shows which providers' key pages confuse users (PRODUCT-1730).
+  | "provider_key_rejected"
   | "agent_created"
   | "agent_installed_from_store"
   | "agent_shared"

--- a/app/src/lib/api-key-connect-error.ts
+++ b/app/src/lib/api-key-connect-error.ts
@@ -40,3 +40,16 @@ export function apiKeyConnectReason(err: unknown): ApiKeyConnectReason | null {
     ? (reason as ApiKeyConnectReason)
     : null;
 }
+
+/**
+ * A verdict the USER fixes — a bad key or a key blocked by its own account
+ * settings. The connect dialog renders the typed copy inline, so the tauri
+ * wrapper silences these: no red toast, no Sentry (13 events / 11 users of
+ * pasted-wrong keys buried real provider failures, PRODUCT-1730). A
+ * `provider_unavailable` verdict (5xx / timeout / network) and a reason-less
+ * failure stay loud — those may be Houston's or the provider's fault.
+ */
+export function isApiKeyUserRejection(err: unknown): boolean {
+  const reason = apiKeyConnectReason(err);
+  return reason === "invalid_key" || reason === "key_restricted";
+}

--- a/app/src/lib/api-key-reason-copy.ts
+++ b/app/src/lib/api-key-reason-copy.ts
@@ -1,0 +1,46 @@
+import type { ApiKeyConnectReason } from "./api-key-connect-error";
+
+/** Verification verdicts (from the engine's typed `reason`) → inline copy. */
+const REASON_COPY = {
+  invalid_key: "apiKey.errorInvalidKey",
+  key_restricted: "apiKey.errorKeyRestricted",
+  provider_unavailable: "apiKey.errorProviderUnavailable",
+} as const satisfies Record<ApiKeyConnectReason, string>;
+
+export type ApiKeyReasonCopyKey =
+  | (typeof REASON_COPY)[ApiKeyConnectReason]
+  | "apiKey.errorNvidiaAccountGated"
+  | "apiKey.errorBedrockInvalidKey"
+  | "apiKey.errorHuggingfaceInferenceGated"
+  | "apiKey.errorGoogleKeyRestricted";
+
+/**
+ * The `providers` namespace key the connect dialog renders for a verdict.
+ * Providers whose rejection has a KNOWN remedy get their own sentence; the
+ * generic "check the key" / "create a key without restrictions" copy sent
+ * those users in circles:
+ *  - NVIDIA `key_restricted` is an ACCOUNT gate: NVIDIA has to enable
+ *    "Public API Endpoints" on the account's org (HOU-890).
+ *  - Bedrock's console lists keys by NAME and shows the VALUE once, so a
+ *    rejected key is usually the name pasted in place of the value
+ *    (PRODUCT-1477).
+ *  - Hugging Face `key_restricted` is a fine-grained token missing the
+ *    "Make calls to Inference Providers" permission (PRODUCT-1730).
+ *  - Google `key_restricted` is the key's own restrictions in AI Studio /
+ *    Cloud Console, or the Gemini API not enabled on its project
+ *    (PRODUCT-1730).
+ */
+export function apiKeyReasonCopyKey(
+  providerId: string,
+  reason: ApiKeyConnectReason,
+): ApiKeyReasonCopyKey {
+  if (reason === "key_restricted") {
+    if (providerId === "nvidia") return "apiKey.errorNvidiaAccountGated";
+    if (providerId === "huggingface")
+      return "apiKey.errorHuggingfaceInferenceGated";
+    if (providerId === "google") return "apiKey.errorGoogleKeyRestricted";
+  }
+  if (providerId === "amazon-bedrock" && reason === "invalid_key")
+    return "apiKey.errorBedrockInvalidKey";
+  return REASON_COPY[reason];
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -42,6 +42,7 @@ import {
   isAgentPathCreating,
   type WarmingWriteOptions,
 } from "./agent-warming-guard";
+import { isApiKeyUserRejection } from "./api-key-connect-error";
 import { isKeyGoneError, isKeyLimitError } from "./api-keys-model";
 import { isAssistantUnavailableError } from "./assistant-availability";
 import {
@@ -1997,12 +1998,20 @@ export const tauriProvider = {
       undefined,
       // The connect dialog surfaces the failure inline with the engine's typed
       // reason (bad key / restricted key / provider outage) — a red bug toast
-      // on top double-surfaces a user-fixable state. Capture stays on so
-      // verification failures keep reaching Sentry. The gateway's owner/admin
-      // refusal of a member's org-level connect is an expected state the
-      // dialog explains inline too, so it is silenced here (no toast, no
-      // Sentry) rather than routed to the surfacing layer's info toast.
-      { toast: false, silence: isOrgAdminRequiredError },
+      // on top double-surfaces a user-fixable state. A bad or under-scoped
+      // key is the USER's state, not a Houston bug: those verdicts are
+      // silenced (the dialog tracks them as `provider_key_rejected` instead,
+      // PRODUCT-1730). A no-verdict outage and a reason-less failure keep
+      // capturing so real provider / host faults still reach Sentry. The
+      // gateway's owner/admin refusal of a member's org-level connect is an
+      // expected state the dialog explains inline too, so it is silenced
+      // here (no toast, no Sentry) rather than routed to the surfacing
+      // layer's info toast.
+      {
+        toast: false,
+        silence: (err) =>
+          isOrgAdminRequiredError(err) || isApiKeyUserRejection(err),
+      },
     ),
   /**
    * Connect an OpenAI-compatible (local / BYO model) server: a base URL + model

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -95,12 +95,17 @@
       "bedrock3": "Paste the key value below. It starts with \"ABSK\". The name shown in the list (\"BedrockAPIKey-...\") is not the key.",
       "azure1": "In the Azure portal, open your Azure OpenAI (or Foundry) resource and go to \"Keys and endpoint\".",
       "azure2": "Copy one of the two keys and the endpoint URL.",
-      "azure3": "Deploy the models you want to use, each named exactly like the model (for example \"gpt-5.5\"), then paste the endpoint and key here."
+      "azure3": "Deploy the models you want to use, each named exactly like the model (for example \"gpt-5.5\"), then paste the endpoint and key here.",
+      "huggingface1": "Open the Hugging Face tokens page with the button above and sign in, or create a free account.",
+      "huggingface2": "Click \"Create new token\". A \"Read\" token works. If you pick \"Fine-grained\", check \"Make calls to Inference Providers\" under Inference.",
+      "huggingface3": "Copy the token that starts with \"hf_\" and paste it below."
     },
     "errorInvalidKey": "{{name}} didn't accept this key. Check it and paste it again.",
     "errorKeyRestricted": "This key is blocked by settings in your {{name}} account. Create a new key without restrictions using the button above, then paste it here.",
     "errorNvidiaAccountGated": "Your key is valid, but NVIDIA isn't serving any chat models to your account right now. Make sure your key is a Personal Key from org.ngc.nvidia.com with \"Public API Endpoints\" under Services Included. If it still fails, ask NVIDIA support to enable model access for your account.",
     "errorBedrockInvalidKey": "Amazon Bedrock didn't accept this key. Make sure you pasted the key value (it starts with \"ABSK\"), not its name from the list (\"BedrockAPIKey-...\"). AWS shows the value only once, so generate a new key if you no longer have it.",
+    "errorHuggingfaceInferenceGated": "Your token is valid, but it isn't allowed to run models. Open the Hugging Face tokens page with the button above and create a token with \"Make calls to Inference Providers\" checked (a \"Read\" token also works), then paste it here.",
+    "errorGoogleKeyRestricted": "Google is blocking this key through its own settings. In Google AI Studio or Google Cloud, open the key, remove its application and API restrictions (or allow the Generative Language API), or create a new key without restrictions with the button above, then paste it here.",
     "errorProviderUnavailable": "We couldn't reach {{name}} to check your key, so nothing was saved. Please try again in a moment.",
     "errorOrgAdminRequired": "Only an owner or admin can connect AI for the organization. Ask one of them to set it up, or to add you to an agent so you can connect your own key."
   },

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -95,12 +95,17 @@
       "bedrock3": "Pega el valor de la clave abajo. Empieza con \"ABSK\". El nombre que aparece en la lista (\"BedrockAPIKey-...\") no es la clave.",
       "azure1": "En el portal de Azure, abre tu recurso de Azure OpenAI (o Foundry) y entra a \"Claves y punto de conexión\".",
       "azure2": "Copia una de las dos claves y la URL del punto de conexión.",
-      "azure3": "Implementa los modelos que quieras usar, cada uno con el mismo nombre del modelo (por ejemplo \"gpt-5.5\"), y pega aquí el punto de conexión y la clave."
+      "azure3": "Implementa los modelos que quieras usar, cada uno con el mismo nombre del modelo (por ejemplo \"gpt-5.5\"), y pega aquí el punto de conexión y la clave.",
+      "huggingface1": "Abre la página de tokens de Hugging Face con el botón de arriba e inicia sesión, o crea una cuenta gratis.",
+      "huggingface2": "Haz clic en \"Create new token\". Un token \"Read\" funciona. Si eliges \"Fine-grained\", marca \"Make calls to Inference Providers\" en Inference.",
+      "huggingface3": "Copia el token que empieza con \"hf_\" y pégalo abajo."
     },
     "errorInvalidKey": "{{name}} no aceptó esta clave. Revísala y pégala de nuevo.",
     "errorKeyRestricted": "Esta clave está bloqueada por la configuración de tu cuenta de {{name}}. Crea una clave nueva sin restricciones con el botón de arriba y pégala aquí.",
     "errorNvidiaAccountGated": "Tu clave es válida, pero NVIDIA no está sirviendo modelos de chat a tu cuenta en este momento. Asegúrate de que tu clave sea una Personal Key de org.ngc.nvidia.com con \"Public API Endpoints\" en Services Included. Si aun así falla, pide al soporte de NVIDIA que habilite el acceso a modelos para tu cuenta.",
     "errorBedrockInvalidKey": "Amazon Bedrock no aceptó esta clave. Asegúrate de pegar el valor de la clave (empieza con \"ABSK\") y no su nombre de la lista (\"BedrockAPIKey-...\"). AWS muestra el valor una sola vez, así que genera una clave nueva si ya no lo tienes.",
+    "errorHuggingfaceInferenceGated": "Tu token es válido, pero no tiene permiso para ejecutar modelos. Abre la página de tokens de Hugging Face con el botón de arriba y crea un token con \"Make calls to Inference Providers\" marcado (un token \"Read\" también funciona), y pégalo aquí.",
+    "errorGoogleKeyRestricted": "Google está bloqueando esta clave por su propia configuración. En Google AI Studio o Google Cloud, abre la clave, quita sus restricciones de aplicación y de API (o permite la Generative Language API), o crea una clave nueva sin restricciones con el botón de arriba, y pégala aquí.",
     "errorProviderUnavailable": "No pudimos conectar con {{name}} para verificar tu clave, así que no se guardó nada. Inténtalo de nuevo en un momento.",
     "errorOrgAdminRequired": "Solo un propietario o administrador puede conectar la IA de la organización. Pídele a uno de ellos que la configure, o que te agregue a un agente para que conectes tu propia clave."
   },

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -95,12 +95,17 @@
       "bedrock3": "Cole o valor da chave abaixo. Ele começa com \"ABSK\". O nome exibido na lista (\"BedrockAPIKey-...\") não é a chave.",
       "azure1": "No portal do Azure, abra seu recurso do Azure OpenAI (ou Foundry) e acesse \"Chaves e endpoint\".",
       "azure2": "Copie uma das duas chaves e a URL do endpoint.",
-      "azure3": "Implante os modelos que quiser usar, cada um com o mesmo nome do modelo (por exemplo \"gpt-5.5\"), e cole aqui o endpoint e a chave."
+      "azure3": "Implante os modelos que quiser usar, cada um com o mesmo nome do modelo (por exemplo \"gpt-5.5\"), e cole aqui o endpoint e a chave.",
+      "huggingface1": "Abra a página de tokens do Hugging Face com o botão acima e faça login, ou crie uma conta grátis.",
+      "huggingface2": "Clique em \"Create new token\". Um token \"Read\" funciona. Se escolher \"Fine-grained\", marque \"Make calls to Inference Providers\" em Inference.",
+      "huggingface3": "Copie o token que começa com \"hf_\" e cole abaixo."
     },
     "errorInvalidKey": "{{name}} não aceitou esta chave. Confira e cole de novo.",
     "errorKeyRestricted": "Esta chave está bloqueada pelas configurações da sua conta {{name}}. Crie uma chave nova sem restrições usando o botão acima e cole aqui.",
     "errorNvidiaAccountGated": "Sua chave é válida, mas a NVIDIA não está servindo modelos de chat para a sua conta neste momento. Confira se sua chave é uma Personal Key de org.ngc.nvidia.com com \"Public API Endpoints\" em Services Included. Se ainda falhar, peça ao suporte da NVIDIA para habilitar o acesso aos modelos na sua conta.",
     "errorBedrockInvalidKey": "A Amazon Bedrock não aceitou esta chave. Confira se você colou o valor da chave (começa com \"ABSK\") e não o nome da lista (\"BedrockAPIKey-...\"). A AWS mostra o valor só uma vez, então gere uma chave nova se você não o tiver mais.",
+    "errorHuggingfaceInferenceGated": "Seu token é válido, mas não tem permissão para executar modelos. Abra a página de tokens do Hugging Face com o botão acima e crie um token com \"Make calls to Inference Providers\" marcado (um token \"Read\" também funciona), depois cole aqui.",
+    "errorGoogleKeyRestricted": "O Google está bloqueando esta chave pelas configurações dela. No Google AI Studio ou no Google Cloud, abra a chave, remova as restrições de aplicativo e de API (ou permita a Generative Language API), ou crie uma chave nova sem restrições com o botão acima, depois cole aqui.",
     "errorProviderUnavailable": "Não conseguimos acessar {{name}} para verificar sua chave, então nada foi salvo. Tente de novo em instantes.",
     "errorOrgAdminRequired": "Só um proprietário ou administrador pode conectar a IA da organização. Peça a um deles para configurar, ou para adicionar você a um agente para conectar sua própria chave."
   },

--- a/app/tests/api-key-connect-error.test.ts
+++ b/app/tests/api-key-connect-error.test.ts
@@ -1,6 +1,9 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { apiKeyConnectReason } from "../src/lib/api-key-connect-error.ts";
+import {
+  apiKeyConnectReason,
+  isApiKeyUserRejection,
+} from "../src/lib/api-key-connect-error.ts";
 
 // The two adapter error shapes the connect dialog can catch: the cloud control
 // plane throws with a PARSED JSON body (HoustonEngineError), the local
@@ -50,5 +53,38 @@ describe("apiKeyConnectReason", () => {
     strictEqual(apiKeyConnectReason(new Error("plain")), null);
     strictEqual(apiKeyConnectReason(undefined), null);
     strictEqual(apiKeyConnectReason("string error"), null);
+  });
+});
+
+// A user-fixable verdict is silenced by `tauriProvider.setApiKey` (no toast, no
+// Sentry) and rendered inline; a no-verdict outage and a reason-less failure
+// stay loud (PRODUCT-1730). A false positive here drops a real bug report.
+describe("isApiKeyUserRejection", () => {
+  it("matches the two verdicts the user fixes, on both error shapes", () => {
+    strictEqual(
+      isApiKeyUserRejection(
+        cloudError({ error: "deepseek rejected…", reason: "invalid_key" }),
+      ),
+      true,
+    );
+    strictEqual(
+      isApiKeyUserRejection(
+        localError('{"error":"blocked","reason":"key_restricted"}'),
+      ),
+      true,
+    );
+  });
+
+  it("keeps provider outages and reason-less failures loud", () => {
+    strictEqual(
+      isApiKeyUserRejection(
+        cloudError({ error: "down", reason: "provider_unavailable" }),
+      ),
+      false,
+    );
+    strictEqual(isApiKeyUserRejection(cloudError({ error: "nope" })), false);
+    strictEqual(isApiKeyUserRejection(localError("Bad Gateway")), false);
+    strictEqual(isApiKeyUserRejection(new Error("plain")), false);
+    strictEqual(isApiKeyUserRejection(undefined), false);
   });
 });

--- a/app/tests/api-key-reason-copy.test.ts
+++ b/app/tests/api-key-reason-copy.test.ts
@@ -1,0 +1,111 @@
+import { ok, strictEqual } from "node:assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { apiKeyReasonCopyKey } from "../src/lib/api-key-reason-copy.ts";
+
+// The connect dialog's verdict → copy map. Providers with a KNOWN remedy must
+// name it: the generic "check the key" sent Hugging Face users (a token
+// missing the Inference Providers permission) and Google users (a key with
+// its own restrictions) in circles (PRODUCT-1730). Every key it returns must
+// exist in the en source of truth, and the remedy sentences must name the
+// thing to change.
+const EN = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "../src/locales/en/providers.json"),
+    "utf8",
+  ),
+) as { apiKey: Record<string, string> };
+
+const read = (key: string) => EN.apiKey[key.replace(/^apiKey\./, "")];
+
+describe("apiKeyReasonCopyKey", () => {
+  it("names the Inference Providers permission for a restricted huggingface token", () => {
+    const key = apiKeyReasonCopyKey("huggingface", "key_restricted");
+    strictEqual(key, "apiKey.errorHuggingfaceInferenceGated");
+    ok(read(key)?.includes("Make calls to Inference Providers"));
+  });
+
+  it("names the key's own restrictions for a restricted google key", () => {
+    const key = apiKeyReasonCopyKey("google", "key_restricted");
+    strictEqual(key, "apiKey.errorGoogleKeyRestricted");
+    ok(read(key)?.includes("restrictions"));
+  });
+
+  it("keeps the earlier per-provider remedies", () => {
+    strictEqual(
+      apiKeyReasonCopyKey("nvidia", "key_restricted"),
+      "apiKey.errorNvidiaAccountGated",
+    );
+    strictEqual(
+      apiKeyReasonCopyKey("amazon-bedrock", "invalid_key"),
+      "apiKey.errorBedrockInvalidKey",
+    );
+  });
+
+  it("falls back to the generic verdict copy everywhere else", () => {
+    strictEqual(
+      apiKeyReasonCopyKey("huggingface", "invalid_key"),
+      "apiKey.errorInvalidKey",
+    );
+    strictEqual(
+      apiKeyReasonCopyKey("deepseek", "invalid_key"),
+      "apiKey.errorInvalidKey",
+    );
+    strictEqual(
+      apiKeyReasonCopyKey("google", "provider_unavailable"),
+      "apiKey.errorProviderUnavailable",
+    );
+  });
+
+  it("every returned key exists in the en locale", () => {
+    for (const provider of [
+      "huggingface",
+      "google",
+      "nvidia",
+      "amazon-bedrock",
+      "x",
+    ])
+      for (const reason of [
+        "invalid_key",
+        "key_restricted",
+        "provider_unavailable",
+      ] as const)
+        ok(
+          read(apiKeyReasonCopyKey(provider, reason)),
+          `${provider}/${reason}`,
+        );
+  });
+});
+
+// `analytics.ts` can't be imported here (posthog-js comes with it), so the
+// rejection counter's contract is pinned against the source: the event must be
+// in the name union and both its props in ALLOWED_PROPS, or `cleanProps`
+// silently drops them and the dashboard goes quiet.
+const ANALYTICS = readFileSync(
+  join(import.meta.dirname, "../src/lib/analytics.ts"),
+  "utf8",
+);
+const TAURI = readFileSync(
+  join(import.meta.dirname, "../src/lib/tauri.ts"),
+  "utf8",
+);
+
+describe("provider_key_rejected wiring", () => {
+  it("declares the analytics event and its props", () => {
+    ok(ANALYTICS.includes('| "provider_key_rejected"'));
+    const allowed = ANALYTICS.slice(
+      ANALYTICS.indexOf("const ALLOWED_PROPS = new Set<AnalyticsProperty>(["),
+    );
+    ok(allowed.includes('"provider",'));
+    ok(allowed.includes('"error_kind",'));
+  });
+
+  it("setApiKey silences user-fixable verdicts so they never reach Sentry", () => {
+    const from = TAURI.indexOf('"set_provider_api_key"');
+    ok(from >= 0);
+    const call = TAURI.slice(from, TAURI.indexOf("setCustomEndpoint:", from));
+    ok(call.includes("isApiKeyUserRejection(err)"));
+    ok(call.includes("toast: false"));
+  });
+});

--- a/packages/runtime/src/auth/huggingface-verify.ts
+++ b/packages/runtime/src/auth/huggingface-verify.ts
@@ -1,0 +1,25 @@
+import { ApiKeyVerifyError } from "./verify-errors";
+
+export const HUGGINGFACE_PROVIDER_ID = "huggingface";
+
+/**
+ * Hugging Face answers a fine-grained token that lacks the "Make calls to
+ * Inference Providers" permission with 403 `"This authentication method does
+ * not have sufficient permissions to call Inference Providers on behalf of
+ * user <name>"`. The token itself authenticated (a garbage token gets 401
+ * "Invalid credentials"), so this is a `key_restricted` verdict — the remedy
+ * is the token's permissions page, not re-pasting it (PRODUCT-1730).
+ */
+export function huggingfaceInferenceGated(
+  providerId: string,
+  message: string,
+): ApiKeyVerifyError | null {
+  if (providerId !== HUGGINGFACE_PROVIDER_ID) return null;
+  const lower = message.toLowerCase();
+  if (!lower.includes("inference providers") || !lower.includes("permission"))
+    return null;
+  return new ApiKeyVerifyError(
+    `this ${providerId} token is not allowed to call Inference Providers — create a token with "Make calls to Inference Providers" enabled (${message})`,
+    "key_restricted",
+  );
+}

--- a/packages/runtime/src/auth/verify-api-key.test.ts
+++ b/packages/runtime/src/auth/verify-api-key.test.ts
@@ -340,3 +340,34 @@ test("google: a non-JSON error body still surfaces, with the raw text", async ()
     message: expect.stringMatching(/Bad Gateway/),
   });
 });
+
+test("huggingface's Inference Providers permission gate reads as key_restricted", async () => {
+  // A fine-grained token without "Make calls to Inference Providers"
+  // (Sentry HOUSTON-APP-5CN, PRODUCT-1730): the token authenticated, the
+  // permission is missing — never "check the key and paste it again".
+  completeSimple.mockResolvedValue(
+    reply({
+      stopReason: "error",
+      errorMessage:
+        '403 "This authentication method does not have sufficient permissions to call Inference Providers on behalf of user someone"',
+    }),
+  );
+  await expect(verifyApiKey("huggingface", "hf_scoped")).rejects.toMatchObject({
+    name: "ApiKeyVerifyError",
+    reason: "key_restricted",
+    message: expect.stringMatching(/Make calls to Inference Providers/),
+  });
+});
+
+test("a huggingface 401 still reads as an invalid key", async () => {
+  completeSimple.mockResolvedValue(
+    reply({
+      stopReason: "error",
+      errorMessage:
+        '401 {"error":"Invalid credentials in Authorization header"}',
+    }),
+  );
+  await expect(verifyApiKey("huggingface", "hf_bad")).rejects.toMatchObject({
+    reason: "invalid_key",
+  });
+});

--- a/packages/runtime/src/auth/verify-api-key.ts
+++ b/packages/runtime/src/auth/verify-api-key.ts
@@ -3,6 +3,7 @@ import { classifyProviderError } from "../ai/provider-error";
 import { modelFor, safeGetModel } from "../ai/providers";
 import { QWEN_PROVIDER_ID } from "../ai/qwen-dashscope";
 import { XIAOMI_PROVIDER_ID } from "../ai/xiaomi-endpoint";
+import { huggingfaceInferenceGated } from "./huggingface-verify";
 import { nvidiaGated, retryNvidiaFallbacks } from "./nvidia-verify";
 import { verifyQwenRegions } from "./qwen-verify";
 import {
@@ -112,6 +113,11 @@ export async function verifyApiKey(
     );
     if (message === null) return;
   }
+
+  // Hugging Face's permission gate is a 403 the taxonomy reads as plain
+  // auth; it is a token-permission fix, so it carries its own verdict.
+  const hfGated = huggingfaceInferenceGated(providerId, message);
+  if (hfGated) throw hfGated;
 
   const classified = classifyProviderError({
     provider: providerId,


### PR DESCRIPTION
## Summary

PRODUCT-1730

`set_provider_api_key` rejections (deepseek / qwen / nvidia 401s, google and huggingface 403s) are user-fixable states the connect dialog already explains inline, but `tauriProvider.setApiKey` kept `capture` on for them: 13 Sentry events / 11 users on 0.6.17 to 0.6.20 (HOUSTON-APP-5CN, 54F, 5DH, 5CK, 5D3), burying real provider failures and counting as `app_error_shown`.

### Root cause
- `setApiKey` passed `{ toast: false, silence: isOrgAdminRequiredError }`: the red toast was suppressed but every verification verdict still reached Sentry by design.
- Hugging Face's `403 "This authentication method does not have sufficient permissions to call Inference Providers"` was classified as plain auth (`invalid_key`), so a fine-grained token missing that permission got "check the key and paste it again".
- Google's `key_restricted` and huggingface's rejection shared generic copy that never named the actual setting to change.

### Fix
- **Quiet, typed verdicts.** `isApiKeyUserRejection` (`app/src/lib/api-key-connect-error.ts`) matches `invalid_key` / `key_restricted`; `setApiKey` silences those (logged, no toast, no Sentry). `provider_unavailable` and reason-less failures stay loud.
- **Counted, not captured.** The dialog tracks silenced verdicts as `provider_key_rejected` with `provider` + `error_kind` so the provider mix that confuses users stays visible in PostHog.
- **Runtime verdict.** `packages/runtime/src/auth/huggingface-verify.ts` turns the Inference Providers permission 403 into `key_restricted` with a message that names the permission.
- **Remedy copy (en/es/pt).** `apiKey.errorHuggingfaceInferenceGated` names "Make calls to Inference Providers"; `apiKey.errorGoogleKeyRestricted` names the key's application/API restrictions. Hugging Face also gets a 3-step key guide in the dialog (same pattern as NVIDIA / Bedrock).
- Verdict → copy map extracted to `app/src/lib/api-key-reason-copy.ts`.

### Tests
- `packages/runtime/src/auth/verify-api-key.test.ts`: huggingface permission 403 → `key_restricted`; huggingface 401 still `invalid_key`.
- `app/tests/api-key-connect-error.test.ts`: `isApiKeyUserRejection` on both error shapes, outages / reason-less stay loud.
- `app/tests/api-key-reason-copy.test.ts`: huggingface / google copy keys resolve and name the remedy; `provider_key_rejected` declared with allowed props; `setApiKey` wiring pinned.

`pnpm check`, `cd app && pnpm tsgo --noEmit`, `pnpm check-locales`, `pnpm test` (4254 pass), runtime `src/auth` suite (263 pass) all green.

## Before (reproduce)
1. On main, open Settings → AI providers → DeepSeek (or Qwen / NVIDIA / Google / Hugging Face) → Connect.
2. Paste a garbage key (e.g. `sk-nope`) and click Connect.
3. The dialog shows "DeepSeek didn't accept this key" inline, and a `set_provider_api_key: deepseek rejected this API key …` event lands in Sentry (`app_error_shown` fires).
4. For Hugging Face, paste a fine-grained token created WITHOUT "Make calls to Inference Providers": the dialog says "check it and paste it again", which is the wrong remedy.

## After (verify)
1. Same steps with a garbage key: the inline copy is unchanged, the log tail shows `[engine:set_provider_api_key] …`, no Sentry event, and PostHog receives `provider_key_rejected { provider: "deepseek", error_kind: "invalid_key" }`.
2. Hugging Face with an under-scoped fine-grained token: the dialog reads "Your token is valid, but it isn't allowed to run models … create a token with "Make calls to Inference Providers" checked", and the dialog shows the 3-step Hugging Face guide.
3. Google with a key that has API restrictions: the dialog names the key's restrictions in AI Studio / Cloud Console.
4. Provider outage (stop the network mid-verify or a 5xx): still captured to Sentry as before.
