### PR TITLE
fix(shell): carry whisper-cli's stderr tail on a dictation crash (PRODUCT-1731)

### DIFF
--- a/app/src-tauri/src/dictation/args.rs
+++ b/app/src-tauri/src/dictation/args.rs
@@ -1,0 +1,72 @@
+//! The whisper-cli argument line: language-hint validation and the flag set
+//! that keeps stdout to the bare transcript.
+
+use std::path::Path;
+
+/// Validate the language hint against the supported set; anything missing or
+/// unrecognized falls through to whisper's autodetect.
+pub(super) fn normalize_lang(raw: Option<&str>) -> &'static str {
+    match raw.map(str::trim) {
+        Some("en") => "en",
+        Some("es") => "es",
+        Some("pt") => "pt",
+        _ => "auto",
+    }
+}
+
+/// `-nt` (no timestamps) + `-np` (no progress prints) keep stdout to the bare
+/// transcript; no `-o*` flags means whisper writes no output files.
+pub(super) fn build_args(model: &Path, wav: &Path, lang: &str, threads: usize) -> Vec<String> {
+    vec![
+        "-m".into(),
+        model.to_string_lossy().into_owned(),
+        "-f".into(),
+        wav.to_string_lossy().into_owned(),
+        "-l".into(),
+        lang.into(),
+        "-t".into(),
+        threads.to_string(),
+        "-nt".into(),
+        "-np".into(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lang_hint_maps_supported_langs() {
+        assert_eq!(normalize_lang(Some("en")), "en");
+        assert_eq!(normalize_lang(Some("es")), "es");
+        assert_eq!(normalize_lang(Some("pt")), "pt");
+        assert_eq!(normalize_lang(Some("auto")), "auto");
+    }
+
+    #[test]
+    fn lang_hint_defaults_to_auto() {
+        assert_eq!(normalize_lang(None), "auto");
+        assert_eq!(normalize_lang(Some("fr")), "auto");
+        assert_eq!(normalize_lang(Some("")), "auto");
+    }
+
+    #[test]
+    fn args_carry_model_wav_lang_threads_and_flags() {
+        let args = build_args(Path::new("/m/model.bin"), Path::new("/t/clip.wav"), "es", 4);
+        assert_eq!(
+            args,
+            vec![
+                "-m",
+                "/m/model.bin",
+                "-f",
+                "/t/clip.wav",
+                "-l",
+                "es",
+                "-t",
+                "4",
+                "-nt",
+                "-np",
+            ]
+        );
+    }
+}

--- a/app/src-tauri/src/dictation/mod.rs
+++ b/app/src-tauri/src/dictation/mod.rs
@@ -10,8 +10,11 @@
 //! staged by Tauri's `externalBin` and resolved via [`crate::child_guard`],
 //! sharing the same orphan-prevention discipline as the engine sidecar.
 
+mod args;
 mod cpu;
 mod model;
+mod stderr_tail;
+mod temp_wav;
 mod types;
 mod verify;
 mod wav;

--- a/app/src-tauri/src/dictation/model.rs
+++ b/app/src-tauri/src/dictation/model.rs
@@ -42,9 +42,17 @@ pub fn model_path(app: &AppHandle) -> Result<PathBuf, String> {
 
 /// Ready = the file exists AND is exactly the expected size. A size check is a
 /// cheap corruption guard that avoids re-hashing 181 MB on every status poll;
-/// the full sha256 is enforced once, at download time.
-fn is_ready(path: &Path) -> bool {
-    matches!(std::fs::metadata(path), Ok(m) if m.len() == MODEL_SIZE_BYTES)
+/// the full sha256 is enforced once, at download time. `transcribe_audio`
+/// gates on the same predicate: a wrong-size file at the final path (a
+/// partial copy from an older layout, disk trouble) answers "model-not-ready"
+/// so the frontend offers the download again, which replaces it, instead of
+/// handing whisper-cli a blob it will refuse or crash on.
+pub(super) fn is_ready(path: &Path) -> bool {
+    has_size(path, MODEL_SIZE_BYTES)
+}
+
+fn has_size(path: &Path, expected: u64) -> bool {
+    matches!(std::fs::metadata(path), Ok(m) if m.len() == expected)
 }
 
 #[tauri::command]
@@ -148,5 +156,27 @@ fn emit(app: &AppHandle, received: u64, total: u64, phase: ModelProgressPhase) {
     // logged (the documented exception to the no-silent-failure rule).
     if let Err(e) = app.emit(PROGRESS_EVENT, payload) {
         tracing::error!("[dictation] failed to emit progress event: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ready_requires_the_exact_size() {
+        let dir = std::env::temp_dir().join(format!("dict-ready-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("m.bin");
+        std::fs::write(&path, b"12345").unwrap();
+
+        assert!(has_size(&path, 5));
+        assert!(!has_size(&path, 4), "a truncated file is not ready");
+        assert!(!has_size(&path, 6), "an oversized file is not ready");
+        assert!(
+            !has_size(&dir.join("missing.bin"), 0),
+            "absent is not ready"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/app/src-tauri/src/dictation/stderr_tail.rs
+++ b/app/src-tauri/src/dictation/stderr_tail.rs
@@ -1,0 +1,122 @@
+//! The last few KiB of a sidecar's stderr, kept so a crash carries its own
+//! evidence.
+//!
+//! whisper-cli reports every failure on stderr and nowhere else: a
+//! `GGML_ASSERT` prints `file:line: condition` plus a backtrace before
+//! `abort()`, the ggml terminate handler prints the uncaught exception, and a
+//! refused model load prints the loader's reason. On Windows `abort()`
+//! surfaces to the parent only as exit status `0xc0000409`
+//! (STATUS_STACK_BUFFER_OVERRUN via `__fastfail`), which names nothing. The
+//! shell used to route stderr to NUL, so the Sentry event for that exit
+//! (PRODUCT-1731) was a bare status code. The tail is bounded because model
+//! loading alone logs dozens of lines and an unbounded buffer would grow with
+//! the clip; the crash site is always at the END of stderr.
+
+use std::collections::VecDeque;
+use std::io::Read;
+
+/// Bytes of stderr retained. Enough for a ggml assert + backtrace, small
+/// enough to ride a Sentry event as `extra` without truncation.
+pub const STDERR_TAIL_BYTES: usize = 4096;
+
+/// A fixed-capacity byte window over the end of a stream.
+pub struct TailBuffer {
+    cap: usize,
+    bytes: VecDeque<u8>,
+}
+
+impl TailBuffer {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            cap,
+            bytes: VecDeque::with_capacity(cap),
+        }
+    }
+
+    /// Append, evicting from the front so at most `cap` bytes remain.
+    pub fn push(&mut self, chunk: &[u8]) {
+        let keep = chunk.len().min(self.cap);
+        let incoming = &chunk[chunk.len() - keep..];
+        let overflow = (self.bytes.len() + incoming.len()).saturating_sub(self.cap);
+        self.bytes.drain(..overflow);
+        self.bytes.extend(incoming);
+    }
+
+    /// The retained bytes as trimmed text. A window cut mid-codepoint yields a
+    /// replacement char at the start, never a decode failure.
+    pub fn into_string(self) -> String {
+        let bytes: Vec<u8> = self.bytes.into_iter().collect();
+        String::from_utf8_lossy(&bytes).trim().to_string()
+    }
+}
+
+/// Drain `reader` to EOF, keeping only the last [`STDERR_TAIL_BYTES`]. Read
+/// errors end the drain with whatever was retained: the tail is diagnostic
+/// context, never the reason a transcription fails.
+pub fn drain_tail<R: Read>(mut reader: R) -> String {
+    let mut tail = TailBuffer::new(STDERR_TAIL_BYTES);
+    let mut buf = [0u8; 1024];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => tail.push(&buf[..n]),
+        }
+    }
+    tail.into_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_everything_under_capacity() {
+        let mut tail = TailBuffer::new(16);
+        tail.push(b"hello ");
+        tail.push(b"world");
+        assert_eq!(tail.into_string(), "hello world");
+    }
+
+    #[test]
+    fn keeps_only_the_last_cap_bytes_across_pushes() {
+        let mut tail = TailBuffer::new(8);
+        tail.push(b"abcdef");
+        tail.push(b"ghijkl");
+        assert_eq!(tail.into_string(), "efghijkl");
+    }
+
+    #[test]
+    fn a_single_oversized_chunk_keeps_its_end() {
+        let mut tail = TailBuffer::new(4);
+        tail.push(b"0123456789");
+        assert_eq!(tail.into_string(), "6789");
+    }
+
+    #[test]
+    fn drain_tail_returns_the_end_of_a_long_stream() {
+        let noise = "whisper_model_load: loading model\n".repeat(400);
+        let crash = "ggml.c:123: GGML_ASSERT(rc == 0) failed\n";
+        let stream = format!("{noise}{crash}");
+        let tail = drain_tail(stream.as_bytes());
+        assert!(tail.len() <= STDERR_TAIL_BYTES);
+        assert!(
+            tail.ends_with("GGML_ASSERT(rc == 0) failed"),
+            "tail: {tail}"
+        );
+    }
+
+    #[test]
+    fn drain_tail_of_empty_stream_is_empty() {
+        assert_eq!(drain_tail(&b""[..]), "");
+    }
+
+    #[test]
+    fn mid_codepoint_cut_never_fails() {
+        let mut tail = TailBuffer::new(3);
+        tail.push("ñx".as_bytes()); // ñ is 2 bytes; cap 3 keeps all
+        assert_eq!(tail.into_string(), "ñx");
+        let mut cut = TailBuffer::new(2);
+        cut.push("ñx".as_bytes()); // keeps the 2nd byte of ñ + 'x'
+        assert_eq!(cut.into_string(), "\u{FFFD}x");
+    }
+}

--- a/app/src-tauri/src/dictation/temp_wav.rs
+++ b/app/src-tauri/src/dictation/temp_wav.rs
@@ -1,0 +1,56 @@
+//! A uniquely-named temp WAV whose file is removed when the handle drops,
+//! regardless of how the transcription returns.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Monotonic suffix so concurrent transcriptions never collide on a temp path.
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+pub struct TempWav {
+    path: PathBuf,
+}
+
+impl TempWav {
+    pub fn write(bytes: &[u8]) -> Result<Self, String> {
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!(
+            "houston-dictation-{}-{seq}-{nanos}.wav",
+            std::process::id()
+        ));
+        std::fs::write(&path, bytes)
+            .map_err(|e| format!("dictation: write temp wav {}: {e}", path.display()))?;
+        Ok(Self { path })
+    }
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempWav {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            tracing::debug!("dictation: temp wav cleanup failed: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temp_wav_written_then_removed_on_drop() {
+        let path;
+        {
+            let wav = TempWav::write(b"RIFFdata").unwrap();
+            path = wav.path().to_path_buf();
+            assert_eq!(std::fs::read(&path).unwrap(), b"RIFFdata");
+        }
+        assert!(!path.exists(), "temp wav removed when handle drops");
+    }
+}

--- a/app/src-tauri/src/dictation/types.rs
+++ b/app/src-tauri/src/dictation/types.rs
@@ -15,6 +15,54 @@ pub struct DictationModelStatus {
     pub cpu_supported: bool,
 }
 
+/// What `transcribe_audio` rejects with. Untagged: a `Message` crosses the
+/// IPC as the plain string the frontend already matches on (the sentinels
+/// `"model-not-ready"` / `"dictation-unsupported-cpu"` and every setup error),
+/// while a `SidecarFailure` is an object carrying whisper-cli's stderr tail so
+/// the Sentry report for a crash names the crash site (PRODUCT-1731). The
+/// `message` of a `SidecarFailure` keeps the exact pre-existing wording so the
+/// Sentry issue for each exit flavor stays continuous.
+#[derive(Debug, serde::Serialize)]
+#[serde(untagged)]
+pub enum DictationError {
+    Message(String),
+    #[serde(rename_all = "camelCase")]
+    SidecarFailure {
+        kind: SidecarFailureKind,
+        message: String,
+        stderr_tail: String,
+    },
+}
+
+/// Discriminator the frontend narrows a `SidecarFailure` on.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SidecarFailureKind {
+    SidecarFailure,
+}
+
+impl From<String> for DictationError {
+    fn from(message: String) -> Self {
+        Self::Message(message)
+    }
+}
+
+impl From<&str> for DictationError {
+    fn from(message: &str) -> Self {
+        Self::Message(message.to_string())
+    }
+}
+
+impl DictationError {
+    pub fn sidecar(message: impl Into<String>, stderr_tail: impl Into<String>) -> Self {
+        Self::SidecarFailure {
+            kind: SidecarFailureKind::SidecarFailure,
+            message: message.into(),
+            stderr_tail: stderr_tail.into(),
+        }
+    }
+}
+
 /// A single progress tick emitted on the `dictation-model-progress` channel
 /// while [`super::download_dictation_model`] runs.
 #[derive(Clone, serde::Serialize)]
@@ -53,6 +101,27 @@ mod tests {
         assert!(json.contains("\"modelId\":\"ggml-small-q5_1\""));
         assert!(json.contains("\"sizeBytes\":42"));
         assert!(json.contains("\"cpuSupported\":true"));
+    }
+
+    #[test]
+    fn message_error_serializes_as_a_bare_string() {
+        let json = serde_json::to_string(&DictationError::from("model-not-ready")).unwrap();
+        assert_eq!(json, "\"model-not-ready\"");
+    }
+
+    #[test]
+    fn sidecar_failure_serializes_with_kind_and_camel_case_tail() {
+        let err = DictationError::sidecar(
+            "dictation: whisper exited with exit code: 0xc0000409",
+            "ggml.c:1: GGML_ASSERT(x) failed",
+        );
+        let json: serde_json::Value = serde_json::to_value(&err).unwrap();
+        assert_eq!(json["kind"], "sidecar-failure");
+        assert_eq!(
+            json["message"],
+            "dictation: whisper exited with exit code: 0xc0000409"
+        );
+        assert_eq!(json["stderrTail"], "ggml.c:1: GGML_ASSERT(x) failed");
     }
 
     #[test]

--- a/app/src-tauri/src/dictation/whisper.rs
+++ b/app/src-tauri/src/dictation/whisper.rs
@@ -8,22 +8,26 @@
 //! (Unix process group + `killpg`, Windows kill-on-close Job Object).
 
 use std::io::{BufReader, Read};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use tauri::ipc::{InvokeBody, Request};
 use tauri::{AppHandle, Manager};
 
+use super::args::{build_args, normalize_lang};
+use super::stderr_tail::drain_tail;
+use super::temp_wav::TempWav;
+use super::types::DictationError;
 use super::{cpu, model, wav};
 use crate::child_guard;
 
-/// Monotonic suffix so concurrent transcriptions never collide on a temp path.
-static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
-
 #[tauri::command]
-pub async fn transcribe_audio(app: AppHandle, request: Request<'_>) -> Result<String, String> {
+pub async fn transcribe_audio(
+    app: AppHandle,
+    request: Request<'_>,
+) -> Result<String, DictationError> {
     let InvokeBody::Raw(bytes) = request.body() else {
         return Err("transcribe_audio expects a raw byte payload".into());
     };
@@ -43,8 +47,9 @@ pub async fn transcribe_audio(app: AppHandle, request: Request<'_>) -> Result<St
     }
 
     let model_path = model::model_path(&app)?;
-    if std::fs::metadata(&model_path).is_err() {
-        // Exact string — the frontend maps it to the "download the model" flow.
+    // Exact string — the frontend maps it to the "download the model" flow,
+    // which also replaces a wrong-size file (see `model::is_ready`).
+    if !model::is_ready(&model_path) {
         return Err("model-not-ready".into());
     }
 
@@ -67,42 +72,19 @@ pub async fn transcribe_audio(app: AppHandle, request: Request<'_>) -> Result<St
     run_whisper(&binary, &args, timeout).await
 }
 
-/// Validate the language hint against the supported set; anything missing or
-/// unrecognized falls through to whisper's autodetect.
-fn normalize_lang(raw: Option<&str>) -> &'static str {
-    match raw.map(str::trim) {
-        Some("en") => "en",
-        Some("es") => "es",
-        Some("pt") => "pt",
-        _ => "auto",
-    }
-}
-
-/// `-nt` (no timestamps) + `-np` (no progress prints) keep stdout to the bare
-/// transcript; no `-o*` flags means whisper writes no output files.
-fn build_args(model: &Path, wav: &Path, lang: &str, threads: usize) -> Vec<String> {
-    vec![
-        "-m".into(),
-        model.to_string_lossy().into_owned(),
-        "-f".into(),
-        wav.to_string_lossy().into_owned(),
-        "-l".into(),
-        lang.into(),
-        "-t".into(),
-        threads.to_string(),
-        "-nt".into(),
-        "-np".into(),
-    ]
-}
-
-/// Spawn the hardened child, drain its stdout, and enforce the timeout by
-/// polling `try_wait`. On timeout the whole process group / job is killed and
-/// `Err("transcription-timeout")` returned.
-async fn run_whisper(binary: &Path, args: &[String], timeout: Duration) -> Result<String, String> {
+/// Spawn the hardened child, drain its stdout and stderr, and enforce the
+/// timeout by polling `try_wait`. On timeout the whole process group / job is
+/// killed and `transcription-timeout` returned. Both failures carry the
+/// stderr tail: whisper-cli names its crash site there and nowhere else.
+async fn run_whisper(
+    binary: &Path,
+    args: &[String],
+    timeout: Duration,
+) -> Result<String, DictationError> {
     let mut cmd = Command::new(binary);
     cmd.args(args)
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .stdin(Stdio::null());
 
     #[cfg(unix)]
@@ -127,16 +109,19 @@ async fn run_whisper(binary: &Path, args: &[String], timeout: Duration) -> Resul
             child
                 .kill()
                 .map_err(|e| format!("dictation: kill after job-bind fail: {e}"))?;
-            return Err(format!("dictation: bind to job object: {e}"));
+            return Err(format!("dictation: bind to job object: {e}").into());
         }
     };
 
-    // Drain stdout on a thread so a full pipe buffer can't deadlock the child.
+    // Drain both pipes on threads so a full pipe buffer can't deadlock the
+    // child (whisper logs its whole model load to stderr).
     let stdout = child.stdout.take().ok_or("dictation: no stdout")?;
-    let reader = std::thread::spawn(move || {
+    let stdout_reader = std::thread::spawn(move || {
         let mut buf = String::new();
         BufReader::new(stdout).read_to_string(&mut buf).map(|_| buf)
     });
+    let stderr = child.stderr.take().ok_or("dictation: no stderr")?;
+    let stderr_reader = std::thread::spawn(move || drain_tail(stderr));
 
     let deadline = Instant::now() + timeout;
     let status = loop {
@@ -152,103 +137,112 @@ async fn run_whisper(binary: &Path, args: &[String], timeout: Duration) -> Resul
                 child
                     .kill()
                     .map_err(|e| format!("dictation: kill on timeout: {e}"))?;
-                return Err("transcription-timeout".into());
+                // Reap so the pipes close and the tail thread reaches EOF: what
+                // whisper printed before it hung is the only clue to why.
+                child
+                    .wait()
+                    .map_err(|e| format!("dictation: reap after timeout: {e}"))?;
+                let tail = join_tail(stderr_reader);
+                tracing::warn!(
+                    "[dictation] whisper timed out after {timeout:?}; stderr tail: {tail}"
+                );
+                return Err(DictationError::sidecar("transcription-timeout", tail));
             }
             None => tokio::time::sleep(Duration::from_millis(50)).await,
         }
     };
 
-    let text = reader
+    let text = stdout_reader
         .join()
         .map_err(|_| "dictation: stdout reader panicked".to_string())?
         .map_err(|e| format!("dictation: read whisper stdout: {e}"))?;
+    let tail = join_tail(stderr_reader);
     if !status.success() {
-        return Err(format!("dictation: whisper exited with {status}"));
+        // Exact wording of the pre-existing message: the Sentry issue per exit
+        // flavor stays continuous, the tail is what is new (PRODUCT-1731).
+        tracing::warn!("[dictation] whisper exited with {status}; stderr tail: {tail}");
+        return Err(DictationError::sidecar(
+            format!("dictation: whisper exited with {status}"),
+            tail,
+        ));
     }
     Ok(text.trim().to_string())
 }
 
-/// A uniquely-named temp WAV whose file is removed when this handle drops,
-/// regardless of how the transcription returns.
-struct TempWav {
-    path: PathBuf,
-}
-
-impl TempWav {
-    fn write(bytes: &[u8]) -> Result<Self, String> {
-        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let path = std::env::temp_dir().join(format!(
-            "houston-dictation-{}-{seq}-{nanos}.wav",
-            std::process::id()
-        ));
-        std::fs::write(&path, bytes)
-            .map_err(|e| format!("dictation: write temp wav {}: {e}", path.display()))?;
-        Ok(Self { path })
-    }
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TempWav {
-    fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_file(&self.path) {
-            tracing::debug!("dictation: temp wav cleanup failed: {e}");
-        }
-    }
+/// A panicked tail thread yields a marker, never a lost transcription result:
+/// the tail is context for a failure, not a failure of its own.
+fn join_tail(reader: JoinHandle<String>) -> String {
+    reader
+        .join()
+        .unwrap_or_else(|_| "<stderr reader panicked>".to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn lang_hint_maps_supported_langs() {
-        assert_eq!(normalize_lang(Some("en")), "en");
-        assert_eq!(normalize_lang(Some("es")), "es");
-        assert_eq!(normalize_lang(Some("pt")), "pt");
-        assert_eq!(normalize_lang(Some("auto")), "auto");
-    }
-
-    #[test]
-    fn lang_hint_defaults_to_auto() {
-        assert_eq!(normalize_lang(None), "auto");
-        assert_eq!(normalize_lang(Some("fr")), "auto");
-        assert_eq!(normalize_lang(Some("")), "auto");
-    }
-
-    #[test]
-    fn args_carry_model_wav_lang_threads_and_flags() {
-        let args = build_args(Path::new("/m/model.bin"), Path::new("/t/clip.wav"), "es", 4);
-        assert_eq!(
-            args,
-            vec![
-                "-m",
-                "/m/model.bin",
-                "-f",
-                "/t/clip.wav",
-                "-l",
-                "es",
-                "-t",
-                "4",
-                "-nt",
-                "-np",
-            ]
-        );
-    }
-
-    #[test]
-    fn temp_wav_written_then_removed_on_drop() {
-        let path;
-        {
-            let wav = TempWav::write(b"RIFFdata").unwrap();
-            path = wav.path().to_path_buf();
-            assert_eq!(std::fs::read(&path).unwrap(), b"RIFFdata");
+    /// A real child that writes to stderr and exits non-zero: the failure must
+    /// carry the END of stderr, with the exit-status wording unchanged.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn nonzero_exit_carries_stderr_tail() {
+        let script = "for i in $(seq 1 300); do echo \"whisper_model_load: line $i\" >&2; done; \
+                      echo 'ggml.c:9: GGML_ASSERT(rc == 0) failed' >&2; exit 3";
+        let args = vec!["-c".to_string(), script.to_string()];
+        let err = run_whisper(Path::new("/bin/sh"), &args, Duration::from_secs(10))
+            .await
+            .unwrap_err();
+        match err {
+            DictationError::SidecarFailure {
+                message,
+                stderr_tail,
+                ..
+            } => {
+                assert_eq!(message, "dictation: whisper exited with exit status: 3");
+                assert!(
+                    stderr_tail.ends_with("GGML_ASSERT(rc == 0) failed"),
+                    "tail: {stderr_tail}"
+                );
+                assert!(stderr_tail.len() <= super::super::stderr_tail::STDERR_TAIL_BYTES);
+            }
+            other => panic!("expected a sidecar failure, got {other:?}"),
         }
-        assert!(!path.exists(), "temp wav removed when handle drops");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn timeout_kills_the_child_and_carries_stderr_tail() {
+        let script = "echo 'loading model' >&2; sleep 30";
+        let args = vec!["-c".to_string(), script.to_string()];
+        let started = Instant::now();
+        let err = run_whisper(Path::new("/bin/sh"), &args, Duration::from_millis(200))
+            .await
+            .unwrap_err();
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "child was reaped"
+        );
+        match err {
+            DictationError::SidecarFailure {
+                message,
+                stderr_tail,
+                ..
+            } => {
+                assert_eq!(message, "transcription-timeout");
+                assert_eq!(stderr_tail, "loading model");
+            }
+            other => panic!("expected a sidecar failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn success_returns_trimmed_stdout_and_ignores_stderr() {
+        let script = "echo 'noise' >&2; echo '  hello world  '";
+        let args = vec!["-c".to_string(), script.to_string()];
+        let text = run_whisper(Path::new("/bin/sh"), &args, Duration::from_secs(10))
+            .await
+            .unwrap();
+        assert_eq!(text, "hello world");
     }
 }

--- a/app/src/lib/dictation/sidecar-failure.ts
+++ b/app/src/lib/dictation/sidecar-failure.ts
@@ -1,0 +1,50 @@
+/**
+ * What `transcribe_audio` rejects with, mirroring `DictationError` in
+ * `app/src-tauri/src/dictation/types.rs`: a plain string (the sentinels
+ * `"model-not-ready"` / `"dictation-unsupported-cpu"`, every setup error) or
+ * the `DictationSidecarFailure` object below. Import-free so it loads under
+ * the bare Node test runner.
+ */
+
+/** The object `transcribe_audio` rejects with when whisper-cli itself failed
+ *  (non-zero exit, or killed on timeout), mirroring
+ *  `DictationError::SidecarFailure` in `dictation/types.rs`. `message` is the
+ *  same text the plain-string rejection used to carry; `stderrTail` is the
+ *  end of the sidecar's stderr, where whisper names its crash site
+ *  (PRODUCT-1731). */
+export interface DictationSidecarFailure {
+  kind: "sidecar-failure";
+  message: string;
+  stderrTail: string;
+}
+
+export function isDictationSidecarFailure(
+  err: unknown,
+): err is DictationSidecarFailure {
+  if (typeof err !== "object" || err === null) return false;
+  const candidate = err as Partial<DictationSidecarFailure>;
+  return (
+    candidate.kind === "sidecar-failure" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.stderrTail === "string"
+  );
+}
+
+/** Tauri rejects with a raw string (Rust's `Err(String)`, e.g. the sentinel
+ *  `"model-not-ready"`), a `DictationSidecarFailure` object, or an `Error`;
+ *  normalize to plain text. */
+export function dictationErrorText(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (isDictationSidecarFailure(err)) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/** Sentry `extra` for a transcription failure: the sidecar's stderr tail when
+ *  there is one, so the report shows the crash site next to the exit code. */
+export function dictationErrorExtra(
+  err: unknown,
+): Record<string, string> | undefined {
+  if (!isDictationSidecarFailure(err)) return undefined;
+  return { whisper_stderr_tail: err.stderrTail || "<empty>" };
+}

--- a/app/src/lib/dictation/types.ts
+++ b/app/src/lib/dictation/types.ts
@@ -1,11 +1,18 @@
 /**
  * Wire shapes the Rust shell's three dictation commands speak
  * (`app/src-tauri/src/dictation/`), plus small pure helpers used by the
- * composer wiring. Kept dependency-free (bar `../locale`) so it loads under
- * the bare Node test runner.
+ * composer wiring. The rejection shapes live in `sidecar-failure.ts`, which
+ * is import-free so it loads under the bare Node test runner.
  */
 
 import { normalizeLocale } from "../locale";
+
+export {
+  type DictationSidecarFailure,
+  dictationErrorExtra,
+  dictationErrorText,
+  isDictationSidecarFailure,
+} from "./sidecar-failure";
 
 /** Mirrors `DictationModelStatus` in `app/src-tauri/src/dictation/types.rs`
  *  (`dictation_model_status`'s return shape). */
@@ -41,14 +48,6 @@ export function resolveDictationLangHint(
   resolvedLanguage: string | undefined,
 ): DictationLangHint {
   return normalizeLocale(resolvedLanguage) ?? "auto";
-}
-
-/** Tauri rejects with either a raw string (Rust's `Err(String)`, e.g. the
- *  sentinel `"model-not-ready"`) or an `Error`; normalize to plain text. */
-export function dictationErrorText(err: unknown): string {
-  if (typeof err === "string") return err;
-  if (err instanceof Error) return err.message;
-  return String(err);
 }
 
 /** Bytes -> whole MB, floored at 1 so a tiny/zero size never reads as "0 MB". */

--- a/app/src/lib/dictation/use-dictation.ts
+++ b/app/src/lib/dictation/use-dictation.ts
@@ -19,6 +19,7 @@ import { type DictationRecording, startDictationRecording } from "./recorder";
 import {
   DICTATION_UNSUPPORTED_CPU,
   type DictationLangHint,
+  dictationErrorExtra,
   dictationErrorText as errorText,
 } from "./types";
 import {
@@ -109,8 +110,12 @@ export function useDictation({
         } else {
           // Report-only path first, then authored copy: the user spoke and
           // pressed stop, so a silent drop reads as "it sent nothing"
-          // (PRODUCT-1448) — retrying is a real action they can take.
-          showErrorToast("dictation_transcribe", errorText(err), err);
+          // (PRODUCT-1448) — retrying is a real action they can take. A
+          // sidecar crash rides with whisper's stderr tail (PRODUCT-1731):
+          // the exit code alone (0xc0000409) names nothing.
+          showErrorToast("dictation_transcribe", errorText(err), err, {
+            extra: dictationErrorExtra(err),
+          });
           addToast({
             title: t("composer.dictation.failed"),
             variant: "error",

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -23,6 +23,9 @@ export interface ErrorToastOptions {
    *  genuinely different failures counted separately while one failure hitting
    *  N callers counts once. */
   userMessage?: string;
+  /** Diagnostic context attached to the Sentry event as `extra` (never a tag:
+   *  free text such as a sidecar's stderr tail must not become a facet). */
+  extra?: Record<string, unknown>;
 }
 
 /**
@@ -196,10 +199,14 @@ export function showErrorToast(
   // Dev build with Sentry suppressed: initSentry already bailed, so don't.
   if (sentrySuppressedInDev) return;
   markReportedToSentry(originalError);
-  void sentryCapture(createSentryReportError(command, message, originalError), {
-    source: command,
-    error_kind: classifyAnalyticsError(message),
-  }).catch((flushErr: unknown) => {
+  void sentryCapture(
+    createSentryReportError(command, message, originalError),
+    {
+      source: command,
+      error_kind: classifyAnalyticsError(message),
+    },
+    options?.extra,
+  ).catch((flushErr: unknown) => {
     console.error("[sentry] failed to flush captured error", flushErr);
   });
 }

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -502,7 +502,9 @@ export function osStopMigrationSourceHost(): Promise<void> {
  *  raw-payload pattern as `osSaveDownload`) so a multi-megabyte clip can't
  *  freeze the webview; the language hint rides the `x-dictation-lang` header.
  *  Rejects with the exact string "model-not-ready" when the model hasn't
- *  been downloaded yet, or "transcription-timeout" on a stalled transcribe. */
+ *  been downloaded (or is the wrong size on disk), or with a
+ *  `DictationSidecarFailure` object (message "transcription-timeout" or
+ *  "dictation: whisper exited with ...") carrying whisper's stderr tail. */
 export function osTranscribeAudio(
   wav: Uint8Array,
   langHint: string,

--- a/app/src/lib/sentry.ts
+++ b/app/src/lib/sentry.ts
@@ -171,12 +171,13 @@ export function initSentry(): void {
 export async function captureException(
   error: unknown,
   context?: Record<string, string>,
+  extra?: Record<string, unknown>,
 ): Promise<string> {
   if (!initialized) return "";
   const normalized = error instanceof Error ? error : new Error(String(error));
   const eventId = Sentry.captureException(
     normalized,
-    context ? { tags: context } : undefined,
+    context || extra ? { tags: context, extra } : undefined,
   );
   const flushed = await Sentry.flush(5000);
   // By the time flush resolves, the wrapper's send() has run for this envelope

--- a/app/tests/dictation-error-shape.test.ts
+++ b/app/tests/dictation-error-shape.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  dictationErrorExtra,
+  dictationErrorText,
+  isDictationSidecarFailure,
+} from "../src/lib/dictation/sidecar-failure.ts";
+
+// PRODUCT-1731: `transcribe_audio` rejects with either the plain strings the
+// composer already matches on, or a `DictationSidecarFailure` object that
+// carries whisper-cli's stderr tail. The message text must stay the string
+// Sentry has always seen (issue continuity), the tail rides as `extra`.
+
+const crash = {
+  kind: "sidecar-failure",
+  message: "dictation: whisper exited with exit code: 0xc0000409",
+  stderrTail: "ggml.c:9: GGML_ASSERT(rc == 0) failed",
+};
+
+describe("dictation rejection shapes", () => {
+  it("keeps plain-string sentinels as-is", () => {
+    assert.equal(dictationErrorText("model-not-ready"), "model-not-ready");
+    assert.equal(dictationErrorExtra("model-not-ready"), undefined);
+    assert.equal(isDictationSidecarFailure("model-not-ready"), false);
+  });
+
+  it("reads a sidecar failure's message as the error text", () => {
+    assert.equal(isDictationSidecarFailure(crash), true);
+    assert.equal(dictationErrorText(crash), crash.message);
+  });
+
+  it("surfaces the stderr tail as Sentry extra", () => {
+    assert.deepEqual(dictationErrorExtra(crash), {
+      whisper_stderr_tail: crash.stderrTail,
+    });
+  });
+
+  it("marks an empty tail so the report says the sidecar printed nothing", () => {
+    assert.deepEqual(dictationErrorExtra({ ...crash, stderrTail: "" }), {
+      whisper_stderr_tail: "<empty>",
+    });
+  });
+
+  it("does not mistake other objects for a sidecar failure", () => {
+    assert.equal(isDictationSidecarFailure(null), false);
+    assert.equal(isDictationSidecarFailure({ message: "x" }), false);
+    assert.equal(
+      isDictationSidecarFailure({ kind: "sidecar-failure", message: "x" }),
+      false,
+    );
+    assert.equal(dictationErrorText(new Error("boom")), "boom");
+    assert.equal(dictationErrorExtra(new Error("boom")), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

PRODUCT-1731. One Windows user's dictation dies with `whisper exited with exit code: 0xc0000409` (three events across 0.6.17 and 0.6.20), plus a `transcription-timeout` from another user on 0.6.18.

**Root cause of the blind spot.** `0xc0000409` (STATUS_STACK_BUFFER_OVERRUN) is what the MSVC runtime raises for *any* `abort()` via `__fastfail`: a `GGML_ASSERT`, an uncaught C++ exception (`bad_alloc` in `whisper_init_state` / `whisper_full`), or a real /GS cookie fault. Model-load exceptions are funneled by whisper.cpp 1.9.1 into a null return (exit 3), so this is a crash *after* load. Every one of those paths prints its site to stderr and nowhere else, and `run_whisper` routed the sidecar's stderr to `Stdio::null()`. The Sentry event was a bare exit code with nothing to act on.

**Fix.**
- `run_whisper` pipes stderr, drains it on a thread into a bounded 4 KiB tail (`dictation/stderr_tail.rs`; the crash site is always at the END, model loading alone logs dozens of lines), and rejects with a typed `DictationError::SidecarFailure { kind, message, stderrTail }` on a non-zero exit or timeout. The `message` wording is unchanged so the Sentry issue per exit flavor stays continuous. On timeout the child is reaped after the kill so the tail reaches EOF. The tail is also `tracing::warn`ed into the shell log (bug reports).
- Frontend narrows the object (`isDictationSidecarFailure`), reports the same message, and attaches the tail as Sentry `extra.whisper_stderr_tail` (`showErrorToast` and `captureException` gain an `extra` pass-through). The user still gets the existing "didn't work, try again" toast.
- `transcribe_audio` now gates on the same exact-size predicate the status probe uses instead of bare file existence: a wrong-size model file answers `model-not-ready`, which re-offers the download and replaces the file, instead of handing whisper-cli a blob to refuse or crash on.
- `whisper.rs` split to stay under the line limit: `args.rs`, `temp_wav.rs`, `stderr_tail.rs`. Frontend rejection shapes live in `dictation/sidecar-failure.ts` (import-free so the bare Node runner loads it).

## Before

1. On Windows x64, install a build and download the dictation model.
2. Force a sidecar abort, e.g. replace `binaries/whisper-cli-x86_64-pc-windows-msvc.exe` with a stub that writes `GGML_ASSERT(x) failed` to stderr and calls `abort()`, or make `%APPDATA%\ai.gethouston.app\models\whisper\ggml-small-q5_1.bin` the wrong size.
3. Click the mic, speak, click "Stop and insert".
4. Sentry event `dictation_transcribe: dictation: whisper exited with exit code: 0xc0000409` with no stderr; a wrong-size model is handed to the CLI (exit 3, same blind report).

## After

1. Same steps with the abort stub: the Sentry event keeps the same title and now carries `extra.whisper_stderr_tail` ending in the assert line; the shell log has a `[dictation] whisper exited with ...; stderr tail: ...` line.
2. Wrong-size model: the "Set up voice typing" dialog reopens; Download replaces the file; dictation works.
3. Tests: `cd app/src-tauri && cargo test dictation` (28 pass; real-child tests for non-zero exit, timeout reap, success), `cd app && pnpm test` (`dictation-error-shape.test.ts`), `pnpm check`, `pnpm tsgo --noEmit`, `pnpm check-locales`.
