### PR TITLE
feat(chat): people stack left of the chat header, tappable, hidden when solo

### DIFF
--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,14 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v83 - 2026-09-10
+
+The open chat's header moves the people stack to the left, beside the agent's
+name and task line, and makes it a button that opens the full roster (it was a
+hover-only tooltip, dead on touch). The stack is absent while nobody but the
+viewer is on the task. The right edge is now only panel controls: the chat
+actions menu, the expand toggle, and close.
+
 ## v82 - 2026-09-10
 
 Custom integration details gain a name and website editor on desktop and phone

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 82
+version: 83
 
 components:
   - id: custom-integration-details
@@ -110,8 +110,9 @@ components:
     states: [closed, actions-open, open-unfiltered, filtered, no-results, current-message]
     variants: [conversation-overlay]
     behavior: >-
-      The chat header's three-dot menu (left of the people stack and close
-      control) offers Find plus status-aware mission actions. Choosing Find
+      The chat header's three-dot menu (leading the panel controls at the
+      right edge, beside the close control) offers Find plus status-aware
+      mission actions. Choosing Find
       shows the compact conversation map before a query is entered.
       Filtering is case- and accent-insensitive across every loaded message;
       selecting a result scrolls to and briefly highlights that message. Delete
@@ -731,14 +732,19 @@ components:
       everywhere). Past five faces the rest collapse into a solid "+N" chip that
       expands to the full roster, and the card body reserves a right gutter sized
       to the stack so no text ever runs underneath it. Server-stamped attribution
-      only (multiplayer); an unattributed card renders exactly as before.
+      only (multiplayer); an unattributed card renders exactly as before. The
+      open chat's header carries the same stack on the LEFT, beside the agent's
+      name and task line and apart from the panel controls, as a button that
+      opens the full roster; it is absent while nobody but the viewer is on
+      the task, so a solo chat never shows your own face as a dead control.
     a11y: >-
       article/button role; title as label; checkbox labeled; status not
       color-only; each action button is a >=24px hit box whose icon-only glyph
       carries an accessible label naming what it does, so approve and archive
       are told apart by name, not shape; the face stack is a labeled group, each face names its person
       (tooltip + title) and the "+N" chip is a labeled control, so no contributor
-      is reachable by hover alone.
+      is reachable by hover alone; in the chat header the whole stack is one
+      labeled button, so it works by touch.
     since: 1
 
   - id: mission-board

--- a/packages/web/e2e/chat-header-people.spec.ts
+++ b/packages/web/e2e/chat-header-people.spec.ts
@@ -1,0 +1,91 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+import { AUTH_WEB_URL, E2E_VIEWER, signInAsViewer } from "./support/identity";
+import { missionCard, openTeamSection } from "./support/team-nav";
+
+/**
+ * The open chat's header people stack: who ELSE is on this task. It sits on
+ * the left beside the agent's name, apart from the panel controls, and is a
+ * button that opens the roster (a hover tooltip was its only affordance, so
+ * it was dead on touch). A task nobody but the viewer is on shows no stack
+ * at all: your own face as a dead control was the complaint.
+ *
+ * Signed in (identity-ON server) because "nobody but me" needs a viewer id.
+ */
+
+test.use({ baseURL: AUTH_WEB_URL });
+
+const PEOPLE_LABEL = "People on this task";
+const SOLO_TITLE = "Connect Google Calendar";
+const TEAM_TITLE = "Plan a trip to Tokyo";
+
+async function seed(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, {
+    data: { multiplayer: true, teams: true, role: "owner" },
+  });
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: {
+      id: "act-solo",
+      title: SOLO_TITLE,
+      status: "done",
+      created_by: E2E_VIEWER.uid,
+      contributors: [{ user_id: E2E_VIEWER.uid, name: E2E_VIEWER.displayName }],
+    },
+  });
+}
+
+const panel = (page: import("@playwright/test").Page) =>
+  page.getByTestId("mission-panel");
+
+test("a task with only the viewer on it shows no people stack in the chat header", async ({
+  page,
+  request,
+}) => {
+  await seed(request);
+  await signInAsViewer(page);
+  await openTeamSection(page, "Tasks");
+  await missionCard(page, SOLO_TITLE).click();
+  await expect(panel(page).getByText(`Task: ${SOLO_TITLE}`)).toBeVisible();
+  await expect(
+    panel(page).locator(`[role="group"][aria-label="${PEOPLE_LABEL}"]`),
+  ).toHaveCount(0);
+  // The panel controls are still all there.
+  await expect(
+    panel(page).getByRole("button", { name: "Chat actions" }),
+  ).toBeVisible();
+  await expect(panel(page).getByTestId("panel-width-toggle")).toBeVisible();
+  await expect(
+    panel(page).getByRole("button", { name: "Close panel" }),
+  ).toBeVisible();
+});
+
+test("a team task's stack sits left of the controls and opens the roster on click", async ({
+  page,
+  request,
+}) => {
+  await seed(request);
+  await signInAsViewer(page);
+  await openTeamSection(page, "Tasks");
+  await missionCard(page, TEAM_TITLE).click();
+  await expect(panel(page).getByText(`Task: ${TEAM_TITLE}`)).toBeVisible();
+
+  const stack = panel(page).getByRole("button", { name: "All people" });
+  await expect(stack).toBeVisible();
+  await expect(stack.locator('[data-slot="avatar"]')).toHaveCount(2);
+
+  // Left of the menu: the stack belongs with the task, the controls with
+  // the panel.
+  const stackBox = await stack.boundingBox();
+  const menuBox = await panel(page)
+    .getByRole("button", { name: "Chat actions" })
+    .boundingBox();
+  expect(stackBox && menuBox && stackBox.x + stackBox.width <= menuBox.x).toBe(
+    true,
+  );
+
+  await stack.click();
+  const roster = page.getByRole("dialog");
+  await expect(roster.getByText("Ada Lovelace")).toBeVisible();
+  await expect(roster.getByText("Bob Stone")).toBeVisible();
+});

--- a/packages/web/e2e/mobile/chat-header-people.spec.ts
+++ b/packages/web/e2e/mobile/chat-header-people.spec.ts
@@ -1,0 +1,52 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { expect, test } from "../support/fixtures";
+import { AUTH_WEB_URL, E2E_VIEWER, signInAsViewer } from "../support/identity";
+import { openPhoneTeamSection } from "../support/mobile-nav";
+import { screen } from "../support/team-nav";
+
+/**
+ * The phone twin of chat-header-people.spec.ts: the pushed mission chat's
+ * header shows the people stack only when someone else is on the task, and
+ * a TAP (no hover on a phone) opens the roster.
+ */
+
+test.use({ baseURL: AUTH_WEB_URL });
+
+const PEOPLE_LABEL = "People on this task";
+
+test("solo task: no stack; team task: tap opens the roster", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, {
+    data: { multiplayer: true, teams: true, role: "owner" },
+  });
+  await request.post(`${FAKE_HOST_URL}/agents/houston-assistant/activities`, {
+    data: {
+      id: "act-solo",
+      title: "Connect Google Calendar",
+      status: "done",
+      created_by: E2E_VIEWER.uid,
+      contributors: [{ user_id: E2E_VIEWER.uid, name: E2E_VIEWER.displayName }],
+    },
+  });
+  await signInAsViewer(page);
+  await openPhoneTeamSection(page, "mission-control");
+
+  await screen(page).getByText("Connect Google Calendar").tap();
+  const chat = page.getByTestId("mission-chat-screen");
+  await expect(chat.getByText("Task: Connect Google Calendar")).toBeVisible();
+  await expect(
+    chat.locator(`[role="group"][aria-label="${PEOPLE_LABEL}"]`),
+  ).toHaveCount(0);
+  await chat.getByTestId("mission-chat-back").tap();
+
+  await screen(page).getByText("Plan a trip to Tokyo").tap();
+  await expect(chat.getByText("Task: Plan a trip to Tokyo")).toBeVisible();
+  const stack = chat.getByRole("button", { name: "All people" });
+  await expect(stack).toBeVisible();
+  await stack.tap();
+  const roster = page.getByRole("dialog");
+  await expect(roster.getByText("Ada Lovelace")).toBeVisible();
+  await expect(roster.getByText("Bob Stone")).toBeVisible();
+});

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -829,6 +829,7 @@ export function AIBoard({
       agentName={panelAgentName ?? panelItem?.group}
       missionLabelOverride={panelMissionLabel}
       people={panelItem?.people}
+      selfId={currentUserId}
       peopleLabel={cardLabels?.people}
       peopleExpandLabel={cardLabels?.peopleExpand}
       closeLabel={cardLabels?.closePanel}

--- a/ui/board/src/kanban-detail-panel.tsx
+++ b/ui/board/src/kanban-detail-panel.tsx
@@ -2,6 +2,7 @@ import { cn } from "@houston-ai/core";
 import { Loader2, XIcon } from "lucide-react";
 import { forwardRef } from "react";
 import { KanbanPeople } from "./kanban-people";
+import { hasPeopleBeyond } from "./kanban-people-logic";
 import type { KanbanPerson } from "./types";
 
 const STATUS_LABEL: Record<string, string> = {
@@ -35,6 +36,9 @@ export interface KanbanDetailPanelProps {
   missionLabelOverride?: string;
   /** Human contributors shown as an avatar face stack in the header. */
   people?: KanbanPerson[];
+  /** The viewer. A stack that holds nobody BUT the viewer is not rendered:
+   *  "who is on this task" only says something when someone else is. */
+  selfId?: string;
   /** Accessible group label for the people face stack (English default "People"). */
   peopleLabel?: string;
   /** Accessible label for the people stack's expandable "+N" chip. */
@@ -62,6 +66,7 @@ export const KanbanDetailPanel = forwardRef<
     agentName,
     missionLabelOverride,
     people,
+    selfId,
     peopleLabel = "People",
     peopleExpandLabel,
     closeLabel = "Close panel",
@@ -74,6 +79,7 @@ export const KanbanDetailPanel = forwardRef<
   const isRunning = status ? runningStatuses.includes(status) : false;
   const missionLabel =
     missionLabelOverride ?? (title ? `Mission: ${title}` : subtitle);
+  const showPeople = hasPeopleBeyond(people, selfId);
 
   return (
     <div ref={ref} className="flex flex-col h-full min-h-0">
@@ -92,7 +98,7 @@ export const KanbanDetailPanel = forwardRef<
           <div className="flex items-center gap-3 max-w-3xl mx-auto w-full">
             {leading}
             {avatar}
-            <div className="min-w-0 flex-1">
+            <div className="min-w-0">
               <p className="text-sm font-semibold text-ink">
                 {agentName ?? title}
               </p>
@@ -112,27 +118,28 @@ export const KanbanDetailPanel = forwardRef<
                 </p>
               )}
             </div>
-            {isRunning && (
-              <Loader2 className="size-4 animate-spin text-blue-500 shrink-0" />
-            )}
-            {/* Actions sit BEFORE the face stack: the overflow menu reads as
-              panel chrome next to the close button, while the people stack
-              stays glued to the close affordance on the right edge. */}
-            {actions}
-            {people && people.length > 0 && (
-              /* `surface="background"` because this header wears `bg-background`,
-               not the card tier: the default `ring-input` ring would paint a
-               white halo band around each face instead of a cutout. */
+            {/* The people stack sits on the LEFT with the identity block: it
+              is about the task, while the menu and the window controls are
+              about the panel and sit together at the right edge. It is a
+              button (the roster popover) so it works on touch; a hover
+              tooltip alone was dead on a phone. Absent when nobody but the
+              viewer is on the task, where it only ever showed your own face. */}
+            {showPeople && (
               <KanbanPeople
                 people={people}
                 size="md"
                 surface="background"
                 label={peopleLabel}
-                expandable
+                roster
                 expandLabel={peopleExpandLabel}
                 className="shrink-0"
               />
             )}
+            <div className="min-w-0 flex-1" />
+            {isRunning && (
+              <Loader2 className="size-4 animate-spin text-blue-500 shrink-0" />
+            )}
+            {actions}
             {onClose && (
               <button
                 type="button"

--- a/ui/board/src/kanban-detail-panel.tsx
+++ b/ui/board/src/kanban-detail-panel.tsx
@@ -94,9 +94,14 @@ export const KanbanDetailPanel = forwardRef<
           token ChatPanel and the panes wear, so header, chat, and pane are
           one color — no seam on the light canvas / dark transparent). */}
       {!hideHeader && (
-        <div className="shrink-0 bg-background px-4 py-3 dark:bg-transparent">
-          <div className="flex items-center gap-3 max-w-3xl mx-auto w-full">
-            {leading}
+        <div className="flex shrink-0 items-center gap-3 bg-background px-4 py-3 dark:bg-transparent">
+          {/* The leading slot (a Back control) sits OUTSIDE the capped row, at
+              the panel's own left edge: the way back belongs to the panel, not
+              to the reading column, so a wide chat never strands it mid-screen
+              beside the avatar. The rest of the header centers on the room
+              that remains. */}
+          {leading}
+          <div className="flex min-w-0 flex-1 items-center gap-3 max-w-3xl mx-auto">
             {avatar}
             <div className="min-w-0">
               <p className="text-sm font-semibold text-ink">

--- a/ui/board/src/kanban-detail-panel.tsx
+++ b/ui/board/src/kanban-detail-panel.tsx
@@ -94,13 +94,20 @@ export const KanbanDetailPanel = forwardRef<
           token ChatPanel and the panes wear, so header, chat, and pane are
           one color — no seam on the light canvas / dark transparent). */}
       {!hideHeader && (
-        <div className="flex shrink-0 items-center gap-3 bg-background px-4 py-3 dark:bg-transparent">
-          {/* The leading slot (a Back control) sits OUTSIDE the capped row, at
-              the panel's own left edge: the way back belongs to the panel, not
-              to the reading column, so a wide chat never strands it mid-screen
-              beside the avatar. The rest of the header centers on the room
-              that remains. */}
-          {leading}
+        <div className="@container relative flex shrink-0 items-center gap-3 bg-background px-4 py-3 dark:bg-transparent">
+          {/* The leading slot (a Back control) belongs to the panel's frame,
+              not to the reading column, so it sits at the panel's own left
+              edge. Once the header is wide enough that the capped row leaves
+              room for it (the 48rem cap plus the widest localized Back), it
+              leaves the flow entirely so the row centers on the FULL width
+              and lines up with the message column and composer beneath. On
+              a narrower header it stays in flow and the row centers on the
+              room that remains, never underneath it. */}
+          {leading && (
+            <div className="shrink-0 @min-[67rem]:absolute @min-[67rem]:top-1/2 @min-[67rem]:left-4 @min-[67rem]:-translate-y-1/2">
+              {leading}
+            </div>
+          )}
           <div className="flex min-w-0 flex-1 items-center gap-3 max-w-3xl mx-auto">
             {avatar}
             <div className="min-w-0">

--- a/ui/board/src/kanban-people-logic.ts
+++ b/ui/board/src/kanban-people-logic.ts
@@ -5,6 +5,17 @@ import type { KanbanPerson } from "./types";
  *  detail-panel stack, so it shows more faces (~5) before overflowing. */
 export const CARD_PEOPLE_MAX = 5;
 
+/** Is anyone on this stack OTHER than the viewer? The chat header shows the
+ *  stack only then: "who is on this task" says nothing when the answer is
+ *  just you. With no viewer id (single player, identity off) any stamped
+ *  person counts. */
+export function hasPeopleBeyond(
+  people: KanbanPerson[] | undefined,
+  selfId: string | undefined,
+): boolean {
+  return !!people && people.some((person) => person.id !== selfId);
+}
+
 /** Up-to-two-initials derived from a display label. Splits on whitespace and
  *  takes the first letter of the first and last word (single word → first two
  *  letters); empty/letterless input falls back to "?". Pure, JSX-free so it can

--- a/ui/board/src/kanban-people-roster.tsx
+++ b/ui/board/src/kanban-people-roster.tsx
@@ -1,0 +1,34 @@
+import { PopoverContent } from "@houston-ai/core";
+import { FACE_SIZE, Face, TEXT_SIZE } from "./kanban-people-face";
+import type { KanbanPerson } from "./types";
+
+/** The popover body listing EVERY person on a face stack (face + label), so
+ *  nobody behind a "+N" chip or a hover-only tooltip is unreachable. Shared by
+ *  the chip trigger and the whole-stack trigger so both open the same list. */
+export function KanbanPeopleRoster({ people }: { people: KanbanPerson[] }) {
+  return (
+    <PopoverContent
+      align="start"
+      onClick={(e) => e.stopPropagation()}
+      className="w-56 p-1"
+    >
+      <div className="max-h-64 overflow-y-auto">
+        {people.map((person) => (
+          <div
+            key={person.id}
+            className="flex items-center gap-2 rounded-md px-2 py-1.5"
+          >
+            <Face
+              person={person}
+              faceSize={FACE_SIZE.md}
+              textSize={TEXT_SIZE.md}
+            />
+            <span className="min-w-0 flex-1 truncate text-sm text-ink">
+              {person.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </PopoverContent>
+  );
+}

--- a/ui/board/src/kanban-people.tsx
+++ b/ui/board/src/kanban-people.tsx
@@ -3,7 +3,6 @@ import {
   AvatarGroupCount,
   cn,
   Popover,
-  PopoverContent,
   PopoverTrigger,
 } from "@houston-ai/core";
 import {
@@ -21,6 +20,7 @@ import {
   overflowCount,
   visiblePeople,
 } from "./kanban-people-logic";
+import { KanbanPeopleRoster } from "./kanban-people-roster";
 import type { KanbanPerson } from "./types";
 
 export type { KanbanPeopleSurface };
@@ -44,8 +44,12 @@ export interface KanbanPeopleProps {
    *  by default (a static, non-interactive chip). */
   expandable?: boolean;
   /** Accessible label for the expandable "+N" trigger / popover (e.g. "All
-   *  people"). Only used when `expandable`. */
+   *  people"). Only used when `expandable` or `roster`. */
   expandLabel?: string;
+  /** The WHOLE stack is a button opening the roster popover. The stack has no
+   *  visible label of its own and a hover tooltip is dead on touch, so a
+   *  stack that must work on the phone (the chat header) needs this. */
+  roster?: boolean;
   className?: string;
 }
 
@@ -60,6 +64,7 @@ export function KanbanPeople({
   label = "People",
   expandable = false,
   expandLabel,
+  roster = false,
   className,
 }: KanbanPeopleProps) {
   if (!people || people.length === 0) return null;
@@ -78,7 +83,7 @@ export function KanbanPeople({
     RING_CHIP[surface],
   );
 
-  return (
+  const stack = (
     <AvatarGroup
       role="group"
       aria-label={label}
@@ -115,29 +120,7 @@ export function KanbanPeople({
                 +{extra}
               </button>
             </PopoverTrigger>
-            <PopoverContent
-              align="start"
-              onClick={(e) => e.stopPropagation()}
-              className="w-56 p-1"
-            >
-              <div className="max-h-64 overflow-y-auto">
-                {people.map((person) => (
-                  <div
-                    key={person.id}
-                    className="flex items-center gap-2 rounded-md px-2 py-1.5"
-                  >
-                    <Face
-                      person={person}
-                      faceSize={FACE_SIZE.md}
-                      textSize={TEXT_SIZE.md}
-                    />
-                    <span className="min-w-0 flex-1 truncate text-sm text-ink">
-                      {person.label}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </PopoverContent>
+            <KanbanPeopleRoster people={people} />
           </Popover>
         ) : (
           <AvatarGroupCount className={chipClass} title={`+${extra}`}>
@@ -145,5 +128,21 @@ export function KanbanPeople({
           </AvatarGroupCount>
         ))}
     </AvatarGroup>
+  );
+  if (!roster) return stack;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={expandLabel ?? label}
+          className="flex shrink-0 items-center rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+        >
+          {stack}
+        </button>
+      </PopoverTrigger>
+      <KanbanPeopleRoster people={people} />
+    </Popover>
   );
 }

--- a/ui/board/tests/kanban-people.test.ts
+++ b/ui/board/tests/kanban-people.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import {
   CARD_PEOPLE_MAX,
+  hasPeopleBeyond,
   initialsFor,
   overflowCount,
   peopleGutterClass,
@@ -191,5 +192,28 @@ describe("peopleGutterClass", () => {
         `gutter for ${slots} circles is narrower than the stack`,
       );
     }
+  });
+});
+
+describe("hasPeopleBeyond", () => {
+  it("is false with no stack at all", () => {
+    assert.equal(hasPeopleBeyond(undefined, "me"), false);
+    assert.equal(hasPeopleBeyond([], "me"), false);
+  });
+
+  it("is false when the viewer is the only person", () => {
+    assert.equal(hasPeopleBeyond([person("me", "Me")], "me"), false);
+  });
+
+  it("is true once anyone else is on it, whether or not the viewer is", () => {
+    assert.equal(
+      hasPeopleBeyond([person("me", "Me"), person("u-bob", "Bob")], "me"),
+      true,
+    );
+    assert.equal(hasPeopleBeyond([person("u-bob", "Bob")], "me"), true);
+  });
+
+  it("counts any stamped person when the viewer is unknown", () => {
+    assert.equal(hasPeopleBeyond([person("u-ada", "Ada")], undefined), true);
   });
 });


### PR DESCRIPTION
## Why

The open chat's header showed the humans on the task as a face stack glued to the close button, and its only affordance was a hover tooltip. On touch it did nothing, and on a task nobody else is on it was just your own initial sitting among the panel controls like a button with no action. The right-hand row read as menu, expand, avatar, close.

## What

- The people stack moves **left**, beside the agent's name and task line, apart from the panel controls. Menu, expand toggle, and close now sit together at the right edge.
- The whole stack is a **button that opens the full roster** popover, so it works by touch. The +N chip's roster list is extracted to `kanban-people-roster.tsx` and shared (`KanbanPeople` gains `roster`).
- The stack is **absent while nobody but the viewer is on the task** (`hasPeopleBeyond`, viewer id threaded as `selfId` from `currentUserId`).
- Both breakpoints: the phone's pushed mission chat renders the same header (back chevron, avatar, name, stack, menu).

Cards are untouched: the board's face stacks and +N chip keep their current behavior.

## Checks

- `pnpm check`, `ui/board` typecheck + unit tests (new `hasPeopleBeyond` cases)
- e2e: new `chat-header-people.spec.ts` (desktop, signed in) and `mobile/chat-header-people.spec.ts`; `chat-wide`, `board-people`, `mobile/mission-chat` still green
- `pnpm check:parity` (inventory v82 + changelog)
- `test:visual` passes unchanged: single-player baselines carry no attribution, so no pixels move