### PR TITLE
fix(chat): keep model-choice writes inside the agent's allowed-models ceiling (PRODUCT-1734)

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -96,7 +96,7 @@ import {
   genericErrorDescription,
   logAndReportError,
 } from "../lib/error-report";
-
+import { showExpectedStateToast } from "../lib/error-toast";
 import { skillDisplayTitle } from "../lib/humanize-skill-name";
 import { encodeInteractionAnswersMessage } from "../lib/interaction-answers-marker";
 import { localizeApprovalQuestion } from "../lib/interaction-approval-labels";
@@ -108,6 +108,7 @@ import {
   finalCredentialNames,
 } from "../lib/interaction-outcomes";
 import { providerForModel, providerOffersModel } from "../lib/model-labels";
+import { isModelNotAllowedError } from "../lib/model-not-allowed";
 import {
   isModelAllowed,
   modelSelectorDecision,
@@ -912,6 +913,10 @@ export function useAgentChatPanel({
         }
         await tauriProvider.setLastUsed(prov, mod);
       } catch (err) {
+        // A ceiling that moved under the user is already surfaced by the
+        // model-choice mutation as an expected state; a red toast on top would
+        // call it a bug twice (PRODUCT-1734).
+        if (isModelNotAllowedError(err)) return;
         addToast({
           title: t("chat:errors.modelPersistFailed"),
           description: genericErrorDescription("model_persist_failed", err),
@@ -1032,10 +1037,10 @@ export function useAgentChatPanel({
   const selectModel = useCallback(
     (prov: string, mod: string) => {
       if (modelDecision.personal && !isModelAllowed(allowedModels, mod)) {
-        addToast({
-          title: t("chat:errors.modelNotAllowed"),
-          variant: "error",
-        });
+        showExpectedStateToast(
+          t("chat:errors.modelNotAllowed"),
+          t("chat:errors.modelNotAllowedBody"),
+        );
         return;
       }
       if (modelDecision.personal && !selectedActivityId) {
@@ -1059,7 +1064,6 @@ export function useAgentChatPanel({
     [
       modelDecision.personal,
       allowedModels,
-      addToast,
       t,
       selectedActivityId,
       setModelChoice,
@@ -1070,6 +1074,17 @@ export function useAgentChatPanel({
   const selectEffort = useCallback(
     (effort: EffortLevel) => {
       if (modelDecision.personal) {
+        // The effort re-write carries the resolved model, so it is clamped to
+        // the ceiling the same way a model pick is: an EMPTY ceiling ("no model
+        // allowed") leaves the fallback outside it, and the gateway would answer
+        // `model_not_allowed` (PRODUCT-1734).
+        if (!isModelAllowed(allowedModels, personalDefaultPin.model)) {
+          showExpectedStateToast(
+            t("chat:errors.modelNotAllowed"),
+            t("chat:errors.modelNotAllowedBody"),
+          );
+          return;
+        }
         setModelChoice.mutate({
           provider: personalDefaultPin.provider,
           model: personalDefaultPin.model,
@@ -1081,6 +1096,8 @@ export function useAgentChatPanel({
     },
     [
       modelDecision.personal,
+      allowedModels,
+      t,
       setModelChoice,
       personalDefaultPin.provider,
       personalDefaultPin.model,

--- a/app/src/hooks/queries/use-agent-model-choice.ts
+++ b/app/src/hooks/queries/use-agent-model-choice.ts
@@ -3,6 +3,9 @@ import type {
   AgentModelChoiceInfo,
 } from "@houston-ai/engine-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { showExpectedStateToast } from "../../lib/error-toast";
+import i18n from "../../lib/i18n";
+import { isModelNotAllowedError } from "../../lib/model-not-allowed";
 import {
   toCanonicalProviderId,
   toDisplayProviderId,
@@ -58,10 +61,14 @@ export function useAgentModelChoice(agentId: string, enabled: boolean) {
  * Teams v2: set the ACTING user's model choice for this agent. The gateway
  * validates the model is within the agent's `allowedModels` ceiling (else it
  * answers `model_not_allowed`) and clamps the acting user's turns to it. No
- * `onError` toast: `tauriAgentModelChoice.set` routes through `call()`, which
- * surfaces + reports the failure once; adding one here would double-toast. The
- * cache updates optimistically so a racing send sees the new pin, rolls back on
- * failure, and refetches after the request settles.
+ * generic `onError` toast: `tauriAgentModelChoice.set` routes through `call()`,
+ * which surfaces + reports the failure once; adding one here would double-toast.
+ * The one exception is `model_not_allowed`, which `call()` silences (an expected
+ * state, PRODUCT-1734): the ceiling changed under the user, so THIS hook shows
+ * the plain informational toast and the settle-time refetch below pulls the new
+ * ceiling, snapping the composer to a model that can run. The cache updates
+ * optimistically so a racing send sees the new pin, rolls back on failure, and
+ * refetches after the request settles.
  */
 export function useSetAgentModelChoice(agentId: string) {
   const qc = useQueryClient();
@@ -80,8 +87,14 @@ export function useSetAgentModelChoice(agentId: string) {
       }
       return { prev };
     },
-    onError: (_err, _choice, ctx) => {
+    onError: (err, _choice, ctx) => {
       if (ctx?.prev !== undefined) qc.setQueryData(key, ctx.prev);
+      if (isModelNotAllowedError(err)) {
+        showExpectedStateToast(
+          i18n.t("chat:errors.modelNotAllowed"),
+          i18n.t("chat:errors.modelNotAllowedBody"),
+        );
+      }
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: key });

--- a/app/src/lib/model-not-allowed.ts
+++ b/app/src/lib/model-not-allowed.ts
@@ -1,0 +1,26 @@
+/**
+ * The gateway's `model_not_allowed` rejection of a per-agent model-choice write
+ * (`PUT /v1/agents/:slug/model-choice`, cloud `modelchoice.go`): the pick is
+ * outside the agent's allowed-models ceiling. An EXPECTED business state, not a
+ * Houston bug (PRODUCT-1734): the composer clamps its picker and its effort
+ * re-write to the ceiling it last fetched, so the write only reaches this
+ * rejection when a manager narrowed the ceiling under the user (the cached
+ * ceiling is at most 30s stale) or when a choice stored before the narrowing is
+ * re-sent by an effort click. The remedy is a re-fetch, which the mutation
+ * already does on settle, plus a plain informational toast — never the red
+ * "report a bug" pair.
+ *
+ * The Go edge answers the FLAT `{error: "<sentence>", code: "model_not_allowed"}`
+ * shape, which `HoustonEngineError.code` (nested `{error: {code}}`) does not
+ * read; `shareErrorCode` covers both. DOM-free so it unit-tests
+ * (`app/tests/model-not-allowed.test.ts`).
+ */
+
+import { shareErrorCode } from "./share-via-team.ts";
+
+export const MODEL_NOT_ALLOWED_CODE = "model_not_allowed";
+
+/** True for a gateway `model_not_allowed` rejection of a model-choice write. */
+export function isModelNotAllowedError(err: unknown): boolean {
+  return shareErrorCode(err) === MODEL_NOT_ALLOWED_CODE;
+}

--- a/app/src/lib/model-selector-lock.ts
+++ b/app/src/lib/model-selector-lock.ts
@@ -108,12 +108,18 @@ export interface ModelPin {
  * shows what will actually run:
  *  1. an open mission's pin when its model remains inside the ceiling, carrying
  *     the personal resolution's effort because activities have no effort field;
- *  2. the user's stored `choice` when present;
+ *  2. the user's stored `choice` when present AND still inside the ceiling;
  *  3. else, when a ceiling exists and the shared `fallback` model is outside it,
  *     a ceiling model the user can actually run (`pickCeilingPin`: the
  *     fallback provider's own id first, then any connected provider's, then
  *     the first entry on its catalogued provider);
  *  4. else the shared `fallback` (agent / pod default) unchanged.
+ *
+ * A stored choice OUTSIDE the ceiling never wins (PRODUCT-1734): the gateway
+ * hands the stored pick back unclamped after a manager narrows the ceiling, and
+ * showing it would make the composer name a model the next turn cannot run
+ * while every effort click re-sent it and got `model_not_allowed` back. Such a
+ * choice is treated as absent, keeping only its effort as the user's preference.
  */
 export function resolvePersonalModelPin(
   choice: AgentModelChoice | null | undefined,
@@ -122,17 +128,18 @@ export function resolvePersonalModelPin(
   missionPin: ModelPin | null,
   resolver: CeilingResolver,
 ): ModelPin {
-  const personalPin = choice
-    ? {
-        provider: choice.provider,
-        model: choice.model,
-        effort: choice.effort,
-      }
-    : allowedModels != null &&
-        allowedModels.length > 0 &&
-        !allowedModels.includes(fallback.model)
-      ? pickCeilingPin(allowedModels, fallback, resolver)
-      : fallback;
+  const personalPin =
+    choice && isModelAllowed(allowedModels, choice.model)
+      ? {
+          provider: choice.provider,
+          model: choice.model,
+          effort: choice.effort,
+        }
+      : resolveCeilingDefault(
+          allowedModels,
+          choice?.effort ? { ...fallback, effort: choice.effort } : fallback,
+          resolver,
+        );
   if (missionPin && isModelAllowed(allowedModels, missionPin.model)) {
     return {
       provider: missionPin.provider,
@@ -141,4 +148,22 @@ export function resolvePersonalModelPin(
     };
   }
   return personalPin;
+}
+
+/**
+ * The pin when there is no usable stored choice: a ceiling model the user can
+ * run when the fallback sits outside a non-empty ceiling, else the fallback
+ * itself (no ceiling, in-ceiling fallback, or an EMPTY ceiling that leaves
+ * nothing to snap to — the composer guards the write in that last case).
+ */
+function resolveCeilingDefault(
+  allowedModels: string[] | null | undefined,
+  fallback: ModelPin,
+  resolver: CeilingResolver,
+): ModelPin {
+  return allowedModels != null &&
+    allowedModels.length > 0 &&
+    !allowedModels.includes(fallback.model)
+    ? pickCeilingPin(allowedModels, fallback, resolver)
+    : fallback;
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -68,6 +68,7 @@ import { isUploadTooLargeError } from "./files-upload-limits";
 import i18n from "./i18n";
 import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
+import { isModelNotAllowedError } from "./model-not-allowed";
 import { isNetworkTransportError } from "./network-transport-error";
 import { isNoAgentForProviderWriteError } from "./no-agent-provider-write-error";
 import { isOrgAdminRequiredError } from "./org-admin-required-error";
@@ -545,7 +546,9 @@ export const tauriAgentSettings = {
  * `allowedModels` ceiling. `get` degrades to `null` on a non-Teams host (the
  * engine-client swallows the 404); `set` 400s `model_not_allowed` outside the
  * ceiling. Both route through `call()` so failures surface as a toast + Report
- * bug, same as the wrappers above.
+ * bug, same as the wrappers above — except `model_not_allowed`, an expected
+ * state (the ceiling moved under the user, PRODUCT-1734) that is logged here
+ * and surfaced by `useSetAgentModelChoice` as a plain informational toast.
  */
 export const tauriAgentModelChoice = {
   get: (agentSlugOrId: string) =>
@@ -556,8 +559,11 @@ export const tauriAgentModelChoice = {
     agentSlugOrId: string,
     choice: import("@houston-ai/engine-client").AgentModelChoice,
   ) =>
-    call<void>("set_agent_model_choice", () =>
-      getEngine().setAgentModelChoice(agentSlugOrId, choice),
+    call<void>(
+      "set_agent_model_choice",
+      () => getEngine().setAgentModelChoice(agentSlugOrId, choice),
+      undefined,
+      { silence: isModelNotAllowedError },
     ),
 };
 

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -120,6 +120,7 @@
     "stopSession": "Couldn't stop the task. Please try again.",
     "modelPersistFailed": "Failed to save model preference",
     "modelNotAllowed": "This model isn't allowed for this agent",
+    "modelNotAllowedBody": "This agent's allowed models changed. Pick another one from the list.",
     "missionRowFailed": "We could not save this task to your board. Your message was still sent.",
     "interactionDismissFailed": "Couldn't dismiss the request."
   },

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -120,6 +120,7 @@
     "stopSession": "No se pudo detener la tarea. Inténtalo de nuevo.",
     "modelPersistFailed": "No se pudo guardar la preferencia de modelo",
     "modelNotAllowed": "Este modelo no está permitido para este agente",
+    "modelNotAllowedBody": "Los modelos permitidos de este agente cambiaron. Elige otro de la lista.",
     "missionRowFailed": "No pudimos guardar esta tarea en tu tablero. Tu mensaje sí fue enviado.",
     "interactionDismissFailed": "No pudimos descartar la solicitud."
   },

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -120,6 +120,7 @@
     "stopSession": "Não foi possível parar a tarefa. Tente novamente.",
     "modelPersistFailed": "Não foi possível salvar a preferência de modelo",
     "modelNotAllowed": "Este modelo não é permitido para este agente",
+    "modelNotAllowedBody": "Os modelos permitidos deste agente mudaram. Escolha outro da lista.",
     "missionRowFailed": "Não conseguimos salvar esta tarefa no seu quadro. Sua mensagem foi enviada.",
     "interactionDismissFailed": "Não foi possível descartar a solicitação."
   },

--- a/app/tests/model-not-allowed.test.ts
+++ b/app/tests/model-not-allowed.test.ts
@@ -1,0 +1,49 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isModelNotAllowedError } from "../src/lib/model-not-allowed.ts";
+
+// Structural shape of HoustonEngineError(status, body): the classifier reads
+// the body, so the fixtures carry just that (same approach as agent-gone.test).
+const engineError = (status: number, body: unknown) =>
+  Object.assign(new Error(`engine error ${status}`), { status, body });
+
+describe("isModelNotAllowedError", () => {
+  it("matches the gateway's FLAT model_not_allowed body (the shipped shape)", () => {
+    // cloud `modelchoice.go` answers `{error: "<sentence>", code: "model_not_allowed"}`.
+    strictEqual(
+      isModelNotAllowedError(
+        engineError(400, {
+          error: "model not allowed for this agent",
+          code: "model_not_allowed",
+        }),
+      ),
+      true,
+    );
+  });
+
+  it("matches the nested engine shape too", () => {
+    strictEqual(
+      isModelNotAllowedError(
+        engineError(400, {
+          error: { code: "model_not_allowed", message: "model not allowed" },
+        }),
+      ),
+      true,
+    );
+  });
+
+  it("does not match other 400s, transport errors, or bare strings", () => {
+    strictEqual(
+      isModelNotAllowedError(
+        engineError(400, { error: "model must be a non-empty string" }),
+      ),
+      false,
+    );
+    strictEqual(
+      isModelNotAllowedError(new TypeError("Failed to fetch")),
+      false,
+    );
+    strictEqual(isModelNotAllowedError("model_not_allowed"), false);
+    strictEqual(isModelNotAllowedError(null), false);
+  });
+});

--- a/app/tests/model-selector-lock.test.ts
+++ b/app/tests/model-selector-lock.test.ts
@@ -131,6 +131,54 @@ describe("resolvePersonalModelPin", () => {
     );
   });
 
+  it("drops a stored choice the ceiling no longer allows, keeping its effort (PRODUCT-1734)", () => {
+    // A manager narrowed the ceiling after the choice was stored: the gateway
+    // hands the stale pick back unclamped. The composer must not show it (the
+    // next turn cannot run it) nor re-send it on an effort click.
+    const resolver = {
+      offers: (provider: string, model: string) =>
+        provider === "anthropic" && model === "claude-opus-5",
+      providerFor: () => "anthropic",
+      connected: ["anthropic"],
+    };
+    deepStrictEqual(
+      resolvePersonalModelPin(
+        { provider: "openai", model: "gpt-6-astra", effort: "low" },
+        ["claude-opus-5"],
+        fallback,
+        null,
+        resolver,
+      ),
+      { provider: "anthropic", model: "claude-opus-5", effort: "low" },
+    );
+  });
+
+  it("keeps an in-ceiling fallback over an out-of-ceiling stored choice", () => {
+    deepStrictEqual(
+      resolvePersonalModelPin(
+        { provider: "openai", model: "gpt-6-astra", effort: "low" },
+        ["claude"],
+        fallback,
+        null,
+        blind,
+      ),
+      { provider: "anthropic", model: "claude", effort: "low" },
+    );
+  });
+
+  it("keeps a stored choice when there is no ceiling", () => {
+    deepStrictEqual(
+      resolvePersonalModelPin(
+        { provider: "openai", model: "gpt-6-astra", effort: "low" },
+        null,
+        fallback,
+        null,
+        blind,
+      ),
+      { provider: "openai", model: "gpt-6-astra", effort: "low" },
+    );
+  });
+
   it("keeps the fallback when there is no ceiling", () => {
     deepStrictEqual(
       resolvePersonalModelPin(null, null, fallback, null, blind),


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1734 (Sentry HOUSTON-APP-500, `set_agent_model_choice: model not allowed for this agent (engine error 400)`, 13 users).

**Root cause.** The gateway (`modelchoice.go`) returns the user's stored per-agent model choice **unclamped** after a manager narrows the agent's allowed-models ceiling, and only rejects at write time. The composer took that stored choice verbatim (`resolvePersonalModelPin` step 2): the trigger named a model the next turn could not run, and every **effort** click re-sent it to `PUT /model-choice`, which answered `400 model_not_allowed` straight into a red toast + Sentry. The Sentry breadcrumbs looked like picker opens because the effort button shares the model trigger's exact classes (`span` / `svg.size-3.5 > rect` are its label and gauge); the PUT lands ~100 ms after that click, far too fast for a pick inside the popover. The residual model-row events are the same ceiling-moved-under-the-user race (the cached ceiling is up to 30 s stale).

**Fix.**
- `resolvePersonalModelPin`: a stored choice outside the ceiling never wins; it is treated as absent (its effort carries) so the pin snaps to a ceiling model the user can run via `pickCeilingPin`, mirroring the gateway's per-turn clamp.
- `selectEffort` clamps its model to the ceiling the same way a model pick does (an empty `[]` ceiling would otherwise re-send the fallback).
- `model_not_allowed` is an expected state: `call()` silences it (logged, no Sentry, no red toast), `useSetAgentModelChoice` shows a plain informational toast ("This model isn't allowed for this agent / This agent's allowed models changed…") and refetches the ceiling on settle, and `applyProviderModel` skips its red persist toast for it. New classifier `app/src/lib/model-not-allowed.ts` reads the gateway's flat `{error, code}` body.
- en / es / pt copy for the toast body.

The picker already hid out-of-ceiling rows and showed the "N more models are turned off in your workspace" footer; nothing changed there.

## Verification

**Before (reproduce on `main`):** in a Teams org, as a member of a shared agent, pick model A in the composer (stored choice). As a manager, set the agent's allowed models to a list that excludes A. Back as the member (within 30 s, or after a reload: the GET still returns A), click the effort gauge next to the model trigger. Result: red "we have a problem" toast, `PUT /v1/agents/<slug>/model-choice` → 400 `model_not_allowed` in the network tab, a Sentry event under `set_agent_model_choice`, and the trigger keeps naming A.

**After (this branch):** same steps. The trigger now names a model inside the new ceiling as soon as the choice/ceiling query refreshes; clicking the effort gauge writes that in-ceiling model and succeeds (200). If the ceiling changes between the fetch and a write, the write answers 400 and the user sees one blue informational toast, no red toast, no Sentry event, and the picker re-fetches and snaps to an allowed model. With an empty ceiling (`[]`), the effort click shows the same informational toast and sends nothing.

Checks run: `pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (4265 pass, incl. new `model-not-allowed.test.ts` and 3 new `resolvePersonalModelPin` cases), `pnpm check-locales`, `pnpm --filter houston-web typecheck`.
