### PR TITLE
fix(integrations): settle the connect poll quietly when its connection is gone (PRODUCT-1733)

### DIFF
--- a/app/src/components/integrations/connect-announce.ts
+++ b/app/src/components/integrations/connect-announce.ts
@@ -16,7 +16,10 @@ import { INTEGRATION_PROVIDER, type PollOutcome } from "./model";
  * neutral toast pointing at the pending row's Finish action, never a red one
  * with a bug report — walking away is normal behavior, not a crash; a
  * provider-side failure is an error toast with no auto bug report either.
- * A cancel is silent by design and never reaches here.
+ * A cancel is silent by design and never reaches here; a connection that
+ * vanished under the poll (`gone`) reaches here and stays silent too — the
+ * user disconnected it themselves (or the provider let it lapse), and the
+ * row's own notice line already says so (PRODUCT-1733).
  */
 export function useConnectAnnounce(): {
   /** The app's real catalog name, never the machine slug. */

--- a/app/src/components/integrations/connect-flow-registry.ts
+++ b/app/src/components/integrations/connect-flow-registry.ts
@@ -66,6 +66,9 @@ export interface FlowEntry {
   cancelled: boolean;
   /** The hosted OAuth link, so "Reopen" can reopen the same page. */
   redirectUrl: string | null;
+  /** The pending connection the poll reads, once the link is minted, so a
+   *  disconnect of THAT account (or of the whole app) can stop the poll. */
+  connectionId: string | null;
   /** This flow's run, so a second surface asking for the same app JOINS it
    *  (and observes the same outcome) instead of being turned away. Assigned
    *  synchronously right after {@link beginFlow}, before any await. */
@@ -102,6 +105,7 @@ export function beginFlow(
     waker,
     cancelled: false,
     redirectUrl: null,
+    connectionId: null,
     promise: null,
   };
   reg.set(toolkit, entry);
@@ -128,6 +132,24 @@ export function cancelFlow(reg: FlowRegistry, toolkit: string): void {
   if (!entry) return;
   entry.cancelled = true;
   entry.waker.wake();
+}
+
+/**
+ * A disconnect is about to remove `connectionId` of `toolkit` (every account
+ * of the app when omitted): stop a poll that is waiting on that very
+ * connection, so it never reads the id the user just removed (PRODUCT-1733).
+ * Removing ONE other account leaves a pending sibling's poll running — that
+ * OAuth is still the user's to finish.
+ */
+export function cancelFlowForDisconnect(
+  reg: FlowRegistry,
+  toolkit: string,
+  connectionId?: string,
+): void {
+  const entry = reg.get(toolkit);
+  if (!entry) return;
+  if (connectionId !== undefined && entry.connectionId !== connectionId) return;
+  cancelFlow(reg, toolkit);
 }
 
 /** Wake ONE flow's poll to check right now ("I have finished"). */

--- a/app/src/components/integrations/connect-flow-run.ts
+++ b/app/src/components/integrations/connect-flow-run.ts
@@ -29,9 +29,12 @@ export type ConnectStep = "starting" | "waiting" | "blocked";
  *  - `failed`    — the provider rejected or revoked the OAuth;
  *  - `stopped`   — the poll budget ran out because the user walked away; the
  *    app's own catalog row, now marked "Finishing up", picks it back up.
- * A cancel leaves nothing: the user already knows.
+ *  - `cancelled` — the pending connection vanished under the poll (the user
+ *    disconnected the app mid-OAuth, or the provider expired it); the row
+ *    says so once, quietly, and goes back to Available (PRODUCT-1733).
+ * A cancel the user asked for leaves nothing: the user already knows.
  */
-export type ConnectNotice = "connected" | "failed" | "stopped";
+export type ConnectNotice = "connected" | "failed" | "stopped" | "cancelled";
 
 /**
  * How long the success confirmation stays on the row BEFORE the connections
@@ -71,7 +74,9 @@ export interface ConnectRunDeps {
    * they walked away long ago — yanking focus then would be focus-stealing.
    */
   focus: () => Promise<void>;
-  /** Toast the outcome (success / neutral / error). Never called for a cancel. */
+  /** Toast the outcome (success / neutral / error). Never called for a cancel;
+   *  called for `gone`, where the voice stays silent (the row's notice is the
+   *  one surface). */
   announce: (toolkit: string, outcome: PollOutcome) => void;
   /** Free the slug so it can be connected again. */
   release: (toolkit: string) => void;
@@ -118,6 +123,7 @@ export async function runConnectFlow(
     try {
       const { redirectUrl, connectionId } = await deps.mintLink(toolkit);
       entry.redirectUrl = redirectUrl;
+      entry.connectionId = connectionId;
       // A cancel that landed while the link was still minting must NOT go on to
       // pop the OAuth tab: bail with the same silent outcome the poll yields.
       if (entry.cancelled) {
@@ -194,5 +200,6 @@ export function noticeFor(
 ): ConnectNotice {
   if (outcome === "active") return "connected";
   if (outcome === "timeout") return "stopped";
+  if (outcome === "gone") return "cancelled";
   return "failed";
 }

--- a/app/src/components/integrations/connect-notice-line.tsx
+++ b/app/src/components/integrations/connect-notice-line.tsx
@@ -12,7 +12,10 @@ import type { ConnectNotice } from "./connect-flow-run";
  * repeating the same sentence on the row said one thing three times over. What
  * belongs here is the state: "Connected", "Could not connect". The abandoned
  * case keeps its sentence because it is the actionable one: it says the app can
- * be connected again, right where it sits.
+ * be connected again, right where it sits. A connection that vanished under
+ * the poll (`cancelled`) has NO toast at all: the user disconnected it
+ * themselves, or the provider let it lapse, so this quiet line is the one
+ * surface (PRODUCT-1733).
  *
  * Lives apart from {@link ConnectFlowInline} so a surface can show the outcome
  * without pulling in the whole live-phase block.
@@ -45,6 +48,9 @@ export function ConnectNoticeLine({
         {t("waiting.failed")}
       </NoticeLine>
     );
+  }
+  if (notice === "cancelled") {
+    return <NoticeLine tone="muted">{t("waiting.cancelled")}</NoticeLine>;
   }
   return (
     <NoticeLine tone="muted">

--- a/app/src/components/integrations/model.ts
+++ b/app/src/components/integrations/model.ts
@@ -2,6 +2,7 @@ import type {
   Capabilities,
   IntegrationConnection,
 } from "@houston-ai/engine-client";
+import { isIntegrationConnectionGoneError } from "../../lib/integration-connection-gone.ts";
 
 /**
  * The integrations provider (platform mode): Houston holds the platform key
@@ -30,12 +31,15 @@ export const POLL_INTERVAL_MS = 2000;
 export const POLL_MAX_ATTEMPTS = 150; // ~5 min at 2s/attempt.
 
 /**
- * Outcome of the post-connect poll loop. `timeout` and `error` are first-class
- * results, NOT silent fall-throughs: the caller MUST surface them so an
- * abandoned or failed browser OAuth never leaves the user staring at a stopped
- * spinner with no explanation.
+ * Outcome of the post-connect poll loop. `timeout`, `error` and `gone` are
+ * first-class results, NOT silent fall-throughs: the caller MUST surface them
+ * so an abandoned, failed or removed browser OAuth never leaves the user
+ * staring at a stopped spinner with no explanation. `gone` is the pending
+ * connection vanishing under the poll (the user disconnected the app
+ * mid-OAuth, or the provider expired it) — expected, never a bug
+ * (PRODUCT-1733).
  */
-export type PollOutcome = "active" | "error" | "timeout" | "cancelled";
+export type PollOutcome = "active" | "error" | "timeout" | "cancelled" | "gone";
 
 /**
  * Poll one connection until the user finishes the app's OAuth in their browser,
@@ -51,8 +55,12 @@ export type PollOutcome = "active" | "error" | "timeout" | "cancelled";
  *                    immediately instead of running out the full budget.
  *
  * Returns `"active"` on success, `"error"` if the OAuth failed or was revoked,
- * `"cancelled"` if the flow was cancelled mid-wait, and `"timeout"` once the
- * attempt budget is spent while still pending.
+ * `"cancelled"` if the flow was cancelled mid-wait, `"gone"` when the
+ * connection no longer exists (its read answers 404), and `"timeout"` once the
+ * attempt budget is spent while still pending. A 404 landing on a poll that was
+ * ALREADY cancelled (the user's own disconnect raced the in-flight read) is
+ * the cancel, not a second outcome. Any other poll failure still rejects so
+ * the caller's catch surfaces it.
  */
 export async function pollConnectionUntilActive(deps: {
   poll: () => Promise<IntegrationConnection>;
@@ -67,7 +75,13 @@ export async function pollConnectionUntilActive(deps: {
     if (deps.isCancelled()) return "cancelled";
     await deps.sleep(intervalMs);
     if (deps.isCancelled()) return "cancelled";
-    const conn = await deps.poll();
+    let conn: IntegrationConnection;
+    try {
+      conn = await deps.poll();
+    } catch (err) {
+      if (!isIntegrationConnectionGoneError(err)) throw err;
+      return deps.isCancelled() ? "cancelled" : "gone";
+    }
     if (conn.status === "active") return "active";
     if (conn.status === "error") return "error";
   }

--- a/app/src/hooks/queries/use-integrations.ts
+++ b/app/src/hooks/queries/use-integrations.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { cancelFlowForDisconnect } from "../../components/integrations/connect-flow-registry";
 import { integrationsSupported } from "../../components/integrations/model";
 import { analytics } from "../../lib/analytics";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriIntegrations } from "../../lib/tauri";
+import { connectFlowRegistry } from "../../stores/connect-flow";
 import { useCapabilities } from "../use-capabilities";
 
 /**
@@ -85,6 +87,12 @@ export function useDisconnectIntegration(provider: string) {
       toolkit: string;
       connectionId?: string;
     }) => tauriIntegrations.disconnect(provider, toolkit, connectionId),
+    // A connect poll waiting on the connection being removed must stop NOW,
+    // before the removal lands: otherwise its next read 404s on the id the
+    // user just took away (PRODUCT-1733).
+    onMutate: ({ toolkit, connectionId }) => {
+      cancelFlowForDisconnect(connectFlowRegistry, toolkit, connectionId);
+    },
     onSuccess: (_data, { toolkit }) => {
       analytics.track("integration_disconnected", {
         integration_slug: toolkit,

--- a/app/src/lib/integration-connection-gone.ts
+++ b/app/src/lib/integration-connection-gone.ts
@@ -1,0 +1,28 @@
+/**
+ * A connect-poll read answered "this connection no longer exists"
+ * (HOUSTON-APP-52Q / PRODUCT-1733).
+ *
+ * The poll (`pollConnectionUntilActive`) reads ONE connection by the id the
+ * connect link was minted with, so `/v1/integrations/<provider>/connections/<id>`
+ * has exactly one 404 path: the host's `connection not found`, answered when
+ * the pending connection is gone. That happens for two expected reasons, and
+ * neither is a Houston bug:
+ *
+ *  - the user disconnected the app while its OAuth was still pending (the
+ *    disconnect removes every connection of the toolkit, the pending one
+ *    included, and a poll already in flight lands after it);
+ *  - the provider expired or revoked the pending connection before the user
+ *    finished signing in.
+ *
+ * Either way the honest outcome is "the connect ended", so the read is
+ * silenced (`call()` still logs it; no red bug toast, no Sentry report) and
+ * the poll settles as `"gone"`. Like `isAgentGoneError`, the classifier keys
+ * on the structural `.status`: the host emits a bare-string error body with
+ * no typed `kind`, and both engine adapters (`HoustonEngineError`) carry the
+ * status. Applied ONLY to the poll read; the disconnect write and the
+ * connections list keep the default loud surfacing.
+ */
+export function isIntegrationConnectionGoneError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as { status?: unknown }).status === 404;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -66,6 +66,7 @@ import {
 import { isEngineWakingError } from "./engine-waking-error";
 import { isUploadTooLargeError } from "./files-upload-limits";
 import i18n from "./i18n";
+import { isIntegrationConnectionGoneError } from "./integration-connection-gone";
 import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
 import { isNetworkTransportError } from "./network-transport-error";
@@ -2212,9 +2213,16 @@ export const tauriIntegrations = {
           isToolkitOauthUnavailableError(err) || isToolkitNoAuthError(err),
       },
     ),
+  /** The connect poll's status read. A 404 means the pending connection is
+   *  gone (the user disconnected the app mid-OAuth, or the provider expired
+   *  it) — the poll settles as `gone` (PRODUCT-1733), so it is silenced here
+   *  rather than reported as a bug. */
   connection: (provider: string, connectionId: string) =>
-    call("integration_connection", () =>
-      getEngine().integrationConnection(provider, connectionId),
+    call(
+      "integration_connection",
+      () => getEngine().integrationConnection(provider, connectionId),
+      { provider, connectionId },
+      { silence: isIntegrationConnectionGoneError },
     ),
   /** `connectionId` narrows the removal to ONE account of the toolkit (a
    *  toolkit can hold several — two Gmail logins); omitted removes them all. */

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -59,6 +59,7 @@
     "cancel": "Cancel",
     "connected": "Connected",
     "failed": "Could not connect",
+    "cancelled": "Connection cancelled",
     "stopped": "We stopped checking on {{app}}. Connect it again when you are done."
   },
   "pendingRecovery": {

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -59,6 +59,7 @@
     "cancel": "Cancelar",
     "connected": "Conectada",
     "failed": "No se pudo conectar",
+    "cancelled": "Conexión cancelada",
     "stopped": "Dejamos de revisar {{app}}. Conéctala de nuevo cuando hayas acabado."
   },
   "pendingRecovery": {

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -59,6 +59,7 @@
     "cancel": "Cancelar",
     "connected": "Conectado",
     "failed": "Não foi possível conectar",
+    "cancelled": "Conexão cancelada",
     "stopped": "Paramos de verificar o {{app}}. Conecte de novo quando você acabar."
   },
   "pendingRecovery": {

--- a/app/tests/connect-flow-registry.test.ts
+++ b/app/tests/connect-flow-registry.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
   beginFlow,
   cancelFlow,
+  cancelFlowForDisconnect,
   createRegistry,
   endFlow,
   flowPromise,
@@ -164,5 +165,54 @@ describe("connect-flow registry — wake + redirect are per slug", () => {
     strictEqual(flowRedirectUrl(reg, "gmail"), "https://oauth.example/gmail");
     // A slug with no live flow reads null (reopen after end is a no-op).
     strictEqual(flowRedirectUrl(reg, "slack"), null);
+  });
+});
+
+describe("connect-flow registry — cancel on disconnect (PRODUCT-1733)", () => {
+  it("removing the whole app stops its pending poll", () => {
+    const reg = createRegistry();
+    const waker = countingWaker();
+    const entry = beginFlow(reg, "gmail", waker);
+    if (!entry) throw new Error("expected an entry");
+    entry.connectionId = "ca_pending";
+    cancelFlowForDisconnect(reg, "gmail");
+    strictEqual(entry.cancelled, true);
+    strictEqual(waker.wakes, 1);
+  });
+
+  it("removing THE account being polled stops the poll", () => {
+    const reg = createRegistry();
+    const entry = beginFlow(reg, "gmail", countingWaker());
+    if (!entry) throw new Error("expected an entry");
+    entry.connectionId = "ca_pending";
+    cancelFlowForDisconnect(reg, "gmail", "ca_pending");
+    strictEqual(entry.cancelled, true);
+  });
+
+  it("removing ANOTHER account of the app leaves the pending poll running", () => {
+    // Two Gmail logins: the user drops the old one while the new one's OAuth is
+    // still open in the browser. That OAuth is still theirs to finish.
+    const reg = createRegistry();
+    const waker = countingWaker();
+    const entry = beginFlow(reg, "gmail", waker);
+    if (!entry) throw new Error("expected an entry");
+    entry.connectionId = "ca_pending";
+    cancelFlowForDisconnect(reg, "gmail", "ca_old");
+    strictEqual(entry.cancelled, false);
+    strictEqual(waker.wakes, 0);
+  });
+
+  it("a single-account removal while the link is still minting leaves the flow alone", () => {
+    const reg = createRegistry();
+    const entry = beginFlow(reg, "gmail", countingWaker());
+    if (!entry) throw new Error("expected an entry");
+    cancelFlowForDisconnect(reg, "gmail", "ca_old");
+    strictEqual(entry.cancelled, false);
+  });
+
+  it("is a no-op for a slug with no flow", () => {
+    const reg = createRegistry();
+    cancelFlowForDisconnect(reg, "gmail");
+    strictEqual(reg.size, 0);
   });
 });

--- a/app/tests/connect-flow-run.test.ts
+++ b/app/tests/connect-flow-run.test.ts
@@ -30,6 +30,7 @@ function harness(
     waker: { wait: () => Promise.resolve(), wake: () => {} },
     cancelled: false,
     redirectUrl: null,
+    connectionId: null,
     promise: null,
   };
   const statuses = overrides.statuses ?? ["active"];
@@ -96,6 +97,37 @@ describe("runConnectFlow — phase order", () => {
 });
 
 describe("runConnectFlow — outcomes", () => {
+  it("records the minted connection id on the entry so a disconnect can find the poll", async () => {
+    const { deps, entry } = harness();
+    await runConnectFlow("slack", deps);
+    strictEqual(entry.connectionId, "ca_1");
+  });
+
+  it("a connection removed under the poll settles as 'cancelled' on the row, with no toast copy of its own", async () => {
+    // PRODUCT-1733: the user disconnected the app while its OAuth was still
+    // pending (or the provider expired it), so the status read 404s. That is
+    // the connect ending, not an engine failure: no `null` return (which would
+    // paint the row "failed" and means "call() already toasted a bug").
+    const { deps, events } = harness({
+      readConnection: () =>
+        Promise.reject(
+          Object.assign(new Error("connection not found"), {
+            status: 404,
+          }),
+        ),
+    });
+    strictEqual(await runConnectFlow("slack", deps), "gone");
+    strictEqual(events.includes("notice:slack=cancelled"), true);
+    strictEqual(events.includes("notice:slack=failed"), false);
+    strictEqual(events.includes("toast:slack=gone"), true);
+    strictEqual(events.includes("invalidate"), true);
+    strictEqual(
+      events.includes("focus"),
+      false,
+      "nothing landed to snap back to",
+    );
+  });
+
   it("a landed OAuth confirms on the row, toasts, dwells, THEN refreshes", async () => {
     const { deps, events } = harness();
     strictEqual(await runConnectFlow("slack", deps), "active");

--- a/app/tests/integration-connection-gone.test.ts
+++ b/app/tests/integration-connection-gone.test.ts
@@ -1,0 +1,35 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isIntegrationConnectionGoneError } from "../src/lib/integration-connection-gone.ts";
+
+/**
+ * The connect poll's "connection not found" classifier (PRODUCT-1733). Keys
+ * on the structural `.status` both engine adapters carry, like
+ * `isAgentGoneError`: the host answers a bare-string body with no typed kind.
+ */
+describe("isIntegrationConnectionGoneError", () => {
+  it("matches the host's 404 on the connection read", () => {
+    const err = Object.assign(new Error("connection not found"), {
+      status: 404,
+    });
+    strictEqual(isIntegrationConnectionGoneError(err), true);
+  });
+
+  it("stays loud for every other status and shape", () => {
+    strictEqual(
+      isIntegrationConnectionGoneError(
+        Object.assign(new Error("upstream"), { status: 502 }),
+      ),
+      false,
+    );
+    strictEqual(
+      isIntegrationConnectionGoneError(
+        Object.assign(new Error("gone"), { status: "404" }),
+      ),
+      false,
+    );
+    strictEqual(isIntegrationConnectionGoneError(new Error("x")), false);
+    strictEqual(isIntegrationConnectionGoneError("404"), false);
+    strictEqual(isIntegrationConnectionGoneError(null), false);
+  });
+});

--- a/app/tests/integrations-module-connect-poll.test.ts
+++ b/app/tests/integrations-module-connect-poll.test.ts
@@ -81,6 +81,63 @@ describe("pollConnectionUntilActive (new module)", () => {
     strictEqual(calls, 5);
   });
 
+  it("returns 'gone' when the connection read answers 404 (PRODUCT-1733)", async () => {
+    // The user disconnected the app mid-OAuth, or the provider expired the
+    // pending connection: the id the poll reads no longer exists. Expected,
+    // so the loop settles instead of rejecting into the bug surface.
+    let calls = 0;
+    const outcome = await pollConnectionUntilActive({
+      poll: () => {
+        calls++;
+        return calls < 2
+          ? Promise.resolve(conn("pending"))
+          : Promise.reject(
+              Object.assign(new Error("connection not found"), {
+                status: 404,
+              }),
+            );
+      },
+      sleep: noSleep,
+      isCancelled: () => false,
+      maxAttempts: 10,
+    });
+    strictEqual(outcome, "gone");
+    strictEqual(calls, 2);
+  });
+
+  it("a 404 landing on an already-cancelled poll is the cancel, not a second outcome", async () => {
+    // The Sentry shape (HOUSTON-APP-52Q): the disconnect that cancelled the
+    // flow raced a read already in flight, which then 404s.
+    let cancelled = false;
+    const outcome = await pollConnectionUntilActive({
+      poll: () => {
+        cancelled = true;
+        return Promise.reject(
+          Object.assign(new Error("connection not found"), { status: 404 }),
+        );
+      },
+      sleep: noSleep,
+      isCancelled: () => cancelled,
+      maxAttempts: 10,
+    });
+    strictEqual(outcome, "cancelled");
+  });
+
+  it("propagates a non-404 poll rejection so the caller's catch surfaces it", async () => {
+    await rejects(
+      pollConnectionUntilActive({
+        poll: () =>
+          Promise.reject(
+            Object.assign(new Error("upstream down"), { status: 502 }),
+          ),
+        sleep: noSleep,
+        isCancelled: () => false,
+        maxAttempts: 10,
+      }),
+      /upstream down/,
+    );
+  });
+
   it("propagates a poll rejection so the caller's catch surfaces it", async () => {
     await rejects(
       pollConnectionUntilActive({
@@ -249,6 +306,30 @@ describe("connect surfaces", () => {
     ok(
       hook.includes("flowPromise(connectFlowRegistry"),
       "a second caller joins the running flow",
+    );
+  });
+
+  it("a connection that vanished under the poll is quiet: silenced read, row line, no toast (PRODUCT-1733)", () => {
+    const bridge = read("../src/lib/tauri.ts");
+    ok(
+      bridge.includes("silence: isIntegrationConnectionGoneError"),
+      "the poll read silences the gone 404 so it never reaches Sentry",
+    );
+    const voice = read("../src/components/integrations/connect-announce.ts");
+    ok(
+      !voice.includes('outcome === "gone"'),
+      "the voice has no toast for a connection the user removed themselves",
+    );
+    const line = read("../src/components/integrations/connect-notice-line.tsx");
+    ok(
+      line.includes('notice === "cancelled"') &&
+        line.includes("waiting.cancelled"),
+      "the row says the connection was cancelled, once, quietly",
+    );
+    const hook = read("../src/hooks/queries/use-integrations.ts");
+    ok(
+      hook.includes("cancelFlowForDisconnect(connectFlowRegistry"),
+      "a disconnect stops the poll waiting on the connection it removes",
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1733 (Sentry HOUSTON-APP-52Q: `integration_connection: connection not found (engine error 404)`, 31 events / 29 users since July, still on 0.6.18/0.6.20).

**Root cause.** The post-connect poll (`pollConnectionUntilActive`) keeps reading a connection by the id the connect link was minted with. When the user disconnects the app while that OAuth is still pending (the latest event: "Add another account" → detail dialog → Disconnect → confirm, all within 7 seconds), the disconnect removes every connection of the toolkit, the pending one included, and the poll already in flight lands on the host's `404 connection not found`. The provider expiring a pending connection produces the same shape. `call("integration_connection")` treated that as an unexpected engine error: red bug toast plus a Sentry report. The runner's catch then painted the row "failed" and returned `null`.

**Fix.**
- `pollConnectionUntilActive`: a 404 on the status read settles the poll with a new outcome `gone`. A 404 that lands on a poll that was already cancelled (the user's own disconnect raced the in-flight read, which is exactly the Sentry shape) stays `cancelled`. Any other rejection still propagates to the caller's catch.
- `tauri.ts` `connection`: the gone 404 is silenced through `isIntegrationConnectionGoneError` (new `app/src/lib/integration-connection-gone.ts`, keyed on `.status === 404` like `isAgentGoneError`). It is still logged; 5xx stays loud.
- `runConnectFlow` maps `gone` to a new row notice `cancelled` ("Connection cancelled", en/es/pt), no toast, and refreshes the connections query so the row goes back to Available.
- `useDisconnectIntegration` cancels the poll waiting on the connection it is about to remove (`cancelFlowForDisconnect`): the whole app, or the one account being polled (the flow entry now records its `connectionId` after the mint). Removing a different account of the same app leaves a pending sibling's OAuth running.

## Tests

- `app/tests/integrations-module-connect-poll.test.ts`: 404 → `gone`; 404 on an already-cancelled poll → `cancelled`; 502 still rejects; source guard that the read is silenced, the row line exists, the voice has no `gone` toast, and the disconnect mutation cancels the flow.
- `app/tests/connect-flow-run.test.ts`: the entry records the minted connection id; a gone read settles as `cancelled` on the row (not `failed`, not `null`), invalidates, no focus snap-back.
- `app/tests/connect-flow-registry.test.ts`: `cancelFlowForDisconnect` for whole-app, matching account, non-matching account, still-minting, and no-flow cases.
- `app/tests/integration-connection-gone.test.ts`: the classifier.

`pnpm check`, `cd app && pnpm tsgo --noEmit`, `cd app && pnpm test` (4272 pass), `cd app && pnpm check-locales`, `pnpm --filter houston-web typecheck` all green.

## Before the fix (reproduce)

1. Integrations → connect an app that allows several accounts (Gmail). Open its detail dialog → "Add another account". Do NOT finish the OAuth in the browser; the row shows "Finish connecting Gmail".
2. Open the detail dialog again → Disconnect → confirm.
3. Within ~2 s the row flips to "Could not connect", a red "report a bug" toast appears, the frontend log shows `[toast:integration_connection] connection not found (engine error 404)`, and a Sentry event lands in HOUSTON-APP-52Q.

## After the fix (verify)

1. Same steps 1 and 2.
2. The poll stops as soon as Disconnect is confirmed: no toast, no red row state, no Sentry event. If a read was already in flight, the 404 is logged only (`[engine:integration_connection] ...`) and the row shows nothing (it was the user's own cancel).
3. Provider-side expiry (or a manual `DELETE`/disconnect of the pending connection from another device): the row shows the muted "Connection cancelled" line for a few seconds, no toast, and the app returns to Available.
4. Done when: no `integration_connection` 404 in Sentry on the release that carries the fix.
