### PR TITLE
fix(skills): resolve skills.sh ids that drift from the upstream folder, hide proven-gone skills (PRODUCT-1729)

### DIFF
--- a/app/src/components/agent/use-community-skill-handlers.ts
+++ b/app/src/components/agent/use-community-skill-handlers.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useInstallCommunitySkill } from "../../hooks/queries";
 import { analytics } from "../../lib/analytics";
+import { isUnavailableSkillError } from "../../lib/skill-install-expected-state";
 import { tauriSkills } from "../../lib/tauri";
 import { useUIStore } from "../../stores/ui";
 
@@ -58,17 +59,24 @@ export function useCommunitySkillHandlers(agentPath: string) {
               title: t("store.installFailedAlready"),
               variant: "info",
             });
+          } else if (isUnavailableSkillError(err)) {
+            // Expected upstream state, not a bug (PRODUCT-1729): the host
+            // proved the author removed or renamed the skill, or deleted the
+            // repo, and the card is being dropped. Plain info, never the red
+            // "report a bug" pair.
+            addToast({
+              title: t("store.installUnavailable"),
+              variant: "info",
+            });
           } else {
             const key =
-              kind === "skill_not_in_repo"
-                ? "store.installFailedRepoMissing"
-                : kind === "skill_malformed"
-                  ? "store.installFailedMalformed"
-                  : kind === "rate_limited" || kind === "github_rate_limited"
-                    ? "store.installFailedRateLimited"
-                    : kind === "offline"
-                      ? "store.installFailedOffline"
-                      : "store.installFailedGeneric";
+              kind === "skill_malformed"
+                ? "store.installFailedMalformed"
+                : kind === "rate_limited" || kind === "github_rate_limited"
+                  ? "store.installFailedRateLimited"
+                  : kind === "offline"
+                    ? "store.installFailedOffline"
+                    : "store.installFailedGeneric";
             addToast({ title: t(key), variant: "error" });
           }
         }

--- a/app/src/components/skills-view/use-skills-view-actions.ts
+++ b/app/src/components/skills-view/use-skills-view-actions.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
 import { queryKeys } from "../../lib/query-keys";
+import { isUnavailableSkillError } from "../../lib/skill-install-expected-state";
 import { tauriAgent, tauriSkills } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
 import type { WorkspaceSkillRow } from "../../lib/workspace-skills";
@@ -69,8 +70,15 @@ export function useSkillsViewActions() {
             r.status === "rejected" &&
             classifySkillError(r.reason) === "already_installed",
         );
+        // The skill is gone upstream for EVERY agent alike (PRODUCT-1729):
+        // one expected-state line, not a red toast naming each agent.
+        const allUnavailable = failures.every(({ r }) =>
+          isUnavailableSkillError(r.status === "rejected" ? r.reason : null),
+        );
         if (allAlready && okCount === 0) {
           addToast({ title: t("store.installFailedAlready"), variant: "info" });
+        } else if (allUnavailable) {
+          addToast({ title: t("store.installUnavailable"), variant: "info" });
         } else if (!allAlready) {
           addToast({
             title: t("global.installFailedFor", {
@@ -80,7 +88,15 @@ export function useSkillsViewActions() {
           });
         }
       }
-      if (okCount === 0) throw new Error("install failed for every agent");
+      // Rethrow the FIRST real rejection so its typed `kind` survives: the
+      // marketplace card keys its next state on it (an unavailable skill is
+      // dropped, anything else re-enables the button).
+      if (okCount === 0) {
+        const first = failures[0]?.r;
+        throw first?.status === "rejected"
+          ? first.reason
+          : new Error("install failed for every agent");
+      }
       const first = settled.find((r) => r.status === "fulfilled");
       return first?.status === "fulfilled" ? first.value : skill.skillId;
     },

--- a/app/src/lib/skill-install-expected-state.ts
+++ b/app/src/lib/skill-install-expected-state.ts
@@ -1,0 +1,35 @@
+/**
+ * A community skill install that failed because the skill no longer exists
+ * where skills.sh says it does: the author removed or renamed it
+ * (`skill_not_in_repo`, proven by the host's full repo scan) or deleted the
+ * repo (`repo_not_found`, GitHub's 404). skills.sh keeps indexing both for
+ * months, so users hit these on cards they did nothing wrong with; the install
+ * handler shows the expected-state copy and drops the card, so the engine-call
+ * layer logs it and stops there: no red toast, no Sentry issue (PRODUCT-1729,
+ * HOUSTON-APP-5D7 / 5CS). Rate limits, offline, and untyped failures stay loud.
+ *
+ * Dependency-free (the typed `kind` is read here, not via `@houston-ai/skills`,
+ * whose root barrel the app's node:test runner cannot load) so it is testable
+ * directly (app/tests/skill-install-expected-state.test.ts).
+ */
+export function isUnavailableSkillError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("kind" in err)) return false;
+  const kind = (err as { kind?: unknown }).kind;
+  return kind === "skill_not_in_repo" || kind === "repo_not_found";
+}
+
+/**
+ * A community skill PREVIEW that failed for a reason outside Houston: the skill
+ * or repo is gone (above), or GitHub could not be listed right now (the
+ * unauthenticated `api.github.com` quota, `github_rate_limited`, or a
+ * transport drop, `offline`). The detail modal renders its visible error state
+ * either way (use-skill-preview.ts), and a card click is not worth a Sentry
+ * issue for weather. The INSTALL path deliberately keeps rate limits and
+ * offline loud: that is a user-initiated write with its own retry copy.
+ */
+export function isExpectedSkillPreviewError(err: unknown): boolean {
+  if (isUnavailableSkillError(err)) return true;
+  if (!err || typeof err !== "object" || !("kind" in err)) return false;
+  const kind = (err as { kind?: unknown }).kind;
+  return kind === "github_rate_limited" || kind === "offline";
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -77,6 +77,10 @@ import { toDisplayProviderIdOrNull } from "./provider-overrides";
 import { normalizeLegacyModel } from "./providers";
 import { healStaleRosterFromError } from "./roster-heal";
 import { isSharedSkillsUnconfiguredError } from "./shared-skills-availability";
+import {
+  isExpectedSkillPreviewError,
+  isUnavailableSkillError,
+} from "./skill-install-expected-state";
 import { isExpectedSkillSearchError } from "./skill-search-expected-state";
 import { isStaleAttachmentError } from "./stale-attachment";
 import {
@@ -891,15 +895,17 @@ export const tauriSkills = {
       () =>
         getEngine().previewCommunitySkill(agentPath, source, skillId, signal),
       undefined,
-      // `skill_not_in_repo` on a preview is an expected upstream state, not a
-      // Houston bug: the skills.sh index keeps listing skills whose GitHub
-      // repo was deleted, and preview deliberately skips the recursive scan
-      // that install runs (github-lookup.ts), so deeply nested skills miss
-      // here yet install fine. The detail modal already shows its visible
-      // error state (use-skill-preview.ts), so no Sentry capture — that
-      // second surface is what kept HOUSTON-APP-4XZ alive after PRODUCT-1382
-      // fixed every findable layout. Every other failure stays captured.
-      { toast: false, silenceKinds: ["skill_not_in_repo"] },
+      // A missing skill (`skill_not_in_repo`), a deleted repo
+      // (`repo_not_found`), or GitHub not listable right now on a preview is
+      // an expected upstream state, not a Houston bug: the skills.sh index
+      // keeps listing skills whose GitHub repo was deleted, and preview
+      // deliberately skips the recursive scan that install runs
+      // (github-lookup.ts), so deeply nested skills miss here yet install
+      // fine. The detail modal already shows its visible error state
+      // (use-skill-preview.ts), so no Sentry capture — that second surface is
+      // what kept HOUSTON-APP-4XZ alive after PRODUCT-1382 fixed every
+      // findable layout. Every other failure stays captured.
+      { toast: false, silence: isExpectedSkillPreviewError },
     ),
   installCommunity: (
     agentPath: string,
@@ -920,7 +926,11 @@ export const tauriSkills = {
           signal,
         ),
       undefined,
-      { toast: false },
+      // The same expected upstream states as preview (PRODUCT-1729): the host
+      // proved the skill or its repo is gone, the handler shows the authored
+      // "no longer available" state and drops the card. Every other install
+      // failure (rate limit, offline, malformed) stays captured.
+      { toast: false, silence: isUnavailableSkillError },
     );
   },
 };

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -78,7 +78,7 @@
       "productivity": "Productivity"
     },
     "installFailedAlready": "Already installed",
-    "installFailedRepoMissing": "The author removed this skill.",
+    "installUnavailable": "This skill is no longer available from its author.",
     "installFailedMalformed": "This skill's file is broken. Try a different one.",
     "installFailedRateLimited": "Skills.sh is busy. Wait a moment and click again.",
     "installFailedOffline": "Couldn't connect. Check your internet and try again.",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -78,7 +78,7 @@
       "productivity": "Productividad"
     },
     "installFailedAlready": "Ya instalado",
-    "installFailedRepoMissing": "El autor eliminó este skill.",
+    "installUnavailable": "Este skill ya no está disponible de su autor.",
     "installFailedMalformed": "El archivo de este skill está dañado. Prueba con otro.",
     "installFailedRateLimited": "Skills.sh está ocupado. Espera un momento y haz clic de nuevo.",
     "installFailedOffline": "No se pudo conectar. Revisa tu internet e inténtalo de nuevo.",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -78,7 +78,7 @@
       "productivity": "Produtividade"
     },
     "installFailedAlready": "Já instalado",
-    "installFailedRepoMissing": "O autor removeu este skill.",
+    "installUnavailable": "Este skill não está mais disponível do autor.",
     "installFailedMalformed": "O arquivo deste skill está com problema. Tente outro.",
     "installFailedRateLimited": "O Skills.sh está ocupado. Aguarde um momento e clique de novo.",
     "installFailedOffline": "Não foi possível conectar. Verifique sua internet e tente de novo.",

--- a/app/tests/skill-install-expected-state.test.ts
+++ b/app/tests/skill-install-expected-state.test.ts
@@ -1,0 +1,83 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { HoustonEngineError } from "../../packages/web/src/engine-adapter/client/errors.ts";
+import {
+  isExpectedSkillPreviewError,
+  isUnavailableSkillError,
+} from "../src/lib/skill-install-expected-state.ts";
+
+/** The engine-client's error exposes `kind` from `error.details.kind`. */
+function engineClientError(kind: string, status = 404): Error {
+  return Object.assign(new Error(`engine error (${kind})`), {
+    name: "HoustonEngineError",
+    status,
+    kind,
+  });
+}
+
+describe("isUnavailableSkillError (PRODUCT-1729)", () => {
+  it("treats a skill missing from a live repo as expected on the web adapter's shape", () => {
+    const err = new HoustonEngineError(404, {
+      error: {
+        code: "NOT_FOUND",
+        message: "Could not find 'spreadsheet' in openai/skills",
+        kind: "skill_not_in_repo",
+        details: { kind: "skill_not_in_repo" },
+      },
+    });
+    strictEqual(isUnavailableSkillError(err), true);
+  });
+
+  it("treats a deleted repo as expected on the engine-client's shape", () => {
+    strictEqual(
+      isUnavailableSkillError(engineClientError("repo_not_found")),
+      true,
+    );
+    strictEqual(
+      isUnavailableSkillError(engineClientError("skill_not_in_repo")),
+      true,
+    );
+  });
+
+  it("keeps rate limits and offline loud for the install handler's own copy", () => {
+    strictEqual(
+      isUnavailableSkillError(engineClientError("github_rate_limited", 429)),
+      false,
+    );
+    strictEqual(
+      isUnavailableSkillError(engineClientError("offline", 503)),
+      false,
+    );
+  });
+
+  it("keeps untyped failures loud", () => {
+    strictEqual(isUnavailableSkillError(new Error("boom")), false);
+    strictEqual(isUnavailableSkillError(null), false);
+  });
+});
+
+describe("isExpectedSkillPreviewError (PRODUCT-1729)", () => {
+  it("adds GitHub quota and transport misses to the quiet preview set", () => {
+    strictEqual(
+      isExpectedSkillPreviewError(
+        engineClientError("github_rate_limited", 429),
+      ),
+      true,
+    );
+    strictEqual(
+      isExpectedSkillPreviewError(engineClientError("offline", 503)),
+      true,
+    );
+    strictEqual(
+      isExpectedSkillPreviewError(engineClientError("repo_not_found")),
+      true,
+    );
+  });
+  it("keeps a malformed skill and untyped failures loud", () => {
+    strictEqual(
+      isExpectedSkillPreviewError(engineClientError("skill_malformed", 400)),
+      false,
+    );
+    strictEqual(isExpectedSkillPreviewError(new Error("boom")), false);
+  });
+});

--- a/packages/host/src/skills/community.ts
+++ b/packages/host/src/skills/community.ts
@@ -1,5 +1,6 @@
 import type { CommunitySkill } from "@houston/protocol";
 import { fetchCommunitySearch } from "./community-fetch";
+import { type GoneRegistry, goneRegistry } from "./gone-registry";
 
 /**
  * skills.sh community directory client. The host owns the resilience the KB
@@ -7,6 +8,9 @@ import { fetchCommunitySearch } from "./community-fetch";
  * outbound requests are globally spaced, and stale cached results are
  * returned during a temporary 429/network failure — so a rate-limited
  * marketplace degrades to slightly-old results instead of an error wall.
+ * Results whose repo or skill the install lookup has PROVED gone (the gone
+ * registry, PRODUCT-1729) are dropped on the way out: skills.sh keeps indexing
+ * deleted repos and renamed skills for months.
  */
 
 const SEARCH_ENDPOINT = "https://skills.sh/api/search";
@@ -45,6 +49,8 @@ export interface CommunityDirectoryOptions {
   freshTtlMs?: number;
   staleTtlMs?: number;
   popularFreshTtlMs?: number;
+  /** Proven-gone repos/skills to hide; the process singleton by default. */
+  gone?: GoneRegistry;
 }
 
 /** Per-request overrides that preserve process-wide cache and rate spacing. */
@@ -67,6 +73,7 @@ export class CommunityDirectory {
   private readonly freshTtlMs: number;
   private readonly staleTtlMs: number;
   private readonly popularFreshTtlMs: number;
+  private readonly gone: GoneRegistry;
 
   private readonly entries = new Map<string, CachedSearch>();
   private popularEntry: CachedSearch | null = null;
@@ -84,6 +91,12 @@ export class CommunityDirectory {
     this.freshTtlMs = opts.freshTtlMs ?? SEARCH_FRESH_TTL_MS;
     this.staleTtlMs = opts.staleTtlMs ?? SEARCH_STALE_TTL_MS;
     this.popularFreshTtlMs = opts.popularFreshTtlMs ?? POPULAR_FRESH_TTL_MS;
+    this.gone = opts.gone ?? goneRegistry;
+  }
+
+  /** Drop entries the install lookup has proved gone since they were cached. */
+  private alive(skills: CommunitySkill[]): CommunitySkill[] {
+    return skills.filter((s) => !this.gone.isGone(s.source, s.skillId));
   }
 
   /** Search with shared cache/spacing and optional request-scoped I/O. */
@@ -97,13 +110,13 @@ export class CommunityDirectory {
 
     const cached = this.entries.get(key);
     if (cached && this.now() - cached.fetchedAt <= this.freshTtlMs)
-      return cached.skills;
+      return this.alive(cached.skills);
 
     await this.waitForRequestSlot();
     try {
       const skills = await this.fetchSearch(trimmed, opts);
       this.entries.set(key, { skills, fetchedAt: this.now() });
-      return skills;
+      return this.alive(skills);
     } catch (err) {
       if (opts.signal?.aborted) throw opts.signal.reason ?? err;
       const stale = this.entries.get(key);
@@ -111,7 +124,7 @@ export class CommunityDirectory {
         console.warn(
           `[host-skills] community search failed, returning cached results: ${err}`,
         );
-        return stale.skills;
+        return this.alive(stale.skills);
       }
       throw err;
     }
@@ -121,13 +134,13 @@ export class CommunityDirectory {
   async popular(opts: CommunitySearchOptions = {}): Promise<CommunitySkill[]> {
     const fresh = this.popularEntry;
     if (fresh && this.now() - fresh.fetchedAt <= this.popularFreshTtlMs)
-      return fresh.skills.slice(0, POPULAR_LIMIT);
+      return this.alive(fresh.skills).slice(0, POPULAR_LIMIT);
 
     await this.waitForRequestSlot();
     try {
       const skills = await this.fetchSearch(POPULAR_SEED, opts);
       this.popularEntry = { skills, fetchedAt: this.now() };
-      return skills.slice(0, POPULAR_LIMIT);
+      return this.alive(skills).slice(0, POPULAR_LIMIT);
     } catch (err) {
       if (opts.signal?.aborted) throw opts.signal.reason ?? err;
       const stale = this.popularEntry;
@@ -135,7 +148,7 @@ export class CommunityDirectory {
         console.warn(
           `[host-skills] popular feed fetch failed, returning cached results: ${err}`,
         );
-        return stale.skills.slice(0, POPULAR_LIMIT);
+        return this.alive(stale.skills).slice(0, POPULAR_LIMIT);
       }
       throw err;
     }

--- a/packages/host/src/skills/github-lookup.test.ts
+++ b/packages/host/src/skills/github-lookup.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { locateSkillMd } from "./github-lookup";
+import { GoneRegistry } from "./gone-registry";
 import { SkillRemoteError } from "./remote-error";
 
 type Route = (url: string) => Response | null;
@@ -79,13 +80,163 @@ test("locateSkillMd matches by frontmatter name when the directory differs", asy
   expect(md).toBe(FM);
 });
 
-test("locateSkillMd throws skill_not_in_repo when nothing matches", async () => {
+test("locateSkillMd throws skill_not_in_repo when a live repo holds nothing matching", async () => {
+  const gone = new GoneRegistry();
   const err = await locateSkillMd(
-    fakeFetch(() => new Response("", { status: 404 })),
+    fakeFetch((url) =>
+      url.includes("git/trees/HEAD")
+        ? jsonRes({ tree: [{ path: "README.md", type: "blob" }] })
+        : new Response("", { status: 404 }),
+    ),
     "owner/repo",
     "ghost",
+    { gone },
   ).catch((e) => e);
   expect(err).toBeInstanceOf(SkillRemoteError);
+  expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+  // The recursive scan listed the whole repo, so the absence is proven and
+  // search must stop offering the card (PRODUCT-1729).
+  expect(gone.isGone("owner/repo", "ghost")).toBe(true);
+  expect(gone.isGone("owner/repo")).toBe(false);
+});
+
+test("locateSkillMd throws repo_not_found when GitHub answers 404 for the repo (PRODUCT-1729)", async () => {
+  // The HOUSTON-APP-5CS shape: sales-skills/sales was deleted upstream but
+  // skills.sh keeps listing sales-digital-products. Every raw-CDN guess AND
+  // the tree call 404.
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch(() => new Response("", { status: 404 })),
+    "sales-skills/sales",
+    "sales-digital-products",
+    { gone },
+  ).catch((e) => e);
+  expect(err).toBeInstanceOf(SkillRemoteError);
+  expect((err as SkillRemoteError).kind).toBe("repo_not_found");
+  expect(gone.isGone("sales-skills/sales")).toBe(true);
+});
+
+test("locateSkillMd reports a GitHub rate limit instead of a missing skill, and records nothing", async () => {
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch((url) =>
+      url.includes("api.github.com")
+        ? new Response("rate limited", { status: 403 })
+        : new Response("", { status: 404 }),
+    ),
+    "owner/repo",
+    "writing-great-skills",
+    { gone },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("github_rate_limited");
+  expect(gone.isGone("owner/repo", "writing-great-skills")).toBe(false);
+});
+
+test("locateSkillMd does not record a miss from a truncated recursive listing", async () => {
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch((url) =>
+      url.includes("recursive=1")
+        ? jsonRes({ tree: [], truncated: true })
+        : url.includes("git/trees/HEAD")
+          ? jsonRes({ tree: [] })
+          : new Response("", { status: 404 }),
+    ),
+    "owner/repo",
+    "ghost",
+    { gone },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+  expect(gone.isGone("owner/repo", "ghost")).toBe(false);
+});
+
+test("locateSkillMd resolves an id slugified from a Title Case frontmatter name (PRODUCT-1729)", async () => {
+  // The HOUSTON-APP-5D7 shape: claude-office-skills/skills keeps
+  // `pdf-ocr/SKILL.md` declaring `name: PDF OCR Extraction`; skills.sh lists it
+  // as `pdf-ocr-extraction`. The shallow scan sees the root `pdf-ocr` dir
+  // (and the looser `pdf` sibling), fetches both, and the slugified name wins.
+  let recursiveCalls = 0;
+  const PDF_OCR = "---\nname: PDF OCR Extraction\n---\n\n# PDF OCR";
+  const PDF = "---\nname: PDF Tools\n---\n\n# PDF";
+  const md = await locateSkillMd(
+    fakeFetch(
+      (url) => {
+        if (url.includes("recursive=1")) recursiveCalls++;
+        return null;
+      },
+      (url) =>
+        url.endsWith("git/trees/HEAD")
+          ? jsonRes({
+              tree: [
+                { path: "pdf", type: "tree", sha: "p1" },
+                { path: "pdf-ocr", type: "tree", sha: "p2" },
+                { path: "excel", type: "tree", sha: "p3" },
+              ],
+            })
+          : null,
+      rawAt("pdf-ocr/SKILL.md", PDF_OCR),
+      rawAt("pdf/SKILL.md", PDF),
+    ),
+    "owner/repo",
+    "pdf-ocr-extraction",
+    { deepScan: false },
+  );
+  expect(md).toBe(PDF_OCR);
+  expect(recursiveCalls).toBe(0);
+});
+
+test("locateSkillMd resolves a renamed skill whose old id is a kebab prefix, via the recursive scan (PRODUCT-1729)", async () => {
+  // The HOUSTON-APP-5D7 shape: anthropics/knowledge-work-plugins renamed
+  // `user-research-synthesis` to `design/skills/user-research/SKILL.md`
+  // (frontmatter `name: user-research`); skills.sh still lists the old id.
+  // Nothing in the repo contains the full id, so only the prefix rule finds
+  // it. A one-segment `user/SKILL.md` sibling must NOT be taken.
+  const USER_RESEARCH = "---\nname: user-research\n---\n\n# User Research";
+  const USER = "---\nname: user\n---\n\n# User";
+  const md = await locateSkillMd(
+    fakeFetch(
+      (url) =>
+        url.includes("recursive=1")
+          ? jsonRes({
+              tree: [
+                { path: "design/skills/user/SKILL.md", type: "blob" },
+                { path: "design/skills/user-research/SKILL.md", type: "blob" },
+                { path: "sales/skills/lead-research/SKILL.md", type: "blob" },
+              ],
+            })
+          : url.includes("git/trees/HEAD")
+            ? jsonRes({
+                tree: [
+                  { path: "design", type: "tree", sha: "d1" },
+                  { path: "sales", type: "tree", sha: "s1" },
+                ],
+              })
+            : null,
+      rawAt("design/skills/user-research/SKILL.md", USER_RESEARCH),
+      rawAt("design/skills/user/SKILL.md", USER),
+    ),
+    "owner/repo",
+    "user-research-synthesis",
+  );
+  expect(md).toBe(USER_RESEARCH);
+});
+
+test("locateSkillMd never takes a one-segment prefix directory for a longer id", async () => {
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch(
+      (url) =>
+        url.includes("git/trees/HEAD")
+          ? jsonRes({
+              tree: [{ path: "user/SKILL.md", type: "blob" }],
+            })
+          : null,
+      rawAt("user/SKILL.md", "---\nname: user\n---\n\n# User"),
+    ),
+    "owner/repo",
+    "user-research-synthesis",
+    { gone },
+  ).catch((e) => e);
   expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
 });
 
@@ -272,4 +423,177 @@ test("locateSkillMd with deepScan: false still succeeds on a common-path hit", a
     { deepScan: false },
   );
   expect(md).toBe("hit");
+});
+
+test("locateSkillMd rejects a prefix directory whose frontmatter names a different skill", async () => {
+  // Installing the WRONG skill is worse than a 404: `user-research/` declaring
+  // `name: competitor-analysis` is some other skill under a matching folder.
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch(
+      (url) =>
+        url.includes("git/trees/HEAD")
+          ? jsonRes({
+              tree: [{ path: "design/user-research/SKILL.md", type: "blob" }],
+            })
+          : null,
+      rawAt(
+        "design/user-research/SKILL.md",
+        "---\nname: competitor-analysis\n---\n\n# Competitors",
+      ),
+    ),
+    "owner/repo",
+    "user-research-synthesis",
+    { gone },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+  expect(gone.isGone("owner/repo", "user-research-synthesis")).toBe(true);
+});
+
+test("locateSkillMd does not record a miss when a listed candidate could not be read", async () => {
+  // The tree lists a plausible path but its raw fetch fails (CDN 503): the
+  // repo was NOT proven empty of the skill, so nothing is hidden for a day.
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch(
+      (url) =>
+        url.includes("git/trees/HEAD")
+          ? jsonRes({
+              tree: [{ path: "tools/deep-research/SKILL.md", type: "blob" }],
+            })
+          : null,
+      (url) =>
+        url.includes("tools/deep-research/SKILL.md")
+          ? new Response("", { status: 503 })
+          : null,
+    ),
+    "owner/repo",
+    "deep-research",
+    { gone },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("offline");
+  expect(gone.isGone("owner/repo", "deep-research")).toBe(false);
+});
+
+test("locateSkillMd does not record a miss when the recursive candidate cap left paths unread", async () => {
+  const gone = new GoneRegistry();
+  const blobs = Array.from({ length: 45 }, (_, i) => ({
+    path: `packs/p${i}/writing-plans-${i}/SKILL.md`,
+    type: "blob",
+  }));
+  const err = await locateSkillMd(
+    fakeFetch(
+      (url) =>
+        url.includes("git/trees/HEAD") ? jsonRes({ tree: blobs }) : null,
+      (url) =>
+        url.includes("raw.githubusercontent.com") && url.includes("packs/")
+          ? new Response("---\nname: other\n---\n\n# Other")
+          : null,
+    ),
+    "owner/repo",
+    "writing-plans",
+    { gone },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+  expect(gone.isGone("owner/repo", "writing-plans")).toBe(false);
+});
+
+test("locateSkillMd confirms a tree 404 against the repo endpoint before calling the repo gone", async () => {
+  // A 404 on git/trees/HEAD alone is "resource not found" (the ref, say); the
+  // repo itself still answers 200, so it must not be hidden for a day.
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch((url) =>
+      url.endsWith("api.github.com/repos/owner/repo")
+        ? jsonRes({ full_name: "owner/repo" })
+        : new Response("", { status: 404 }),
+    ),
+    "owner/repo",
+    "ghost",
+    { gone },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("offline");
+  expect(gone.isGone("owner/repo")).toBe(false);
+});
+
+test("locateSkillMd with deepScan: false reports a rate-limited shallow scan as such, not as a missing skill", async () => {
+  const err = await locateSkillMd(
+    fakeFetch((url) =>
+      url.includes("api.github.com")
+        ? new Response("", { status: 403 })
+        : new Response("", { status: 404 }),
+    ),
+    "owner/repo",
+    "ghost",
+    { deepScan: false },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("github_rate_limited");
+});
+
+test("locateSkillMd finds a skill whose directory shares nothing with its declared name", async () => {
+  // skills.sh keys on the frontmatter `name:`, so `odd/location/SKILL.md`
+  // declaring `name: ghost` IS the `ghost` skill. Nothing in the path
+  // resembles the id; only reading every SKILL.md finds it — and without that
+  // read the recursive scan could never prove the skill absent.
+  const md = await locateSkillMd(
+    fakeFetch(
+      (url) =>
+        url.includes("git/trees/HEAD")
+          ? jsonRes({
+              tree: [
+                { path: "odd/location/SKILL.md", type: "blob" },
+                { path: "other/SKILL.md", type: "blob" },
+              ],
+            })
+          : null,
+      rawAt("odd/location/SKILL.md", "---\nname: ghost\n---\n\n# Ghost"),
+      rawAt("other/SKILL.md", "---\nname: other\n---\n\n# Other"),
+    ),
+    "owner/repo",
+    "ghost",
+  );
+  expect(md).toBe("---\nname: ghost\n---\n\n# Ghost");
+});
+
+test("locateSkillMd with deepScan: false keeps a rate-limited skills/ subtree listing as such", async () => {
+  const err = await locateSkillMd(
+    fakeFetch((url) => {
+      if (url.endsWith("git/trees/HEAD"))
+        return jsonRes({ tree: [{ path: "skills", type: "tree", sha: "s1" }] });
+      if (url.endsWith("git/trees/s1"))
+        return new Response("", { status: 403 });
+      return new Response("", { status: 404 });
+    }),
+    "owner/repo",
+    "ghost",
+    { deepScan: false },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("github_rate_limited");
+});
+
+test("locateSkillMd types a candidate whose body stream resets as offline, not missing", async () => {
+  const gone = new GoneRegistry();
+  const err = await locateSkillMd(
+    fakeFetch(
+      (url) =>
+        url.includes("git/trees/HEAD")
+          ? jsonRes({ tree: [{ path: "tools/ghost/SKILL.md", type: "blob" }] })
+          : null,
+      (url) =>
+        url.includes("tools/ghost/SKILL.md")
+          ? new Response(
+              new ReadableStream({
+                pull(controller) {
+                  controller.error(new Error("stream reset"));
+                },
+              }),
+            )
+          : null,
+    ),
+    "owner/repo",
+    "ghost",
+    { gone },
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("offline");
+  expect(gone.isGone("owner/repo", "ghost")).toBe(false);
 });

--- a/packages/host/src/skills/github-lookup.ts
+++ b/packages/host/src/skills/github-lookup.ts
@@ -1,11 +1,8 @@
 import { fetchSkillMdAtPath } from "./github";
-import { extractFrontmatterName, skillIdFromPath } from "./github-parse";
+import { recursiveScan, type ScanMiss, shallowScan } from "./github-tree-scan";
+import { type GoneRegistry, goneRegistry } from "./gone-registry";
 import { probePluginMarketplace } from "./plugin-marketplace";
 import { SkillRemoteError } from "./remote-error";
-
-const GH_HEADERS = { "User-Agent": "houston-skills/1.0" };
-/** Cap on how many fuzzy SKILL.md candidates the shallow scan will fetch. */
-const SHALLOW_CANDIDATE_CAP = 6;
 
 export interface LocateSkillMdOptions {
   /**
@@ -18,10 +15,10 @@ export interface LocateSkillMdOptions {
    *      roots to probe (plugin-marketplace.ts, PRODUCT-1382).
    *   2. Shallow tree scan (ALWAYS run) — at most two SMALL non-recursive
    *      `api.github.com` calls (the repo root, then the `skills/` subtree if
-   *      present); fuzzy-matches directory names against `skillId` and confirms
-   *      the winner by its frontmatter `name:`. Finds the common "declared slug
-   *      differs from the directory name" shape (e.g. `skills/use-ai-sdk/` with
-   *      `name: ai-sdk`) cheaply.
+   *      present); matches directory names against `skillId` and confirms
+   *      the winner by its frontmatter `name:` (github-tree-scan.ts). Finds
+   *      the common "declared slug differs from the directory name" shape
+   *      (e.g. `skills/use-ai-sdk/` with `name: ai-sdk`) cheaply.
    *   3. Recursive tree scan — ONE big `?recursive=1` call over the WHOLE repo
    *      (measured 10+ seconds and a large chunk of the 60-req/hour
    *      unauthenticated `api.github.com` rate limit on a real monorepo).
@@ -29,8 +26,16 @@ export interface LocateSkillMdOptions {
    *      nested skill; the read-only preview flow passes `false` — a preview
    *      miss just shows "couldn't load the description" and isn't worth the
    *      cost on every marketplace card click. Install still works.
+   *
+   * Every confirming tier tolerates the two ways a skills.sh id drifts from
+   * the repo (skill-id-match.ts, PRODUCT-1729): the index slugifies the
+   * declared `name:` (`pdf-ocr/` declaring `PDF OCR Extraction` is listed as
+   * `pdf-ocr-extraction`), and a skill renamed upstream keeps its old id as a
+   * kebab prefix (`user-research-synthesis` → `user-research/`).
    */
   deepScan?: boolean;
+  /** Where proven misses are recorded; the process singleton by default. */
+  gone?: GoneRegistry;
 }
 
 /**
@@ -39,8 +44,16 @@ export interface LocateSkillMdOptions {
  * two never drift. `source` is an already-normalized `owner/repo`. Runs the
  * tiers documented on {@link LocateSkillMdOptions.deepScan} — cheap path
  * guesses, the plugin-marketplace probe, a shallow tree scan, then (install
- * only) the recursive scan — and returns the raw SKILL.md text or throws
- * `skill_not_in_repo`.
+ * only) the recursive scan — and returns the raw SKILL.md text or throws:
+ *
+ *   - `repo_not_found` when GitHub answers 404 for the repo itself (deleted,
+ *     renamed, or private) — recorded in the gone registry so search stops
+ *     listing the repo's skills;
+ *   - `github_rate_limited` / `offline` when the api.github.com tiers could
+ *     not run, so a quota or transport miss never reads as "the author
+ *     removed this skill";
+ *   - `skill_not_in_repo` otherwise — recorded in the registry only when the
+ *     recursive scan ran to completion and proved the absence.
  */
 export async function locateSkillMd(
   fetchImpl: typeof fetch,
@@ -48,6 +61,7 @@ export async function locateSkillMd(
   skillId: string,
   opts: LocateSkillMdOptions = {},
 ): Promise<string> {
+  const gone = opts.gone ?? goneRegistry;
   // Tier 1 — common path patterns, cheap (no api.github.com call). Tried
   // concurrently but priority-ordered: prefer candidates[0]'s result over
   // [1]'s over [2]'s when more than one happens to exist.
@@ -75,143 +89,55 @@ export async function locateSkillMd(
   if (marketplaceMd !== null) return marketplaceMd;
 
   // Tier 2 — shallow scan, always (≤2 small non-recursive api.github.com calls).
-  const shallow = await shallowFindSkillPath(fetchImpl, source, skillId);
-  if (shallow) return shallow.rawMd;
+  const shallow = await shallowScan(fetchImpl, source, skillId);
+  if (shallow.kind === "found") return shallow.candidate.rawMd;
+  if (shallow.reason === "repo_gone") throw repoGone(gone, source, skillId);
 
-  // Tier 3 — recursive scan, expensive; install-only (deepScan).
-  if (opts.deepScan ?? true) {
-    const path = await findSkillPathInRepo(fetchImpl, source, skillId).catch(
-      () => null,
+  // Tier 3 — recursive scan, expensive; install-only (deepScan). A preview
+  // reports the shallow miss as-is: a shallow "absent" is not proof (the skill
+  // may be nested), so nothing is recorded.
+  if (!(opts.deepScan ?? true))
+    throw missError(source, skillId, shallow.reason);
+  const deep = await recursiveScan(fetchImpl, source, skillId);
+  if (deep.kind === "found") return deep.candidate.rawMd;
+  if (deep.reason === "repo_gone") throw repoGone(gone, source, skillId);
+  // Only a COMPLETE listing with every candidate read proves the skill is
+  // gone; anything less is a plain miss that must not poison search for a day.
+  if (deep.reason === "absent") gone.markSkillGone(source, skillId);
+  throw missError(source, skillId, deep.reason);
+}
+
+function repoGone(
+  gone: GoneRegistry,
+  source: string,
+  skillId: string,
+): SkillRemoteError {
+  gone.markRepoGone(source);
+  return new SkillRemoteError(
+    "repo_not_found",
+    `GitHub answered 404 for ${source} while looking for '${skillId}'`,
+  );
+}
+
+/** The typed error for a scan miss: quota and transport keep their own kinds
+ *  so they never read as "the author removed this skill". */
+function missError(
+  source: string,
+  skillId: string,
+  reason: Exclude<ScanMiss, "repo_gone">,
+): SkillRemoteError {
+  if (reason === "rate_limited")
+    return new SkillRemoteError(
+      "github_rate_limited",
+      `GitHub rate limit hit while listing ${source} for '${skillId}'`,
     );
-    if (path) {
-      const rawMd = await fetchSkillMdAtPath(fetchImpl, source, path).catch(
-        () => null,
-      );
-      if (rawMd !== null) return rawMd;
-    }
-  }
-
-  throw new SkillRemoteError(
+  if (reason === "unreachable")
+    return new SkillRemoteError(
+      "offline",
+      `Could not read ${source} while looking for '${skillId}'`,
+    );
+  return new SkillRemoteError(
     "skill_not_in_repo",
     `Could not find '${skillId}' in ${source}`,
   );
-}
-
-type TreeEntry = { path: string; type: string; sha?: string };
-
-/** One NON-recursive Git Trees call, parsed to its entries; null on any miss. */
-async function fetchTree(
-  fetchImpl: typeof fetch,
-  source: string,
-  ref: string,
-): Promise<TreeEntry[] | null> {
-  const res = await fetchImpl(
-    `https://api.github.com/repos/${source}/git/trees/${ref}`,
-    { headers: GH_HEADERS },
-  ).catch(() => null);
-  if (!res?.ok) return null;
-  const body = (await res.json().catch(() => null)) as {
-    tree?: TreeEntry[];
-  } | null;
-  return body && Array.isArray(body.tree) ? body.tree : null;
-}
-
-/**
- * Cheap middle tier: at most two NON-recursive Git Trees calls (the repo root,
- * then the `skills/` subtree if present) list top-level and `skills/*`
- * directory names, we fuzzy-match those against `skillId` (either contains the
- * other, case-insensitive), and confirm the winner by its frontmatter `name:`.
- * This resolves the common "author-declared slug differs from the directory
- * name" shape without the recursive scan's cost. Returns the matching path AND
- * its already-fetched content so `locateSkillMd` needn't re-fetch. null on any
- * miss. Exact directory matches were already covered by the guess tier, so a
- * fuzzy-only match here is enough (an exact one matching again is harmless).
- */
-async function shallowFindSkillPath(
-  fetchImpl: typeof fetch,
-  source: string,
-  skillId: string,
-): Promise<{ path: string; rawMd: string } | null> {
-  const root = await fetchTree(fetchImpl, source, "HEAD");
-  if (!root) return null;
-
-  const id = skillId.toLowerCase();
-  const fuzzy = (name: string): boolean => {
-    const n = name.toLowerCase();
-    return n.includes(id) || id.includes(n);
-  };
-
-  // `skills/`-nested candidates rank ahead of top-level ones.
-  const topLevel: string[] = [];
-  let skillsSha: string | undefined;
-  for (const entry of root) {
-    if (entry.type !== "tree") continue;
-    if (entry.path === "skills") skillsSha = entry.sha;
-    if (fuzzy(entry.path)) topLevel.push(`${entry.path}/SKILL.md`);
-  }
-
-  const nested: string[] = [];
-  if (skillsSha) {
-    const sub = await fetchTree(fetchImpl, source, skillsSha);
-    for (const entry of sub ?? []) {
-      if (entry.type === "tree" && fuzzy(entry.path))
-        nested.push(`skills/${entry.path}/SKILL.md`);
-    }
-  }
-
-  const paths = [...nested, ...topLevel].slice(0, SHALLOW_CANDIDATE_CAP);
-  if (paths.length === 0) return null;
-
-  const fetched = await Promise.allSettled(
-    paths.map((path) => fetchSkillMdAtPath(fetchImpl, source, path)),
-  );
-  for (let i = 0; i < paths.length; i++) {
-    const result = fetched[i];
-    const path = paths[i];
-    if (
-      path &&
-      result?.status === "fulfilled" &&
-      extractFrontmatterName(result.value) === skillId
-    )
-      return { path, rawMd: result.value };
-  }
-  return null;
-}
-
-/**
- * Locate a SKILL.md matching `skillId` via the RECURSIVE Git Trees API — one
- * call over the whole repo (expensive, rate-limited; install-only). Two passes:
- * exact directory-name match first, then peek at frontmatter `name:` for paths
- * containing the id (capped at 10 fetches).
- */
-async function findSkillPathInRepo(
-  fetchImpl: typeof fetch,
-  source: string,
-  skillId: string,
-): Promise<string | null> {
-  const res = await fetchImpl(
-    `https://api.github.com/repos/${source}/git/trees/HEAD?recursive=1`,
-    { headers: GH_HEADERS },
-  );
-  if (!res.ok) return null;
-  const tree = (await res.json().catch(() => null)) as {
-    tree?: Array<{ path: string; type: string }>;
-  } | null;
-  if (!tree || !Array.isArray(tree.tree)) return null;
-
-  const repoName = source.split("/").at(-1) ?? source;
-  const fuzzy: string[] = [];
-  for (const entry of tree.tree) {
-    if (entry.type !== "blob" || !entry.path.endsWith("SKILL.md")) continue;
-    if (skillIdFromPath(entry.path, repoName) === skillId) return entry.path;
-    if (entry.path.includes(skillId)) fuzzy.push(entry.path);
-  }
-  for (const path of fuzzy.slice(0, 10)) {
-    const content = await fetchSkillMdAtPath(fetchImpl, source, path).catch(
-      () => null,
-    );
-    if (content !== null && extractFrontmatterName(content) === skillId)
-      return path;
-  }
-  return null;
 }

--- a/packages/host/src/skills/github-tree-fetch.ts
+++ b/packages/host/src/skills/github-tree-fetch.ts
@@ -1,0 +1,125 @@
+import { readSkillMdAtPath } from "./github";
+import { pickBestCandidate, type ScoredCandidate } from "./skill-id-match";
+
+/**
+ * The api.github.com primitives behind the tree scans (github-tree-scan.ts):
+ * one Git Trees listing typed by WHY it came back empty, the repo-endpoint
+ * confirmation a tree 404 needs, and the candidate confirmation step that
+ * keeps "read and rejected" apart from "could not read".
+ */
+
+const GH_HEADERS = { "User-Agent": "houston-skills/1.0" };
+
+export type TreeEntry = { path: string; type: string; sha?: string };
+
+/**
+ * Why a scan came back empty. Only `absent` is proof: every listed candidate
+ * was read and rejected. `repo_gone` is GitHub's 404 for the repository
+ * itself (deleted, renamed, or private; skills.sh keeps listing it for
+ * months). `rate_limited` (403/429) and `unreachable` (a transport failure, an
+ * unusable answer, or a listed candidate whose raw read failed with anything
+ * but a 404) say nothing about the repo, and `incomplete` means the listing
+ * was truncated or a fetch cap left candidates unread. The caller must NOT
+ * record any of those three as a proven miss. A listed directory whose
+ * SKILL.md 404s is ordinary absence: the shallow scan lists directories, not
+ * SKILL.md files.
+ */
+export type ScanMiss =
+  | "absent"
+  | "repo_gone"
+  | "rate_limited"
+  | "unreachable"
+  | "incomplete";
+
+export type ScanResult =
+  | { kind: "found"; candidate: ScoredCandidate }
+  | { kind: "miss"; reason: ScanMiss };
+
+export type TreeFetch =
+  | { kind: "ok"; entries: TreeEntry[]; truncated: boolean }
+  | { kind: "miss"; reason: ScanMiss };
+
+export async function fetchTree(
+  fetchImpl: typeof fetch,
+  source: string,
+  ref: string,
+  recursive: boolean,
+): Promise<TreeFetch> {
+  const url = `https://api.github.com/repos/${source}/git/trees/${ref}${
+    recursive ? "?recursive=1" : ""
+  }`;
+  const res = await fetchImpl(url, { headers: GH_HEADERS }).catch(() => null);
+  if (!res) return { kind: "miss", reason: "unreachable" };
+  if (res.status === 404) return { kind: "miss", reason: "repo_gone" };
+  if (res.status === 403 || res.status === 429)
+    return { kind: "miss", reason: "rate_limited" };
+  if (!res.ok) return { kind: "miss", reason: "unreachable" };
+  const body = (await res.json().catch(() => null)) as {
+    tree?: TreeEntry[];
+    truncated?: boolean;
+  } | null;
+  if (!body || !Array.isArray(body.tree))
+    return { kind: "miss", reason: "unreachable" };
+  return { kind: "ok", entries: body.tree, truncated: body.truncated === true };
+}
+
+/**
+ * A tree 404 alone is "resource not found": the ref, or a repo GitHub hides.
+ * Only the repository endpoint's own 404 proves the repo is gone, so it is
+ * confirmed there (one extra call, only on this rare path) before the caller
+ * hides the whole repo for a day.
+ */
+async function confirmRepoGone(
+  fetchImpl: typeof fetch,
+  source: string,
+): Promise<ScanMiss> {
+  const res = await fetchImpl(`https://api.github.com/repos/${source}`, {
+    headers: GH_HEADERS,
+  }).catch(() => null);
+  if (!res) return "unreachable";
+  if (res.status === 404) return "repo_gone";
+  if (res.status === 403 || res.status === 429) return "rate_limited";
+  return "unreachable";
+}
+
+/** The HEAD tree, with a 404 confirmed against the repo endpoint. */
+export async function fetchHeadTree(
+  fetchImpl: typeof fetch,
+  source: string,
+  recursive: boolean,
+): Promise<TreeFetch> {
+  const tree = await fetchTree(fetchImpl, source, "HEAD", recursive);
+  if (tree.kind === "miss" && tree.reason === "repo_gone")
+    return { kind: "miss", reason: await confirmRepoGone(fetchImpl, source) };
+  return tree;
+}
+
+/**
+ * Read and confirm candidate paths (already priority-ordered), honouring
+ * `cap`. Any failed (non-404) read makes the miss `unreachable` and any
+ * capped-off candidate makes it `incomplete`: neither may be recorded as
+ * absence.
+ */
+export async function confirmCandidates(
+  fetchImpl: typeof fetch,
+  source: string,
+  skillId: string,
+  ordered: string[],
+  cap: number,
+): Promise<ScanResult> {
+  const paths = ordered.slice(0, cap);
+  if (paths.length === 0) return { kind: "miss", reason: "absent" };
+  const reads = await Promise.all(
+    paths.map((path) => readSkillMdAtPath(fetchImpl, source, path)),
+  );
+  const fetched = paths.map((path, i) => {
+    const read = reads[i];
+    return { path, rawMd: read?.kind === "ok" ? read.rawMd : null };
+  });
+  const best = pickBestCandidate(skillId, fetched);
+  if (best) return { kind: "found", candidate: best };
+  if (reads.some((r) => r.kind === "failed"))
+    return { kind: "miss", reason: "unreachable" };
+  if (ordered.length > cap) return { kind: "miss", reason: "incomplete" };
+  return { kind: "miss", reason: "absent" };
+}

--- a/packages/host/src/skills/github-tree-scan.ts
+++ b/packages/host/src/skills/github-tree-scan.ts
@@ -1,0 +1,136 @@
+import { skillIdFromPath } from "./github-parse";
+import {
+  confirmCandidates,
+  fetchHeadTree,
+  fetchTree,
+  type ScanMiss,
+  type ScanResult,
+} from "./github-tree-fetch";
+import {
+  dirNameOf,
+  isCandidateDir,
+  matchSkillId,
+  sortCandidateDirs,
+} from "./skill-id-match";
+
+/**
+ * The two api.github.com tiers of the skill lookup (github-lookup.ts): the
+ * cheap shallow scan and the expensive recursive scan. Both confirm fetched
+ * candidates through `confirmCandidates` (github-tree-fetch.ts), so the
+ * id-vs-directory tolerance (skill-id-match.ts) and the "proven absent vs.
+ * could not read" distinction are one rule for every tier.
+ */
+
+/** Cap on how many candidate SKILL.md files the shallow scan will read. */
+const SHALLOW_CANDIDATE_CAP = 6;
+/**
+ * Cap on confirmation reads in the recursive scan. Every SKILL.md in the repo
+ * is a candidate (skills.sh keys on the declared `name:`, so a skill may live
+ * under any directory), ordered likeliest first; raw-CDN reads are cheap and
+ * concurrent, and a repo with more SKILL.md files than this yields
+ * `incomplete`, never a proven absence.
+ */
+const RECURSIVE_CANDIDATE_CAP = 40;
+
+export type { ScanMiss, ScanResult } from "./github-tree-fetch";
+
+/**
+ * Cheap middle tier: at most two NON-recursive Git Trees calls (the repo root,
+ * then the `skills/` subtree if present) list top-level and `skills/*`
+ * directory names. Directories that could stand for `skillId` are read and
+ * the best-confirmed one wins. `skills/`-nested candidates rank ahead of
+ * top-level ones, and more specific names ahead of loose ones, so the read
+ * cap never drops the likeliest candidate. Exact directory matches were
+ * already covered by the guess tier.
+ */
+export async function shallowScan(
+  fetchImpl: typeof fetch,
+  source: string,
+  skillId: string,
+): Promise<ScanResult> {
+  const root = await fetchHeadTree(fetchImpl, source, false);
+  if (root.kind === "miss") return root;
+
+  const topLevel: string[] = [];
+  let skillsSha: string | undefined;
+  for (const entry of root.entries) {
+    if (entry.type !== "tree") continue;
+    if (entry.path === "skills") skillsSha = entry.sha;
+    if (isCandidateDir(skillId, entry.path)) topLevel.push(entry.path);
+  }
+
+  const nested: string[] = [];
+  let subtreeMiss: ScanMiss | null = null;
+  if (skillsSha) {
+    const sub = await fetchTree(fetchImpl, source, skillsSha, false);
+    if (sub.kind === "ok")
+      for (const entry of sub.entries) {
+        if (entry.type === "tree" && isCandidateDir(skillId, entry.path))
+          nested.push(entry.path);
+      }
+    else subtreeMiss = sub.reason;
+  }
+
+  const ordered = [
+    ...sortCandidateDirs(skillId, nested).map((d) => `skills/${d}/SKILL.md`),
+    ...sortCandidateDirs(skillId, topLevel).map((d) => `${d}/SKILL.md`),
+  ];
+  const result = await confirmCandidates(
+    fetchImpl,
+    source,
+    skillId,
+    ordered,
+    SHALLOW_CANDIDATE_CAP,
+  );
+  // A `skills/` subtree we could not list may hold the skill: its own reason
+  // (quota, transport) outranks a top-level "absent".
+  if (result.kind === "miss" && result.reason === "absent" && subtreeMiss)
+    return { kind: "miss", reason: subtreeMiss };
+  return result;
+}
+
+/**
+ * Locate a SKILL.md matching `skillId` via the RECURSIVE Git Trees API — one
+ * call over the whole repo (expensive, rate-limited; install-only). Every
+ * SKILL.md is read (capped) and confirmed by frontmatter, likeliest first: an
+ * exact directory-name match, then directories that are a kebab prefix of the
+ * id or paths containing it, then the rest — a skill declaring `name: ghost`
+ * may sit under any directory, so absence is only proven once ALL of them were
+ * read. A truncated listing cannot prove absence, so it reports `incomplete`.
+ */
+export async function recursiveScan(
+  fetchImpl: typeof fetch,
+  source: string,
+  skillId: string,
+): Promise<ScanResult> {
+  const tree = await fetchHeadTree(fetchImpl, source, true);
+  if (tree.kind === "miss") return tree;
+
+  const repoName = source.split("/").at(-1) ?? source;
+  const exact: string[] = [];
+  const fuzzy: string[] = [];
+  const rest: string[] = [];
+  for (const entry of tree.entries) {
+    if (entry.type !== "blob" || !entry.path.endsWith("SKILL.md")) continue;
+    if (skillIdFromPath(entry.path, repoName) === skillId)
+      exact.push(entry.path);
+    else if (
+      matchSkillId(skillId, dirNameOf(entry.path)) !== "none" ||
+      entry.path.includes(skillId)
+    )
+      fuzzy.push(entry.path);
+    else rest.push(entry.path);
+  }
+  fuzzy.sort((a, b) => dirNameOf(b).length - dirNameOf(a).length);
+
+  const result = await confirmCandidates(
+    fetchImpl,
+    source,
+    skillId,
+    [...exact, ...fuzzy, ...rest],
+    RECURSIVE_CANDIDATE_CAP,
+  );
+  if (result.kind === "miss" && result.reason === "absent" && tree.truncated)
+    return { kind: "miss", reason: "incomplete" };
+  return result;
+}

--- a/packages/host/src/skills/github.ts
+++ b/packages/host/src/skills/github.ts
@@ -32,16 +32,40 @@ export async function fetchSkillMdAtPath(
   source: string,
   path: string,
 ): Promise<string> {
-  const res = await fetchImpl(
-    `https://raw.githubusercontent.com/${source}/HEAD/${path}`,
-    { headers: GH_HEADERS },
-  );
-  if (!res.ok)
+  const read = await readSkillMdAtPath(fetchImpl, source, path);
+  if (read.kind !== "ok")
     throw new SkillRemoteError(
       "offline",
       `Could not fetch '${path}' from ${source}`,
     );
-  return res.text();
+  return read.rawMd;
+}
+
+/**
+ * The non-throwing read the tree scans use, keeping the two misses apart: a
+ * `missing` path (404: the directory simply holds no SKILL.md) is evidence of
+ * absence, a `failed` one (transport, 5xx) is not.
+ */
+export type SkillMdRead =
+  | { kind: "ok"; rawMd: string }
+  | { kind: "missing" }
+  | { kind: "failed" };
+
+export async function readSkillMdAtPath(
+  fetchImpl: typeof fetch,
+  source: string,
+  path: string,
+): Promise<SkillMdRead> {
+  const res = await fetchImpl(
+    `https://raw.githubusercontent.com/${source}/HEAD/${path}`,
+    { headers: GH_HEADERS },
+  ).catch(() => null);
+  if (!res) return { kind: "failed" };
+  if (res.status === 404) return { kind: "missing" };
+  if (!res.ok) return { kind: "failed" };
+  // A body-stream reset after the headers is the same "could not read".
+  const rawMd = await res.text().catch(() => null);
+  return rawMd === null ? { kind: "failed" } : { kind: "ok", rawMd };
 }
 
 /**

--- a/packages/host/src/skills/gone-registry.test.ts
+++ b/packages/host/src/skills/gone-registry.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import { GoneRegistry } from "./gone-registry";
+
+test("GoneRegistry answers gone for a repo and every skill in it, case-insensitively", () => {
+  const gone = new GoneRegistry({ now: () => 0 });
+  gone.markRepoGone("Sales-Skills/Sales");
+  expect(gone.isGone("sales-skills/sales")).toBe(true);
+  expect(gone.isGone("sales-skills/sales", "sales-kit")).toBe(true);
+  expect(gone.isGone("other/repo", "sales-kit")).toBe(false);
+});
+
+test("GoneRegistry scopes a skill mark to that skill only", () => {
+  const gone = new GoneRegistry({ now: () => 0 });
+  gone.markSkillGone("openai/skills", "spreadsheet");
+  expect(gone.isGone("openai/skills", "spreadsheet")).toBe(true);
+  expect(gone.isGone("openai/skills", "pdf")).toBe(false);
+  expect(gone.isGone("openai/skills")).toBe(false);
+});
+
+test("GoneRegistry forgets a mark after the TTL", () => {
+  const clock = { t: 0 };
+  const gone = new GoneRegistry({ now: () => clock.t, ttlMs: 1_000 });
+  gone.markRepoGone("owner/repo");
+  clock.t = 1_000;
+  expect(gone.isGone("owner/repo")).toBe(true);
+  clock.t = 1_001;
+  expect(gone.isGone("owner/repo")).toBe(false);
+});
+
+test("GoneRegistry evicts the oldest mark beyond maxEntries", () => {
+  const gone = new GoneRegistry({ now: () => 0, maxEntries: 2 });
+  gone.markRepoGone("a/a");
+  gone.markRepoGone("b/b");
+  gone.markRepoGone("c/c");
+  expect(gone.isGone("a/a")).toBe(false);
+  expect(gone.isGone("b/b")).toBe(true);
+  expect(gone.isGone("c/c")).toBe(true);
+});

--- a/packages/host/src/skills/gone-registry.ts
+++ b/packages/host/src/skills/gone-registry.ts
@@ -1,0 +1,73 @@
+/**
+ * Process-wide memory of community skills the install lookup PROVED absent
+ * (PRODUCT-1729): a repo GitHub answers 404 for (deleted or renamed), or a
+ * skill a full recursive scan of a live repo could not find. skills.sh keeps
+ * indexing both for months, so without this the same dead card comes back on
+ * every search and every click is another 404. `CommunityDirectory` filters
+ * search and popular results against it; `locateSkillMd` writes to it.
+ *
+ * Only a certain miss is recorded. A rate-limited or truncated scan is not
+ * proof of absence and never lands here. Entries expire after a day so an
+ * author who restores a repo, or a re-indexed skill, comes back on its own.
+ */
+
+const GONE_TTL_MS = 24 * 60 * 60_000;
+const GONE_MAX_ENTRIES = 1024;
+
+export interface GoneRegistryOptions {
+  now?: () => number;
+  ttlMs?: number;
+  maxEntries?: number;
+}
+
+export class GoneRegistry {
+  private readonly now: () => number;
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  /** `owner/repo` for a gone repo, `owner/repo#skillId` for a gone skill. */
+  private readonly entries = new Map<string, number>();
+
+  constructor(opts: GoneRegistryOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.ttlMs = opts.ttlMs ?? GONE_TTL_MS;
+    this.maxEntries = opts.maxEntries ?? GONE_MAX_ENTRIES;
+  }
+
+  /** GitHub answered 404 for the whole repo. */
+  markRepoGone(source: string): void {
+    this.store(source.toLowerCase());
+  }
+
+  /** A complete scan of a live repo found no SKILL.md for the id. */
+  markSkillGone(source: string, skillId: string): void {
+    this.store(`${source.toLowerCase()}#${skillId}`);
+  }
+
+  /** True when the repo, or (with `skillId`) that skill in it, is known gone. */
+  isGone(source: string, skillId?: string): boolean {
+    const repo = source.toLowerCase();
+    if (this.live(repo)) return true;
+    return skillId !== undefined && this.live(`${repo}#${skillId}`);
+  }
+
+  private live(key: string): boolean {
+    const markedAt = this.entries.get(key);
+    if (markedAt === undefined) return false;
+    if (this.now() - markedAt <= this.ttlMs) return true;
+    this.entries.delete(key);
+    return false;
+  }
+
+  /** FIFO-capped insert; nothing else sweeps the map. */
+  private store(key: string): void {
+    this.entries.delete(key);
+    if (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next();
+      if (!oldest.done) this.entries.delete(oldest.value);
+    }
+    this.entries.set(key, this.now());
+  }
+}
+
+/** The one instance the lookup writes and the directory reads. */
+export const goneRegistry = new GoneRegistry();

--- a/packages/host/src/skills/preview.test.ts
+++ b/packages/host/src/skills/preview.test.ts
@@ -118,14 +118,27 @@ test("previewCommunitySkill nulls optional fields on a minimal SKILL.md", async 
   });
 });
 
-test("previewCommunitySkill throws skill_not_in_repo when nothing matches", async () => {
+test("previewCommunitySkill throws skill_not_in_repo when a live repo holds nothing matching", async () => {
   const err = await previewCommunitySkill(
-    fakeFetch(() => new Response("", { status: 404 })),
+    fakeFetch((url) =>
+      url.includes("git/trees/HEAD")
+        ? new Response(JSON.stringify({ tree: [] }), { status: 200 })
+        : new Response("", { status: 404 }),
+    ),
     "owner/repo",
     "ghost",
   ).catch((e) => e);
   expect(err).toBeInstanceOf(SkillRemoteError);
   expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+});
+
+test("previewCommunitySkill throws repo_not_found when GitHub 404s the repo itself", async () => {
+  const err = await previewCommunitySkill(
+    fakeFetch(() => new Response("", { status: 404 })),
+    "owner/repo",
+    "ghost",
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("repo_not_found");
 });
 
 test("previewCommunitySkill rejects an unparseable source before any fetch", async () => {
@@ -150,6 +163,9 @@ test("previewCommunitySkill never runs the expensive RECURSIVE tree scan", async
   const err = await previewCommunitySkill(
     fakeFetch((url) => {
       if (url.includes("recursive=1")) recursiveCalls++;
+      // The shallow scan sees a live repo with nothing at the root.
+      if (url.includes("git/trees/HEAD"))
+        return new Response(JSON.stringify({ tree: [] }), { status: 200 });
       return null;
     }),
     "owner/repo",
@@ -262,7 +278,8 @@ test("PreviewDirectory negatively caches a failure for 10min, then retries", asy
       attempts++;
       return new Response("", { status: 404 });
     }
-    if (url.includes("git/trees")) return new Response("", { status: 404 });
+    if (url.includes("git/trees"))
+      return new Response(JSON.stringify({ tree: [] }), { status: 200 });
     return null;
   });
   const dir = new PreviewDirectory({ now: () => clock.t });
@@ -308,4 +325,25 @@ test("PreviewDirectory does not cache invalid_repo_source", async () => {
   expect((e2 as SkillRemoteError).kind).toBe("invalid_repo_source");
   // Rejected before any fetch, both times — never cached, never fetched.
   expect(fetchCalls).toBe(0);
+});
+
+test("PreviewDirectory does not negatively cache a GitHub rate limit (PRODUCT-1729)", async () => {
+  let treeCalls = 0;
+  const fetchImpl = fakeFetch((url) => {
+    if (url.includes("git/trees")) {
+      treeCalls++;
+      return new Response("", { status: 403 });
+    }
+    return new Response("", { status: 404 });
+  });
+  const dir = new PreviewDirectory({ now: () => 0 });
+  const e1 = await dir
+    .preview(fetchImpl, "owner/repo", "ghost")
+    .catch((e) => e);
+  expect((e1 as SkillRemoteError).kind).toBe("github_rate_limited");
+  const e2 = await dir
+    .preview(fetchImpl, "owner/repo", "ghost")
+    .catch((e) => e);
+  expect((e2 as SkillRemoteError).kind).toBe("github_rate_limited");
+  expect(treeCalls).toBe(2);
 });

--- a/packages/host/src/skills/preview.ts
+++ b/packages/host/src/skills/preview.ts
@@ -2,7 +2,7 @@ import { parseSkillMd } from "@houston/domain";
 import type { CommunitySkillPreview } from "@houston/protocol";
 import { locateSkillMd } from "./github-lookup";
 import { normalizeSource } from "./github-parse";
-import { SkillRemoteError } from "./remote-error";
+import { SkillRemoteError, type SkillRemoteErrorKind } from "./remote-error";
 
 /**
  * Upper bound on the returned `content` body. A preview modal never needs more
@@ -73,6 +73,12 @@ function clipContent(body: string): string {
   );
 }
 
+const UNCACHED_KINDS: ReadonlySet<SkillRemoteErrorKind> = new Set([
+  "invalid_repo_source",
+  "offline",
+  "github_rate_limited",
+]);
+
 const PREVIEW_FRESH_TTL_MS = 24 * 60 * 60_000;
 const PREVIEW_FAILURE_TTL_MS = 10 * 60_000;
 const PREVIEW_MAX_ENTRIES = 256;
@@ -95,8 +101,10 @@ export interface PreviewDirectoryOptions {
  * (community.ts). Successful previews stay fresh for 24h; thrown
  * `SkillRemoteError`s are NEGATIVELY cached for 10 minutes so repeated clicks on
  * a permanently-missing skill don't refetch — EXCEPT `invalid_repo_source`,
- * which is a client bug (garbage input) not worth a cache slot and is rethrown
- * uncached. Keyed `${source}#${skillId}`. `fetchImpl` is passed per call (the
+ * which is a client bug (garbage input) not worth a cache slot, and the
+ * transient kinds (`offline`, `github_rate_limited`), which say nothing about
+ * the skill and must not pin a "missing" answer on a GitHub hiccup; both are
+ * rethrown uncached. Keyed `${source}#${skillId}`. `fetchImpl` is passed per call (the
  * route already holds it per request), so ONE process-wide instance — held as a
  * module-level singleton in the route layer, like `CommunityDirectory` — serves
  * every request while keeping the class trivially injectable in tests via `now`.
@@ -150,7 +158,7 @@ export class PreviewDirectory {
       this.store(key, { result, fetchedAt: this.now() });
       return result;
     } catch (err) {
-      if (err instanceof SkillRemoteError && err.kind !== "invalid_repo_source")
+      if (err instanceof SkillRemoteError && !UNCACHED_KINDS.has(err.kind))
         this.store(key, {
           result: { error: err },
           fetchedAt: this.now(),

--- a/packages/host/src/skills/remote.test.ts
+++ b/packages/host/src/skills/remote.test.ts
@@ -8,6 +8,7 @@ import {
   skillIdFromPath,
   slugifyInstallId,
 } from "./github-parse";
+import { GoneRegistry } from "./gone-registry";
 import { installCommunitySkill, installSkillsFromRepo } from "./install";
 import { SkillRemoteError } from "./remote-error";
 
@@ -238,6 +239,37 @@ test("community search maps a persistent 429 to rate_limited when no cache", asy
   expect((err as SkillRemoteError).kind).toBe("rate_limited");
 });
 
+test("community search hides skills the install lookup proved gone, even from a cached result (PRODUCT-1729)", async () => {
+  const clock = fakeClock();
+  const gone = new GoneRegistry({ now: clock.now });
+  const dead = {
+    ...SKILL_HIT,
+    id: "sales-skills/sales/sales-kit",
+    skillId: "sales-kit",
+    source: "sales-skills/sales",
+  };
+  const renamed = { ...SKILL_HIT, id: "owner/repo/ghost", skillId: "ghost" };
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    gone,
+    fetchImpl: fakeFetch(() => jsonRes({ skills: [SKILL_HIT, dead, renamed] })),
+  });
+  expect((await dir.search("sales")).length).toBe(3);
+
+  gone.markRepoGone("Sales-Skills/sales");
+  gone.markSkillGone("owner/repo", "ghost");
+  // Same fresh cache entry, now filtered on the way out.
+  expect((await dir.search("sales")).map((s) => s.id)).toEqual([SKILL_HIT.id]);
+  expect((await dir.popular()).map((s) => s.id)).toEqual([SKILL_HIT.id]);
+
+  // A day later the marks expire and the cards may return.
+  clock.state.t += 25 * 60 * 60_000;
+  expect(gone.isGone("sales-skills/sales")).toBe(false);
+  expect(gone.isGone("owner/repo", "ghost")).toBe(false);
+});
+
 test("queries under two chars return empty without a network call", async () => {
   const dir = new CommunityDirectory({
     fetchImpl: fakeFetch(() => {
@@ -441,7 +473,22 @@ test("installCommunitySkill finds the skill under common paths and uses the fron
   expect(md).toContain("name: writing-plans");
 });
 
-test("installCommunitySkill surfaces skill_not_in_repo when nothing matches", async () => {
+test("installCommunitySkill surfaces skill_not_in_repo when a live repo holds nothing matching", async () => {
+  const err = await installCommunitySkill(
+    fakeFetch((url) =>
+      url.includes("git/trees/HEAD")
+        ? new Response(JSON.stringify({ tree: [] }), { status: 200 })
+        : new Response("", { status: 404 }),
+    ),
+    new MemoryVfs(),
+    ROOT,
+    "owner/repo",
+    "ghost",
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+});
+
+test("installCommunitySkill surfaces repo_not_found when GitHub 404s the whole repo", async () => {
   const err = await installCommunitySkill(
     fakeFetch(() => new Response("", { status: 404 })),
     new MemoryVfs(),
@@ -449,7 +496,7 @@ test("installCommunitySkill surfaces skill_not_in_repo when nothing matches", as
     "owner/repo",
     "ghost",
   ).catch((e) => e);
-  expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+  expect((err as SkillRemoteError).kind).toBe("repo_not_found");
 });
 
 test("a wedged skills.sh surfaces the typed upstream_timeout error instead of hanging", async () => {

--- a/packages/host/src/skills/skill-id-match.ts
+++ b/packages/host/src/skills/skill-id-match.ts
@@ -1,0 +1,112 @@
+import { extractFrontmatterName, slugifyInstallId } from "./github-parse";
+
+/**
+ * How a candidate SKILL.md stands for a skills.sh id. skills.sh derives its id
+ * from the SLUGIFIED frontmatter `name:` at index time, so the id can differ
+ * from the directory name in two real shapes (PRODUCT-1729):
+ *
+ *   - `pdf-ocr/SKILL.md` declares `name: PDF OCR Extraction`; the index lists
+ *     `pdf-ocr-extraction`. Slugifying the declared name recovers the id.
+ *   - `user-research/SKILL.md` was renamed upstream after the index recorded
+ *     `user-research-synthesis`; nothing in the repo carries the suffix any
+ *     more. The id still STARTS with the folder / declared slug.
+ *
+ * A prefix only counts when the shorter slug has at least two kebab segments:
+ * `user-research` may stand for `user-research-synthesis`, but a bare `user`
+ * or `pdf` directory is far too loose to install in the id's name.
+ */
+export type SkillIdMatch = "exact" | "prefix" | "none";
+
+const MIN_PREFIX_SEGMENTS = 2;
+
+/** The match between a skills.sh id and one directory name or declared `name:`. */
+export function matchSkillId(
+  skillId: string,
+  candidate: string | null | undefined,
+): SkillIdMatch {
+  if (!candidate) return "none";
+  const slug = slugifyInstallId(candidate);
+  if (slug === skillId) return "exact";
+  const segments = slug.split("-").filter(Boolean).length;
+  if (segments >= MIN_PREFIX_SEGMENTS && skillId.startsWith(`${slug}-`))
+    return "prefix";
+  return "none";
+}
+
+/** True when the directory alone is worth fetching to confirm by frontmatter. */
+export function isCandidateDir(skillId: string, dirName: string): boolean {
+  const n = dirName.toLowerCase();
+  const id = skillId.toLowerCase();
+  return n.includes(id) || id.includes(n) || matchSkillId(id, n) !== "none";
+}
+
+/**
+ * Confidence that a fetched SKILL.md IS the skill the id names. Higher wins; 0
+ * is a miss. An exact match on the slugified `name:` (what skills.sh indexed)
+ * or on the directory (what the guess tier already trusts) stands alone. A
+ * prefix match only counts when the directory AND the declared name agree on
+ * the same shorter slug: a renamed skill keeps both in step, whereas
+ * `user-research/SKILL.md` declaring `name: competitor-analysis` is some other
+ * skill that happens to live under a matching folder, and installing it in
+ * the id's name would be worse than a 404.
+ */
+export function candidateScore(
+  skillId: string,
+  dirName: string,
+  rawMd: string,
+): number {
+  const fmName = extractFrontmatterName(rawMd);
+  const byName = matchSkillId(skillId, fmName);
+  const byDir = matchSkillId(skillId, dirName);
+  if (byName === "exact") return 4;
+  if (byDir === "exact") return 3;
+  if (
+    byName === "prefix" &&
+    byDir === "prefix" &&
+    fmName !== null &&
+    slugifyInstallId(fmName) === slugifyInstallId(dirName)
+  )
+    return 2;
+  return 0;
+}
+
+export interface ScoredCandidate {
+  path: string;
+  rawMd: string;
+}
+
+/**
+ * The best-scoring fetched candidate, or null when none matches. Ties keep the
+ * earlier entry so callers' priority order (nested before top-level, longer
+ * directory names before shorter) is the tie-break.
+ */
+export function pickBestCandidate(
+  skillId: string,
+  fetched: Array<{ path: string; rawMd: string | null }>,
+): ScoredCandidate | null {
+  let best: { score: number; candidate: ScoredCandidate } | null = null;
+  for (const { path, rawMd } of fetched) {
+    if (rawMd === null) continue;
+    const score = candidateScore(skillId, dirNameOf(path), rawMd);
+    if (score > 0 && (best === null || score > best.score))
+      best = { score, candidate: { path, rawMd } };
+  }
+  return best?.candidate ?? null;
+}
+
+/** `design/skills/user-research/SKILL.md` → `user-research`; root → "". */
+export function dirNameOf(path: string): string {
+  const parts = path.split("/");
+  return parts.length >= 2 ? (parts[parts.length - 2] ?? "") : "";
+}
+
+/**
+ * Order candidate directory names most-specific first: an exact or prefix
+ * match on the id before a loose "contains" match, then longer names before
+ * shorter ones, so a fetch cap never drops the likeliest candidate.
+ */
+export function sortCandidateDirs(skillId: string, dirs: string[]): string[] {
+  const weight = (dir: string) =>
+    matchSkillId(skillId, dir) === "none" ? 0 : 1;
+  return [...dirs].sort((a, b) => weight(b) - weight(a) || b.length - a.length);
+}

--- a/ui/skills/src/skill-marketplace-detail.tsx
+++ b/ui/skills/src/skill-marketplace-detail.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import {
   SkillPreviewModal,
   type SkillPreviewState,
@@ -38,6 +38,13 @@ export function SkillMarketplaceDetail({
   const installed =
     entry === "installed" ||
     (slug !== null && (installedSkillNames?.has(slug) ?? false));
+
+  // The skill was just proven gone upstream (PRODUCT-1729): its card is being
+  // dropped, so the modal closes with it rather than re-arming an Install
+  // button that can only fail the same way.
+  useEffect(() => {
+    if (entry === "unavailable") onClose();
+  }, [entry, onClose]);
 
   return (
     <SkillPreviewModal

--- a/ui/skills/src/skill-marketplace-grid-parts.tsx
+++ b/ui/skills/src/skill-marketplace-grid-parts.tsx
@@ -12,6 +12,10 @@ import type { ReactNode } from "react";
 import type { SkillMarketplacePhase } from "./skill-marketplace-grid";
 import type { ResolvedGridLabels } from "./skill-marketplace-grid-model";
 import { SkillMarketplaceRow } from "./skill-marketplace-row";
+import {
+  availableSkills,
+  type MarketplaceInstallState,
+} from "./skill-marketplace-state-model";
 import type { CommunitySkill } from "./types";
 
 const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
@@ -109,7 +113,7 @@ export interface MarketplaceBodyProps {
   /** Visible skills after client-side publisher filtering. */
   filtered: CommunitySkill[];
   labels: ResolvedGridLabels;
-  installState: Map<string, "installing" | "installed" | "failed">;
+  installState: MarketplaceInstallState;
   installedSkillNames?: Set<string>;
   onInstall: (skill: CommunitySkill) => void;
   onOpenDetail: (skill: CommunitySkill) => void;
@@ -148,8 +152,13 @@ export function MarketplaceBody({
   if (phase.kind === "idle") {
     return <MutedNotice>{l.typeToSearch}</MutedNotice>;
   }
-  if (filtered.length === 0) {
-    return null;
+  const shown = availableSkills(filtered, installState);
+  if (shown.length === 0) {
+    // The last visible card was dropped as unavailable: say so rather than
+    // leaving a blank body under a query that did return results.
+    return phase.kind === "results" ? (
+      <MutedNotice>{l.noResults(phase.query)}</MutedNotice>
+    ) : null;
   }
   return (
     <div
@@ -158,7 +167,7 @@ export function MarketplaceBody({
         phase.kind === "searching" && "pointer-events-none opacity-60",
       )}
     >
-      {filtered.map((skill) => {
+      {shown.map((skill) => {
         const slug = (skill.skillId || skill.name).toLowerCase();
         const installed =
           installState.get(skill.id) === "installed" ||

--- a/ui/skills/src/skill-marketplace-grid.tsx
+++ b/ui/skills/src/skill-marketplace-grid.tsx
@@ -31,6 +31,7 @@ import {
   PublisherChips,
 } from "./skill-marketplace-grid-parts";
 import type { SkillMarketplaceCardLabels } from "./skill-marketplace-row";
+import type { MarketplaceInstallState } from "./skill-marketplace-state-model";
 import { ownerOf } from "./skill-marketplace-util";
 import type { CommunitySkill } from "./types";
 
@@ -75,7 +76,7 @@ export interface SkillMarketplaceGridProps {
   onCategoryChange: (next: string) => void;
   /** Category picker entries (localized), shown only when non-empty. */
   categoryOptions: SkillCategoryOption[];
-  installState: Map<string, "installing" | "installed" | "failed">;
+  installState: MarketplaceInstallState;
   installedSkillNames?: Set<string>;
   onInstall: (skill: CommunitySkill) => void;
   onOpenDetail: (skill: CommunitySkill) => void;

--- a/ui/skills/src/skill-marketplace-shelves-model.ts
+++ b/ui/skills/src/skill-marketplace-shelves-model.ts
@@ -8,6 +8,10 @@
  * runner, which cannot load `.tsx`.
  */
 
+import {
+  availableSkills,
+  type MarketplaceInstallState,
+} from "./skill-marketplace-state-model.ts";
 import { ownerOf } from "./skill-marketplace-util.ts";
 import type { CommunitySkill } from "./types";
 
@@ -127,11 +131,16 @@ export function dedupeAcrossShelves(
 
 /** A shelf renders only while loading or once it has ready cards — a ready
  *  shelf emptied by {@link dedupeAcrossShelves} hides like an errored one. */
-export function isShelfVisible(state: ShelfState): boolean {
-  return (
-    state.status === "loading" ||
-    (state.status === "ready" && state.skills.length > 0)
-  );
+export function isShelfVisible(
+  state: ShelfState,
+  installState?: MarketplaceInstallState,
+): boolean {
+  if (state.status === "loading") return true;
+  if (state.status !== "ready") return false;
+  const skills = installState
+    ? availableSkills(state.skills, installState)
+    : state.skills;
+  return skills.length > 0;
 }
 
 /**

--- a/ui/skills/src/skill-marketplace-shelves.tsx
+++ b/ui/skills/src/skill-marketplace-shelves.tsx
@@ -18,6 +18,10 @@ import {
   isShelfVisible,
   type ResolvedShelf,
 } from "./skill-marketplace-shelves-model";
+import {
+  availableSkills,
+  type MarketplaceInstallState,
+} from "./skill-marketplace-state-model";
 import type { CommunitySkill } from "./types";
 
 const SKELETON_KEYS = ["a", "b", "c", "d"];
@@ -34,7 +38,7 @@ export interface SkillMarketplaceShelvesProps {
   shelves: ResolvedShelf[];
   allFailed: boolean;
   onRetry: () => void;
-  installState: Map<string, "installing" | "installed" | "failed">;
+  installState: MarketplaceInstallState;
   installedSkillNames?: Set<string>;
   onInstall: (skill: CommunitySkill) => void;
   onOpenDetail: (skill: CommunitySkill) => void;
@@ -62,7 +66,7 @@ function ShelfCardRow({
   cardLabels,
 }: {
   skills: CommunitySkill[];
-  installState: Map<string, "installing" | "installed" | "failed">;
+  installState: MarketplaceInstallState;
   installedSkillNames?: Set<string>;
   onInstall: (skill: CommunitySkill) => void;
   onOpenDetail: (skill: CommunitySkill) => void;
@@ -70,7 +74,7 @@ function ShelfCardRow({
 }) {
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-      {skills.map((skill) => {
+      {availableSkills(skills, installState).map((skill) => {
         const slug = (skill.skillId || skill.name).toLowerCase();
         const installed =
           installState.get(skill.id) === "installed" ||
@@ -115,7 +119,7 @@ export function SkillMarketplaceShelves({
   return (
     <div className="flex flex-col gap-5">
       {dedupeAcrossShelves(shelves)
-        .filter((shelf) => isShelfVisible(shelf.state))
+        .filter((shelf) => isShelfVisible(shelf.state, installState))
         .map((shelf) => (
           <section key={shelf.id}>
             <div className="mb-2 flex items-center justify-between gap-3">

--- a/ui/skills/src/skill-marketplace-state-model.ts
+++ b/ui/skills/src/skill-marketplace-state-model.ts
@@ -12,6 +12,44 @@ import { classifySkillError } from "./skill-error-kinds.ts";
 import type { SkillMarketplacePhase } from "./skill-marketplace-grid";
 import type { CommunitySkill } from "./types";
 
+/**
+ * Per-skill install state as the grid consumes it. `unavailable` is the
+ * install that failed because the skill no longer exists where skills.sh says
+ * it does (the author removed or renamed it, or deleted the repo): the card is
+ * dropped from every list for the rest of the session rather than re-enabling
+ * an install button that can only 404 again (PRODUCT-1729).
+ */
+export type MarketplaceInstallStatus =
+  | "installing"
+  | "installed"
+  | "failed"
+  | "unavailable";
+
+export type MarketplaceInstallState = Map<string, MarketplaceInstallStatus>;
+
+/**
+ * What a rejected install means for the card. `aborted` leaves the state
+ * untouched (the section cancelled it); `unavailable` hides the card; `failed`
+ * re-enables the button so the user can retry after the app's toast.
+ */
+export function installOutcome(
+  err: unknown,
+): "aborted" | "unavailable" | "failed" {
+  const cls = classifySkillError(err);
+  if (cls === "aborted") return "aborted";
+  if (cls === "skill_not_in_repo" || cls === "repo_not_found")
+    return "unavailable";
+  return "failed";
+}
+
+/** The skills still worth showing: everything not proven unavailable. */
+export function availableSkills(
+  skills: CommunitySkill[],
+  installState: MarketplaceInstallState,
+): CommunitySkill[] {
+  return skills.filter((s) => installState.get(s.id) !== "unavailable");
+}
+
 /** The selected-category value that means "no category filter". */
 export const CATEGORY_ALL = "all";
 

--- a/ui/skills/src/use-skill-marketplace-state.ts
+++ b/ui/skills/src/use-skill-marketplace-state.ts
@@ -10,10 +10,12 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { classifySkillError } from "./skill-error-kinds";
 import type { SkillMarketplacePhase } from "./skill-marketplace-grid";
 import {
   effectiveSearchTerm,
+  installOutcome,
+  type MarketplaceInstallState,
+  type MarketplaceInstallStatus,
   resultsPhase,
   searchErrorPhase,
   searchingPrevious,
@@ -22,10 +24,7 @@ import type { CommunitySkill } from "./types";
 
 const SEARCH_DEBOUNCE_MS = 350;
 
-export type MarketplaceInstallState = Map<
-  string,
-  "installing" | "installed" | "failed"
->;
+export type { MarketplaceInstallState, MarketplaceInstallStatus };
 
 export interface UseSkillMarketplaceStateArgs {
   /** Section open state — drives reset-on-close. */
@@ -141,8 +140,9 @@ export function useSkillMarketplaceState({
     };
   }, [query, categoryQuery, onSearch, open]);
 
-  // Install with a per-skill state machine. The failure state re-enables the
-  // button; the visible failure reason (toast) is surfaced by the app caller.
+  // Install with a per-skill state machine. `failed` re-enables the button and
+  // `unavailable` drops the card; the visible reason (toast) is surfaced by the
+  // app caller either way.
   const install = useCallback(
     (skill: CommunitySkill) => {
       installAbortsRef.current.get(skill.id)?.abort();
@@ -156,8 +156,9 @@ export function useSkillMarketplaceState({
         })
         .catch((err) => {
           if (controller.signal.aborted) return;
-          if (classifySkillError(err) === "aborted") return;
-          setInstallState((prev) => new Map(prev).set(skill.id, "failed"));
+          const outcome = installOutcome(err);
+          if (outcome === "aborted") return;
+          setInstallState((prev) => new Map(prev).set(skill.id, outcome));
         })
         .finally(() => {
           installAbortsRef.current.delete(skill.id);

--- a/ui/skills/tests/skill-marketplace-shelves.test.ts
+++ b/ui/skills/tests/skill-marketplace-shelves.test.ts
@@ -132,6 +132,21 @@ describe("isShelfVisible", () => {
   it("hides a ready shelf the cross-shelf dedupe emptied", () => {
     assert.equal(isShelfVisible({ status: "ready", skills: [] }), false);
   });
+  it("hides a ready shelf whose every card was dropped as unavailable (PRODUCT-1729)", () => {
+    const state = {
+      status: "ready" as const,
+      skills: [skill("a"), skill("b")],
+    };
+    const dropped = new Map<string, "unavailable">([
+      ["a", "unavailable"],
+      ["b", "unavailable"],
+    ]);
+    assert.equal(isShelfVisible(state, dropped), false);
+    assert.equal(
+      isShelfVisible(state, new Map([["a", "unavailable" as const]])),
+      true,
+    );
+  });
 });
 
 describe("dedupeAcrossShelves", () => {

--- a/ui/skills/tests/skill-marketplace-state.test.ts
+++ b/ui/skills/tests/skill-marketplace-state.test.ts
@@ -1,8 +1,10 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  availableSkills,
   CATEGORY_ALL,
   effectiveSearchTerm,
+  installOutcome,
   resultsPhase,
   searchErrorPhase,
   searchingPrevious,
@@ -127,5 +129,38 @@ describe("searchingPrevious", () => {
   });
   it("resets to empty from idle", () => {
     assert.deepEqual(searchingPrevious({ kind: "idle" }), []);
+  });
+});
+
+describe("installOutcome (PRODUCT-1729)", () => {
+  it("leaves an aborted install untouched", () => {
+    const aborted = new Error("aborted");
+    aborted.name = "AbortError";
+    assert.equal(installOutcome(aborted), "aborted");
+  });
+  it("marks a skill the author removed or renamed as unavailable", () => {
+    assert.equal(installOutcome({ kind: "skill_not_in_repo" }), "unavailable");
+    assert.equal(installOutcome({ kind: "repo_not_found" }), "unavailable");
+  });
+  it("keeps every other failure retryable", () => {
+    assert.equal(installOutcome({ kind: "offline" }), "failed");
+    assert.equal(installOutcome({ kind: "github_rate_limited" }), "failed");
+    assert.equal(installOutcome(new Error("boom")), "failed");
+  });
+});
+
+describe("availableSkills", () => {
+  it("drops only the cards proven unavailable this session", () => {
+    const a = skill("a");
+    const b = skill("b");
+    const c = skill("c");
+    const state = new Map<
+      string,
+      "installing" | "installed" | "failed" | "unavailable"
+    >([
+      ["a", "unavailable"],
+      ["b", "failed"],
+    ]);
+    assert.deepEqual(availableSkills([a, b, c], state), [b, c]);
   });
 });


### PR DESCRIPTION
Fixes PRODUCT-1729 (HOUSTON-APP-5D7, 5CS, 5CM, 4Z9).

## Root cause

skills.sh does not index a community skill under its GitHub folder name. It indexes the **slugified frontmatter `name:`** (`claude-office-skills/skills/pdf-ocr/SKILL.md` declares `name: PDF OCR Extraction`, so the index id is `pdf-ocr-extraction`), and it keeps a skill's **old id after an upstream rename** (`user-research-synthesis` now lives at `anthropics/knowledge-work-plugins/design/skills/user-research/`, name `user-research`). `locateSkillMd` compared the raw frontmatter string to the id and only read paths containing the id, so both shapes fell through every tier to `skill_not_in_repo`.

Two more things compounded it: the install path in `tauri.ts` reported every such miss to Sentry as a bug with a red toast (the preview path had been silenced by #1346), and the lookup swallowed api.github.com rate limits into the same "author removed this skill" kind. Meanwhile skills.sh kept listing repos GitHub answers 404 for (`sales-skills/sales`) and skills renamed away (`openai/skills#spreadsheet`, `mattpocock/skills#writing-great-skills`).

## Fix

**Host**
- `skill-id-match.ts`: one matching rule for every confirming tier. Exact on the slugified `name:` or the directory; a kebab-prefix match only when the directory and the declared name agree on the same slug of two or more segments, so a `user/` folder, or a `user-research/` folder declaring a different skill, is never installed in the id's name.
- `github-tree-fetch.ts` / `github-tree-scan.ts` (split out of `github-lookup.ts`): scans report *why* they missed. Only a complete listing with every candidate read and rejected is `absent`; a rate limit, transport failure, body-stream reset, truncated tree, or read cap is not proof. A tree 404 is confirmed against `GET /repos/{owner}/{repo}` before it counts as the repo being gone. The recursive scan reads every SKILL.md (likeliest first, capped at 40), since a skill's directory may share nothing with its name.
- `github-lookup.ts`: throws `repo_not_found` for a gone repo and `github_rate_limited` / `offline` when GitHub could not be listed.
- `gone-registry.ts`: 24h memory of proven-gone repos and skills; `CommunityDirectory.search/popular` filter results against it.
- `preview.ts`: transient kinds are no longer negatively cached.

**App / ui**
- `installCommunity` and `previewCommunity` silence the expected upstream states (`skill_not_in_repo`, `repo_not_found`; preview also `github_rate_limited`, `offline`): logged, no red toast, no Sentry.
- A not-in-repo install shows the authored "This skill is no longer available from its author." as an info toast and the card is dropped for the session (`unavailable` install outcome in `ui/skills`); the detail modal closes with it, an emptied result body shows "no results", an emptied shelf hides. The global Skills page rethrows the first typed rejection so its card follows.

## Verification

Live probe of the six ids from Sentry through `locateSkillMd` on this branch:

| Source | Id | Before | After |
| -- | -- | -- | -- |
| anthropics/knowledge-work-plugins | user-research-synthesis | `skill_not_in_repo` | resolves `design/skills/user-research/SKILL.md` |
| claude-office-skills/skills | pdf-ocr-extraction | `skill_not_in_repo` | resolves `pdf-ocr/SKILL.md` |
| claude-office-skills/skills | lead-research-assistant | `skill_not_in_repo` | resolves `lead-research/SKILL.md` |
| openai/skills | spreadsheet | `skill_not_in_repo` (Sentry) | `skill_not_in_repo` (quiet, card dropped) |
| mattpocock/skills | writing-great-skills | `skill_not_in_repo` (Sentry) | `skill_not_in_repo` (quiet, card dropped) |
| sales-skills/sales | sales-digital-products | `skill_not_in_repo` (Sentry) | `repo_not_found` (quiet, repo hidden from search for 24h) |

**Reproduce before the fix** (on `main`): open an agent's Skills tab, search `pdf ocr`, click Install on "pdf ocr extraction" from claude-office-skills. Red toast "The author removed this skill.", a Sentry `install_community_skill` 404 event, and the card's Install button re-arms.

**Verify after**: same steps install the skill (it appears in the installed list as `pdf-ocr-extraction`). Search `sales digital`, install "sales-digital-products" from sales-skills: an info toast "This skill is no longer available from its author.", the card disappears, no Sentry event, and re-running the search no longer lists sales-skills/sales results until the host restarts or 24h pass.

Checks: `pnpm check`, `pnpm --filter @houston/host test` (2270), `ui/skills` typecheck + test (93), `app` tsgo + `check-locales` + test (4265), `houston-web` typecheck, `check:parity`, `check:boundaries`.
