### PR TITLE
fix(runtime): exit only from the drain on SIGTERM so in-flight turns finish (PRODUCT-1758)

### DIFF
--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -48,8 +48,6 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         state.beginDrain();
         scheduler.stop();
         watcher.stop();
-        standingFrameCapture?.stop();
-        frameForwarder?.stop();
         // Drain the last accrued stretch before the runtimes go down; the
         // sampler swallows report failures, so this never blocks a shutdown.
         await usageSampler?.stop();
@@ -62,6 +60,11 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
             ? opts.shutdownDrainMs + SHUTDOWN_EXIT_SLACK_MS
             : undefined,
         );
+        // Only now: the standing capture pumps the frames of the turns the
+        // runtimes just finished draining, and stopping it before the drain
+        // would drop them (and their terminal frame) from the turn log.
+        standingFrameCapture?.stop();
+        await frameForwarder?.stop();
         await sharedMirror?.stop();
         await syncDaemon?.stop();
         await new Promise<void>((resolve, reject) => {

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -4,6 +4,7 @@ import { config } from "./config";
 import { installRuntimeLogging } from "./observability/logging";
 import { anyTurnRunning } from "./session/bus";
 import { beginDrain } from "./session/drain";
+import { drainTurnsThenExit } from "./session/graceful-shutdown";
 import {
   beginWorkerShutdown,
   type WorkerRegistration,
@@ -219,40 +220,6 @@ async function exitNow() {
   process.exit(0);
 }
 
-// How often the drain re-checks for a still-running turn, and the beat it
-// waits after the last one ends so its terminal frame reaches the host before
-// the listener goes away.
-const DRAIN_POLL_MS = 250;
-const DRAIN_SETTLE_MS = 500;
-
-/**
- * Wait for every in-flight turn to finish, bounded by the configured drain
- * budget, then exit. An idle runtime leaves at once; a busy one keeps its
- * turn alive until the turn ends or the budget runs out (the pod's
- * termination grace, or the host's SIGKILL escalation, is the hard stop).
- */
-function drainTurnsThenExit(): void {
-  const deadline = Date.now() + config.shutdownDrainMs;
-  const tick = () => {
-    if (anyTurnRunning() && Date.now() < deadline) {
-      setTimeout(tick, DRAIN_POLL_MS).unref();
-      return;
-    }
-    if (anyTurnRunning()) {
-      logger.warn(
-        "runtime drain deadline reached with a turn still running; exiting",
-        {
-          drainMs: config.shutdownDrainMs,
-        },
-      );
-    }
-    setTimeout(() => {
-      void exitNow();
-    }, DRAIN_SETTLE_MS).unref();
-  };
-  tick();
-}
-
 function shutdown(signal: string) {
   if (shuttingDown) return;
   shuttingDown = true;
@@ -260,16 +227,30 @@ function shutdown(signal: string) {
   logger.info("runtime shutdown requested", { signal });
   workerDrain = beginWorkerShutdown(signal, workerRegistration);
   shadowDrain = drainTranscriptShadow();
+  // Every runtime but a registered pool worker drains the turns it holds and
+  // refuses new ones (session/drain.ts) within its own budget, listener up
+  // the whole time; the drain is the ONLY exit path there. Closing the
+  // listener here and exiting from its callback (the pre-drain shape) exited
+  // in seconds with turns still running, because nothing holds a connection
+  // open while a fire-and-forget turn runs (PRODUCT-1758).
+  if (!workerRegistration) {
+    drainTurnsThenExit({
+      server,
+      drainMs: config.shutdownDrainMs,
+      anyTurnRunning,
+      exit: exitNow,
+      log: logger,
+    });
+    return;
+  }
+  // A registered pool worker keeps serving its in-flight turn until the
+  // response ends (sync-back + terminal frame): that response IS the open
+  // connection close() waits on, and the pod's termination grace is the hard
+  // deadline there.
   server.close(() => {
     void exitNow();
   });
-  // A registered pool worker keeps serving its in-flight turn until the
-  // response ends (sync-back + terminal frame); the pod's termination grace is
-  // the hard deadline there. Every other runtime drains the turns it holds
-  // and refuses new ones (session/drain.ts) within its own budget.
-  if (!workerRegistration) {
-    drainTurnsThenExit();
-  } else if (signal === "single-use") {
+  if (signal === "single-use") {
     // A single-use worker shuts itself down after its one turn's response has
     // already ended (settled() runs in the turn's finally). Unlike SIGTERM it
     // has NO kubelet SIGKILL backstop, so a lingering idle/keep-alive

--- a/packages/runtime/src/session/graceful-shutdown.test.ts
+++ b/packages/runtime/src/session/graceful-shutdown.test.ts
@@ -1,0 +1,116 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  DRAIN_POLL_MS,
+  DRAIN_SETTLE_MS,
+  drainTurnsThenExit,
+  type GracefulShutdownDeps,
+} from "./graceful-shutdown";
+
+function harness(overrides: Partial<GracefulShutdownDeps> = {}) {
+  const server = { close: vi.fn() };
+  const exit = vi.fn();
+  const log = { info: vi.fn(), warn: vi.fn() };
+  let running = true;
+  const deps: GracefulShutdownDeps = {
+    server,
+    drainMs: 480_000,
+    anyTurnRunning: () => running,
+    exit,
+    log,
+    ...overrides,
+  };
+  return {
+    deps,
+    server,
+    exit,
+    log,
+    endTurn: () => {
+      running = false;
+    },
+  };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+test("a running turn holds the process: no close, no exit, for as long as it runs", () => {
+  const h = harness();
+  drainTurnsThenExit(h.deps);
+  vi.advanceTimersByTime(60_000);
+  expect(h.server.close).not.toHaveBeenCalled();
+  expect(h.exit).not.toHaveBeenCalled();
+  expect(h.log.info).toHaveBeenCalledWith(
+    expect.stringContaining("holding in-flight turns"),
+    { drainMs: 480_000 },
+  );
+});
+
+test("once the last turn ends the listener closes and the process exits, once", () => {
+  const h = harness();
+  drainTurnsThenExit(h.deps);
+  vi.advanceTimersByTime(10_000);
+  h.endTurn();
+  vi.advanceTimersByTime(DRAIN_POLL_MS + DRAIN_SETTLE_MS);
+  expect(h.server.close).toHaveBeenCalledTimes(1);
+  expect(h.exit).toHaveBeenCalledTimes(1);
+  vi.advanceTimersByTime(60_000);
+  expect(h.exit).toHaveBeenCalledTimes(1);
+  expect(h.log.warn).not.toHaveBeenCalled();
+});
+
+test("an idle runtime leaves after the settle beat", () => {
+  const h = harness();
+  h.endTurn();
+  drainTurnsThenExit(h.deps);
+  expect(h.exit).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(DRAIN_SETTLE_MS);
+  expect(h.server.close).toHaveBeenCalledTimes(1);
+  expect(h.exit).toHaveBeenCalledTimes(1);
+  expect(h.log.info).not.toHaveBeenCalled();
+});
+
+test("the drain budget is the hard stop: a turn still running at the deadline is abandoned with a warning", () => {
+  const h = harness({ drainMs: 5_000 });
+  drainTurnsThenExit(h.deps);
+  vi.advanceTimersByTime(4_999);
+  expect(h.exit).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(DRAIN_POLL_MS + DRAIN_SETTLE_MS);
+  expect(h.exit).toHaveBeenCalledTimes(1);
+  expect(h.log.warn).toHaveBeenCalledWith(
+    expect.stringContaining("drain deadline reached"),
+    { drainMs: 5_000 },
+  );
+});
+
+test("the listener keeps answering while a turn drains (the host probes /busy through it)", async () => {
+  vi.useRealTimers();
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ busy: true }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no port");
+  const url = `http://127.0.0.1:${address.port}/busy`;
+  let running = true;
+  const exit = vi.fn();
+  drainTurnsThenExit({
+    server,
+    drainMs: 10_000,
+    anyTurnRunning: () => running,
+    exit,
+    log: { info: () => {}, warn: () => {} },
+  });
+  // The pre-fix shape closed the listener at signal time; a probe here
+  // would have been refused.
+  const response = await fetch(url);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ busy: true });
+  expect(exit).not.toHaveBeenCalled();
+  running = false;
+  await vi.waitFor(() => expect(exit).toHaveBeenCalledTimes(1), {
+    timeout: 5_000,
+  });
+  await expect(fetch(url)).rejects.toThrow();
+});

--- a/packages/runtime/src/session/graceful-shutdown.ts
+++ b/packages/runtime/src/session/graceful-shutdown.ts
@@ -1,0 +1,71 @@
+/**
+ * Server-mode shutdown: hold the process alive until every in-flight turn has
+ * ended (or the drain budget is spent), THEN close the listener and exit —
+ * exactly once, from here.
+ *
+ * The listener stays up for the whole drain on purpose. Turns are
+ * fire-and-forget (the start route answers 202 and the turn runs on the bus),
+ * so nothing holds an HTTP connection open while a turn runs and a
+ * `server.close(cb)` at signal time completes at once. Exiting from that
+ * callback — the pre-drain shape — killed a pod's running turns within
+ * seconds of SIGTERM while 589 s of termination grace went unused
+ * (PRODUCT-1758). Keeping the listener open is also what lets the drain latch
+ * (drain.ts) answer: new turns get 503 + Retry-After and `/busy` reads true,
+ * so the host's activity probe keeps reporting the pod busy until it is gone.
+ */
+
+export interface DrainableServer {
+  close(callback?: (error?: Error) => void): unknown;
+}
+
+export interface GracefulShutdownDeps {
+  server: DrainableServer;
+  /** How long a still-running turn may hold the process (HOUSTON_RUNTIME_DRAIN_MS). */
+  drainMs: number;
+  anyTurnRunning: () => boolean;
+  /** Final exit: flushes and calls process.exit. Invoked exactly once. */
+  exit: () => void | Promise<void>;
+  log: {
+    info: (...values: unknown[]) => void;
+    warn: (...values: unknown[]) => void;
+  };
+  now?: () => number;
+}
+
+/** How often the drain re-checks for a still-running turn. */
+export const DRAIN_POLL_MS = 250;
+/**
+ * The beat after the last turn ends before the listener goes away, so the
+ * turn's terminal frame reaches the host's capture first.
+ */
+export const DRAIN_SETTLE_MS = 500;
+
+export function drainTurnsThenExit(deps: GracefulShutdownDeps): void {
+  const now = deps.now ?? Date.now;
+  const deadline = now() + deps.drainMs;
+  if (deps.anyTurnRunning()) {
+    deps.log.info("runtime draining: holding in-flight turns until they end", {
+      drainMs: deps.drainMs,
+    });
+  }
+  // Timers stay ref'd: the drain is the one thing keeping this process alive
+  // once the host has dropped its connections, and an unref'd settle timer
+  // would let Node exit naturally before `exit` flushed the logs.
+  const tick = () => {
+    if (deps.anyTurnRunning() && now() < deadline) {
+      setTimeout(tick, DRAIN_POLL_MS);
+      return;
+    }
+    if (deps.anyTurnRunning()) {
+      deps.log.warn(
+        "runtime drain deadline reached with a turn still running; exiting",
+        { drainMs: deps.drainMs },
+      );
+    }
+    setTimeout(() => {
+      deps.server.close();
+      void deps.exit();
+    }, DRAIN_SETTLE_MS);
+  };
+  tick();
+}


### PR DESCRIPTION
## Summary

Sentry [HOUSTON-APP-5DX](https://houston-cd.sentry.io/issues/7724932565/): three `EngineRestartedMidTurnError` on one pod boot (`ran=1207s`, `1485s`, `fenced=true`). Linear: PRODUCT-1758.

**Not the 6h converger cap.** The pod was not rolled (same ReplicaSet, last roll completed 19:37Z). At 20:34:35Z the GKE cluster autoscaler removed a node and evicted the pod with `gracePeriod=600`. The container died at 20:34:46, 11 s later, with three turns that had been running 15 to 25 minutes.

**Root cause.** `packages/runtime/src/main.ts` `shutdown()` did `server.close(() => exitNow())` and, in parallel, started the drain loop from PR #1493. Turns are fire-and-forget (the start route answers 202; the host stops its standing frame capture before it SIGTERMs the runtime), so the listener had no open connections: `close` completed immediately and `process.exit(0)` ran with the turns still alive. The drain never got a tick. Same shape on every engine pod evicted in that scale-down and on every force-roll since 2026-09-04.

**Fix.**
- Runtime, server mode: the listener stays up for the whole drain (the design in `session/drain.ts`: new turns get 503 + Retry-After, `/busy` reads true), and the process exits exactly once, from the drain, after every turn ended or `HOUSTON_RUNTIME_DRAIN_MS` is spent. Extracted to `session/graceful-shutdown.ts` with tests. Pool-worker mode keeps its response-ends-then-exit path.
- Host: `standingFrameCapture.stop()` / `frameForwarder.stop()` move after `shutdownAllAndWait`, so frames of turns that finish during the drain still reach the turn log (the forwarder's flush is now awaited; it is bounded).

**Known limit (follow-up, cloud side).** On an eviction the ReplicaSet creates the replacement pod immediately, so the new pod hydrates from blob while the old one is still draining. A held turn now completes on the old pod, but the replacement still sees its in-flight marker and settles it as "restarted". On a converger roll (Recreate) there is no overlap.

## Before

1. Engine pod with a turn running for minutes; `kubectl delete pod` (or autoscaler eviction).
2. Container log: `runtime shutdown requested signal=SIGTERM` then nothing; `ContainerDied` within ~10 s despite `terminationGracePeriodSeconds: 600`.
3. Replacement pod logs `[turn] engine restarted mid-turn` and Sentry gets an `EngineRestartedMidTurnError`.

Local demonstration of the old shape:
```sh
node -e 'const s=require("node:http").createServer().listen(0,()=>{const t=Date.now();s.close(()=>console.log("close cb after",Date.now()-t,"ms"))})'
# close cb after 0 ms
```

## After

1. Same delete on a busy pod: runtime logs `runtime draining: holding in-flight turns until they end {drainMs: 480000}`, `/busy` keeps answering `true`, the turn finishes, then the process exits and the host runs its final sync.
2. A turn past the budget logs `runtime drain deadline reached with a turn still running; exiting` (the honest interruption).
3. `pnpm --filter @houston/runtime exec vitest run src/session/graceful-shutdown.test.ts` covers hold, settle, deadline, and listener-stays-up.

## Checks

- `pnpm check` clean
- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` green (232 / 245 / 23 files)
- `tsc --noEmit` clean in runtime and host
