### PR TITLE
fix(integrations): custom MCP OAuth detect follows the endpoint's own discovery; Sign in never dies silently

### DIFF
--- a/app/src/components/chat-credential-interaction-card.tsx
+++ b/app/src/components/chat-credential-interaction-card.tsx
@@ -5,14 +5,23 @@ import {
   type StepChrome,
 } from "@houston-ai/chat";
 import { Button } from "@houston-ai/core";
-import { Check, CornerDownLeft, KeyRound, Loader2, LogIn } from "lucide-react";
+import {
+  Check,
+  CornerDownLeft,
+  ExternalLink,
+  KeyRound,
+  Loader2,
+  LogIn,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  claimSignInTab,
   useAgentCustomIntegrations,
   useStartCustomOAuth,
   useSubmitCustomCredential,
 } from "../hooks/queries";
+import { tauriSystem } from "../lib/tauri";
 import { useUIStore } from "../stores/ui";
 import { ChatStepDeclineButton } from "./chat-step-decline-button";
 import { CustomCredentialForm } from "./integrations/custom-credential-form";
@@ -99,11 +108,29 @@ export function ChatCredentialInteractionCard({
   const submit = useSubmitCustomCredential(agentId);
   const signIn = useStartCustomOAuth(agentId);
   const [ready, setReady] = useState(false);
-  // The browser sign-in was opened from THIS card (set on SUCCESS only — a
-  // failed start keeps the plain Sign in button and shows no false waiting
-  // line); the flip to "active" (delivered by CustomIntegrationsChanged) is
-  // then this step's completion.
+  // The browser sign-in was opened from THIS card (set once the browser TOOK
+  // the URL — a failed start or a refused open keeps the plain Sign in button
+  // and shows no false waiting line); the flip to "active" (delivered by
+  // CustomIntegrationsChanged) is then this step's completion.
   const [signInStarted, setSignInStarted] = useState(false);
+  // The web build's popup blocker refused the open after the async mint: the
+  // minted URL is kept for an explicit click, which the browser honors.
+  const blockedUrl =
+    signIn.data && !signIn.data.opened && !signInStarted
+      ? signIn.data.authorizeUrl
+      : null;
+  const openBlocked = () => {
+    if (!blockedUrl) return;
+    void tauriSystem.openUrl(blockedUrl).then((opened) => {
+      if (opened) setSignInStarted(true);
+    });
+  };
+  const startSignIn = () => {
+    signIn.mutate(
+      { slug: toolkit, tab: claimSignInTab() },
+      { onSuccess: ({ opened }) => setSignInStarted(opened) },
+    );
+  };
   // The favicon the Integrations card already wears (PRODUCT-1172); the
   // LogIn glyph is the no-icon (or failed-image) fallback.
   const [iconFailed, setIconFailed] = useState(false);
@@ -238,6 +265,28 @@ export function ChatCredentialInteractionCard({
                 {t("credential.signingIn")}
               </p>
             )}
+            {blockedUrl && (
+              <div className="flex flex-col items-start gap-1.5" role="status">
+                <p className="text-ink text-sm">
+                  {t("credential.signInBlocked")}
+                </p>
+                <Button
+                  className="gap-1.5"
+                  onClick={openBlocked}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  <ExternalLink className="size-3.5" />
+                  {t("credential.openSignIn")}
+                </Button>
+              </div>
+            )}
+            {signIn.isError && !signIn.isPending && (
+              <p className="text-ink text-sm" role="alert">
+                {t("credential.signInFailed")}
+              </p>
+            )}
           </div>
         ) : missing ? (
           <p className="text-balance text-ink text-sm leading-snug">
@@ -278,11 +327,7 @@ export function ChatCredentialInteractionCard({
               <Button
                 className="gap-1.5"
                 disabled={signIn.isPending}
-                onClick={() => {
-                  signIn.mutate(toolkit, {
-                    onSuccess: () => setSignInStarted(true),
-                  });
-                }}
+                onClick={startSignIn}
                 size="sm"
                 type="button"
               >

--- a/app/src/components/integrations-view/integrations-ready.tsx
+++ b/app/src/components/integrations-view/integrations-ready.tsx
@@ -2,6 +2,7 @@ import { CatalogShell } from "@houston-ai/core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  claimSignInTab,
   useDisconnectIntegration,
   useIntegrationToolkits,
 } from "../../hooks/queries";
@@ -127,7 +128,7 @@ export function IntegrationsReady({
                           `integrations:installed:${slug}`,
                         ),
                     })
-                  : custom.signIn.mutate(slug)
+                  : custom.signIn.mutate({ slug, tab: claimSignInTab() })
               }
               searching={filtering}
             />

--- a/app/src/components/integrations-view/integrations-view.tsx
+++ b/app/src/components/integrations-view/integrations-view.tsx
@@ -1,7 +1,7 @@
 import { CATALOG_PLANE_MAX_W, CatalogGrid, cn } from "@houston-ai/core";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useIntegrationToolkits } from "../../hooks/queries";
+import { claimSignInTab, useIntegrationToolkits } from "../../hooks/queries";
 import {
   AddCustomButton,
   CustomIntegrationRow,
@@ -135,7 +135,10 @@ export function IntegrationsView() {
                               custom.selection.openKey(value.slug)
                             }
                             onSignIn={(value) =>
-                              custom.signIn.mutate(value.slug)
+                              custom.signIn.mutate({
+                                slug: value.slug,
+                                tab: claimSignInTab(),
+                              })
                             }
                             onRemove={(value) =>
                               custom.selection.openRemove(value.slug)

--- a/app/src/components/integrations/curated-connect-dialog.tsx
+++ b/app/src/components/integrations/curated-connect-dialog.tsx
@@ -11,6 +11,7 @@ import { ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  claimSignInTab,
   useAddCustomIntegration,
   useStartCustomOAuth,
   useSubmitCustomCredential,
@@ -105,17 +106,29 @@ function CuratedConnectBody({
   const name = curated.name;
 
   const startSignIn = () => {
+    // The tab is claimed HERE, inside the click, because the add's round-trip
+    // comes first and would leave the sign-in open outside the gesture.
+    const tab = claimSignInTab();
     add.mutate(curatedAddInput(curated, "oauth"), {
       onSuccess: () =>
-        signIn.mutate(curated.slug, {
-          onSuccess: () => {
-            addToast({
-              title: t("custom.oauth.openedToast", { name }),
-              variant: "info",
-            });
-            onClose();
+        signIn.mutate(
+          { slug: curated.slug, tab },
+          {
+            onSuccess: ({ opened }) => {
+              addToast({
+                title: t(
+                  opened
+                    ? "custom.oauth.openedToast"
+                    : "custom.oauth.blockedToast",
+                  { name },
+                ),
+                variant: "info",
+              });
+              onClose();
+            },
           },
-        }),
+        ),
+      onError: () => tab?.discard(),
     });
   };
 

--- a/app/src/components/integrations/custom-add-flow.tsx
+++ b/app/src/components/integrations/custom-add-flow.tsx
@@ -78,11 +78,24 @@ export function CustomAddFlow({
             if (view.auth === "oauth") {
               // Chain straight into the browser sign-in (PRODUCT-1172); the
               // row flips to active on the CustomIntegrationsChanged event.
-              signIn.mutate(view.slug);
-              addToast({
-                title: t("custom.oauth.openedToast", { name: view.name }),
-                variant: "info",
-              });
+              // This runs after the add's round-trip, outside any click, so
+              // no tab can be claimed: a refused open names the row's own
+              // Sign in button as the way onward.
+              signIn.mutate(
+                { slug: view.slug },
+                {
+                  onSuccess: ({ opened }) =>
+                    addToast({
+                      title: t(
+                        opened
+                          ? "custom.oauth.openedToast"
+                          : "custom.oauth.blockedToast",
+                        { name: view.name },
+                      ),
+                      variant: "info",
+                    }),
+                },
+              );
             } else onNeedsKey(view.slug);
           } else
             addToast({

--- a/app/src/components/integrations/custom-integration-dialogs.tsx
+++ b/app/src/components/integrations/custom-integration-dialogs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  claimSignInTab,
   useCustomIntegrationsFor,
   useRemoveCustomIntegration,
   useStartCustomOAuth,
@@ -104,7 +105,7 @@ export function CustomIntegrationDialogs({
         onSignIn={(integration) => {
           // The browser carries the rest of the flow; the card stays open
           // and flips to active on the CustomIntegrationsChanged event.
-          signIn.mutate(integration.slug);
+          signIn.mutate({ slug: integration.slug, tab: claimSignInTab() });
         }}
         onRemove={(integration) => {
           selection.closeDetail();

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -32,6 +32,7 @@ export {
 export { COMPUTE_USAGE_DAYS, useComputeUsage } from "./use-compute-usage";
 export { useAllConversations, useChatHistory } from "./use-conversations";
 export {
+  claimSignInTab,
   useAddCustomIntegration,
   useAgentCustomIntegrations,
   useCustomIntegrationsFor,

--- a/app/src/hooks/queries/use-custom-integrations.ts
+++ b/app/src/hooks/queries/use-custom-integrations.ts
@@ -5,9 +5,17 @@ import type {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { integrationsSupported } from "../../components/integrations/model";
 import { analytics } from "../../lib/analytics";
+import { type ReservedTab, reserveBrowserTab } from "../../lib/browser-tab";
 import { markCustomOAuthStarted } from "../../lib/custom-oauth-return";
+import { startCustomOAuth } from "../../lib/custom-oauth-start";
+import { isEngineWakingError } from "../../lib/engine-waking-error";
+import { osIsTauri } from "../../lib/os-bridge";
 import { queryKeys } from "../../lib/query-keys";
-import { tauriIntegrations, tauriSystem } from "../../lib/tauri";
+import {
+  surfaceEngineError,
+  tauriIntegrations,
+  tauriSystem,
+} from "../../lib/tauri";
 import { useAgentStore } from "../../stores/agents";
 import { useCapabilities } from "../use-capabilities";
 
@@ -119,24 +127,57 @@ export function useSubmitCustomCredential(agentId?: string) {
 }
 
 /**
+ * Claim the browser tab for a sign-in NOW, inside the click's user
+ * activation: the authorize URL is minted over an async hop, and Safari,
+ * Firefox, and Chrome's strict popup setting refuse a `window.open` issued
+ * after it (PRODUCT-1625). Desktop opens URLs natively and never reserves.
+ * Call from the click handler and pass the result to `useStartCustomOAuth`.
+ */
+export function claimSignInTab(): ReservedTab | null {
+  return osIsTauri() ? null : reserveBrowserTab();
+}
+
+export interface StartCustomOAuthVars {
+  slug: string;
+  /** From `claimSignInTab()` in the click; omit outside a user gesture. */
+  tab?: ReservedTab | null;
+}
+
+/**
  * Start the browser sign-in for an OAuth custom integration (PRODUCT-1172):
  * mint the authorize URL and open it. The outcome lands on the host's
  * callback and arrives here as a `CustomIntegrationsChanged` event, which
- * flips the row to active — no client-side poll. Failures toast via the
- * `call()` wrapper.
+ * flips the row to active — no client-side poll. A refused browser open is a
+ * RESULT (`opened: false`, the URL kept for a manual click), a waking pod is
+ * retried, and the final failure surfaces once through `surfaceEngineError`
+ * (the per-attempt wrapper stays silent) — see `startCustomOAuth`.
  */
 export function useStartCustomOAuth(agentId?: string) {
   return useMutation({
-    mutationFn: async (slug: string) => {
-      const { authorizeUrl } = await tauriIntegrations.customOAuthStart(
-        slug,
-        agentId,
-      );
-      await tauriSystem.openUrl(authorizeUrl);
-    },
-    onSuccess: (_data, slug) => {
+    mutationFn: ({ slug, tab }: StartCustomOAuthVars) =>
+      startCustomOAuth({
+        mint: () =>
+          tauriIntegrations.customOAuthStart(slug, agentId, { surface: false }),
+        open: (url) => tauriSystem.openUrl(url),
+        tab: tab ?? null,
+        isWaking: isEngineWakingError,
+        sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+      }).catch((err: unknown) => {
+        void surfaceEngineError("custom_integration_oauth_start", err, {
+          integration_slug: slug,
+        });
+        throw err;
+      }),
+    onSuccess: (outcome, { slug }) => {
       // Arm the return gate: the sign-in's `CustomIntegrationsChanged` landing
-      // may pull the app back over the browser (PRODUCT-1298).
+      // may pull the app back over the browser (PRODUCT-1298). A refused open
+      // started nothing in the browser, so it arms nothing.
+      if (!outcome.opened) {
+        analytics.track("integration_connect_tab_blocked", {
+          integration_slug: slug,
+        });
+        return;
+      }
       markCustomOAuthStarted();
       analytics.track("custom_integration_oauth_started", {
         integration_slug: slug,

--- a/app/src/lib/custom-oauth-start.ts
+++ b/app/src/lib/custom-oauth-start.ts
@@ -1,0 +1,62 @@
+import type { ReservedTab } from "./browser-tab.ts";
+import { retryWhileWaking } from "./waking-retry.ts";
+
+/**
+ * The client half of a custom integration's browser sign-in (PRODUCT-1172):
+ * mint the authorize URL on the host, then hand it to the browser.
+ *
+ * Three ways this used to end as "I pressed Sign in and nothing happened":
+ *  - the web build's popup blocker refused the `window.open` issued after the
+ *    async mint (Safari, Firefox, strict Chrome), and the refusal was ignored
+ *    — the card went on "waiting for you to finish in your browser" with no
+ *    browser tab in sight. The caller claims a tab INSIDE the click
+ *    (`reserveBrowserTab`) and this navigates it; a refused open is a
+ *    RESULT (`opened: false`) the card turns into an explicit open button.
+ *  - a hosted agent whose pod was asleep answered the mint with the waking
+ *    refusal; the SDK's send path walks a delay ladder on exactly that
+ *    refusal, so the mint does too.
+ *  - any other mint failure was reported but shown as nothing; the caller
+ *    now renders its own retry line from the rejection.
+ *
+ * Pure so `node --test` covers it (app/tests/custom-oauth-start.test.ts).
+ */
+export interface StartCustomOAuthDeps {
+  mint: () => Promise<{ authorizeUrl: string }>;
+  /** The shell's opener: resolves false when the browser refused the open. */
+  open: (url: string) => Promise<boolean>;
+  /** A tab claimed inside the click (web), or null (desktop / no gesture). */
+  tab: ReservedTab | null;
+  isWaking: (err: unknown) => boolean;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export interface StartCustomOAuthOutcome {
+  authorizeUrl: string;
+  /** False when the browser refused the open: the URL is still valid, and a
+   *  fresh click (inside a user gesture) can open it. */
+  opened: boolean;
+}
+
+/** Pauses before the second, third and fourth mint on a waking refusal. */
+export const SIGN_IN_WAKING_RETRY_MS: readonly number[] = [
+  3_000, 6_000, 12_000,
+];
+
+export async function startCustomOAuth(
+  deps: StartCustomOAuthDeps,
+): Promise<StartCustomOAuthOutcome> {
+  let authorizeUrl: string;
+  try {
+    ({ authorizeUrl } = await retryWhileWaking(
+      deps.mint,
+      SIGN_IN_WAKING_RETRY_MS,
+      { isWaking: deps.isWaking, sleep: deps.sleep },
+    ));
+  } catch (err) {
+    // An empty tab whose link never came must not linger.
+    deps.tab?.discard();
+    throw err;
+  }
+  if (deps.tab?.navigate(authorizeUrl)) return { authorizeUrl, opened: true };
+  return { authorizeUrl, opened: await deps.open(authorizeUrl) };
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -2303,11 +2303,21 @@ export const tauriIntegrations = {
     ),
   // OAuth sign-in start (PRODUCT-1172): mint the authorize URL for a custom
   // MCP integration's browser sign-in. Same transport-agent rule as add.
-  customOAuthStart: (slug: string, agentId?: string) =>
-    call("custom_integration_oauth_start", () =>
-      agentId
-        ? getEngine().startAgentCustomIntegrationOAuth(agentId, slug)
-        : getEngine().startCustomIntegrationOAuth(slug),
+  // `options.surface: false` for the waking-retry caller
+  // (`startCustomOAuth`), which surfaces the FINAL error itself.
+  customOAuthStart: (
+    slug: string,
+    agentId?: string,
+    options?: Pick<EngineCallOptions, "surface">,
+  ) =>
+    call(
+      "custom_integration_oauth_start",
+      () =>
+        agentId
+          ? getEngine().startAgentCustomIntegrationOAuth(agentId, slug)
+          : getEngine().startCustomIntegrationOAuth(slug),
+      { integration_slug: slug },
+      options,
     ),
 };
 

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -314,7 +314,10 @@
     "signedInLine": "Signed in to {{name}}.",
     "skippedSignInLine": "Skipped signing in to {{name}}.",
     "signInRedirectLine": "I didn't sign in to {{name}}. Instead, do this: {{text}}",
-    "signedInFollowup": "I've signed in to {{name}}. Please continue."
+    "signedInFollowup": "I've signed in to {{name}}. Please continue.",
+    "signInBlocked": "Your browser blocked the sign-in window.",
+    "openSignIn": "Open the sign-in page",
+    "signInFailed": "The sign-in couldn't start. Try again in a moment, or skip this step."
   },
   "loadingPhrases": [
     "Houston, we have a solution!",

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -214,7 +214,8 @@
     "signIn": "Sign in",
     "signInAgain": "Sign in again",
     "oauth": {
-      "openedToast": "Finish signing in to {{name}} in your browser"
+      "openedToast": "Finish signing in to {{name}} in your browser",
+      "blockedToast": "Your browser blocked the sign-in window. Open {{name}} and press Sign in to try again."
     }
   },
   "curated": {

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -314,7 +314,10 @@
     "signedInLine": "Inicié sesión en {{name}}.",
     "skippedSignInLine": "Omití el inicio de sesión en {{name}}.",
     "signInRedirectLine": "No inicié sesión en {{name}}. En su lugar, haz esto: {{text}}",
-    "signedInFollowup": "Ya inicié sesión en {{name}}. Continúa, por favor."
+    "signedInFollowup": "Ya inicié sesión en {{name}}. Continúa, por favor.",
+    "signInBlocked": "Tu navegador bloqueó la ventana de inicio de sesión.",
+    "openSignIn": "Abrir la página de inicio de sesión",
+    "signInFailed": "No se pudo iniciar el inicio de sesión. Inténtalo de nuevo en un momento u omite este paso."
   },
   "loadingPhrases": [
     "Houston, ¡tenemos una solución!",

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -214,7 +214,8 @@
     "signIn": "Iniciar sesión",
     "signInAgain": "Iniciar sesión de nuevo",
     "oauth": {
-      "openedToast": "Termina de iniciar sesión en {{name}} en tu navegador"
+      "openedToast": "Termina de iniciar sesión en {{name}} en tu navegador",
+      "blockedToast": "Tu navegador bloqueó la ventana de inicio de sesión. Abre {{name}} y pulsa Iniciar sesión para intentarlo de nuevo."
     }
   },
   "curated": {

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -314,7 +314,10 @@
     "signedInLine": "Fiz login em {{name}}.",
     "skippedSignInLine": "Pulei o login em {{name}}.",
     "signInRedirectLine": "Não fiz login em {{name}}. Em vez disso, faça o seguinte: {{text}}",
-    "signedInFollowup": "Já fiz login em {{name}}. Continue, por favor."
+    "signedInFollowup": "Já fiz login em {{name}}. Continue, por favor.",
+    "signInBlocked": "Seu navegador bloqueou a janela de login.",
+    "openSignIn": "Abrir a página de login",
+    "signInFailed": "Não foi possível iniciar o login. Tente de novo em instantes ou pule esta etapa."
   },
   "loadingPhrases": [
     "Houston, temos uma solução!",

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -214,7 +214,8 @@
     "signIn": "Fazer login",
     "signInAgain": "Fazer login de novo",
     "oauth": {
-      "openedToast": "Conclua o login em {{name}} no seu navegador"
+      "openedToast": "Conclua o login em {{name}} no seu navegador",
+      "blockedToast": "Seu navegador bloqueou a janela de login. Abra {{name}} e toque em Fazer login para tentar de novo."
     }
   },
   "curated": {

--- a/app/tests/custom-oauth-start.test.ts
+++ b/app/tests/custom-oauth-start.test.ts
@@ -1,0 +1,110 @@
+import { deepStrictEqual, rejects, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { ReservedTab } from "../src/lib/browser-tab.ts";
+import {
+  SIGN_IN_WAKING_RETRY_MS,
+  startCustomOAuth,
+} from "../src/lib/custom-oauth-start.ts";
+
+class Waking extends Error {}
+
+const URL = "https://issuer.example.com/oauth/authorize?state=abc";
+
+function fakeTab(opts: { closed?: boolean } = {}) {
+  const navigated: string[] = [];
+  let discarded = 0;
+  const tab: ReservedTab = {
+    navigate: (url) => {
+      if (opts.closed) return false;
+      navigated.push(url);
+      return true;
+    },
+    discard: () => {
+      discarded += 1;
+    },
+  };
+  return { tab, navigated, discarded: () => discarded };
+}
+
+function harness(overrides: { tab?: ReservedTab | null; opens?: boolean }) {
+  const opened: string[] = [];
+  const slept: number[] = [];
+  return {
+    opened,
+    slept,
+    deps: {
+      mint: async () => ({ authorizeUrl: URL }),
+      open: async (url: string) => {
+        opened.push(url);
+        return overrides.opens ?? true;
+      },
+      tab: overrides.tab ?? null,
+      isWaking: (err: unknown) => err instanceof Waking,
+      sleep: async (ms: number) => {
+        slept.push(ms);
+      },
+    },
+  };
+}
+
+describe("startCustomOAuth", () => {
+  it("navigates the tab claimed inside the click and never opens a second one", async () => {
+    const { tab, navigated } = fakeTab();
+    const h = harness({ tab });
+    deepStrictEqual(await startCustomOAuth(h.deps), {
+      authorizeUrl: URL,
+      opened: true,
+    });
+    deepStrictEqual(navigated, [URL]);
+    deepStrictEqual(h.opened, []);
+  });
+
+  it("falls back to the plain open when the claimed tab was closed meanwhile", async () => {
+    const { tab } = fakeTab({ closed: true });
+    const h = harness({ tab });
+    strictEqual((await startCustomOAuth(h.deps)).opened, true);
+    deepStrictEqual(h.opened, [URL]);
+  });
+
+  it("reports a refused open as a result, keeping the URL for a manual click", async () => {
+    const h = harness({ opens: false });
+    deepStrictEqual(await startCustomOAuth(h.deps), {
+      authorizeUrl: URL,
+      opened: false,
+    });
+  });
+
+  it("re-mints along the ladder while the pod is waking", async () => {
+    const h = harness({});
+    let attempts = 0;
+    h.deps.mint = async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Waking("waking");
+      return { authorizeUrl: URL };
+    };
+    strictEqual((await startCustomOAuth(h.deps)).opened, true);
+    strictEqual(attempts, 3);
+    deepStrictEqual(h.slept, SIGN_IN_WAKING_RETRY_MS.slice(0, 2));
+  });
+
+  it("surfaces any other mint failure at once and discards the empty tab", async () => {
+    const { tab, discarded } = fakeTab();
+    const h = harness({ tab });
+    h.deps.mint = async () => {
+      throw new Error("registration refused");
+    };
+    await rejects(startCustomOAuth(h.deps), /registration refused/);
+    strictEqual(discarded(), 1);
+    deepStrictEqual(h.slept, []);
+    deepStrictEqual(h.opened, []);
+  });
+
+  it("gives up after the ladder and surfaces the last waking refusal", async () => {
+    const h = harness({});
+    h.deps.mint = async () => {
+      throw new Waking("still waking");
+    };
+    await rejects(startCustomOAuth(h.deps), Waking);
+    deepStrictEqual(h.slept, [...SIGN_IN_WAKING_RETRY_MS]);
+  });
+});

--- a/packages/host/src/integrations/custom/detect.test.ts
+++ b/packages/host/src/integrations/custom/detect.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { detectSource } from "./detect";
+import type { CustomExecutor } from "./executor-host";
+
+const ORIGIN = "https://service.example.com";
+const ENDPOINT = `${ORIGIN}/functions/v1/mcp`;
+const RESOURCE_METADATA = `${ENDPOINT}/.well-known/oauth-protected-resource`;
+const ISSUER = `${ORIGIN}/auth/v1`;
+
+const json = (body: unknown, status = 200, headers = {}) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+
+/** A Supabase-shaped gateway: every guessed well-known path answers 401 (the
+ *  executor's probe reads that as "no OAuth"); only the endpoint's
+ *  WWW-Authenticate hint leads to the real metadata. */
+const gatewayFetch: typeof fetch = async (input) => {
+  const url = String(input instanceof Request ? input.url : input);
+  if (url === ENDPOINT) {
+    return json({ error: "unauthorized" }, 401, {
+      "WWW-Authenticate": `Bearer realm="mcp", resource_metadata="${RESOURCE_METADATA}"`,
+    });
+  }
+  if (url === RESOURCE_METADATA) {
+    return json({ resource: ENDPOINT, authorization_servers: [ISSUER] });
+  }
+  if (url === `${ORIGIN}/.well-known/oauth-authorization-server/auth/v1`) {
+    return json({
+      issuer: ISSUER,
+      authorization_endpoint: `${ISSUER}/oauth/authorize`,
+      token_endpoint: `${ISSUER}/oauth/token`,
+      registration_endpoint: `${ISSUER}/oauth/clients/register`,
+      response_types_supported: ["code"],
+      code_challenge_methods_supported: ["S256"],
+    });
+  }
+  return json({ message: "No API key found in request" }, 401);
+};
+
+const keyOnlyFetch: typeof fetch = async () =>
+  json({ error: "unauthorized" }, 401, { "WWW-Authenticate": "Bearer" });
+
+type Probe = Awaited<ReturnType<CustomExecutor["mcp"]["probeEndpoint"]>>;
+
+function executorWith(probe: Partial<Probe>): CustomExecutor {
+  // The probe output is a union of literal shapes; the fake merges over the
+  // auth-wall default, so it is asserted rather than narrowed.
+  const full = {
+    connected: false,
+    requiresAuthentication: true,
+    requiresOAuth: false,
+    supportsDynamicRegistration: false,
+    name: "service.example.com",
+    slug: "service-example-com",
+    toolCount: null,
+    serverName: null,
+    instructions: null,
+    ...probe,
+  } as Probe;
+  return {
+    integrations: { detect: async () => [] },
+    mcp: { probeEndpoint: async () => full },
+  } as unknown as CustomExecutor;
+}
+
+describe("detectSource: OAuth wall the executor probe could not explain", () => {
+  it("reads an auth wall as OAuth when the endpoint's own discovery finds an authorization server", async () => {
+    const result = await detectSource(executorWith({}), ENDPOINT, {
+      fetchFn: gatewayFetch,
+    });
+    expect(result).toMatchObject({
+      kind: "mcp",
+      requiresAuthentication: true,
+      requiresOAuth: true,
+    });
+  });
+
+  it("keeps the API-key verdict when discovery finds nothing", async () => {
+    const result = await detectSource(executorWith({}), ENDPOINT, {
+      fetchFn: keyOnlyFetch,
+    });
+    expect(result).toMatchObject({ kind: "mcp", requiresAuthentication: true });
+    expect(result.requiresOAuth).toBeUndefined();
+  });
+
+  it("keeps the API-key verdict when discovery itself fails", async () => {
+    const failing: typeof fetch = async () => {
+      throw new Error("offline");
+    };
+    const result = await detectSource(executorWith({}), ENDPOINT, {
+      fetchFn: failing,
+    });
+    expect(result.requiresOAuth).toBeUndefined();
+  });
+
+  it("never runs discovery for an open server", async () => {
+    let calls = 0;
+    const counting: typeof fetch = async (input) => {
+      calls += 1;
+      return gatewayFetch(input);
+    };
+    const result = await detectSource(
+      executorWith({
+        connected: true,
+        requiresAuthentication: false,
+        toolCount: 4,
+        serverName: "Open",
+      }),
+      ENDPOINT,
+      { fetchFn: counting },
+    );
+    expect(result).toMatchObject({ kind: "mcp", name: "Open", toolCount: 4 });
+    expect(result.requiresOAuth).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  it("trusts the executor's own OAuth verdict without a second discovery", async () => {
+    let calls = 0;
+    const counting: typeof fetch = async (input) => {
+      calls += 1;
+      return gatewayFetch(input);
+    };
+    const result = await detectSource(
+      executorWith({ requiresOAuth: true, supportsDynamicRegistration: true }),
+      ENDPOINT,
+      { fetchFn: counting },
+    );
+    expect(result.requiresOAuth).toBe(true);
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/host/src/integrations/custom/detect.ts
+++ b/packages/host/src/integrations/custom/detect.ts
@@ -1,4 +1,6 @@
 import type { CustomExecutor } from "./executor-host";
+import { guardedFetch } from "./fetch-guard";
+import { advertisesOAuth } from "./oauth-discovery";
 import { slugify } from "./slug";
 
 /** What a pasted URL turned out to be — the agent's interview pivot. */
@@ -28,6 +30,7 @@ export interface DetectResult {
 export async function detectSource(
   executor: CustomExecutor,
   url: string,
+  opts: { fetchFn?: typeof fetch } = {},
 ): Promise<DetectResult> {
   const detected = await executor.integrations.detect(url).catch(() => []);
   const first = detected[0];
@@ -40,13 +43,19 @@ export async function detectSource(
   }
   try {
     const probe = await executor.mcp.probeEndpoint(url);
+    // The executor's OAuth verdict is a well-known-path guess; an auth wall
+    // it could not explain gets the sign-in flow's own discovery before it
+    // is called an API key (see advertisesOAuth).
+    const requiresOAuth =
+      probe.requiresOAuth ||
+      (probe.requiresAuthentication &&
+        (await advertisesOAuth(url, opts.fetchFn ?? guardedFetch)));
     return {
       kind: "mcp",
       name: probe.serverName ?? probe.name,
       suggestedSlug: slugify(probe.slug),
-      requiresAuthentication:
-        probe.requiresAuthentication || probe.requiresOAuth,
-      ...(probe.requiresOAuth ? { requiresOAuth: true } : {}),
+      requiresAuthentication: probe.requiresAuthentication || requiresOAuth,
+      ...(requiresOAuth ? { requiresOAuth: true } : {}),
       toolCount: probe.toolCount ?? undefined,
     };
   } catch {

--- a/packages/host/src/integrations/custom/executor-host.ts
+++ b/packages/host/src/integrations/custom/executor-host.ts
@@ -9,6 +9,7 @@ import { createExecutor } from "@executor-js/sdk";
 import { authMethodsOf, TOKEN_VARIABLE } from "./auth-methods";
 import { fallbackAuthTemplate } from "./fallback-auth";
 import { guardedFetch, guardedHttpClientLayer } from "./fetch-guard";
+import { advertisesOAuth } from "./oauth-discovery";
 import type { CustomSecretStore } from "./secrets";
 import {
   HOUSTON_PROVIDER_KEY,
@@ -289,10 +290,15 @@ export class CustomExecutorHost {
       // problem (the reviewed OAuth-only case: the server wants its own
       // sign-in, which Houston cannot connect to yet).
       if (probe.requiresAuthentication && def.auth === "none") {
+        // The executor's OAuth verdict is a well-known-path guess; the
+        // sign-in flow's own discovery decides (detect.ts judges the same way).
+        const oauth =
+          probe.requiresOAuth ||
+          (await advertisesOAuth(def.endpoint, guardedFetch, def.headers));
         return {
           status: "error",
-          message: probe.requiresOAuth
-            ? `the MCP server at ${def.endpoint} only signs in with its own account flow, which Houston cannot connect to yet`
+          message: oauth
+            ? `the MCP server at ${def.endpoint} only signs in with its own account flow - add it again as a service you sign in to`
             : `the MCP server at ${def.endpoint} requires an API key or token - add it again as a service that needs a key`,
         };
       }

--- a/packages/host/src/integrations/custom/oauth-discovery.test.ts
+++ b/packages/host/src/integrations/custom/oauth-discovery.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { advertisesOAuth } from "./oauth-discovery";
 import { beginCustomOAuth } from "./oauth-flow";
 import type { CustomIntegrationDef } from "./types";
 
@@ -150,5 +151,30 @@ describe("custom MCP OAuth discovery compatibility", () => {
       code: "oauth_failed",
       message: "could not discover how Service signs in: probe unavailable",
     });
+  });
+});
+
+describe("advertisesOAuth", () => {
+  it.each([
+    "challenge",
+    "standard",
+  ] as const)("is true whenever the sign-in flow finds authorization-server metadata (%s)", async (discovery) => {
+    const { fetchFn } = server(discovery);
+    expect(await advertisesOAuth(ENDPOINT, fetchFn)).toBe(true);
+  });
+
+  // The SDK's legacy fallback GUESSES `/authorize` at the origin for a wall
+  // with no metadata anywhere: that is a plain bearer wall (an API key), and
+  // calling it OAuth would send the user into a sign-in that cannot exist.
+  it("is false for a bearer wall with no metadata anywhere (legacy guess)", async () => {
+    const { fetchFn } = server("legacy");
+    expect(await advertisesOAuth(ENDPOINT, fetchFn)).toBe(false);
+  });
+
+  it("is false, never a throw, when the probe cannot run", async () => {
+    const fetchFn: typeof fetch = async () => {
+      throw new Error("probe unavailable");
+    };
+    expect(await advertisesOAuth(ENDPOINT, fetchFn)).toBe(false);
   });
 });

--- a/packages/host/src/integrations/custom/oauth-discovery.ts
+++ b/packages/host/src/integrations/custom/oauth-discovery.ts
@@ -26,3 +26,26 @@ export async function discoverCustomOAuth(
 
   return discoverOAuthServerInfo(endpoint, { fetchFn, resourceMetadataUrl });
 }
+
+/**
+ * Whether an auth-walled MCP endpoint signs in with OAuth — judged by the
+ * SAME discovery the sign-in flow runs, so "detect" and "Sign in" can never
+ * disagree. The executor's own probe only guesses well-known paths and reads
+ * a non-404 answer there as "no OAuth": a gateway that answers every unknown
+ * path with 401 (Supabase Edge Functions, verified live with Spark Agency
+ * Hub) made every such server read as "needs an API key", which the agent
+ * then asked for in a loop. A discovery failure is an honest "not OAuth":
+ * the key path stays the fallback.
+ */
+export async function advertisesOAuth(
+  endpoint: string,
+  fetchFn: typeof fetch,
+  headers?: Record<string, string>,
+): Promise<boolean> {
+  try {
+    const info = await discoverCustomOAuth(endpoint, fetchFn, headers);
+    return info.authorizationServerMetadata !== undefined;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem

Beta testers connecting **Spark Agency Hub** (`https://ypfnhscrjrinypexugkt.supabase.co/functions/v1/mcp`, a Supabase Edge Function MCP server) hit two things:

1. Houston's detect said the server **needs an API key** even though it advertises OAuth, so the agent looped asking for a key.
2. When the Sign in card did appear, pressing **Iniciar sesión** sometimes did nothing.

## Root causes (verified live against Spark)

**Detect.** The executor-js probe decides `requiresOAuth` by guessing well-known paths (`/.well-known/oauth-protected-resource/<path>`, `/.well-known/oauth-authorization-server/<path>`). Supabase's gateway answers every unknown path with **401** (`No API key found`), and the probe treats any non-404 as "no OAuth". It never reads the endpoint's `WWW-Authenticate: resource_metadata=...` hint, which is the only working route to the metadata. ae9de4d34 taught the *sign-in flow* to follow that hint, but `detect` (and the compile-time auth-wall message) still trusted the executor's guess. Deterministic: every detect of this server said "API key".

**Sign in does nothing.** Three silent ends in the start mutation:
- web: `window.open` after the async mint is refused by Safari/Firefox/strict Chrome; the refusal was ignored and the card went to "Waiting for you to finish in your browser..." with no tab.
- hosted: a pod asleep at click time answers the mint with the waking refusal; the click just failed.
- any other start failure was reported but shown as nothing (report-only toast), so the button simply sat there.

## Fix

**Host** (`packages/host/src/integrations/custom`)
- `advertisesOAuth()` runs the SAME discovery the sign-in flow uses (well-known, then the `WWW-Authenticate` hint). `detectSource` and `connectedState`'s auth-wall message consult it before calling an auth wall an API key. A wall with no metadata anywhere stays "API key" (the SDK's legacy `/authorize` guess is not OAuth).
- Tests: `detect.test.ts` (Supabase-shaped gateway, key-only wall, failing discovery, open server, executor verdict trusted) + `advertisesOAuth` cases in `oauth-discovery.test.ts`.

**App**
- New pure `lib/custom-oauth-start.ts`: claim a tab inside the click (`claimSignInTab`, the PRODUCT-1625 pattern), navigate it on mint; a refused open is a **result** (`opened: false`, URL kept); a waking refusal is retried along a 3s/6s/12s ladder; any other failure discards the empty tab and surfaces once via `surfaceEngineError`.
- `useStartCustomOAuth` takes `{ slug, tab }`; every call site passes the claimed tab (chat card, Integrations rows, detail dialog, curated dialog; the post-add chain toasts a "browser blocked it, press Sign in on the card" line instead of claiming success).
- Chat credential card: a refused open shows "Your browser blocked the sign-in window" + **Open the sign-in page** (a click the browser honors); a failed start shows a retry line. en/es/pt keys added.
- Node tests: `app/tests/custom-oauth-start.test.ts`.

## Verified
- Live: Spark's `WWW-Authenticate` hint → PRM → Supabase AS metadata → DCR (loopback and gateway redirect URIs both accepted) → authorize URL 302s to Spark's consent page, through the real `beginCustomOAuth` with `guardedFetch`.
- `pnpm check`, `cd app && pnpm tsgo --noEmit`, `pnpm check-locales`, `cd app && pnpm test` (4290 pass), host/runtime/domain vitest, `pnpm --filter houston-web typecheck`, `pnpm check:boundaries`, `pnpm check:parity`.

## Not in this PR
- Integrations page rows still don't render an inline line on a failed start (reported, silent to the user, as before). The chat card is where testers hit it.
