### PR TITLE
fix(local-models): native session says when a renewal is due, so idle desktops keep the bridge

### DIFF
--- a/app/src-tauri/src/local_bridge/commands.rs
+++ b/app/src-tauri/src/local_bridge/commands.rs
@@ -82,6 +82,7 @@ pub fn local_bridge_status(identity: Identity) -> Result<Status, String> {
             generation: 0,
             status: StatusKind::Disabled,
             session_expires_at: None,
+            renewal_due: false,
         }),
     }
 }

--- a/app/src-tauri/src/local_bridge/lifecycle.rs
+++ b/app/src-tauri/src/local_bridge/lifecycle.rs
@@ -70,6 +70,7 @@ pub async fn start(app: AppHandle, args: StartArgs) -> Result<StartResult, Strin
         generation: 0,
         status: StatusKind::Connecting,
         session_expires_at: None,
+        renewal_due: false,
     });
     let identity = args.identity.clone();
     let handle = connect(
@@ -127,9 +128,15 @@ fn update(app: &AppHandle, identity: &Identity, event: BridgeStatus) -> Result<(
                 status.generation = generation;
                 status.session_expires_at = Some(session_expires_at);
                 status.status = StatusKind::Online;
+                status.renewal_due = false;
             }
             BridgeStatus::Renewed { session_expires_at } => {
                 status.session_expires_at = Some(session_expires_at);
+                status.renewal_due = false;
+            }
+            BridgeStatus::RenewalDue { session_expires_at } => {
+                status.session_expires_at = Some(session_expires_at);
+                status.renewal_due = true;
             }
             BridgeStatus::ModelUnavailable => status.status = StatusKind::ModelUnavailable,
             BridgeStatus::Draining => status.status = StatusKind::Reconnecting,

--- a/app/src-tauri/src/local_bridge/types.rs
+++ b/app/src-tauri/src/local_bridge/types.rs
@@ -120,6 +120,9 @@ pub struct Status {
     pub status: StatusKind,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_expires_at: Option<String>,
+    /// The native session wants a fresh ticket now (see `BridgeStatus::RenewalDue`).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub renewal_due: bool,
 }
 #[derive(Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/local-model-bridge/src/lib.rs
+++ b/crates/local-model-bridge/src/lib.rs
@@ -137,7 +137,7 @@ pub async fn connect(
     let callback: Arc<dyn Fn(BridgeStatus) + Send + Sync> = Arc::new(status_callback);
     callback(BridgeStatus::Online {
         generation,
-        session_expires_at,
+        session_expires_at: session_expires_at.clone(),
     });
     let cancel = CancellationToken::new();
     let (commands, receiver) = mpsc::channel(2);
@@ -148,6 +148,7 @@ pub async fn connect(
         receiver,
         callback,
         expiry,
+        session_expires_at,
     ));
     Ok(BridgeHandle {
         cancel,

--- a/crates/local-model-bridge/src/session.rs
+++ b/crates/local-model-bridge/src/session.rs
@@ -35,6 +35,15 @@ pub(crate) fn expiry(value: &str) -> Result<Instant, BridgeError> {
     }
     Ok(Instant::now() + remaining)
 }
+/// When to ask the host for a renewal: two minutes before expiry, never in the
+/// past. Two minutes leaves room for the ticket round trip through the gateway
+/// even when the webview only wakes on our event.
+fn renewal_due(expires: Instant) -> Instant {
+    let now = Instant::now();
+    expires
+        .checked_sub(Duration::from_secs(120))
+        .map_or(now, |due| due.max(now))
+}
 pub(crate) async fn run(
     socket: WebSocketStream<MaybeTlsStream<TcpStream>>,
     target: Arc<Target>,
@@ -42,6 +51,7 @@ pub(crate) async fn run(
     mut commands: mpsc::Receiver<crate::Renewal>,
     callback: Arc<dyn Fn(BridgeStatus) + Send + Sync>,
     mut expires: Instant,
+    mut expires_at: String,
 ) -> Result<(), BridgeError> {
     let (mut sink, mut source) = socket.split();
     let (control, mut controls) = mpsc::channel::<Control>(64);
@@ -75,12 +85,17 @@ pub(crate) async fn run(
     let mut heartbeat = tokio::time::interval(Duration::from_secs(15));
     let mut last_pong = Instant::now();
     let mut renewal_pending = None;
+    let mut renew_at = Some(renewal_due(expires));
     let result = async {
         loop {
             tokio::select! {
                 biased;
                 _ = cancel.cancelled() => return Ok(()),
                 _ = tokio::time::sleep_until(expires) => return Err(BridgeError::Expired),
+                _ = tokio::time::sleep_until(renew_at.unwrap_or(expires)), if renew_at.is_some() => {
+                    renew_at = None;
+                    callback(BridgeStatus::RenewalDue { session_expires_at: expires_at.clone() });
+                }
                 Some(renewal) = commands.recv() => {
                     if renewal_pending.is_some() { return Err(BridgeError::Protocol); }
                     enqueue(&control, Outgoing::Renew { ticket: renewal.ticket })?;
@@ -114,6 +129,8 @@ pub(crate) async fn run(
                             let next = expiry(&session_expires_at)?;
                             if next <= expires { return Err(BridgeError::Protocol); }
                             expires = next;
+                            expires_at = session_expires_at.clone();
+                            renew_at = Some(renewal_due(next));
                             let reply = renewal_pending.take().ok_or(BridgeError::Protocol)?;
                             reply.send(Ok(())).map_err(|_| BridgeError::Closed)?;
                             callback(BridgeStatus::Renewed { session_expires_at });

--- a/crates/local-model-bridge/src/types.rs
+++ b/crates/local-model-bridge/src/types.rs
@@ -38,6 +38,14 @@ pub enum BridgeStatus {
     Renewed {
         session_expires_at: String,
     },
+    /// Fired two minutes before the session expires (and again after every
+    /// renewal). The host must mint a fresh ticket and call `renew`: the
+    /// desktop webview's own timers are suspended while the app idles in
+    /// the background, so a schedule kept only there let sessions lapse.
+    #[serde(rename_all = "camelCase")]
+    RenewalDue {
+        session_expires_at: String,
+    },
     Draining,
     ModelUnavailable,
     Offline {

--- a/crates/local-model-bridge/tests/transport.rs
+++ b/crates/local-model-bridge/tests/transport.rs
@@ -21,6 +21,11 @@ type Socket = WebSocketStream<TcpStream>;
 mod normalization;
 #[allow(clippy::result_large_err)] // Tungstenite fixes the handshake callback error type.
 async fn relay() -> (String, tokio::task::JoinHandle<Socket>) {
+    relay_expiring(600).await
+}
+/// A relay whose `ready` frame puts the session expiry `seconds` away.
+#[allow(clippy::result_large_err)]
+async fn relay_expiring(seconds: i64) -> (String, tokio::task::JoinHandle<Socket>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = format!("ws://{}/bridge", listener.local_addr().unwrap());
     let task = tokio::spawn(async move {
@@ -38,7 +43,7 @@ async fn relay() -> (String, tokio::task::JoinHandle<Socket>) {
         send(
             &mut socket,
             json!({"type":"ready","version":1,"generation":1,
-            "sessionExpiresAt":(chrono::Utc::now()+chrono::Duration::minutes(10)).to_rfc3339()}),
+            "sessionExpiresAt":(chrono::Utc::now()+chrono::Duration::seconds(seconds)).to_rfc3339()}),
         )
         .await;
         socket
@@ -289,6 +294,60 @@ async fn renews_drains_and_drop_closes_the_socket() {
     })
     .await
     .unwrap();
+}
+
+// The desktop webview's timers sleep while the app idles (macOS App Nap), so
+// the native session itself must say when a renewal is due: two minutes before
+// expiry, and again after every renewal moves the expiry.
+#[tokio::test]
+async fn renewal_due_fires_before_expiry_and_rearms_after_renewal() {
+    let (address, relay_task) = relay_expiring(121).await;
+    let (events, mut statuses) = mpsc::unbounded_channel();
+    let handle = connect(
+        config(address, "http://127.0.0.1:1/v1".into()),
+        move |event| {
+            events.send(event).unwrap();
+        },
+    )
+    .await
+    .unwrap();
+    let mut socket = relay_task.await.unwrap();
+    let due = async {
+        loop {
+            if let BridgeStatus::RenewalDue { session_expires_at } = statuses.recv().await.unwrap()
+            {
+                return session_expires_at;
+            }
+        }
+    };
+    let first = tokio::time::timeout(std::time::Duration::from_secs(5), due)
+        .await
+        .expect("renewal due never fired before expiry");
+    assert!(!first.is_empty());
+    let renewal_task = tokio::spawn(async move {
+        handle.renew("renewal-ticket".into()).await.unwrap();
+        handle
+    });
+    assert_eq!(receive(&mut socket).await["type"], "renew");
+    let renewed_at = (chrono::Utc::now() + chrono::Duration::seconds(121)).to_rfc3339();
+    send(
+        &mut socket,
+        json!({"type":"renewed","sessionExpiresAt":renewed_at}),
+    )
+    .await;
+    let again = async {
+        loop {
+            if let BridgeStatus::RenewalDue { session_expires_at } = statuses.recv().await.unwrap()
+            {
+                return session_expires_at;
+            }
+        }
+    };
+    let second = tokio::time::timeout(std::time::Duration::from_secs(5), again)
+        .await
+        .expect("renewal due did not re-arm after the renewal");
+    assert_eq!(second, renewed_at);
+    drop(renewal_task.await.unwrap());
 }
 
 #[tokio::test]

--- a/packages/sdk/src/local-model-bridge/controller.test.ts
+++ b/packages/sdk/src/local-model-bridge/controller.test.ts
@@ -112,6 +112,45 @@ test("connect commits a secret-free journal and explicit bridge descriptor", asy
   expect(h.controller.getSnapshot()).toBe(h.controller.getSnapshot());
   await h.controller.dispose();
 });
+// The desktop webview's timers sleep while the app idles in the background
+// (macOS App Nap): overnight, every session lapsed at the 10-minute mark and
+// the late timer met a 409. The native side now says when a renewal is due.
+test("a native renewal-due notice renews without the timer, once per session", async () => {
+  vi.useFakeTimers();
+  const h = harness();
+  await h.controller.connect(input);
+  const online = h.controller.getSnapshot();
+  // A renewed session carries a later expiry; the fixture's expiry is minted
+  // from the fake clock, so let it move before any renewal is issued.
+  await vi.advanceTimersByTimeAsync(1_000);
+  const renewals = () =>
+    (h.ports.management.session as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call) => call[3] !== undefined,
+    ).length;
+  expect(renewals()).toBe(0);
+  const notice = {
+    bridgeId,
+    generation: online.generation ?? 0,
+    status: "online" as const,
+    sessionExpiresAt: online.sessionExpiresAt,
+    renewalDue: true,
+  };
+  h.event(notice);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(renewals()).toBe(1);
+  expect(h.ports.native.renew).toHaveBeenCalledTimes(1);
+  expect(h.controller.getSnapshot().status).toBe("online");
+  // The same notice again names the session already renewed: nothing happens.
+  h.event(notice);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(renewals()).toBe(1);
+  // The timer for the renewed session still fires on its own schedule.
+  await vi.advanceTimersByTimeAsync(480_000);
+  expect(renewals()).toBe(2);
+  expect(h.ports.report).not.toHaveBeenCalled();
+  await h.controller.dispose();
+});
+
 test("failed renewal authorization stops all automatic retries", async () => {
   vi.useFakeTimers();
   const h = harness();

--- a/packages/sdk/src/local-model-bridge/controller.ts
+++ b/packages/sdk/src/local-model-bridge/controller.ts
@@ -129,18 +129,27 @@ export class LocalModelBridgeController extends LocalBridgeLifecycle {
     clearTimeout(this.lifetime.timer);
     this.lifetime.timer = setTimeout(
       () => {
-        void this.renew(epoch).catch(this.ports.report);
+        void this.renew(epoch, expiresAt).catch(this.ports.report);
       },
       renewalDelay(expiresAt, (this.ports.now ?? Date.now)()),
     );
   }
-  private renew(epoch: number) {
+  /**
+   * Renew the session that expires at `expected`. Two schedules ask for it:
+   * this timer, and the native side's `renewalDue` notice two minutes before
+   * expiry. The webview's timers are suspended while the app idles in the
+   * background (macOS App Nap), so the native notice is what keeps a session
+   * alive overnight; the `expected` fence keeps the two from renewing the
+   * same session twice.
+   */
+  private renew(epoch: number, expected: string | undefined) {
     return this.lifetime.enqueue(async () => {
       if (
         epoch !== this.lifetime.epoch ||
         !this.device ||
         !this.snapshot.descriptor ||
-        this.snapshot.generation === undefined
+        this.snapshot.generation === undefined ||
+        this.snapshot.sessionExpiresAt !== expected
       )
         return;
       try {
@@ -166,7 +175,17 @@ export class LocalModelBridgeController extends LocalBridgeLifecycle {
       this.snapshot.status === "disabled"
     )
       return;
-    if (event.status === "online") return;
+    if (event.status === "online") {
+      const current = this.snapshot.sessionExpiresAt;
+      if (
+        event.renewalDue &&
+        current &&
+        event.sessionExpiresAt &&
+        Date.parse(event.sessionExpiresAt) === Date.parse(current)
+      )
+        void this.renew(this.lifetime.epoch, current).catch(this.ports.report);
+      return;
+    }
     clearTimeout(this.lifetime.timer);
     if (
       event.status === "revoked" ||

--- a/packages/sdk/src/local-model-bridge/types.ts
+++ b/packages/sdk/src/local-model-bridge/types.ts
@@ -73,6 +73,8 @@ export interface LocalBridgeNativeEvent {
   generation: number;
   status: LocalBridgeStatus;
   sessionExpiresAt?: string;
+  /** The native session is two minutes from expiry and wants a fresh ticket. */
+  renewalDue?: boolean;
 }
 export interface LocalBridgeNativePort {
   legacyCandidate(identity: LocalBridgeIdentity): Promise<{


### PR DESCRIPTION
## Symptom

On 0.6.21 with the bridge active in prod, a connected local model drops every 10 minutes whenever the desktop sits idle: Sentry HOUSTON-APP-5E6/5DZ/5DY/5E4 ("Local model connection failed"), a toast per drop, and chats sent right after a drop fail with `bridge_offline`. Gateway timeline for one desktop overnight: `connect` closes after 599 s, then `POST /sessions` with the old generation answers 409 `stale_session`, then a fresh session and reconnect. 39 such cycles in 11 hours, 134 inference calls answered 503 in the gaps.

## Cause

Renewal was scheduled only by a `setTimeout` in the webview (`armRenewal`, 8 minutes into a 10-minute session). macOS suspends WKWebView timers while the app idles in the background (App Nap), so the timer never fired; the native session's own expiry then emitted an event that woke the webview, whose late renewal ran 100 ms after the close and hit the 409. The SDK renews correctly in isolation (added a 5-cycle check while diagnosing); the clock it depended on was the problem. Renewals only survived while the user was actively using the app.

## Fix

- `crates/local-model-bridge`: the session loop emits `BridgeStatus::RenewalDue { sessionExpiresAt }` two minutes before expiry, re-armed after every `renewed`. Tokio timers keep running while the webview sleeps.
- Tauri shell: the status payload carries `renewalDue: true` for that notice (omitted otherwise).
- SDK: `controller.event` renews on the notice; `renew` is fenced by the expiry it targets, so the JS timer and the native notice never renew the same session twice.

## Tests

- crate `tests/transport.rs`: `renewal_due_fires_before_expiry_and_rearms_after_renewal` (12 pass, clippy clean).
- SDK `controller.test.ts`: a renewal-due notice renews without the timer, a repeated notice for the renewed session is ignored, the timer still fires for the renewed session (51 pass).
- `cargo check` on the shell, `pnpm typecheck`, app unit tests (4278 pass).

Not in this PR: the second desktop looping every 20 s on `model_unavailable` for a shared team bridge (its local server does not list `gemma4:26b`), which reports each attempt; and the post-sleep 409 which recovers only through the native offline event.