### PR TITLE
fix(shell): type download save/reveal OS states instead of raw errors (PRODUCT-1732)

### DIFF
--- a/app/src-tauri/src/commands/file_failure.rs
+++ b/app/src-tauri/src/commands/file_failure.rs
@@ -1,0 +1,152 @@
+//! The typed failure the shell's file commands (`save_file.rs`, the reveal
+//! in `os.rs`, `portable.rs`) reject with, and the write helper that keeps
+//! a locked destination from failing at all.
+//!
+//! Before PRODUCT-1732 these commands rejected with the raw OS string, in
+//! the OS language ("El proceso no tiene acceso al archivo porque está
+//! siendo utilizado por otro proceso. (os error 32)"), and the frontend
+//! filed every one as a Sentry bug. They are user states with a remedy:
+//! the destination is open in Excel, the folder is protected, the disk is
+//! full. The frontend classifies `kind` (`app/src/lib/file-op-failure.ts`)
+//! into authored expected-state copy; only `other` is still reported.
+
+use serde::Serialize;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileOpFailureKind {
+    /// Windows sharing violation: another program holds the file open.
+    Locked,
+    /// The OS refused the path (protected folder, read-only file, a policy
+    /// that blocks spawning Explorer).
+    Permission,
+    DiskFull,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileOpFailure {
+    pub kind: FileOpFailureKind,
+    /// The raw diagnostic, still in the OS language; it reaches the
+    /// frontend log and, for `Other`, Sentry. Never shown to the user.
+    pub message: String,
+}
+
+impl FileOpFailure {
+    pub fn other(message: impl Into<String>) -> Self {
+        Self {
+            kind: FileOpFailureKind::Other,
+            message: message.into(),
+        }
+    }
+
+    pub fn from_io(context: &str, err: &io::Error) -> Self {
+        Self {
+            kind: classify(err),
+            message: format!("{context}: {err}"),
+        }
+    }
+}
+
+// ERROR_SHARING_VIOLATION / ERROR_LOCK_VIOLATION: only Windows locks a file
+// against other writers while it is open. Unix code 32 is EPIPE.
+#[cfg(windows)]
+const SHARING_CODES: &[i32] = &[32, 33];
+#[cfg(not(windows))]
+const SHARING_CODES: &[i32] = &[];
+
+fn classify(err: &io::Error) -> FileOpFailureKind {
+    if err
+        .raw_os_error()
+        .is_some_and(|c| SHARING_CODES.contains(&c))
+    {
+        return FileOpFailureKind::Locked;
+    }
+    match err.kind() {
+        io::ErrorKind::PermissionDenied => FileOpFailureKind::Permission,
+        io::ErrorKind::StorageFull => FileOpFailureKind::DiskFull,
+        _ => FileOpFailureKind::Other,
+    }
+}
+
+/// The first `name (n).ext` sibling of `target` that does not exist yet,
+/// the way a browser download dedupes. `target` itself when it is free.
+pub fn free_sibling(target: &Path) -> PathBuf {
+    if !target.exists() {
+        return target.to_path_buf();
+    }
+    let dir = target.parent().map(Path::to_path_buf).unwrap_or_default();
+    let name = target
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "download".to_string());
+    let (stem, ext) = match name.rsplit_once('.') {
+        Some((s, e)) if !s.is_empty() => (s.to_string(), format!(".{e}")),
+        _ => (name.clone(), String::new()),
+    };
+    (2u32..)
+        .map(|n| dir.join(format!("{stem} ({n}){ext}")))
+        .find(|p| !p.exists())
+        .expect("some free filename exists")
+}
+
+/// Where a write actually landed. `renamed_from` is the original file name
+/// when the destination was locked and the bytes went to a free sibling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WrittenFile {
+    pub path: String,
+    pub file_name: String,
+    pub renamed_from: Option<String>,
+}
+
+fn file_name_of(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// Write `bytes` to `target`; when the target exists and the OS refuses to
+/// overwrite it (open in another program, read-only), write to the next free
+/// sibling instead and say so. A protected FOLDER still fails, typed.
+///
+/// The dialog already asked the user to confirm the overwrite, so the first
+/// attempt is the path they chose; only the OS refusal changes the name.
+pub async fn write_with_fallback(
+    target: &Path,
+    bytes: &[u8],
+) -> Result<WrittenFile, FileOpFailure> {
+    let first = match tokio::fs::write(target, bytes).await {
+        Ok(()) => {
+            return Ok(WrittenFile {
+                path: target.to_string_lossy().into_owned(),
+                file_name: file_name_of(target),
+                renamed_from: None,
+            });
+        }
+        Err(err) => err,
+    };
+    let refused_existing = match classify(&first) {
+        FileOpFailureKind::Locked => true,
+        FileOpFailureKind::Permission => target.exists(),
+        _ => false,
+    };
+    if !refused_existing {
+        return Err(FileOpFailure::from_io("Failed to save file", &first));
+    }
+    let sibling = free_sibling(target);
+    tokio::fs::write(&sibling, bytes).await.map_err(|err| {
+        FileOpFailure::from_io("Failed to save file (retry beside a locked file)", &err)
+    })?;
+    Ok(WrittenFile {
+        path: sibling.to_string_lossy().into_owned(),
+        file_name: file_name_of(&sibling),
+        renamed_from: Some(file_name_of(target)),
+    })
+}
+
+#[cfg(test)]
+#[path = "file_failure_tests.rs"]
+mod tests;

--- a/app/src-tauri/src/commands/file_failure_tests.rs
+++ b/app/src-tauri/src/commands/file_failure_tests.rs
@@ -1,0 +1,118 @@
+use super::{classify, free_sibling, write_with_fallback, FileOpFailureKind};
+use std::io;
+
+fn tmp_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "houston-file-failure-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn free_sibling_counts_up_past_taken_names() {
+    let dir = tmp_dir("sibling");
+    let target = dir.join("report.xlsx");
+    assert_eq!(free_sibling(&target), target);
+    std::fs::write(&target, b"x").unwrap();
+    assert_eq!(free_sibling(&target), dir.join("report (2).xlsx"));
+    std::fs::write(dir.join("report (2).xlsx"), b"x").unwrap();
+    assert_eq!(free_sibling(&target), dir.join("report (3).xlsx"));
+    // A dotfile has no stem to split; the counter goes after the whole name.
+    let dotfile = dir.join(".env");
+    std::fs::write(&dotfile, b"x").unwrap();
+    assert_eq!(free_sibling(&dotfile), dir.join(".env (2)"));
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn permission_and_disk_full_classify_by_kind() {
+    let denied = io::Error::new(io::ErrorKind::PermissionDenied, "Access is denied.");
+    assert_eq!(classify(&denied), FileOpFailureKind::Permission);
+    let full = io::Error::new(io::ErrorKind::StorageFull, "no space left on device");
+    assert_eq!(classify(&full), FileOpFailureKind::DiskFull);
+    let other = io::Error::new(io::ErrorKind::NotFound, "gone");
+    assert_eq!(classify(&other), FileOpFailureKind::Other);
+}
+
+#[cfg(windows)]
+#[test]
+fn sharing_violation_is_locked() {
+    // The HOUSTON-APP-53A shape: the destination is open in Excel.
+    assert_eq!(
+        classify(&io::Error::from_raw_os_error(32)),
+        FileOpFailureKind::Locked
+    );
+    assert_eq!(
+        classify(&io::Error::from_raw_os_error(33)),
+        FileOpFailureKind::Locked
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn epipe_is_not_a_lock_off_windows() {
+    assert_ne!(
+        classify(&io::Error::from_raw_os_error(32)),
+        FileOpFailureKind::Locked
+    );
+}
+
+#[tokio::test]
+async fn plain_write_reports_the_chosen_path() {
+    let dir = tmp_dir("plain");
+    let target = dir.join("notes.txt");
+    let written = write_with_fallback(&target, b"hello").await.unwrap();
+    assert_eq!(written.path, target.to_string_lossy());
+    assert_eq!(written.file_name, "notes.txt");
+    assert_eq!(written.renamed_from, None);
+    assert_eq!(std::fs::read(&target).unwrap(), b"hello");
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn refused_existing_file_lands_beside_it() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tmp_dir("locked");
+    let target = dir.join("report.xlsx");
+    std::fs::write(&target, b"old").unwrap();
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o444)).unwrap();
+    if std::fs::write(&target, b"old").is_ok() {
+        return; // root ignores file modes; the refusal can't be staged
+    }
+    let written = write_with_fallback(&target, b"new").await.unwrap();
+    assert_eq!(written.file_name, "report (2).xlsx");
+    assert_eq!(written.renamed_from.as_deref(), Some("report.xlsx"));
+    assert_eq!(std::fs::read(dir.join("report (2).xlsx")).unwrap(), b"new");
+    assert_eq!(std::fs::read(&target).unwrap(), b"old");
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn protected_folder_fails_typed_instead_of_renaming() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tmp_dir("folder");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+    if std::fs::write(dir.join("probe"), b"x").is_ok() {
+        return; // root ignores directory modes
+    }
+    let err = write_with_fallback(&dir.join("report.xlsx"), b"new")
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind, FileOpFailureKind::Permission);
+    assert!(
+        err.message.starts_with("Failed to save file: "),
+        "{}",
+        err.message
+    );
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::remove_dir_all(dir).unwrap();
+}

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 pub mod diagnostics;
 mod dialogs;
+pub mod file_failure;
 pub mod migration;
 pub mod os;
 pub mod portable;

--- a/app/src-tauri/src/commands/os.rs
+++ b/app/src-tauri/src/commands/os.rs
@@ -11,6 +11,8 @@ use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::process::Command;
 
+use super::file_failure::FileOpFailure;
+
 fn expand(p: &str) -> PathBuf {
     super::expand_tilde(&PathBuf::from(p))
 }
@@ -238,18 +240,25 @@ pub async fn reveal_agent(agent_path: String) -> Result<(), String> {
 /// that produce a file outside any agent root (e.g. the portable-agent
 /// exporter writes a `.houstonagent` wherever the user picked in the save
 /// dialog — Desktop, Downloads, USB drive, …).
+///
+/// Rejects typed (`file_failure`): Explorer refusing to launch ("Access is
+/// denied. (os error 5)", HOUSTON-APP-5C6) is a `permission` state the user
+/// can work around, not a bug to report (PRODUCT-1732).
 #[tauri::command(rename_all = "snake_case")]
-pub async fn reveal_path(path: String) -> Result<(), String> {
+pub async fn reveal_path(path: String) -> Result<(), FileOpFailure> {
     let target = expand(&path);
     if !target.exists() {
-        return Err(format!("Path does not exist: {}", target.display()));
+        return Err(FileOpFailure::other(format!(
+            "Path does not exist: {}",
+            target.display()
+        )));
     }
-    reveal_in_file_manager(&target).map_err(|e| format!("Failed to reveal path: {e}"))
+    reveal_in_file_manager(&target).map_err(|e| FileOpFailure::from_io("Failed to reveal path", &e))
 }
 
 /// Open the OS file manager with the given path selected (Finder reveal /
 /// Explorer /select / xdg-open on parent dir).
-fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
+fn reveal_in_file_manager(path: &Path) -> Result<(), std::io::Error> {
     #[cfg(target_os = "macos")]
     {
         std::process::Command::new("open")
@@ -257,7 +266,6 @@ fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
             .arg(path)
             .spawn()
             .map(|_| ())
-            .map_err(|e| e.to_string())
     }
     #[cfg(target_os = "windows")]
     {
@@ -272,14 +280,32 @@ fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
         //      the leading quote makes it ignore the verb and open the
         //      default folder (Documents). Use raw_arg so the cmdline goes
         //      out exactly as `/select,C:\path with space\file.txt`.
+        //   3. Some machines refuse to spawn explorer.exe from Houston at all
+        //      ("Access is denied. (os error 5)": an app-control policy, or
+        //      an update-launched instance still under the installer's
+        //      token). The shell verb goes through the running Explorer
+        //      instead of a new process, so opening the parent folder that
+        //      way still gets the user next to the file. The original error
+        //      is what gets reported when both fail.
         use std::os::windows::process::CommandExt;
         let native = path.to_string_lossy().replace('/', "\\");
         let select_arg = format!("/select,{native}");
-        std::process::Command::new("explorer")
+        let spawned = std::process::Command::new("explorer")
             .raw_arg(&select_arg)
             .spawn()
-            .map(|_| ())
-            .map_err(|e| e.to_string())
+            .map(|_| ());
+        let Err(spawn_err) = spawned else {
+            return Ok(());
+        };
+        let parent = path
+            .parent()
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('/', "\\");
+        match spawn_default_open(&parent) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(spawn_err),
+        }
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
@@ -289,6 +315,6 @@ fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
         let mut cmd = std::process::Command::new("xdg-open");
         cmd.arg(parent);
         crate::appimage_env::sanitize_std_command(&mut cmd);
-        cmd.spawn().map(|_| ()).map_err(|e| e.to_string())
+        cmd.spawn().map(|_| ())
     }
 }

--- a/app/src-tauri/src/commands/portable.rs
+++ b/app/src-tauri/src/commands/portable.rs
@@ -10,25 +10,26 @@
 use std::path::PathBuf;
 
 use super::dialogs::{open_dialog, save_dialog};
+use super::file_failure::{write_with_fallback, FileOpFailure, WrittenFile};
 
 const WIN_FILTER: &str = "Houston Agent (*.houstonagent)|*.houstonagent|All files (*.*)|*.*";
 
 /// Show a save dialog and write the provided bytes to the chosen path.
-/// Returns the path the user picked, or `None` if cancelled.
+/// Returns where the file landed (a free sibling name when the chosen file
+/// was locked, see `file_failure`), or `None` if cancelled.
 #[tauri::command(rename_all = "snake_case")]
 pub async fn save_portable_agent(
     default_name: String,
     bytes: Vec<u8>,
-) -> Result<Option<String>, String> {
-    let Some(path) = save_dialog("Save shared agent", &default_name, Some(WIN_FILTER)).await?
+) -> Result<Option<WrittenFile>, FileOpFailure> {
+    let Some(path) = save_dialog("Save shared agent", &default_name, Some(WIN_FILTER))
+        .await
+        .map_err(FileOpFailure::other)?
     else {
         return Ok(None);
     };
     let target = PathBuf::from(&path);
-    tokio::fs::write(&target, bytes)
-        .await
-        .map_err(|e| format!("Failed to save file: {e}"))?;
-    Ok(Some(path))
+    write_with_fallback(&target, &bytes).await.map(Some)
 }
 
 /// Show an open dialog and return the bytes of the chosen file. Returns

--- a/app/src-tauri/src/commands/save_file.rs
+++ b/app/src-tauri/src/commands/save_file.rs
@@ -12,10 +12,12 @@
 //! the percent-encoded `x-download-name` request header.
 
 use percent_encoding::percent_decode_str;
+use std::path::PathBuf;
 use tauri::ipc::{InvokeBody, Request};
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use super::dialogs::save_dialog;
+use super::file_failure::{write_with_fallback, FileOpFailure, WrittenFile};
 
 /// The suggested filename, decoded from the `x-download-name` header and
 /// stripped of path separators so it can't steer the dialog's directory.
@@ -34,54 +36,45 @@ fn requested_name(request: &Request<'_>) -> String {
     }
 }
 
-/// Pick a save destination and write the payload there. Returns the chosen
-/// path, or `None` when the user cancelled the dialog.
+/// Pick a save destination and write the payload there. Returns where the
+/// file landed, or `None` when the user cancelled the dialog.
+///
+/// A destination the OS refuses to overwrite (open in Excel: Windows sharing
+/// violation, HOUSTON-APP-53A) is written beside under a free `name (2).ext`
+/// and reported as `renamed_from`; the remaining failures are typed so the
+/// frontend can tell a protected folder from a bug (PRODUCT-1732).
 ///
 /// Linux has no dialog helper yet (mirrors the portable share flow); there we
 /// write straight into the OS download directory under a collision-free name,
 /// which matches what a browser download would do anyway.
 #[tauri::command]
-pub async fn save_download(request: Request<'_>) -> Result<Option<String>, String> {
+pub async fn save_download(request: Request<'_>) -> Result<Option<WrittenFile>, FileOpFailure> {
     let InvokeBody::Raw(bytes) = request.body() else {
-        return Err("save_download expects a raw byte payload".into());
+        return Err(FileOpFailure::other(
+            "save_download expects a raw byte payload",
+        ));
     };
     let name = requested_name(&request);
     let Some(path) = pick_destination(&name).await? else {
         return Ok(None);
     };
-    tokio::fs::write(&path, bytes)
-        .await
-        .map_err(|e| format!("Failed to save file: {e}"))?;
-    Ok(Some(path))
+    write_with_fallback(&path, bytes).await.map(Some)
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-async fn pick_destination(name: &str) -> Result<Option<String>, String> {
-    save_dialog("Save file", name, None).await
+async fn pick_destination(name: &str) -> Result<Option<PathBuf>, FileOpFailure> {
+    let picked = save_dialog("Save file", name, None)
+        .await
+        .map_err(FileOpFailure::other)?;
+    Ok(picked.map(PathBuf::from))
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-async fn pick_destination(name: &str) -> Result<Option<String>, String> {
+async fn pick_destination(name: &str) -> Result<Option<PathBuf>, FileOpFailure> {
     // No native dialog on this platform — save into ~/Downloads like a
     // browser would, deduplicating "name.ext" → "name (2).ext".
     let dir = dirs::download_dir()
         .or_else(dirs::home_dir)
-        .ok_or_else(|| "Could not resolve a download directory".to_string())?;
-    Ok(Some(dedupe_path(&dir, name).to_string_lossy().into_owned()))
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn dedupe_path(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
-    let first = dir.join(name);
-    if !first.exists() {
-        return first;
-    }
-    let (stem, ext) = match name.rsplit_once('.') {
-        Some((s, e)) if !s.is_empty() => (s.to_string(), format!(".{e}")),
-        _ => (name.to_string(), String::new()),
-    };
-    (2u32..)
-        .map(|n| dir.join(format!("{stem} ({n}){ext}")))
-        .find(|p| !p.exists())
-        .expect("some free filename exists")
+        .ok_or_else(|| FileOpFailure::other("Could not resolve a download directory"))?;
+    Ok(Some(super::file_failure::free_sibling(&dir.join(name))))
 }

--- a/app/src/components/portable/export-wizard.tsx
+++ b/app/src/components/portable/export-wizard.tsx
@@ -25,8 +25,11 @@ import { analytics } from "../../lib/analytics";
 import { signInWithGoogle } from "../../lib/auth";
 import { getEngine } from "../../lib/engine";
 import { genericErrorDescription } from "../../lib/error-report";
+import { showExpectedStateToast } from "../../lib/error-toast";
+import { planFileOpFailure } from "../../lib/file-op-failure";
 import { isIdentityConfigured } from "../../lib/identity";
-import { osRevealPath } from "../../lib/os-bridge";
+import { logger } from "../../lib/logger";
+import { osRevealPath, type WrittenFile } from "../../lib/os-bridge";
 import {
   buildAnonymizeOverrides,
   buildStorePublishRequest,
@@ -186,11 +189,12 @@ export function ExportAgentWizard() {
       });
       const filename = `${agent.name.replace(/[^a-z0-9._-]+/gi, "-")}.houstonagent`;
       const u8 = new Uint8Array(bytes);
-      const savedPath = await invoke<string | null>("save_portable_agent", {
+      const saved = await invoke<WrittenFile | null>("save_portable_agent", {
         default_name: filename,
         bytes: Array.from(u8),
       });
-      if (savedPath) {
+      if (saved) {
+        const savedPath = saved.path;
         analytics.track("agent_shared", {
           agent_slug: agent.id,
           source: "export_wizard",
@@ -202,24 +206,46 @@ export function ExportAgentWizard() {
           action: {
             label: t("export.toasts.revealAction"),
             onClick: () => {
-              void osRevealPath(savedPath).catch((err) =>
+              void osRevealPath(savedPath).catch((err) => {
+                const plan = planFileOpFailure("reveal", err);
+                logger.error(
+                  `[export:reveal] ${plan.failure.kind}: ${plan.failure.message}`,
+                );
+                if (plan.surface === "expected") {
+                  showExpectedStateToast(
+                    t("export.errors.revealFailed"),
+                    t(`export.errors.${plan.copy}`),
+                  );
+                  return;
+                }
                 addToast({
                   variant: "error",
                   title: t("export.errors.revealFailed"),
                   description: genericErrorDescription("export_reveal", err),
-                }),
-              );
+                });
+              });
             },
           },
         });
         handleClose();
       }
     } catch (err) {
-      addToast({
-        variant: "error",
-        title: t("export.errors.saveFailed"),
-        description: genericErrorDescription("export_save", err),
-      });
+      const plan = planFileOpFailure("save", err);
+      logger.error(
+        `[export:save] ${plan.failure.kind}: ${plan.failure.message}`,
+      );
+      if (plan.surface === "expected") {
+        showExpectedStateToast(
+          t("export.errors.saveFailed"),
+          t(`export.errors.${plan.copy}`),
+        );
+      } else {
+        addToast({
+          variant: "error",
+          title: t("export.errors.saveFailed"),
+          description: genericErrorDescription("export_save", err),
+        });
+      }
     } finally {
       setSaving(false);
     }

--- a/app/src/hooks/use-save-download.ts
+++ b/app/src/hooks/use-save-download.ts
@@ -1,6 +1,8 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { genericErrorDescription } from "../lib/error-report";
+import { showExpectedStateToast } from "../lib/error-toast";
+import { planFileOpFailure } from "../lib/file-op-failure";
 import { logger } from "../lib/logger";
 import { osRevealPath } from "../lib/os-bridge";
 import { saveBlob } from "../lib/save-blob";
@@ -11,8 +13,13 @@ import { useUIStore } from "../stores/ui";
  *
  * Browser builds stay silent on success (the browser shows its own download
  * UI); the desktop shell writes the file natively and gets a "Saved" toast
- * with a reveal action. Never rejects — a failure surfaces as an error toast
- * (beta policy: no silent failures), a cancelled save dialog stays quiet.
+ * with a reveal action. Never rejects — a failure surfaces as a toast (beta
+ * policy: no silent failures), a cancelled save dialog stays quiet.
+ *
+ * The shell rejects typed (`file-op-failure.ts`): the destination open in
+ * another program, a protected folder, a full disk are states the user can
+ * fix and read as informational copy with no report; only `other` is a bug
+ * (PRODUCT-1732). The raw OS diagnostic always reaches the frontend log.
  */
 export function useSaveDownload(): (name: string, blob: Blob) => Promise<void> {
   const { t } = useTranslation("agents");
@@ -26,22 +33,50 @@ export function useSaveDownload(): (name: string, blob: Blob) => Promise<void> {
         addToast({
           variant: "success",
           title: t("files.toasts.savedTitle"),
-          description: t("files.toasts.savedDescription", { name }),
+          description:
+            result.renamedFrom === null
+              ? t("files.toasts.savedDescription", { name: result.fileName })
+              : t("files.toasts.savedRenamedDescription", {
+                  name: result.fileName,
+                  original: result.renamedFrom,
+                }),
           action: {
             label: t("files.toasts.revealAction"),
             onClick: () => {
-              void osRevealPath(path).catch((err) =>
+              void osRevealPath(path).catch((err) => {
+                const plan = planFileOpFailure("reveal", err);
+                logger.error(
+                  `[files:reveal-download] ${plan.failure.kind}: ${plan.failure.message}`,
+                );
+                if (plan.surface === "expected") {
+                  showExpectedStateToast(
+                    t("files.toasts.revealFailed"),
+                    t(`files.toasts.${plan.copy}`),
+                  );
+                  return;
+                }
                 addToast({
                   variant: "error",
                   title: t("files.toasts.revealFailed"),
                   description: genericErrorDescription("reveal_download", err),
-                }),
-              );
+                });
+              });
             },
           },
         });
       } catch (err) {
-        logger.error(`[files:save-download] ${String(err)}`, name);
+        const plan = planFileOpFailure("save", err);
+        logger.error(
+          `[files:save-download] ${plan.failure.kind}: ${plan.failure.message}`,
+          name,
+        );
+        if (plan.surface === "expected") {
+          showExpectedStateToast(
+            t("files.toasts.saveFailedTitle"),
+            t(`files.toasts.${plan.copy}`),
+          );
+          return;
+        }
         addToast({
           variant: "error",
           title: t("files.toasts.saveFailedTitle"),
@@ -49,6 +84,6 @@ export function useSaveDownload(): (name: string, blob: Blob) => Promise<void> {
         });
       }
     },
-    [t, addToast],
+    [addToast, t],
   );
 }

--- a/app/src/lib/file-op-failure.ts
+++ b/app/src/lib/file-op-failure.ts
@@ -1,0 +1,84 @@
+// The typed failure the shell's file commands reject with
+// (app/src-tauri/src/commands/file_failure.rs) and the one decision every
+// caller makes with it: is this a state the user can act on, or a bug to
+// report? Dependency-free so it is node-testable directly
+// (app/tests/file-op-failure.test.ts).
+
+export type FileOpFailureKind = "locked" | "permission" | "disk_full" | "other";
+
+export interface FileOpFailure {
+  kind: FileOpFailureKind;
+  /** The raw OS diagnostic, in the OS language. Log it, never show it. */
+  message: string;
+}
+
+const KINDS: ReadonlySet<string> = new Set([
+  "locked",
+  "permission",
+  "disk_full",
+  "other",
+]);
+
+/**
+ * Read a shell rejection into a `FileOpFailure`. A plain string (an older
+ * command, a dialog that could not open) or a thrown `Error` is `other`, so
+ * the caller never branches on the raw shape.
+ */
+export function toFileOpFailure(err: unknown): FileOpFailure {
+  if (err !== null && typeof err === "object" && "kind" in err) {
+    const raw = err as Record<string, unknown>;
+    if (typeof raw.kind === "string" && KINDS.has(raw.kind)) {
+      return {
+        kind: raw.kind as FileOpFailureKind,
+        message: typeof raw.message === "string" ? raw.message : "",
+      };
+    }
+  }
+  return {
+    kind: "other",
+    message: err instanceof Error ? err.message : String(err),
+  };
+}
+
+export type FileOp = "save" | "reveal";
+
+/** The authored expected-state copy a failure maps to, keyed the same way in
+ *  every locale namespace that carries file toasts. */
+export type FileOpStateCopy =
+  | "saveLocked"
+  | "savePermission"
+  | "saveDiskFull"
+  | "revealPermission";
+
+export type FileOpFailurePlan =
+  | { surface: "expected"; copy: FileOpStateCopy; failure: FileOpFailure }
+  | { surface: "report"; failure: FileOpFailure };
+
+/**
+ * Where a failed save / reveal goes: an informational toast with authored
+ * copy for the OS states a user can fix (the destination is open in another
+ * program, the folder is protected, the disk is full: HOUSTON-APP-53A and
+ * -5C6 were these, filed as bugs in the OS language), or the report path
+ * for everything else. A reveal has one expected state: Explorer refusing
+ * to launch. A locked or full-disk reveal is not a thing, so it reports.
+ */
+export function planFileOpFailure(op: FileOp, err: unknown): FileOpFailurePlan {
+  const failure = toFileOpFailure(err);
+  const copy = expectedCopy(op, failure.kind);
+  return copy === null
+    ? { surface: "report", failure }
+    : { surface: "expected", copy, failure };
+}
+
+function expectedCopy(
+  op: FileOp,
+  kind: FileOpFailureKind,
+): FileOpStateCopy | null {
+  if (op === "save") {
+    if (kind === "locked") return "saveLocked";
+    if (kind === "permission") return "savePermission";
+    if (kind === "disk_full") return "saveDiskFull";
+    return null;
+  }
+  return kind === "permission" ? "revealPermission" : null;
+}

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -290,10 +290,20 @@ export function osRevealPath(path: string): Promise<void> {
 export function osSaveDownload(
   fileName: string,
   bytes: Uint8Array,
-): Promise<string | null> {
-  return invoke<string | null>("save_download", bytes, {
+): Promise<WrittenFile | null> {
+  return invoke<WrittenFile | null>("save_download", bytes, {
     headers: { "x-download-name": encodeURIComponent(fileName) },
   });
+}
+
+/** Where a shell save landed. `renamedFrom` is the name the user chose when
+ *  that file was open in another program and the bytes went to a free
+ *  `name (2).ext` beside it instead (PRODUCT-1732). The save commands reject
+ *  with a `FileOpFailure` (`file-op-failure.ts`), never a raw OS string. */
+export interface WrittenFile {
+  path: string;
+  fileName: string;
+  renamedFrom: string | null;
 }
 
 /** Open an agent-relative file with the user's default application. */

--- a/app/src/lib/save-blob.ts
+++ b/app/src/lib/save-blob.ts
@@ -2,7 +2,16 @@ import { isTauri } from "@tauri-apps/api/core";
 import { osSaveDownload } from "./os-bridge";
 
 export type SaveBlobResult =
-  | { kind: "saved"; path: string | null }
+  | {
+      kind: "saved";
+      /** Non-null only on the native path; browsers manage their own
+       *  download location. */
+      path: string | null;
+      /** The name on disk: the requested one, or the free sibling the shell
+       *  fell back to when the requested file was open in another program. */
+      fileName: string;
+      renamedFrom: string | null;
+    }
   | { kind: "cancelled" };
 
 /**
@@ -20,8 +29,10 @@ export async function saveBlob(
 ): Promise<SaveBlobResult> {
   if (isTauri()) {
     const bytes = new Uint8Array(await blob.arrayBuffer());
-    const path = await osSaveDownload(name, bytes);
-    return path === null ? { kind: "cancelled" } : { kind: "saved", path };
+    const written = await osSaveDownload(name, bytes);
+    return written === null
+      ? { kind: "cancelled" }
+      : { kind: "saved", ...written };
   }
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -32,5 +43,5 @@ export async function saveBlob(
   a.remove();
   // Revoke once the download has had time to start.
   setTimeout(() => URL.revokeObjectURL(url), 10_000);
-  return { kind: "saved", path: null };
+  return { kind: "saved", path: null, fileName: name, renamedFrom: null };
 }

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -199,7 +199,12 @@
       "revealAction": "Show in File Manager",
       "revealFailed": "Couldn’t show the file",
       "saveFailedTitle": "Couldn’t save the file",
-      "openFailedTitle": "Couldn’t open the file"
+      "openFailedTitle": "Couldn’t open the file",
+      "savedRenamedDescription": "Saved as {{name}} because {{original}} is open in another program.",
+      "saveLocked": "That file is open in another program. Close it there and download again.",
+      "savePermission": "Houston isn't allowed to save into that folder. Choose another folder, like Downloads.",
+      "saveDiskFull": "There isn't enough free space on this computer to save the file.",
+      "revealPermission": "Houston isn't allowed to open that folder on this computer. Look for the file where you saved it."
     },
     "modifiedToday": "Today"
   },

--- a/app/src/locales/en/portable.json
+++ b/app/src/locales/en/portable.json
@@ -66,7 +66,11 @@
       "anonymizeFailed": "Anonymize step failed.",
       "saveFailed": "Could not save the file.",
       "noPreview": "No preview available.",
-      "revealFailed": "Could not open that folder."
+      "revealFailed": "Could not open that folder.",
+      "saveLocked": "That file is open in another program. Close it there and save again.",
+      "savePermission": "Houston isn't allowed to save into that folder. Choose another folder, like Downloads.",
+      "saveDiskFull": "There isn't enough free space on this computer to save the file.",
+      "revealPermission": "Houston isn't allowed to open that folder on this computer. Look for the file where you saved it."
     },
     "toasts": {
       "savedTitle": "File saved",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -199,7 +199,12 @@
       "revealAction": "Mostrar en el Explorador de Archivos",
       "revealFailed": "No se pudo mostrar el archivo",
       "saveFailedTitle": "No se pudo guardar el archivo",
-      "openFailedTitle": "No se pudo abrir el archivo"
+      "openFailedTitle": "No se pudo abrir el archivo",
+      "savedRenamedDescription": "Se guardó como {{name}} porque {{original}} está abierto en otro programa.",
+      "saveLocked": "Ese archivo está abierto en otro programa. Ciérralo ahí y vuelve a descargarlo.",
+      "savePermission": "Houston no tiene permiso para guardar en esa carpeta. Elige otra carpeta, como Descargas.",
+      "saveDiskFull": "No hay suficiente espacio libre en este computador para guardar el archivo.",
+      "revealPermission": "Houston no tiene permiso para abrir esa carpeta en este computador. Busca el archivo donde lo guardaste."
     },
     "modifiedToday": "Hoy"
   },

--- a/app/src/locales/es/portable.json
+++ b/app/src/locales/es/portable.json
@@ -66,7 +66,11 @@
       "anonymizeFailed": "Falló la anonimización.",
       "saveFailed": "No pude guardar el archivo.",
       "noPreview": "No hay vista previa.",
-      "revealFailed": "No pude abrir esa carpeta."
+      "revealFailed": "No pude abrir esa carpeta.",
+      "saveLocked": "Ese archivo está abierto en otro programa. Ciérralo ahí y vuelve a guardarlo.",
+      "savePermission": "Houston no tiene permiso para guardar en esa carpeta. Elige otra carpeta, como Descargas.",
+      "saveDiskFull": "No hay suficiente espacio libre en este computador para guardar el archivo.",
+      "revealPermission": "Houston no tiene permiso para abrir esa carpeta en este computador. Busca el archivo donde lo guardaste."
     },
     "toasts": {
       "savedTitle": "Archivo guardado",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -199,7 +199,12 @@
       "revealAction": "Mostrar no Explorador de Arquivos",
       "revealFailed": "Não foi possível mostrar o arquivo",
       "saveFailedTitle": "Não foi possível salvar o arquivo",
-      "openFailedTitle": "Não foi possível abrir o arquivo"
+      "openFailedTitle": "Não foi possível abrir o arquivo",
+      "savedRenamedDescription": "Salvo como {{name}} porque {{original}} está aberto em outro programa.",
+      "saveLocked": "Esse arquivo está aberto em outro programa. Feche-o lá e baixe de novo.",
+      "savePermission": "O Houston não tem permissão para salvar nessa pasta. Escolha outra pasta, como Downloads.",
+      "saveDiskFull": "Não há espaço livre suficiente neste computador para salvar o arquivo.",
+      "revealPermission": "O Houston não tem permissão para abrir essa pasta neste computador. Procure o arquivo onde você o salvou."
     },
     "modifiedToday": "Hoje"
   },

--- a/app/src/locales/pt/portable.json
+++ b/app/src/locales/pt/portable.json
@@ -66,7 +66,11 @@
       "anonymizeFailed": "Falha na anonimização.",
       "saveFailed": "Não consegui salvar o arquivo.",
       "noPreview": "Sem prévia.",
-      "revealFailed": "Não consegui abrir essa pasta."
+      "revealFailed": "Não consegui abrir essa pasta.",
+      "saveLocked": "Esse arquivo está aberto em outro programa. Feche-o lá e salve de novo.",
+      "savePermission": "O Houston não tem permissão para salvar nessa pasta. Escolha outra pasta, como Downloads.",
+      "saveDiskFull": "Não há espaço livre suficiente neste computador para salvar o arquivo.",
+      "revealPermission": "O Houston não tem permissão para abrir essa pasta neste computador. Procure o arquivo onde você o salvou."
     },
     "toasts": {
       "savedTitle": "Arquivo salvo",

--- a/app/tests/file-op-failure.test.ts
+++ b/app/tests/file-op-failure.test.ts
@@ -1,0 +1,108 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  planFileOpFailure,
+  toFileOpFailure,
+} from "../src/lib/file-op-failure.ts";
+
+// PRODUCT-1732: the shell's save / reveal commands reject with a typed
+// failure; the OS states a user can fix become informational copy with no
+// Sentry report, and only `other` still goes down the report path.
+describe("toFileOpFailure", () => {
+  it("reads the shell's typed rejection", () => {
+    deepStrictEqual(
+      toFileOpFailure({
+        kind: "locked",
+        message:
+          "Failed to save file: El proceso no tiene acceso al archivo porque está siendo utilizado por otro proceso. (os error 32)",
+      }),
+      {
+        kind: "locked",
+        message:
+          "Failed to save file: El proceso no tiene acceso al archivo porque está siendo utilizado por otro proceso. (os error 32)",
+      },
+    );
+  });
+
+  it("wraps a plain string (an older command, a dialog failure) as `other`", () => {
+    deepStrictEqual(
+      toFileOpFailure("Failed to open save dialog: program not found"),
+      {
+        kind: "other",
+        message: "Failed to open save dialog: program not found",
+      },
+    );
+  });
+
+  it("wraps a thrown Error and an unknown kind as `other`", () => {
+    strictEqual(toFileOpFailure(new Error("boom")).kind, "other");
+    strictEqual(
+      toFileOpFailure({ kind: "teapot", message: "x" }).kind,
+      "other",
+    );
+  });
+});
+
+describe("planFileOpFailure", () => {
+  it("a locked save is an expected state with the locked copy", () => {
+    const plan = planFileOpFailure("save", {
+      kind: "locked",
+      message: "os error 32",
+    });
+    strictEqual(plan.surface, "expected");
+    strictEqual(plan.surface === "expected" && plan.copy, "saveLocked");
+  });
+
+  it("a protected folder and a full disk are expected save states", () => {
+    const denied = planFileOpFailure("save", {
+      kind: "permission",
+      message: "os error 5",
+    });
+    strictEqual(denied.surface === "expected" && denied.copy, "savePermission");
+    const full = planFileOpFailure("save", {
+      kind: "disk_full",
+      message: "os error 112",
+    });
+    strictEqual(full.surface === "expected" && full.copy, "saveDiskFull");
+  });
+
+  it("Explorer refusing to launch is the one expected reveal state", () => {
+    // HOUSTON-APP-5C6: "Failed to reveal path: Access is denied. (os error 5)".
+    const denied = planFileOpFailure("reveal", {
+      kind: "permission",
+      message: "os error 5",
+    });
+    strictEqual(
+      denied.surface === "expected" && denied.copy,
+      "revealPermission",
+    );
+    strictEqual(
+      planFileOpFailure("reveal", { kind: "locked", message: "" }).surface,
+      "report",
+    );
+    strictEqual(
+      planFileOpFailure("reveal", { kind: "disk_full", message: "" }).surface,
+      "report",
+    );
+  });
+
+  it("`other` and untyped rejections still report", () => {
+    strictEqual(
+      planFileOpFailure("save", { kind: "other", message: "x" }).surface,
+      "report",
+    );
+    strictEqual(planFileOpFailure("save", "raw string").surface, "report");
+    strictEqual(
+      planFileOpFailure("reveal", new Error("boom")).surface,
+      "report",
+    );
+  });
+
+  it("keeps the raw diagnostic on the plan for the frontend log", () => {
+    const plan = planFileOpFailure("save", {
+      kind: "locked",
+      message: "os error 32",
+    });
+    strictEqual(plan.failure.message, "os error 32");
+  });
+});

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -157,9 +157,10 @@ export async function invoke<T = unknown>(
           : "agent.houstonagent";
       const bytes = Array.isArray(args?.bytes) ? (args.bytes as number[]) : [];
       downloadBytes(name, bytes);
-      // Native returns the saved path; the web download has no path, so echo
-      // the filename — callers only use it for a "saved" confirmation toast.
-      return name as T;
+      // Native returns where the file landed (`WrittenFile`); the web download
+      // has no path, so echo the filename — callers only use it for a "saved"
+      // confirmation toast.
+      return { path: name, fileName: name, renamedFrom: null } as T;
     }
     case "open_portable_agent": {
       const bytes = await pickFileBytes(".houstonagent,application/zip");


### PR DESCRIPTION
Fixes PRODUCT-1732.

## Root cause

`save_download`, `save_portable_agent` and `reveal_path` rejected with the raw OS string in the OS language, and `use-save-download.ts` / the export wizard ran every rejection through `genericErrorDescription`, which logs AND reports to Sentry. Two user states filled the buckets:

- **HOUSTON-APP-53A** (33 events, 19 users, all Windows): `Failed to save file: El proceso no tiene acceso al archivo porque está siendo utilizado por otro proceso. (os error 32)`. The user confirmed overwriting a file that is open in Excel/Word; the write hit a sharing violation and failed outright.
- **HOUSTON-APP-5C6** (2 users, Windows): `Failed to reveal path: Access is denied. (os error 5)`. Windows refused to spawn `explorer.exe` from Houston.

Neither is a Houston bug, and the user saw a generic red box with no way forward.

## Fix

**Shell** (`app/src-tauri/src/commands/file_failure.rs`, new)
- Typed rejection `{ kind: locked | permission | disk_full | other, message }` (serde, snake_case), replacing the raw string on the three commands. `message` keeps the OS diagnostic for the frontend log / Sentry.
- `write_with_fallback`: when the chosen file exists and the OS refuses to overwrite it (sharing violation, read-only), the bytes go to the next free sibling (`report (2).xlsx`) and the result carries `renamedFrom`. A protected folder still fails, typed `permission`. The Linux dedupe helper moved here and is shared.
- Windows reveal: if spawning `explorer /select,` fails, fall back to opening the parent folder through the shell `open` verb (goes through the running Explorer); the original error is what gets reported when both fail.

**Frontend**
- `app/src/lib/file-op-failure.ts` (dependency-free): `toFileOpFailure` + `planFileOpFailure(op, err)` → `expected` (with a copy key) or `report`.
- `use-save-download.ts` and `export-wizard.tsx`: expected states go through `showExpectedStateToast` with authored en/es/pt copy and a `logger.error` line, no Sentry. `other` keeps the existing report path. A renamed save toasts "Saved as report (2).xlsx because report.xlsx is open in another program."
- `osSaveDownload` / `saveBlob` return the new `WrittenFile` shape; the web shim mirrors it.

## Tests
- Rust: sibling naming, kind classification (incl. the Windows-only 32/33 → `locked`), plain write, refused-existing-file retry, protected-folder typed failure (`cargo test --lib commands::file_failure`).
- Node: `app/tests/file-op-failure.test.ts` (typed parse, string/Error → `other`, each plan mapping).
- Ran: `pnpm check`, `cd app && pnpm tsgo --noEmit && pnpm check-locales && pnpm test` (4298 pass), `pnpm --filter houston-web typecheck`, `cargo check` (macOS + `--target x86_64-pc-windows-gnu`).

## Reproduce before the fix (Windows)
1. In an agent's Files tab, download `report.xlsx` and save it to Desktop.
2. Open that file in Excel and leave it open.
3. Download the same file again, pick the same path, confirm the overwrite.
4. Red "Couldn't save the file" toast with the generic body; frontend log shows `save_download: Failed to save file: … (os error 32)`; a new event lands in HOUSTON-APP-53A.

## Verify after the fix
1. Repeat steps 1–3.
2. Green "File saved" toast reading "Saved as report (2).xlsx because report.xlsx is open in another program."; `report (2).xlsx` exists beside the original, which is untouched.
3. Frontend log shows nothing for the save (it succeeded); no Sentry event.
4. Save into a folder Windows protects (e.g. `C:\Windows`): informational "Houston isn't allowed to save into that folder…" toast, a `[files:save-download] permission: …` log line, no Sentry event.
5. On a machine where Explorer cannot be spawned by Houston, "Show in File Manager" either opens the parent folder or shows the informational "Houston isn't allowed to open that folder…" toast; HOUSTON-APP-5C6 stays quiet.
