### PR TITLE
fix(chat): wrap long option labels and keep number badges inside the question card (PRODUCT-1769)

### DIFF
--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -116,14 +116,15 @@ test("keeps a long question's footer reachable in a short viewport", async ({
 });
 
 /**
- * PRODUCT-1769: an option label longer than the card must TRUNCATE, never push
- * the row's number badge past the card's edge. The body scrolls inside a Radix
- * viewport whose content wrapper is `display: table` (sized to the widest
- * row), which used to defeat the row's `w-full` + `truncate` so the badge sat
- * beyond the viewport's hidden horizontal overflow. Asserted geometrically —
- * Playwright's visibility check ignores overflow clipping.
+ * PRODUCT-1769: an option label longer than the card WRAPS onto more lines,
+ * fully readable, and never pushes the row's number badge past the card's
+ * edge. The body scrolls inside a Radix viewport whose content wrapper is
+ * `display: table` (sized to the widest row), which used to defeat the row's
+ * `w-full` so the badge sat beyond the viewport's hidden horizontal overflow.
+ * Asserted geometrically — Playwright's visibility check ignores overflow
+ * clipping.
  */
-test("a long option label truncates and keeps its number badge inside the card", async ({
+test("a long option label wraps and keeps its number badge inside the card", async ({
   page,
   request,
 }) => {
@@ -165,8 +166,16 @@ test("a long option label truncates and keeps its number badge inside the card",
   const cardRight = cardBox.x + cardBox.width;
   expect(rowBox.x + rowBox.width).toBeLessThanOrEqual(cardRight);
   expect(badgeBox.x + badgeBox.width).toBeLessThanOrEqual(cardRight);
-  // The label lost width to the ellipsis, not the badge.
-  await expect(row.getByText(longLabel)).toHaveCSS("text-overflow", "ellipsis");
+  // The label wrapped (the row is taller than its single-line sibling) and
+  // every word stays readable: no ellipsis anywhere in the row.
+  const shortRow = page.getByRole("radio", { name: /Email me whatever/ });
+  const shortBox = await shortRow.boundingBox();
+  if (!shortBox) throw new Error("short row geometry missing");
+  expect(rowBox.height).toBeGreaterThan(shortBox.height * 1.5);
+  await expect(row.getByText(longLabel)).not.toHaveCSS(
+    "text-overflow",
+    "ellipsis",
+  );
   await expect(page.getByText("Recommended")).toBeVisible();
 });
 

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -116,6 +116,61 @@ test("keeps a long question's footer reachable in a short viewport", async ({
 });
 
 /**
+ * PRODUCT-1769: an option label longer than the card must TRUNCATE, never push
+ * the row's number badge past the card's edge. The body scrolls inside a Radix
+ * viewport whose content wrapper is `display: table` (sized to the widest
+ * row), which used to defeat the row's `w-full` + `truncate` so the badge sat
+ * beyond the viewport's hidden horizontal overflow. Asserted geometrically —
+ * Playwright's visibility check ignores overflow clipping.
+ */
+test("a long option label truncates and keeps its number badge inside the card", async ({
+  page,
+  request,
+}) => {
+  await page.setViewportSize({ width: 1100, height: 800 });
+  const longLabel =
+    "Look up the case number they send me, check its status in every registry, and reply with the full current state";
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        steps: [
+          {
+            kind: "question",
+            id: "q-long-label",
+            question: "What should I do when they call the webhook?",
+            options: [
+              { id: "lookup", label: longLabel, recommended: true },
+              { id: "notify", label: "Email me whatever they send" },
+            ],
+          },
+        ],
+      },
+    },
+  });
+  await startMission(page, "watch the court registry");
+
+  const row = page.getByRole("radio", {
+    name: new RegExp(longLabel.slice(0, 20)),
+  });
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  const card = page.locator("[data-slot=collapsible]").filter({ has: row });
+  const badge = row.locator("span", { hasText: /^1$/ }).last();
+  const [cardBox, rowBox, badgeBox] = await Promise.all([
+    card.boundingBox(),
+    row.boundingBox(),
+    badge.boundingBox(),
+  ]);
+  if (!cardBox || !rowBox || !badgeBox)
+    throw new Error("card geometry missing");
+  const cardRight = cardBox.x + cardBox.width;
+  expect(rowBox.x + rowBox.width).toBeLessThanOrEqual(cardRight);
+  expect(badgeBox.x + badgeBox.width).toBeLessThanOrEqual(cardRight);
+  // The label lost width to the ellipsis, not the badge.
+  await expect(row.getByText(longLabel)).toHaveCSS("text-overflow", "ellipsis");
+  await expect(page.getByText("Recommended")).toBeVisible();
+});
+
+/**
  * The three-question stepper: only ONE step shows at a time with a
  * compact "N of M" pager. Answer step 1 by option, step 2 by free text, step 3
  * by option; the completion composes ONE structured user message carrying all

--- a/ui/chat/src/interaction-card-parts.tsx
+++ b/ui/chat/src/interaction-card-parts.tsx
@@ -130,8 +130,10 @@ export function QuestionAnswerRow({
  *  until hover/selected, when it fills a soft grey and the badge crossfades
  *  into a trailing arrow — the affordance that a click answers and advances —
  *  in the same right slot, so nothing shifts. Selection is carried by that same
- *  fill, not a border. The option's wire `description` is intentionally NOT
- *  rendered: the label + chip say enough. */
+ *  fill, not a border. A label longer than the row WRAPS onto more lines —
+ *  never an ellipsis: the user is choosing between these sentences, so every
+ *  word must be readable at any panel width (PRODUCT-1769). The option's wire
+ *  `description` is intentionally NOT rendered: the label + chip say enough. */
 export function OptionRow({
   option,
   selected,
@@ -163,8 +165,8 @@ export function OptionRow({
       role="radio"
       type="button"
     >
-      <span className="flex min-w-0 flex-1 items-center gap-2">
-        <span className="min-w-0 truncate text-ink text-sm">
+      <span className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="min-w-0 break-words text-ink text-sm leading-snug">
           {option.label}
         </span>
         {option.recommended && (

--- a/ui/core/src/components/scroll-area.tsx
+++ b/ui/core/src/components/scroll-area.tsx
@@ -22,6 +22,13 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className={cn(
           "size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-focus/50 focus-visible:outline-1",
+          // Radix wraps the children in an inline-styled `display: table` div
+          // that grows to the widest child, so a `w-full` + `truncate` row
+          // inside never shrinks and its right edge is clipped by the
+          // viewport's hidden horizontal overflow (PRODUCT-1769). Block keeps
+          // the wrapper at the viewport width; wider content still scrolls
+          // when a horizontal ScrollBar is mounted.
+          "[&>div]:block!",
           viewportClassName,
         )}
       >


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1769 (cannot see full options in small screen).

**Root cause.** The question card's body scrolls inside the core `ScrollArea` (Radix). Radix wraps the viewport's children in an inline-styled `display: table` div, which sizes itself to the widest child. So the option row's `w-full` never constrained the row: a long option label kept the row at its full text width, pushed the circular number badge past the card's edge, and the viewport's hidden horizontal overflow clipped it. At wide panel widths the labels happened to fit, which is why it only showed on smaller screens.

**Fix, two parts.**
1. `ui/core` `ScrollArea` forces Radix's content wrapper to `display: block` (`[&>div]:block!`), so content stays at the viewport width. Wider content still scrolls when a horizontal `ScrollBar` is mounted (the suggestions strip). The other consumers (chat sidebar steps, progress panel, team identity icon grid, layout sidebar) render identically for content that fits; the visual baseline suite is unchanged.
2. `ui/chat` `OptionRow` wraps long labels onto more lines instead of truncating with an ellipsis. The user is choosing between these sentences, so every word has to be readable at any panel width. The number badge stays in its right slot and the Recommended chip follows the text.

**Test.** New Playwright regression test in `packages/web/e2e/interaction.spec.ts` asserts the row and its badge stay within the card's bounding box, the long label wraps (row taller than its single-line sibling), and nothing carries an ellipsis. It is geometric on purpose: Playwright's visibility check ignores overflow clipping, so the old assertion style would have passed on the bug.

## Before (reproduce on main)

1. Narrow the window until the right-hand chat panel is roughly 600px wide.
2. Send an agent: "Before doing anything else, ask me one multiple-choice question about how you should handle incoming webhook calls. Use your ask-the-user tool, not plain text. Give exactly four options, each label at least 80 characters long, and mark the first one as recommended. Then wait for my answer."
3. The number badges on the right of each option are cut off at the card's edge; only a sliver of the circle shows.

Harness: `pnpm --filter houston-web exec playwright test e2e/interaction.spec.ts --project=chromium -g "badge inside the card"` fails on main.

## After

1. Same steps: every label is fully readable across multiple lines, every badge (1 to 4) is fully visible inside the card, the Recommended chip sits after the first label.
2. Widen the window: labels collapse back to one line, nothing else moves.
3. `pnpm --filter houston-web exec playwright test e2e/interaction.spec.ts e2e/branded-question.spec.ts e2e/sidebar.spec.ts --project=chromium` passes, `pnpm --filter houston-web test:visual` passes with no baseline changes, `pnpm check` and `pnpm typecheck` exit 0.