### PR TITLE
fix(chat): settle the composer pin before a send carries it (PRODUCT-1771)

### DIFF
--- a/app/src/components/agent/routine-setup-chat-board.tsx
+++ b/app/src/components/agent/routine-setup-chat-board.tsx
@@ -109,6 +109,7 @@ export function RoutineSetupChatBoard({
     selectedSessionKey: sessionKey,
     selectedAgentPath: path,
     overrides,
+    resolveSendPin: panel.resolveSendPin,
     sendMessageNow: send.sendMessageNow,
   });
 

--- a/app/src/components/assistant/assistant-chat.tsx
+++ b/app/src/components/assistant/assistant-chat.tsx
@@ -90,6 +90,7 @@ export function AssistantChat({ handle }: { handle: AssistantHandle }) {
     selectedSessionKey: sessionKey,
     selectedAgentPath: path,
     overrides,
+    resolveSendPin: panel.resolveSendPin,
     sendMessageNow: send.sendMessageNow,
   });
 

--- a/app/src/components/board/use-board-chat-wiring.tsx
+++ b/app/src/components/board/use-board-chat-wiring.tsx
@@ -2,6 +2,7 @@ import type { AIBoardProps, MessageMention } from "@houston-ai/board";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenAgentHref } from "../../hooks/use-open-agent-file";
+import { isAgentPathWarming } from "../../lib/agent-warming-guard";
 import { childMissionsOf, parentMissionOf } from "../../lib/child-missions";
 import { modelAcceptsImages } from "../../lib/providers";
 import { useUIStore } from "../../stores/ui";
@@ -88,13 +89,38 @@ export function useBoardChatWiring(source: BoardSource) {
     selectedSessionKey: source.selectedSessionKey,
     selectedAgentPath: source.selectedAgentPath,
     overrides,
+    resolveSendPin: panel.resolveSendPin,
     sendMessageNow: source.sendMessageNow,
   });
 
+  // The first message of a NEW conversation stamps its row with the pin it
+  // ran on, so it waits for the settled pin like a follow-up (PRODUCT-1771).
   const handleCreateConversation = useCallback(
-    (text: string, files: File[], mentions?: MessageMention[]) =>
-      source.createConversation({ text, files, ...overrides, mentions }),
-    [source.createConversation, overrides],
+    async (text: string, files: File[], mentions?: MessageMention[]) => {
+      // Same exemption as the follow-up queue: a warming pod parks the send.
+      const agentPath = source.activeAgent?.folderPath;
+      const pin =
+        agentPath && isAgentPathWarming(agentPath)
+          ? {
+              provider: overrides.providerOverride,
+              model: overrides.modelOverride,
+            }
+          : await panel.resolveSendPin();
+      return source.createConversation({
+        text,
+        files,
+        ...overrides,
+        providerOverride: pin.provider,
+        modelOverride: pin.model,
+        mentions,
+      });
+    },
+    [
+      source.createConversation,
+      source.activeAgent?.folderPath,
+      overrides,
+      panel.resolveSendPin,
+    ],
   );
   const handleNotice = useCallback(
     (message: string) => addToast({ title: message }),

--- a/app/src/components/board/use-board-send-queue.ts
+++ b/app/src/components/board/use-board-send-queue.ts
@@ -2,6 +2,8 @@ import type { AIBoardProps } from "@houston-ai/board";
 import type { MessageMention } from "@houston-ai/chat";
 import { useCallback, useMemo } from "react";
 import { useSessionMessageQueue } from "../../hooks/use-session-message-queue";
+import { isAgentPathWarming } from "../../lib/agent-warming-guard";
+import type { ModelPin } from "../../lib/model-selector-lock";
 import type { SendOverrides } from "./board-source";
 
 /**
@@ -14,17 +16,22 @@ import type { SendOverrides } from "./board-source";
  *
  * `overrides` carry the composer's effective provider/model so the wire
  * mirrors the dropdown; the source decides whether to honor or re-resolve
- * them inside `sendMessageNow`.
+ * them inside `sendMessageNow`. `resolveSendPin` (the chat panel's gate,
+ * PRODUCT-1771) supersedes the captured provider/model at SEND time: a send
+ * fired while the composer is still resolving waits for the settled pin
+ * instead of shipping the guess it was rendered with.
  */
 export function useBoardSendQueue({
   selectedSessionKey,
   selectedAgentPath,
   overrides,
+  resolveSendPin,
   sendMessageNow,
 }: {
   selectedSessionKey: string | null;
   selectedAgentPath: string | null;
   overrides: SendOverrides;
+  resolveSendPin?: () => Promise<ModelPin>;
   sendMessageNow: (
     sessionKey: string,
     text: string,
@@ -32,12 +39,34 @@ export function useBoardSendQueue({
     overrides: SendOverrides,
   ) => Promise<void>;
 }) {
+  const settledOverrides = useCallback(async (): Promise<SendOverrides> => {
+    // A warming / asleep pod holds every read for the whole wake: the send is
+    // parked instead (HOU-693 / HOU-730) and the flush re-reads the row's own
+    // pin (PRODUCT-1643), so waiting here would only freeze the composer.
+    if (
+      !resolveSendPin ||
+      (selectedAgentPath && isAgentPathWarming(selectedAgentPath))
+    )
+      return overrides;
+    const pin = await resolveSendPin();
+    return {
+      ...overrides,
+      providerOverride: pin.provider,
+      modelOverride: pin.model,
+    };
+  }, [overrides, resolveSendPin, selectedAgentPath]);
+
   const sendSelectedNow = useCallback(
     async (text: string, files: File[]) => {
       if (!selectedSessionKey) return;
-      await sendMessageNow(selectedSessionKey, text, files, overrides);
+      await sendMessageNow(
+        selectedSessionKey,
+        text,
+        files,
+        await settledOverrides(),
+      );
     },
-    [selectedSessionKey, sendMessageNow, overrides],
+    [selectedSessionKey, sendMessageNow, settledOverrides],
   );
 
   const messageQueue = useSessionMessageQueue({
@@ -57,9 +86,12 @@ export function useBoardSendQueue({
       files: File[],
       mentions?: MessageMention[],
     ) => {
-      await sendMessageNow(sessionKey, text, files, { ...overrides, mentions });
+      await sendMessageNow(sessionKey, text, files, {
+        ...(await settledOverrides()),
+        mentions,
+      });
     },
-    [sendMessageNow, overrides],
+    [sendMessageNow, settledOverrides],
   );
 
   const queuedMessages = useMemo<AIBoardProps["queuedMessages"]>(

--- a/app/src/components/board/use-mission-control-archived-panel.ts
+++ b/app/src/components/board/use-mission-control-archived-panel.ts
@@ -64,8 +64,7 @@ export function useMissionControlArchivedPanel(
   const onSendMessage = useMissionControlArchivedSend({
     activeAgent,
     selectedItem,
-    providerOverride: panel.effectiveProvider,
-    modelOverride: panel.effectiveModel,
+    resolveSendPin: panel.resolveSendPin,
     onHandoff: handoff,
   });
 

--- a/app/src/components/board/use-mission-control-archived-send.ts
+++ b/app/src/components/board/use-mission-control-archived-send.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
+import type { ModelPin } from "../../lib/model-selector-lock";
 import { perfSpans } from "../../lib/perf-spans";
 import { showSendFailedToast } from "../../lib/send-error-toast";
 import { tauriAttachments, tauriChat } from "../../lib/tauri";
@@ -20,14 +21,13 @@ import type { Agent } from "../../lib/types";
 export function useMissionControlArchivedSend({
   activeAgent,
   selectedItem,
-  providerOverride,
-  modelOverride,
+  resolveSendPin,
   onHandoff,
 }: {
   activeAgent: Agent | null;
   selectedItem: KanbanItem | null;
-  providerOverride: string;
-  modelOverride: string;
+  /** The chat panel's settled pin (PRODUCT-1771), read at send time. */
+  resolveSendPin: () => Promise<ModelPin>;
   /** The archived → active handoff (`useArchivedHandoff`), run once the send
    *  lands and the mission is no longer archived. */
   onHandoff: (missionId: string) => void;
@@ -48,18 +48,19 @@ export function useMissionControlArchivedSend({
           files,
         );
         const prompt = buildAttachmentPrompt(text, files, paths);
+        const pin = await resolveSendPin();
         // The turn stream pushes the user bubble into the conversation VM
         // itself — no app-side optimistic push.
         await tauriChat.send(agentPath, prompt, sessionKey, {
-          providerOverride,
-          modelOverride,
+          providerOverride: pin.provider,
+          modelOverride: pin.model,
           modeOverride: DEFAULT_TURN_MODE,
           mentions,
         });
         perfSpans.messageSent();
         analytics.track("chat_message_sent", {
-          provider: providerOverride,
-          model: modelOverride,
+          provider: pin.provider,
+          model: pin.model,
         });
         for (const f of files)
           analytics.track("file_attached", { file_kind: classifyFileKind(f) });
@@ -72,6 +73,6 @@ export function useMissionControlArchivedSend({
         throw err;
       }
     },
-    [activeAgent, selectedItem, providerOverride, modelOverride, onHandoff],
+    [activeAgent, selectedItem, resolveSendPin, onHandoff],
   );
 }

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -56,8 +56,10 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import type * as configData from "../data/config";
 import {
   useActivity,
+  useAgentConfig,
   useAgentModelChoice,
   useChatHistory,
   useSetAgentModelChoice,
@@ -72,6 +74,7 @@ import {
 } from "../hooks/use-conversation-vm";
 import { useFileToolRenderer } from "../hooks/use-file-tool-renderer";
 import { useProviderStatuses } from "../hooks/use-provider-statuses";
+import { useSendPin } from "../hooks/use-send-pin";
 import { useSession } from "../hooks/use-session";
 import { useSetupGreetingName } from "../hooks/use-setup-greeting";
 import { useStoreSkillLocaleMigration } from "../hooks/use-store-skill-locale-migration";
@@ -84,6 +87,7 @@ import {
   encodeAutoContinueMessage,
   filterAutoContinueFeedItems,
 } from "../lib/auto-continue-message";
+import { agentTierFromConfig } from "../lib/chat-agent-tier";
 import { coherentPinModel, resolveChatModelPin } from "../lib/chat-model-pin";
 import {
   effectiveContextWindow,
@@ -111,6 +115,7 @@ import { providerForModel, providerOffersModel } from "../lib/model-labels";
 import { isModelNotAllowedError } from "../lib/model-not-allowed";
 import {
   isModelAllowed,
+  type ModelPin,
   modelSelectorDecision,
   resolvePersonalModelPin,
 } from "../lib/model-selector-lock";
@@ -138,6 +143,7 @@ import {
 import { queryKeys } from "../lib/query-keys";
 import { reportRejection } from "../lib/report-rejection";
 import { showSendFailedToast } from "../lib/send-error-toast";
+import { sendPinSettled } from "../lib/send-pin-gate";
 import { hasAgentOutput } from "../lib/setup-mission-greeting";
 import {
   buildSkillClaudePrompt,
@@ -315,6 +321,8 @@ interface AgentChatPanelProps {
   /** Displayed provider/model for sending. */
   effectiveProvider: string;
   effectiveModel: string;
+  /** The pin a send must carry, settled at send time (PRODUCT-1771). */
+  resolveSendPin: () => Promise<ModelPin>;
   /** The composer's turn mode (execute | plan); consumers forward it as
    *  `modeOverride` on user-typed sends — an unpinned turn is execute. */
   turnMode: TurnMode;
@@ -455,7 +463,7 @@ export function useAgentChatPanel({
   // Integration connect cards are a new-engine feature: the host advertises
   // its wired providers in capabilities; the legacy Rust engine (null) and
   // unconfigured deployments fall back to plain markdown links.
-  const { capabilities } = useCapabilities();
+  const { capabilities, isLoading: capabilitiesLoading } = useCapabilities();
   const integrationsEnabled = integrationsSupported(capabilities);
 
   // Teams E8: in a multiplayer Teams org the composer's model + effort pickers
@@ -464,10 +472,8 @@ export function useAgentChatPanel({
   // / self-host keeps the shared-config behavior (personal=false, no ceiling).
   // The gateway is the sole enforcer of the ceiling per turn.
   const modelDecision = modelSelectorDecision(capabilities, agent);
-  const { data: modelChoiceInfo } = useAgentModelChoice(
-    agent?.id ?? "",
-    modelDecision.personal,
-  );
+  const { data: modelChoiceInfo, isFetched: modelChoiceFetched } =
+    useAgentModelChoice(agent?.id ?? "", modelDecision.personal);
   const setModelChoice = useSetAgentModelChoice(agent?.id ?? "");
   const allowedModels = modelDecision.personal
     ? (modelChoiceInfo?.allowedModels ?? null)
@@ -500,9 +506,34 @@ export function useAgentChatPanel({
   // CANONICAL id (`openai-codex`) while the catalog, picker and logos speak
   // Houston's DISPLAY id (`openai`), so they are mapped here — the seam
   // `use-agent-model-choice` already applies to a stored model choice.
-  const [agentProvider, setAgentProvider] = useState<string | null>(null);
-  const [agentModel, setAgentModel] = useState<string | null>(null);
-  const [agentEffort, setAgentEffort] = useState<string | null>(null);
+  // Read through the config QUERY, not a one-shot effect (PRODUCT-1771): a
+  // read refused while a space switch leaves routing pending is retried, a
+  // ConfigChanged invalidation follows the file, and `isFetched` tells the
+  // send gate below that the tier is UNKNOWN (still loading) rather than
+  // absent — the two used to be indistinguishable, and "absent" fell through
+  // to the device-wide last-used provider.
+  const agentConfigQuery = useAgentConfig(path ?? undefined);
+  const agentConfigSettled = !path || agentConfigQuery.isFetched;
+  const {
+    provider: agentProvider,
+    model: agentModel,
+    effort: agentEffort,
+  } = useMemo(
+    () => agentTierFromConfig(agentConfigQuery.data),
+    [agentConfigQuery.data],
+  );
+  // Optimistic flip for a shared-mode pick: lands on the cache the tier reads
+  // from, so the picker moves before the config write round-trips.
+  const setAgentTier = useCallback(
+    (patch: Pick<configData.Config, "provider" | "model" | "effort">) => {
+      if (!path) return;
+      queryClient.setQueryData<configData.Config>(
+        queryKeys.config(path),
+        (prev) => ({ ...(prev ?? {}), ...patch }),
+      );
+    },
+    [path, queryClient],
+  );
   // Composer "Mode" pin (execute/plan/auto). It is session-local and every new
   // mission resets to `initialTurnMode` or Ask First. Existing mission switches
   // keep the current per-send pin until the user changes it.
@@ -510,27 +541,7 @@ export function useAgentChatPanel({
     initialTurnMode ?? DEFAULT_TURN_MODE,
   );
   useEffect(() => {
-    if (!path) {
-      setAgentProvider(null);
-      setAgentModel(null);
-      setAgentEffort(null);
-      setTurnMode(initialTurnMode ?? DEFAULT_TURN_MODE);
-      return;
-    }
-    reportRejection(
-      tauriConfig.read(path).then((cfg) => {
-        setAgentProvider(toDisplayProviderIdOrNull(cfg.provider as string));
-        setAgentModel(
-          normalizeLegacyModel(
-            (cfg.model as string) ?? null,
-            cfg.provider as string,
-          ),
-        );
-        setAgentEffort((cfg.effort as string) ?? null);
-      }),
-      "chat.read-agent-model",
-      logAndReportError,
-    );
+    if (!path) setTurnMode(initialTurnMode ?? DEFAULT_TURN_MODE);
   }, [path, initialTurnMode]);
 
   const previousSessionKeyRef = useRef(selectedSessionKey);
@@ -558,7 +569,14 @@ export function useAgentChatPanel({
     );
   }, []);
 
-  const { data: activities } = useActivity(path ?? undefined);
+  const activityQuery = useActivity(path ?? undefined);
+  const activities = activityQuery.data;
+  // The list is served from the cross-agent cache as a PLACEHOLDER first
+  // (`latestCachedAgentActivities`); its rows carry no provider/model, so until
+  // the agent's own read lands the open row's pin is unknown, not absent.
+  const activitySettled =
+    !selectedSessionKey ||
+    (activityQuery.isFetched && !activityQuery.isPlaceholderData);
   const selectedActivity = useMemo(() => {
     if (!selectedSessionKey || !activities) return null;
     return (
@@ -797,6 +815,30 @@ export function useAgentChatPanel({
     };
   }, [rawDisplayModelPin]);
 
+  // Whether every input above has landed (PRODUCT-1771). Before that the pin is
+  // a guess that bottoms out on the device-wide last-used provider, and a send
+  // must not carry a guess as the turn's pin: `resolveSendPin` holds the send
+  // until the composer settles (bounded), then hands it the pin the picker
+  // shows at that moment.
+  const pinSettled = sendPinSettled({
+    agentConfigSettled,
+    activitySettled,
+    capabilitiesSettled: !capabilitiesLoading,
+    choiceSettled: !modelDecision.personal || modelChoiceFetched,
+    statusesSettled: !providerStatusesLoading,
+  });
+  const reportPinTimeout = useCallback(() => {
+    logAndReportError(
+      "chat.send-pin-settle",
+      new Error("composer pin never settled; sent the current pin"),
+    );
+  }, []);
+  const resolveSendPin = useSendPin(
+    displayModelPin,
+    pinSettled,
+    reportPinTimeout,
+  );
+
   // Converge legacy pin-less chats (created before per-conversation pins):
   // stamp the shared agent-derived provider/model onto its activity, so a later
   // change to the agent
@@ -808,6 +850,10 @@ export function useAgentChatPanel({
   useEffect(() => {
     if (!path || !selectedActivity || selectedActivity.provider) return;
     if (!hasMessages) return;
+    // A placeholder row has no pin field at all, and an unsettled composer
+    // would stamp a guess: both looked like a legacy pin-less row and wrote
+    // the device's last-used provider over the chat's real pin (PRODUCT-1771).
+    if (!pinSettled || activityQuery.isPlaceholderData) return;
     if (stampedActivityIds.current.has(selectedActivity.id)) return;
     stampedActivityIds.current.add(selectedActivity.id);
     reportRejection(
@@ -818,7 +864,15 @@ export function useAgentChatPanel({
       "chat.pin-conversation-model",
       logAndReportError,
     );
-  }, [path, selectedActivity, hasMessages, effectiveProvider, effectiveModel]);
+  }, [
+    path,
+    selectedActivity,
+    hasMessages,
+    effectiveProvider,
+    effectiveModel,
+    pinSettled,
+    activityQuery.isPlaceholderData,
+  ]);
 
   // ── Context-usage indicator ───────────────────────────────────────────
   // Latest turn's normalized usage from this session's feed, divided by a
@@ -898,8 +952,7 @@ export function useAgentChatPanel({
             effort: validEffortOrDefault(prov, mod, displayModelPin.effort),
           });
         } else {
-          setAgentProvider(prov);
-          setAgentModel(mod);
+          setAgentTier({ provider: toCanonicalProviderId(prov), model: mod });
           if (path) {
             const cfg = await tauriConfig.read(path);
             await tauriConfig.write(path, {
@@ -927,6 +980,7 @@ export function useAgentChatPanel({
     [
       path,
       selectedActivityId,
+      setAgentTier,
       modelDecision.personal,
       setModelChoice,
       displayModelPin.effort,
@@ -983,7 +1037,7 @@ export function useAgentChatPanel({
     async (effort: EffortLevel) => {
       // Effort is per-agent (not per-activity): persist to the agent config
       // the engine reads at send time. Optimistic flip for the picker.
-      setAgentEffort(effort);
+      setAgentTier({ effort });
       try {
         if (path) {
           const cfg = await tauriConfig.read(path);
@@ -997,7 +1051,7 @@ export function useAgentChatPanel({
         });
       }
     },
-    [path, addToast, t],
+    [path, addToast, t, setAgentTier],
   );
   const handleModeSelect = useCallback(
     (mode: TurnMode) => {
@@ -1176,17 +1230,18 @@ export function useAgentChatPanel({
         editingTurn.turnId,
       );
       setEditingTurn(null);
+      const pin = await resolveSendPin();
       await tauriChat.send(path, text, editingTurn.sessionKey, {
-        providerOverride: displayModelPin.provider,
-        modelOverride: displayModelPin.model,
-        effortOverride: displayModelPin.effort,
+        providerOverride: pin.provider,
+        modelOverride: pin.model,
+        effortOverride: pin.effort,
         modeOverride: turnMode,
       });
       // An ARCHIVED mission was just re-activated by the resend, exactly as
       // any other send into it would.
       onSendReactivatedRef.current?.();
     },
-    [editingTurn, path, displayModelPin, turnMode],
+    [editingTurn, path, resolveSendPin, turnMode],
   );
   const messageEditing = useMemo<AIBoardProps["messageEditing"]>(
     () =>
@@ -1262,6 +1317,7 @@ export function useAgentChatPanel({
       const claudePrompt = buildSkillClaudePrompt(skill, text);
       const encoded = encodeSkillMessage(skill, text, claudePrompt);
       const friendlyTitle = skillDisplayTitle(skill);
+      const pin = await resolveSendPin();
 
       if (sessionKey) {
         // Mid-conversation: optimistic feed push + send, mirrors the
@@ -1280,9 +1336,9 @@ export function useAgentChatPanel({
         await tauriChat.send(path, encodedWithAttachments, sessionKey, {
           // The wire pin must match the picker. In Teams this may be the open
           // mission's pin rather than the agent's effective default.
-          providerOverride: displayModelPin.provider,
-          modelOverride: displayModelPin.model,
-          effortOverride: displayModelPin.effort,
+          providerOverride: pin.provider,
+          modelOverride: pin.model,
+          effortOverride: pin.effort,
           modeOverride: turnMode,
           // A Skill send still carries whatever the user typed alongside it, so
           // the teammates they named there must ride too (HOU-944).
@@ -1306,9 +1362,9 @@ export function useAgentChatPanel({
           },
           encoded,
           {
-            providerOverride: displayModelPin.provider,
-            modelOverride: displayModelPin.model,
-            effortOverride: displayModelPin.effort,
+            providerOverride: pin.provider,
+            modelOverride: pin.model,
+            effortOverride: pin.effort,
             modeOverride: turnMode,
             mentions,
             buildPrompt: async (activityId) => {
@@ -1337,7 +1393,7 @@ export function useAgentChatPanel({
       setActiveSkill(null);
       return true;
     },
-    [activeSkill, agent, path, displayModelPin, turnMode, queryClient],
+    [activeSkill, agent, path, resolveSendPin, turnMode, queryClient],
   );
 
   // Picking a skill from a card or the picker pins it above the regular
@@ -1365,13 +1421,15 @@ export function useAgentChatPanel({
       const message = encodeAutoContinueMessage(
         t("chat:composio.connectedFollowup", { name: appName }),
       );
-      tauriChat
-        .send(path, message, selectedSessionKey, {
-          providerOverride: displayModelPin.provider,
-          modelOverride: displayModelPin.model,
-          effortOverride: displayModelPin.effort,
-          modeOverride: turnMode,
-        })
+      resolveSendPin()
+        .then((pin) =>
+          tauriChat.send(path, message, selectedSessionKey, {
+            providerOverride: pin.provider,
+            modelOverride: pin.model,
+            effortOverride: pin.effort,
+            modeOverride: turnMode,
+          }),
+        )
         // Two-arg `then`, not `.then().catch()`: the rejection handler stays
         // exclusive to the SEND, so a throw inside the handoff callback is
         // never reported as a failed follow-up.
@@ -1389,7 +1447,7 @@ export function useAgentChatPanel({
           },
         );
     },
-    [path, selectedSessionKey, displayModelPin, turnMode, addToast, t],
+    [path, selectedSessionKey, resolveSendPin, turnMode, addToast, t],
   );
   const renderLink = useCallback<NonNullable<AIBoardProps["renderLink"]>>(
     ({ href }) => {
@@ -1468,14 +1526,16 @@ export function useAgentChatPanel({
   const sendInteractionMessage = useCallback(
     (text: string, mode?: TurnMode, approvals?: MessageApproval[]) => {
       if (!path || !selectedSessionKey) return;
-      tauriChat
-        .send(path, text, selectedSessionKey, {
-          providerOverride: displayModelPin.provider,
-          modelOverride: displayModelPin.model,
-          effortOverride: displayModelPin.effort,
-          modeOverride: mode ?? turnMode,
-          ...(approvals?.length ? { approvals } : {}),
-        })
+      resolveSendPin()
+        .then((pin) =>
+          tauriChat.send(path, text, selectedSessionKey, {
+            providerOverride: pin.provider,
+            modelOverride: pin.model,
+            effortOverride: pin.effort,
+            modeOverride: mode ?? turnMode,
+            ...(approvals?.length ? { approvals } : {}),
+          }),
+        )
         // Two-arg `then`, not `.then().catch()`: the rejection handler must stay
         // exclusive to the SEND, or a throw inside the handoff callback would
         // be reported to the user as a failed message.
@@ -1486,7 +1546,7 @@ export function useAgentChatPanel({
           },
         );
     },
-    [path, selectedSessionKey, displayModelPin, turnMode],
+    [path, selectedSessionKey, resolveSendPin, turnMode],
   );
 
   // Resolves a question step's `toolkit` to the app's presentational brand (logo
@@ -2229,10 +2289,11 @@ export function useAgentChatPanel({
               // resume), dropped when redundant, and held INVISIBLY — no
               // queued bubble; the adapter's watchdog probes immediately so a
               // stale hold clears within one round-trip (HOU-849).
+              const pin = await resolveSendPin();
               await tauriChat.send(path, text, selectedSessionKey, {
-                providerOverride: displayModelPin.provider,
-                modelOverride: displayModelPin.model,
-                effortOverride: displayModelPin.effort,
+                providerOverride: pin.provider,
+                modelOverride: pin.model,
+                effortOverride: pin.effort,
                 modeOverride: turnMode,
                 // A refused not-connected send left its prompt's bubble in
                 // the feed already — resending it must not add a second one.
@@ -2257,6 +2318,7 @@ export function useAgentChatPanel({
     },
     [
       displayModelPin,
+      resolveSendPin,
       cardProvider,
       turnMode,
       selectModel,
@@ -2573,6 +2635,7 @@ export function useAgentChatPanel({
     pickerDialog,
     effectiveProvider: displayModelPin.provider,
     effectiveModel: displayModelPin.model,
+    resolveSendPin,
     turnMode,
     currentUserId,
     authorLabels,

--- a/app/src/hooks/use-send-pin.ts
+++ b/app/src/hooks/use-send-pin.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { ModelPin } from "../lib/model-selector-lock";
+import { createSendPinGate, type SendPinGate } from "../lib/send-pin-gate";
+
+/**
+ * The pin a send carries, read at SEND time rather than captured at render:
+ * every send path awaits `resolveSendPin()` and gets the composer's latest
+ * provider/model/effort once its inputs have settled (PRODUCT-1771). While the
+ * composer is still resolving (a space switch, a cold open) the message waits
+ * for the real pin instead of shipping a guess; the wait is bounded by the
+ * gate's timeout so a read that never answers cannot strand the message.
+ *
+ * Stable identity: consumers fold it into `useCallback`s and AIBoard props.
+ */
+export function useSendPin(
+  pin: ModelPin,
+  settled: boolean,
+  onTimeout?: () => void,
+): () => Promise<ModelPin> {
+  const gate = useRef<SendPinGate<ModelPin> | null>(null);
+  const timeoutRef = useRef(onTimeout);
+  timeoutRef.current = onTimeout;
+  if (gate.current === null) {
+    gate.current = createSendPinGate<ModelPin>(pin, () =>
+      timeoutRef.current?.(),
+    );
+  }
+  useEffect(() => {
+    gate.current?.update(pin, settled);
+  }, [pin, settled]);
+  return useCallback(() => {
+    const current = gate.current;
+    return current ? current.resolve() : Promise.reject(new Error("unmounted"));
+  }, []);
+}

--- a/app/src/lib/all-conversations-cache.ts
+++ b/app/src/lib/all-conversations-cache.ts
@@ -57,6 +57,8 @@ interface CachedConversationRow {
   agent_path: string;
   agent?: string;
   routine_id?: string;
+  provider?: string;
+  model?: string;
 }
 
 /** A board activity recovered from a cached conversation row. */
@@ -69,6 +71,8 @@ export interface CachedBoardActivity {
   updated_at?: string;
   agent?: string;
   routine_id?: string;
+  provider?: string;
+  model?: string;
 }
 
 /**
@@ -126,5 +130,9 @@ export function latestCachedAgentActivities(
     updated_at: row.updated_at,
     agent: row.agent,
     routine_id: row.routine_id,
+    // Rows swept before the pin rode along (older persisted caches) stay
+    // pin-less; the chat panel treats a placeholder's pin as unknown anyway.
+    ...(row.provider !== undefined && { provider: row.provider }),
+    ...(row.model !== undefined && { model: row.model }),
   }));
 }

--- a/app/src/lib/chat-agent-tier.ts
+++ b/app/src/lib/chat-agent-tier.ts
@@ -1,0 +1,35 @@
+import type { Config } from "../data/config";
+import { toDisplayProviderIdOrNull } from "./provider-overrides.ts";
+import { normalizeLegacyModel } from "./providers.ts";
+
+/** The agent-config tier of the chat's provider chain, in the display dialect. */
+export interface AgentTier {
+  provider: string | null;
+  model: string | null;
+  effort: string | null;
+}
+
+/** Nothing read yet, or an agent with no configured brain. */
+export const EMPTY_AGENT_TIER: AgentTier = {
+  provider: null,
+  model: null,
+  effort: null,
+};
+
+/**
+ * Project `.houston/config/config.json` onto the composer's agent tier.
+ * Configs store pi's CANONICAL provider id (`openai-codex`) while the picker
+ * speaks Houston's display id (`openai`); legacy Claude aliases (`opus`) are
+ * normalized to explicit ids so a stored alias never falls through to the
+ * provider default. `undefined` (the query has not answered) maps to the empty
+ * tier — callers that need to tell "unknown" from "absent" read the query's
+ * `isFetched` beside this.
+ */
+export function agentTierFromConfig(cfg: Config | undefined): AgentTier {
+  if (!cfg) return EMPTY_AGENT_TIER;
+  return {
+    provider: toDisplayProviderIdOrNull(cfg.provider),
+    model: normalizeLegacyModel(cfg.model ?? null, cfg.provider),
+    effort: cfg.effort ?? null,
+  };
+}

--- a/app/src/lib/send-pin-gate.ts
+++ b/app/src/lib/send-pin-gate.ts
@@ -1,0 +1,102 @@
+/**
+ * The composer's provider/model pin is assembled from several async reads
+ * (the mission row, the agent config, the deployment capabilities, the acting
+ * user's stored choice, the provider probe). Until every one of them has landed
+ * the resolution is a GUESS that bottoms out on the device-wide last-used
+ * provider — and a send fired in that window carried the guess as the turn's
+ * pin, which the gateway passes through and the runtime treats as an explicit
+ * pick (PRODUCT-1771: a Claude chat ran on a local model picked the day before
+ * in another space, while the picker had already settled on Claude).
+ *
+ * Two pure pieces, so the rule is testable without React:
+ *  - `sendPinSettled` — whether every input the resolution reads has settled;
+ *  - `createSendPinGate` — hands a send the LATEST pin only once settled,
+ *    bounded by a timeout so a read that never answers cannot hold a message
+ *    hostage (the pin it then gets is the best the composer has, and the turn
+ *    surfaces its own error card if that is wrong).
+ */
+
+export interface SendPinSignals {
+  /** The agent's config read has answered (success or failure). */
+  agentConfigSettled: boolean;
+  /**
+   * The open conversation's row is the agent's REAL list, not the pin-less
+   * placeholder seeded from the cross-agent cache (`latestCachedAgentActivities`).
+   * True with no conversation open.
+   */
+  activitySettled: boolean;
+  /** The deployment described itself (the personal/shared picker decision). */
+  capabilitiesSettled: boolean;
+  /** The acting user's stored choice was read, when the picker is personal. */
+  choiceSettled: boolean;
+  /** The provider probe answered (a fresh chat auth-gates on it). */
+  statusesSettled: boolean;
+}
+
+/** Whether a send may trust the composer's current pin. */
+export function sendPinSettled(signals: SendPinSignals): boolean {
+  return (
+    signals.agentConfigSettled &&
+    signals.activitySettled &&
+    signals.capabilitiesSettled &&
+    signals.choiceSettled &&
+    signals.statusesSettled
+  );
+}
+
+/** How long a send waits for the pin before going out with the best guess. */
+export const SEND_PIN_SETTLE_TIMEOUT_MS = 15_000;
+
+export interface SendPinGate<T> {
+  /** Record the composer's latest pin and whether its inputs have settled. */
+  update(value: T, settled: boolean): void;
+  /**
+   * The pin a send should carry: the latest value once settled, else the value
+   * current when the wait ends — on settle, or on the timeout.
+   */
+  resolve(timeoutMs?: number): Promise<T>;
+}
+
+export function createSendPinGate<T>(
+  initial: T,
+  onTimeout?: () => void,
+  setTimer: (
+    cb: () => void,
+    ms: number,
+  ) => ReturnType<typeof setTimeout> = setTimeout,
+  clearTimer: (id: ReturnType<typeof setTimeout>) => void = clearTimeout,
+): SendPinGate<T> {
+  let latest = initial;
+  let settled = false;
+  let waiters: (() => void)[] = [];
+
+  const flush = () => {
+    const pending = waiters;
+    waiters = [];
+    for (const wake of pending) wake();
+  };
+
+  return {
+    update(value, isSettled) {
+      latest = value;
+      settled = isSettled;
+      if (settled) flush();
+    },
+    resolve(timeoutMs = SEND_PIN_SETTLE_TIMEOUT_MS) {
+      if (settled) return Promise.resolve(latest);
+      return new Promise<T>((done) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const wake = () => {
+          if (timer !== undefined) clearTimer(timer);
+          done(latest);
+        };
+        waiters.push(wake);
+        timer = setTimer(() => {
+          waiters = waiters.filter((w) => w !== wake);
+          onTimeout?.();
+          done(latest);
+        }, timeoutMs);
+      });
+    },
+  };
+}

--- a/app/tests/all-conversations-cache.test.ts
+++ b/app/tests/all-conversations-cache.test.ts
@@ -82,6 +82,32 @@ describe("latestCachedAgentActivities", () => {
     ]);
   });
 
+  it("keeps a row's provider/model pin, and adds no pin keys to a pin-less row (PRODUCT-1771)", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(
+      queryKeys.allConversations(["agent-a"]),
+      [
+        row("pinned", "agent-a", {
+          provider: "anthropic",
+          model: "claude-opus-5",
+        }),
+        row("legacy", "agent-a"),
+      ],
+      { updatedAt: 1_000 },
+    );
+    const rows = latestCachedAgentActivities(qc, "agent-a") ?? [];
+    deepStrictEqual(
+      rows.map((r) => [r.id, r.provider, r.model]),
+      [
+        ["pinned", "anthropic", "claude-opus-5"],
+        ["legacy", undefined, undefined],
+      ],
+    );
+    // A placeholder must never present a pinned chat as pin-less: the chat
+    // panel would fall through to the device's last-used provider.
+    strictEqual("provider" in rows[1], false);
+  });
+
   it("prefers the newest roster variant that actually has rows", () => {
     const qc = new QueryClient();
     // An older roster variant carries a row for this agent; the newer variant

--- a/app/tests/send-pin-gate.test.ts
+++ b/app/tests/send-pin-gate.test.ts
@@ -1,0 +1,149 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  createSendPinGate,
+  type SendPinSignals,
+  sendPinSettled,
+} from "../src/lib/send-pin-gate.ts";
+
+const allSettled: SendPinSignals = {
+  agentConfigSettled: true,
+  activitySettled: true,
+  capabilitiesSettled: true,
+  choiceSettled: true,
+  statusesSettled: true,
+};
+
+describe("sendPinSettled", () => {
+  it("is true only when every input has landed", () => {
+    strictEqual(sendPinSettled(allSettled), true);
+  });
+
+  for (const key of Object.keys(allSettled) as (keyof SendPinSignals)[]) {
+    it(`waits while ${key} is still pending`, () => {
+      strictEqual(sendPinSettled({ ...allSettled, [key]: false }), false);
+    });
+  }
+});
+
+/** A manual clock so the timeout path is exercised without real timers. */
+function fakeTimers() {
+  const timers = new Map<number, () => void>();
+  let next = 1;
+  return {
+    set: (cb: () => void, _ms: number) => {
+      const id = next++;
+      timers.set(id, cb);
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clear: (id: ReturnType<typeof setTimeout>) => {
+      timers.delete(id as unknown as number);
+    },
+    fire: () => {
+      for (const [id, cb] of [...timers]) {
+        timers.delete(id);
+        cb();
+      }
+    },
+    pending: () => timers.size,
+  };
+}
+
+describe("createSendPinGate", () => {
+  it("answers immediately with the latest pin once settled", async () => {
+    const gate = createSendPinGate({ provider: "guess", model: "" });
+    gate.update({ provider: "anthropic", model: "claude-opus-5" }, true);
+    deepStrictEqual(await gate.resolve(), {
+      provider: "anthropic",
+      model: "claude-opus-5",
+    });
+  });
+
+  it("holds a send while resolving and releases it with the SETTLED pin, never the guess", async () => {
+    const clock = fakeTimers();
+    const gate = createSendPinGate(
+      { provider: "openai-compatible", model: "" },
+      undefined,
+      clock.set,
+      clock.clear,
+    );
+    gate.update({ provider: "openai-compatible", model: "" }, false);
+    let released: { provider: string; model: string } | undefined;
+    const waiting = gate.resolve().then((pin) => {
+      released = pin;
+    });
+    await Promise.resolve();
+    strictEqual(released, undefined);
+    // The row lands: the composer settles on the chat's real pin.
+    gate.update({ provider: "anthropic", model: "claude-opus-5" }, true);
+    await waiting;
+    deepStrictEqual(released, {
+      provider: "anthropic",
+      model: "claude-opus-5",
+    });
+    // The settle cancelled the timeout: nothing left to fire.
+    strictEqual(clock.pending(), 0);
+  });
+
+  it("releases every waiting send on one settle", async () => {
+    const clock = fakeTimers();
+    const gate = createSendPinGate(
+      { provider: "guess", model: "" },
+      undefined,
+      clock.set,
+      clock.clear,
+    );
+    const both = Promise.all([gate.resolve(), gate.resolve()]);
+    gate.update({ provider: "openai", model: "gpt-6-astra" }, true);
+    deepStrictEqual(await both, [
+      { provider: "openai", model: "gpt-6-astra" },
+      { provider: "openai", model: "gpt-6-astra" },
+    ]);
+  });
+
+  it("gives up after the timeout with the best pin it has, and says so", async () => {
+    const clock = fakeTimers();
+    let timedOut = 0;
+    const gate = createSendPinGate(
+      { provider: "anthropic", model: "claude-sonnet-5" },
+      () => {
+        timedOut += 1;
+      },
+      clock.set,
+      clock.clear,
+    );
+    const waiting = gate.resolve(1_000);
+    gate.update({ provider: "anthropic", model: "claude-opus-5" }, false);
+    clock.fire();
+    deepStrictEqual(await waiting, {
+      provider: "anthropic",
+      model: "claude-opus-5",
+    });
+    strictEqual(timedOut, 1);
+    // A later settle must not wake a waiter that already gave up.
+    gate.update({ provider: "openai", model: "gpt-6-astra" }, true);
+    strictEqual(timedOut, 1);
+  });
+
+  it("a settle that later un-settles holds the NEXT send again", async () => {
+    const clock = fakeTimers();
+    const gate = createSendPinGate(
+      { provider: "a", model: "1" },
+      undefined,
+      clock.set,
+      clock.clear,
+    );
+    gate.update({ provider: "a", model: "1" }, true);
+    deepStrictEqual(await gate.resolve(), { provider: "a", model: "1" });
+    gate.update({ provider: "b", model: "2" }, false);
+    let released = false;
+    const waiting = gate.resolve().then(() => {
+      released = true;
+    });
+    await Promise.resolve();
+    strictEqual(released, false);
+    gate.update({ provider: "b", model: "2" }, true);
+    await waiting;
+    strictEqual(released, true);
+  });
+});

--- a/packages/web/src/engine-adapter/activities.ts
+++ b/packages/web/src/engine-adapter/activities.ts
@@ -58,6 +58,9 @@ export function activityToConversation(
     agent_name: agentName,
     agent: a.agent,
     routine_id: a.routine_id,
+    // The pin rides along so a placeholder seeded from this sweep keeps it.
+    ...(a.provider !== undefined && { provider: a.provider }),
+    ...(a.model !== undefined && { model: a.model }),
     // Agent-started marker (PRODUCT-1244): drives the card's tag.
     ...(a.origin_session_key !== undefined && {
       origin_session_key: a.origin_session_key,

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1191,6 +1191,11 @@ export interface ConversationEntry {
   agent_name: string;
   agent?: string;
   routine_id?: string;
+  /** The row's provider/model pin (pi's canonical provider id), carried so a
+   *  board seeded from the cross-agent sweep never presents a pinned chat as
+   *  pin-less (PRODUCT-1771). Absent on rows that were never pinned. */
+  provider?: string;
+  model?: string;
   /** The conversation this mission was started from, present only when the
    *  agent created the mission itself (PRODUCT-1244). Server-stamped. */
   origin_session_key?: string;


### PR DESCRIPTION
## Root cause

PRODUCT-1771. A message sent right after a space switch (or a cold open) ran on the device's last-used provider while the composer had already settled on the chat's real pin. Traced on the incident (Houston org, agent Devin, 2026-09-11 15:17Z): the pod logged `[turn] provider=openai-compatible model=gemma4:12b pinned=true` for a chat whose row, agent config, and stored choice were all Claude, and the next send 36 s later ran `anthropic/claude-opus-5`.

How the composer got there:

1. On a space switch the board first serves **placeholder rows** from the cross-agent cache (`latestCachedAgentActivities`). Those rows carried no `provider`/`model`, so the open chat's mission tier read as *absent* instead of *unknown*.
2. The agent-config tier was a **one-shot `useEffect` read** still in flight.
3. With both tiers empty, `resolveEffectiveProvider` fell through to the **device-wide `default_provider` preference**, which was the local model picked the day before on another org's agent.
4. The legacy-row stamp (HOU-695) mistook the placeholder for a pin-less legacy row and **persisted the guess onto the real row** (the whole-file activity PUT 4 s before the send).
5. The send captured that pin at Enter time and posted seconds later, after the send path's own awaits; by then the label had settled on Claude. The gateway passes an explicit pin through and the runtime runs it `pinned=true`, so the turn ran on the local model.

## Fix

- **Send gate** (`app/src/lib/send-pin-gate.ts`, `app/src/hooks/use-send-pin.ts`): every send path awaits `resolveSendPin()`, which hands the send the composer's latest pin only once the row, agent config, capabilities, stored choice, and provider probe have settled. Bounded by a 15 s timeout that reports (never strands a message). Warming/asleep pods are exempt so the PRODUCT-1643 optimistic send stays intact (their flush re-reads the row pin).
- **Agent tier via the config query** (`chat-agent-tier.ts` + `useAgentConfig`): retried, reactive to `ConfigChanged`, and distinguishes "not read yet" from "no provider".
- **Stamp guard**: the legacy-row stamp skips placeholder rows and unsettled composers.
- **Placeholder rows carry pins**: `ConversationEntry` and the sweep now include `provider`/`model` (additive) so a pinned chat is never presented as pin-less.

Consumers wired: per-agent board, Mission Control, the assistant chat, routine setup board, archived-mission send, and the panel's own sends (edit-resend, skills, interaction answers, integration follow-up, provider-error retry).

## Verification

Before (reproduces on `main`):
1. In space A, open a chat, pick a local model (or any provider B) in the picker so the device's last-used provider becomes B.
2. Switch to space C, open an existing chat pinned to Claude, and press Enter within ~3 s of the switch (the window in which the activity list is still the cached placeholder).
3. The turn runs on provider B (pod log `[turn] provider=<B> … pinned=true`, or B's reconnect card), the row's stored pin is overwritten with B, and the picker settles on Claude.

After:
1. Same steps. The send waits for the row and config reads, then goes out with the chat's own pin; the pod logs `[turn] provider=anthropic model=claude-…`. The row keeps its pin.
2. Send while a pod is asleep: still parks instantly in the warming queue (no wait).

Checks: `pnpm check`, `app` tsgo + `pnpm test` (4310 pass, new `send-pin-gate.test.ts` + cache pin test), `packages/web` typecheck + vitest, `ui/engine-client` tests, `check-locales`, `check:parity`.
