### PR TITLE
fix(routines): routine screen's trigger chip times out instead of spinning forever (PRODUCT-1772)

### DIFF
--- a/app/src/components/agent/routine-activation-chip.tsx
+++ b/app/src/components/agent/routine-activation-chip.tsx
@@ -7,8 +7,10 @@
  *
  * It reads the same per-agent trigger-status query the Routines grid does
  * (shared cache), so opening the chat right after creation streams the live
- * activation. Reconnect routes to the Integrations surface, the same hand-off
- * the grid's row badge uses.
+ * activation, and resolves it through the same verification timeout, so a
+ * routine the host never reports on ends in a concrete error instead of
+ * spinning forever. Reconnect routes to the Integrations surface, the same
+ * hand-off the grid's row badge uses.
  */
 import { Button, cn } from "@houston-ai/core";
 import type { RoutineTriggerBinding } from "@houston-ai/engine-client";
@@ -19,6 +21,7 @@ import { useAgentTriggerStatus } from "../../hooks/queries/use-triggers";
 import { useUIStore } from "../../stores/ui";
 import { INTEGRATIONS_VIEW_ID } from "../integrations-view/id";
 import { triggerActivationKind } from "./routine-trigger-maps";
+import { useTriggerStatusTimeouts } from "./use-trigger-status-timeouts";
 import { WebhookActivationChip } from "./webhook-activation-chip";
 
 interface Props {
@@ -36,10 +39,8 @@ export function RoutineActivationChip({ agentId, routineId, trigger }: Props) {
 
   const routineIds = useMemo(() => [routineId], [routineId]);
   const statusQuery = useAgentTriggerStatus(agentId, true, routineIds);
-  const status = useMemo(
-    () => statusQuery.data?.find((s) => s.routine_id === routineId),
-    [statusQuery.data, routineId],
-  );
+  const statuses = useTriggerStatusTimeouts(routineIds, statusQuery.data);
+  const status = statuses[routineId];
 
   const onReconnect = useCallback(() => {
     setViewMode(INTEGRATIONS_VIEW_ID);

--- a/app/src/components/agent/trigger-status-view-model.ts
+++ b/app/src/components/agent/trigger-status-view-model.ts
@@ -1,6 +1,6 @@
 import type { Routine } from "@houston-ai/engine-client";
 import type { TriggerStatusItem } from "@houston-ai/routines";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useIntegrationToolkits } from "../../hooks/queries/use-integrations";
 import { useCapabilities } from "../../hooks/use-capabilities";
@@ -8,13 +8,10 @@ import { useUIStore } from "../../stores/ui";
 import { INTEGRATION_PROVIDER } from "../integrations/model";
 import { INTEGRATIONS_VIEW_ID } from "../integrations-view/id";
 import {
-  TRIGGER_STATUS_TIMEOUT_MS,
-  timedOutTriggerIds,
-  toStatusMap,
   toTriggerSummaries,
   triggerBoundRoutineIds,
-  withTriggerTimeouts,
 } from "./routine-trigger-maps";
+import { useTriggerStatusTimeouts } from "./use-trigger-status-timeouts";
 
 /** Exactly the trigger props `RoutinesGrid` takes, plus the capability gate. */
 export interface TriggerSurface {
@@ -35,9 +32,9 @@ export interface TriggerSurface {
  *
  * The FETCH stays with the caller and everything downstream of it lives here:
  * a team's cross-agent list (`team-routines/use-team-trigger-statuses.ts`) fans
- * status out per agent and hands it over. Copying the timeout rule into a
- * second surface would be the one duplication we cannot afford: it is the only
- * reason a trigger row cannot lie.
+ * status out per agent and hands it over. The timeout rule itself lives in
+ * `useTriggerStatusTimeouts`, shared with the routine screen's activation chip:
+ * it is the only reason a trigger row cannot lie, so there is exactly one copy.
  *
  * The contract, and the reason this works for a merged list: `routines[i].id`
  * and `statusItems[j].routine_id` are both the GRID's row id. The team list
@@ -73,48 +70,7 @@ export function useTriggerStatusViewModel(
     setViewMode(INTEGRATIONS_VIEW_ID);
   }, [setViewMode]);
 
-  // A trigger routine that never gets a status item would otherwise say
-  // "verifying" forever (an older host, a create that silently failed). Track
-  // when each first appears WITHOUT a status, and once that has lasted past the
-  // timeout, synthesize a concrete error so the row/chip stop spinning.
-  const firstSeenRef = useRef<Record<string, number>>({});
-  const [timeoutTick, setTimeoutTick] = useState(0);
-
-  useEffect(() => {
-    const now = Date.now();
-    const ids = new Set(triggerRowIds);
-    const known = new Set((statusItems ?? []).map((i) => i.routine_id));
-    const seen = firstSeenRef.current;
-    for (const id of triggerRowIds) {
-      if (!known.has(id) && seen[id] === undefined) seen[id] = now;
-    }
-    for (const id of Object.keys(seen)) {
-      if (!ids.has(id) || known.has(id)) delete seen[id];
-    }
-    // Force one re-evaluation at the earliest pending timeout, so a routine
-    // that goes quiet still flips to the error copy even if no poll lands then.
-    const waits = Object.values(seen)
-      .map((seenAt) => seenAt + TRIGGER_STATUS_TIMEOUT_MS - now)
-      .filter((ms) => ms > 0);
-    if (waits.length === 0) return;
-    const timer = setTimeout(
-      () => setTimeoutTick((n) => n + 1),
-      Math.min(...waits),
-    );
-    return () => clearTimeout(timer);
-  }, [triggerRowIds, statusItems]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: timeoutTick is a deliberate recompute trigger — the body reads firstSeenRef.current + Date.now() live, and the timer bumps timeoutTick so an elapsed timeout flips the routine to the error copy.
-  const triggerStatuses = useMemo(() => {
-    const base = toStatusMap(statusItems);
-    const timedOut = timedOutTriggerIds(
-      triggerRowIds,
-      statusItems,
-      firstSeenRef.current,
-      Date.now(),
-    );
-    return withTriggerTimeouts(base, timedOut, t("trigger.statusTimeout"));
-  }, [statusItems, triggerRowIds, timeoutTick, t]);
+  const triggerStatuses = useTriggerStatusTimeouts(triggerRowIds, statusItems);
 
   const triggerSummaries = useMemo(() => {
     const bySlug = new Map(

--- a/app/src/components/agent/use-trigger-status-timeouts.ts
+++ b/app/src/components/agent/use-trigger-status-timeouts.ts
@@ -1,0 +1,74 @@
+import type { TriggerStatusItem } from "@houston-ai/engine-client";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  TRIGGER_STATUS_TIMEOUT_MS,
+  timedOutTriggerIds,
+  toStatusMap,
+  withTriggerTimeouts,
+} from "./routine-trigger-maps";
+
+/**
+ * The ONE machinery that stops a trigger routine saying "verifying" forever:
+ * the per-row status map with a concrete error overlaid on every routine whose
+ * status has been absent past the verification timeout.
+ *
+ * A trigger routine that never gets a status item would otherwise spin without
+ * end — an older host, a create that silently failed, or an agent whose trigger
+ * rows the backend cannot see (PRODUCT-1772: the routine screen's activation
+ * chip read the raw status and had no timeout at all, so a moved agent's
+ * webhook routine showed "Checking your trigger…" across restarts). Every
+ * surface that renders a trigger status resolves it through here — the grid's
+ * row badges via the view model, the routine screen's chip directly — so no
+ * second copy of the timeout rule can drift.
+ *
+ * `triggerRowIds` are the rows that can sit in a "verifying" state at all;
+ * `statusItems` is the fetched list (`null` when the host serves no triggers).
+ * Tracks when each row first appears WITHOUT a status, and once that has lasted
+ * past the timeout, synthesizes the error so the row/chip stop spinning. A real
+ * status item, when it finally lands, always wins.
+ */
+export function useTriggerStatusTimeouts(
+  triggerRowIds: string[],
+  statusItems: TriggerStatusItem[] | null | undefined,
+): Record<string, TriggerStatusItem> {
+  const { t } = useTranslation("routines");
+  const firstSeenRef = useRef<Record<string, number>>({});
+  const [timeoutTick, setTimeoutTick] = useState(0);
+
+  useEffect(() => {
+    const now = Date.now();
+    const ids = new Set(triggerRowIds);
+    const known = new Set((statusItems ?? []).map((i) => i.routine_id));
+    const seen = firstSeenRef.current;
+    for (const id of triggerRowIds) {
+      if (!known.has(id) && seen[id] === undefined) seen[id] = now;
+    }
+    for (const id of Object.keys(seen)) {
+      if (!ids.has(id) || known.has(id)) delete seen[id];
+    }
+    // Force one re-evaluation at the earliest pending timeout, so a routine
+    // that goes quiet still flips to the error copy even if no poll lands then.
+    const waits = Object.values(seen)
+      .map((seenAt) => seenAt + TRIGGER_STATUS_TIMEOUT_MS - now)
+      .filter((ms) => ms > 0);
+    if (waits.length === 0) return;
+    const timer = setTimeout(
+      () => setTimeoutTick((n) => n + 1),
+      Math.min(...waits),
+    );
+    return () => clearTimeout(timer);
+  }, [triggerRowIds, statusItems]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: timeoutTick is a deliberate recompute trigger — the body reads firstSeenRef.current + Date.now() live, and the timer bumps timeoutTick so an elapsed timeout flips the routine to the error copy.
+  return useMemo(() => {
+    const base = toStatusMap(statusItems);
+    const timedOut = timedOutTriggerIds(
+      triggerRowIds,
+      statusItems,
+      firstSeenRef.current,
+      Date.now(),
+    );
+    return withTriggerTimeouts(base, timedOut, t("trigger.statusTimeout"));
+  }, [statusItems, triggerRowIds, timeoutTick, t]);
+}


### PR DESCRIPTION
## Summary

PRODUCT-1772: after moving an agent to another org, its webhook routine's header showed "Checking your trigger…" forever, even across app restarts, and the user could never reach "Create webhook address".

**Root cause.** Two halves:
1. Cloud (the real cause): `MoveAgentRows` never re-keyed `trigger_desired` / `webhook_bindings` / `pending_trigger_events` to the target org, so the target org's trigger-status read returned nothing and the orphan sweep revoked the webhook. Fixed in gethouston/cloud#358.
2. App (this PR): `RoutineActivationChip` on the routine screen read the raw status item and mapped an absent item to "checking" with no timeout, unlike the Routines grid's row badges, which stop after 45s via `useTriggerStatusViewModel`. So a backend that reports nothing spun forever instead of surfacing the existing "Houston couldn't confirm this trigger was set up." error.

**Fix.** The verification timeout is extracted from the view model into `useTriggerStatusTimeouts` (one copy of the rule) and the chip resolves its status through it. Grid behavior is unchanged. The webhook chip's `alert` branch already renders the timeout detail, and the "New key"/"Create webhook address" flows are untouched.

**Tests.** The timeout rule's pure helpers (`timedOutTriggerIds`, `withTriggerTimeouts`) stay covered by `app/tests/routine-trigger-maps.test.ts`; `pnpm check`, `pnpm typecheck`, `cd app && pnpm tsgo --noEmit && pnpm test` (4298 pass) all green.

## Verify

Before: open a routine whose agent's trigger status list is empty (e.g. a just-moved agent on a pre-fix gateway) → the header chip spins on "Checking your trigger…" indefinitely.

After: the same routine flips after 45s to the warning "Houston couldn't confirm this trigger was set up." A routine with a real status still shows checking → active / "Create webhook address" / "Webhook active" as before.

