### PR TITLE
fix(host): trigger-woken routines fire as their creator (PRODUCT-1774)

### DIFF
--- a/packages/host/src/routes/trigger-events.test.ts
+++ b/packages/host/src/routes/trigger-events.test.ts
@@ -24,10 +24,22 @@ const verifier: TokenVerifier = {
 };
 
 class SpyChannel implements RuntimeChannel {
-  fired: { conversationId: string; text: string }[] = [];
+  fired: {
+    conversationId: string;
+    text: string;
+    actingUser?: string;
+    actingAs?: string;
+  }[] = [];
   async dispatch() {}
-  async fireTurn(_ctx: ChannelCtx, conversationId: string, text: string) {
-    this.fired.push({ conversationId, text });
+  async fireTurn(
+    _ctx: ChannelCtx,
+    conversationId: string,
+    text: string,
+    _pin?: unknown,
+    actingUser?: string,
+    actingAs?: string,
+  ) {
+    this.fired.push({ conversationId, text, actingUser, actingAs });
   }
   async cancelTurn() {
     return false;
@@ -98,13 +110,21 @@ async function seedRoutine(r: Routine): Promise<void> {
   await saveRoutines(vfs, workspaceRoot(ws, agent), [r]);
 }
 
-async function post(events: unknown, who = "alice") {
+async function post(events: unknown, who = "alice", extra: object = {}) {
   return fetch(`${base}/agents/${agentId}/trigger-events`, {
     method: "POST",
     headers: auth(who),
-    body: JSON.stringify({ events }),
+    body: JSON.stringify({ events, ...extra }),
   });
 }
+
+/** A gateway-shaped C2 token; pods decode the payload and never verify. */
+function actingAs(sub: string): string {
+  const payload = Buffer.from(JSON.stringify({ sub })).toString("base64url");
+  return `acting-v1.${payload}.signature`;
+}
+
+const EVENT = { id: "e1", routine_id: "r1", trigger_slug: "HOOK", payload: {} };
 
 beforeEach(async () => {
   store = new MemoryWorkspaceStore();
@@ -244,5 +264,57 @@ test("a gateway-proxied (acting-as) request is refused: 404, nothing fires", asy
     }),
   });
   expect(res.status).toBe(404);
+  expect(channel.fired).toHaveLength(0);
+});
+
+test("the creator's minted acting-as token rides the turn (PRODUCT-1774)", async () => {
+  // The control plane mints the creator's C2 token and sends it in the body;
+  // the firer passes it through so the turn resolves the CREATOR's credential
+  // scope (the same identity a scheduled fire carries) instead of the team's.
+  await seedRoutine(routine({ created_by: "creator-1" }));
+  const token = actingAs("creator-1");
+  const res = await post([EVENT], "alice", { actingAs: token });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ result: "fired", event_ids: ["e1"] });
+  expect(channel.fired).toEqual([
+    expect.objectContaining({ actingAs: token, actingUser: undefined }),
+  ]);
+});
+
+test("without a token the bare creator sub rides, as before", async () => {
+  // Self-host in-process delivery and an older control plane send no token.
+  await seedRoutine(routine({ created_by: "creator-1" }));
+  await post([EVENT]);
+  expect(channel.fired).toEqual([
+    expect.objectContaining({ actingUser: "creator-1", actingAs: undefined }),
+  ]);
+});
+
+test("a token for someone other than the creator is refused: 400, nothing fires, no lock burned", async () => {
+  await seedRoutine(routine({ created_by: "creator-1" }));
+  const res = await post([EVENT], "alice", {
+    actingAs: actingAs("someone-else"),
+  });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({
+    error: "acting-as subject does not match the creator of routine r1",
+    code: "routine_creator_mismatch",
+  });
+  expect(channel.fired).toHaveLength(0);
+  // Re-deliverable: the refusal happened before the event's dedup lock was set.
+  expect(await bus.get("trigger-event:e1")).toBeNull();
+});
+
+test("a token on a routine with no recorded creator is refused the same way", async () => {
+  await seedRoutine(routine());
+  const res = await post([EVENT], "alice", { actingAs: actingAs("creator-1") });
+  expect(res.status).toBe(400);
+  expect(channel.fired).toHaveLength(0);
+});
+
+test("a non-string actingAs is a 400", async () => {
+  await seedRoutine(routine({ created_by: "creator-1" }));
+  const res = await post([EVENT], "alice", { actingAs: 42 });
+  expect(res.status).toBe(400);
   expect(channel.fired).toHaveLength(0);
 });

--- a/packages/host/src/routes/trigger-events.ts
+++ b/packages/host/src/routes/trigger-events.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { ACTING_AS_HEADER } from "../auth/acting";
+import { TriggerCreatorMismatchError } from "../triggers/acting";
 import {
   fireTriggerEvents,
   type TriggerEvent,
@@ -109,18 +110,34 @@ export async function handleTriggerEvents(
     events.push(parsed);
   }
 
-  const result = await fireTriggerEvents(
-    {
-      vfs: deps.vfs,
-      paths: deps.paths ?? DEFAULT_PATHS,
-      channels: deps.channels,
-      events: deps.events,
-      lock: deps.triggerLock,
-    },
-    authz.workspace,
-    authz.agent,
-    events,
-  );
-  json(res, 200, result);
+  // The creator's minted C2 token rides in the BODY, never the header: the
+  // header is the proxied-user marker refused above, and the internal delivery
+  // is the only caller of this route (same shape as routine-fires). Optional:
+  // an older control plane, or the self-host process, delivers without it.
+  if (body.actingAs !== undefined && typeof body.actingAs !== "string") {
+    json(res, 400, { error: "malformed 'actingAs'" });
+    return true;
+  }
+  const actingAs = body.actingAs || undefined;
+
+  try {
+    const result = await fireTriggerEvents(
+      {
+        vfs: deps.vfs,
+        paths: deps.paths ?? DEFAULT_PATHS,
+        channels: deps.channels,
+        events: deps.events,
+        lock: deps.triggerLock,
+        actingAs,
+      },
+      authz.workspace,
+      authz.agent,
+      events,
+    );
+    json(res, 200, result);
+  } catch (err) {
+    if (!(err instanceof TriggerCreatorMismatchError)) throw err;
+    json(res, 400, { error: err.message, code: err.code });
+  }
   return true;
 }

--- a/packages/host/src/triggers/acting.ts
+++ b/packages/host/src/triggers/acting.ts
@@ -1,0 +1,37 @@
+import type { Routine } from "@houston/protocol";
+import { actingSubFromHeader } from "../auth/acting";
+
+/**
+ * A trigger delivery carried a minted acting-as token whose subject is not the
+ * routine's creator. Permanent for THIS delivery: the control plane minted the
+ * token from its projected `created_by`, so a mismatch means the projection and
+ * the pod's routines file disagree, and re-posting the same token cannot fix
+ * that. The route answers 400 with this code (parity with `routine-fires.ts`).
+ */
+export class TriggerCreatorMismatchError extends Error {
+  readonly code = "routine_creator_mismatch" as const;
+
+  constructor(routineId: string) {
+    super(
+      `acting-as subject does not match the creator of routine ${routineId}`,
+    );
+    this.name = "TriggerCreatorMismatchError";
+  }
+}
+
+/**
+ * Require the delivery's acting-as token to name the routine's creator.
+ *
+ * Pods hold no gateway HMAC key, so this is the strongest check available on a
+ * pod-token-authenticated internal route: decode the minted payload and demand
+ * its subject equal `created_by`. A token that fires the routine as anyone else
+ * would resolve THAT person's credential scope for a run they never authored.
+ */
+export function assertActingIsCreator(
+  actingAs: string,
+  routine: Routine,
+): void {
+  const sub = actingSubFromHeader(actingAs);
+  if (!sub || !routine.created_by || sub !== routine.created_by)
+    throw new TriggerCreatorMismatchError(routine.id);
+}

--- a/packages/host/src/triggers/fire.ts
+++ b/packages/host/src/triggers/fire.ts
@@ -12,6 +12,7 @@ import { hostProvider, routineProviderUnavailable } from "../providers";
 import { fireRoutineRun, RoutineBusyError } from "../schedule/run";
 import type { FiringJob, RoutineFirer } from "../schedule/scheduler";
 import type { Vfs } from "../vfs";
+import { assertActingIsCreator } from "./acting";
 
 /**
  * One external event delivered to a routine. `id` is the DEDUP key — the cloud
@@ -58,6 +59,18 @@ export interface FireTriggerDeps {
   lock: TriggerEventLock;
   /** Dedup-lock TTL (s). Must outlast the redelivery/retry window. Default 1h. */
   dedupTtlSec?: number;
+  /**
+   * The gateway-minted C2 token for the routine's CREATOR, on the control-plane
+   * → pod path. It makes the run resolve the creator's credential scope, the
+   * same identity a scheduled fire (`routine-fires.ts`) and a Run-now press
+   * carry. Without it a pod cannot elevate the bare `created_by` sub (HOU-976
+   * D10) and the turn lands on the TEAM credential: in a team space where the
+   * creator connected a provider personally, every webhook-woken run failed
+   * "creator has no account connected" while chat and Run now worked
+   * (PRODUCT-1774). Absent on the self-host in-process path, which has one
+   * credential scope anyway.
+   */
+  actingAs?: string;
   now?: () => Date;
   newId?: () => string;
 }
@@ -78,6 +91,7 @@ class TriggerRoutineFirer implements RoutineFirer {
       Record<WorkspaceRuntime, RuntimeChannel>
     >,
     private readonly events: TriggerEvent[],
+    private readonly actingAs?: string,
   ) {}
 
   async fire(job: FiringJob): Promise<void> {
@@ -90,12 +104,15 @@ class TriggerRoutineFirer implements RoutineFirer {
     // runtime stream error nobody persists.
     if (pin.provider && !hostProvider(pin.provider))
       throw new Error(routineProviderUnavailable(pin.provider));
+    // The minted token replaces the bare creator header (ChannelRoutineFirer
+    // parity): the runtime reads acting-as for the credential scope.
     await channel.fireTurn(
       { workspace: job.workspace, agent: job.agent },
       job.conversationId,
       routineTriggerPrompt(job.routine, this.events),
       { ...pin, effort: job.routine.effort },
-      job.routine.created_by,
+      this.actingAs ? undefined : job.routine.created_by,
+      this.actingAs,
     );
   }
 }
@@ -140,6 +157,8 @@ export async function fireTriggerEvents(
   for (const [routineId, group] of byRoutine) {
     // `enabled` is keyed by the same ids `byRoutine` was built from.
     const routine = enabled.get(routineId) as Routine;
+    // Before any lock is burned: a refused delivery must stay re-deliverable.
+    if (deps.actingAs) assertActingIsCreator(deps.actingAs, routine);
     const fresh: TriggerEvent[] = [];
     for (const e of group) {
       if (await deps.lock.setNx(lockKey(e.id), "1", ttl)) fresh.push(e);
@@ -149,7 +168,7 @@ export async function fireTriggerEvents(
       for (const e of group) consumed.push(e.id);
       continue;
     }
-    const firer = new TriggerRoutineFirer(deps.channels, fresh);
+    const firer = new TriggerRoutineFirer(deps.channels, fresh, deps.actingAs);
     try {
       await fireRoutineRun(
         {


### PR DESCRIPTION
Fixes [PRODUCT-1774](https://linear.app/houston-ai/issue/PRODUCT-1774). Pairs with the control-plane half (cloud PR: trigger delivery mints the creator's token); either side deploys first safely.

## Problem

Webhook- and Composio-woken routine runs never carried the creator's identity. The trigger firer fired the turn with the bare `created_by` sub, which a pod cannot elevate (HOU-976 D10), so the run resolved the TEAM credential scope. In a team space where the creator connected Anthropic personally, every webhook fire failed "The routine's creator has no Anthropic account connected" (later "needs to be reconnected") while chat, Run now (PRODUCT-1637) and scheduled fires worked. Daniel's "Anunciar release draft" routine has not completed a webhook run since it was created.

## Change

- `routes/trigger-events.ts`: accepts an optional `actingAs` in the body (never the header, which stays the proxied-user refusal marker). A mismatched creator answers 400 `routine_creator_mismatch`, parity with `routine-fires.ts`.
- `triggers/fire.ts` + new `triggers/acting.ts`: the token must name the routine's `created_by`, checked before any dedup lock is burned so the delivery stays retryable; the firer forwards the token to `fireTurn` and drops the bare header, the same as `ChannelRoutineFirer`.
- Deliveries without a token (self-host in-process path, an older control plane) keep today's bare behavior.

## Tests

`trigger-events.test.ts`: token rides the turn as acting-as; no token keeps the bare creator sub; wrong subject and creator-less routine refuse with 400 and burn no lock; non-string `actingAs` is a 400. `pnpm --filter @houston/host test` (233 files) and `pnpm check` pass.