### PR TITLE
fix(shell): offline Claude sign-in is a connectivity state, not a Sentry error (PRODUCT-1775)

### DIFF
--- a/app/src-tauri/src/claude_login/exit_report.rs
+++ b/app/src-tauri/src/claude_login/exit_report.rs
@@ -1,0 +1,146 @@
+//! Turn a non-zero helper exit into the `claude-login://done` failure payload
+//! and the log line that goes with it.
+//!
+//! Three exit flavors are EXPECTED states rather than Houston failures, and
+//! each is flagged so the frontend can pick an authored surface: the helper
+//! binary cannot run here (signal death), the CLI refused its Windows shell
+//! gate, or the machine has no route to `platform.claude.com`. Those log at
+//! WARN — a Sentry error per attempt from the same offline or unsupported
+//! machines is noise (HOUSTON-APP-543, -4ZP and -5E9 kept regressing on it);
+//! the breadcrumb + backend.log line keeps the diagnosis trail. Anything else
+//! (a declined authorization, a server-side rejection) stays an ERROR.
+
+use std::process::ExitStatus;
+
+use serde_json::{json, Value};
+
+use super::network_gate::is_network_failure;
+use super::shell_gate::is_shell_gate_failure;
+
+/// Classification of one non-zero helper exit.
+pub(super) struct ExitReport {
+    /// `Claude sign-in failed (exit <code>)[: <stderr tail>]`.
+    pub error: String,
+    /// Signal death: the helper binary cannot run on this machine at all, e.g.
+    /// SIGILL from a pre-AVX2 CPU (HOUSTON-APP-543). Declines exit with a code
+    /// and our own cancel/timeout kills never reach this classifier.
+    pub helper_unavailable: bool,
+    /// The CLI ran but refused its Windows shell gate: no runnable Git Bash /
+    /// PowerShell (HOUSTON-APP-4ZP).
+    pub shell_unavailable: bool,
+    /// The CLI could not reach `platform.claude.com`: device offline or DNS /
+    /// route failure (HOUSTON-APP-5E9).
+    pub network_unavailable: bool,
+}
+
+impl ExitReport {
+    pub fn classify(status: &ExitStatus, stderr_tail: &str) -> Self {
+        let helper_unavailable = status.code().is_none();
+        let code = status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| signal_label(status));
+        let tail = stderr_tail.trim();
+        let mut error = format!("Claude sign-in failed (exit {code})");
+        if !tail.is_empty() {
+            error.push_str(": ");
+            error.push_str(tail);
+        }
+        Self {
+            error,
+            helper_unavailable,
+            shell_unavailable: is_shell_gate_failure(tail),
+            network_unavailable: is_network_failure(tail),
+        }
+    }
+
+    /// True for the flavors the frontend degrades or explains on its own.
+    pub fn is_expected_state(&self) -> bool {
+        self.helper_unavailable || self.shell_unavailable || self.network_unavailable
+    }
+
+    /// Log at the level the flavor deserves (see the module doc).
+    pub fn log(&self) {
+        if self.is_expected_state() {
+            tracing::warn!("[claude-login] {}", self.error);
+        } else {
+            tracing::error!("[claude-login] {}", self.error);
+        }
+    }
+
+    /// The `claude-login://done` payload.
+    pub fn payload(&self) -> Value {
+        json!({
+            "success": false,
+            "error": self.error,
+            "helperUnavailable": self.helper_unavailable,
+            "shellUnavailable": self.shell_unavailable,
+            "networkUnavailable": self.network_unavailable,
+        })
+    }
+}
+
+/// Diagnostic label for a signal death: "signal <n>" on Unix (which signal
+/// separates SIGILL/pre-AVX2 from OOM kills and sandbox denials in triage),
+/// bare "signal" where the number is unavailable.
+fn signal_label(status: &ExitStatus) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(sig) = status.signal() {
+            return format!("signal {sig}");
+        }
+    }
+    // Windows ExitStatus::code() is always Some, so this arm is unreachable
+    // there in practice; keep the fn total for any future target.
+    #[cfg(not(unix))]
+    let _ = status;
+    "signal".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn exit_with(code: i32) -> ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_offline_exit_is_an_expected_state_with_the_network_flag() {
+        let report = ExitReport::classify(
+            &exit_with(1),
+            "Login failed: getaddrinfo ETIMEOUT platform.claude.com\n",
+        );
+        assert!(report.network_unavailable);
+        assert!(!report.helper_unavailable);
+        assert!(!report.shell_unavailable);
+        assert!(report.is_expected_state());
+        assert_eq!(
+            report.error,
+            "Claude sign-in failed (exit 1): Login failed: getaddrinfo ETIMEOUT platform.claude.com"
+        );
+        assert_eq!(report.payload()["networkUnavailable"], json!(true));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_declined_exit_stays_a_real_failure() {
+        let report = ExitReport::classify(&exit_with(1), "authentication was declined");
+        assert!(!report.is_expected_state());
+        let payload = report.payload();
+        assert_eq!(payload["helperUnavailable"], json!(false));
+        assert_eq!(payload["shellUnavailable"], json!(false));
+        assert_eq!(payload["networkUnavailable"], json!(false));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_silent_exit_carries_only_the_code() {
+        let report = ExitReport::classify(&exit_with(3), "  \n");
+        assert_eq!(report.error, "Claude sign-in failed (exit 3)");
+    }
+}

--- a/app/src-tauri/src/claude_login/mod.rs
+++ b/app/src-tauri/src/claude_login/mod.rs
@@ -34,6 +34,9 @@
 //!     `shellUnavailable: true` means the CLI started but refused its Windows
 //!     shell gate (no runnable Git Bash / PowerShell; [`shell_gate`]) — same
 //!     degrade path, and a co-located engine gets install-Git copy.
+//!     `networkUnavailable: true` means the CLI could not reach
+//!     `platform.claude.com` (offline, DNS; [`network_gate`]) — the frontend
+//!     shows its connectivity toast instead of the raw CLI text.
 //!
 //! Cancel + child kill run through `ClaudeLoginState`; the background task that
 //! owns the child polls a shared cancel flag and tears the child down when set.
@@ -41,7 +44,9 @@
 //! Split across submodules to stay under the 200-line file limit:
 //!   * [`resolve`] — binary/config-dir resolution, command building, URL parse.
 //!   * [`runner`] — the spawn/stream/wait state machine (`run_login_child`).
+//!   * [`exit_report`] — classify a non-zero exit into flags + log level.
 //!   * [`shell_gate`] — classify the CLI's Windows shell-gate refusal.
+//!   * [`network_gate`] — classify an offline / unreachable-host failure.
 //!   * [`credential`] — extract the cached credential to PUSH to a remote pod.
 
 // `pub(crate)` so `generate_handler!` in `lib.rs` can name the command at its
@@ -52,6 +57,8 @@ pub(crate) mod code_input;
 mod cpu;
 pub(crate) mod credential;
 pub(crate) mod discard;
+mod exit_report;
+mod network_gate;
 mod resolve;
 mod runner;
 mod shell_gate;

--- a/app/src-tauri/src/claude_login/network_gate.rs
+++ b/app/src-tauri/src/claude_login/network_gate.rs
@@ -1,0 +1,85 @@
+//! Recognize a network-transport failure in a failed login's stderr.
+//!
+//! `claude auth login` talks to `platform.claude.com` before it can even print
+//! an authorize URL; with no DNS or no route it exits 1 and prints Node's raw
+//! socket error (`Login failed: getaddrinfo ETIMEOUT platform.claude.com`,
+//! HOUSTON-APP-5E9; `ENOTFOUND`, -56S; `connect ECONNREFUSED`, -5AE). The
+//! device is offline or the host is unreachable — nothing in Houston broke —
+//! so the result is an expected connectivity state: a warn-level log (never a
+//! Sentry error per attempt) plus a flagged `done` payload the frontend turns
+//! into its authored connectivity toast instead of the raw CLI text.
+
+/// Node / undici error codes and phrases the CLI surfaces for a transport
+/// failure. Matched case-insensitively on the stderr tail. TLS and HTTP-status
+/// failures are deliberately absent: a rejected certificate (corporate MITM)
+/// or a `400` from the auth endpoint is a real failure that keeps its surface.
+const NETWORK_MARKERS: [&str; 13] = [
+    // DNS: any getaddrinfo failure, plus the resolver's own codes.
+    "getaddrinfo",
+    "enotfound",
+    "eai_again",
+    "eai_fail",
+    // Connect: Windows reports DNS/connect timeouts as `ETIMEOUT`, POSIX as
+    // `ETIMEDOUT`; neither is a substring of the other.
+    "etimeout",
+    "etimedout",
+    "econnrefused",
+    "econnreset",
+    "enetunreach",
+    "ehostunreach",
+    "enetdown",
+    // undici's wrapper when the cause is not spelled out.
+    "fetch failed",
+    "socket hang up",
+];
+
+/// True when `stderr` carries a network-transport failure.
+pub(super) fn is_network_failure(stderr: &str) -> bool {
+    let lowered = stderr.to_ascii_lowercase();
+    NETWORK_MARKERS.iter().any(|m| lowered.contains(m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_the_dns_failures_seen_in_the_field() {
+        // Verbatim from HOUSTON-APP-5E9 and -56S.
+        assert!(is_network_failure(
+            "Login failed: getaddrinfo ETIMEOUT platform.claude.com"
+        ));
+        assert!(is_network_failure(
+            "Login failed: getaddrinfo ENOTFOUND platform.claude.com"
+        ));
+    }
+
+    #[test]
+    fn recognizes_a_refused_or_timed_out_connect() {
+        // Verbatim from HOUSTON-APP-5AE.
+        assert!(is_network_failure(
+            "Login failed: connect ECONNREFUSED 160.79.104.10:443"
+        ));
+        assert!(is_network_failure(
+            "Login failed: connect ETIMEDOUT 1.2.3.4:443"
+        ));
+        assert!(is_network_failure("TypeError: fetch failed"));
+    }
+
+    #[test]
+    fn ignores_other_login_failures() {
+        // A declined authorization, a server-side rejection, a TLS failure or
+        // the shell gate are not connectivity and must keep their surface.
+        assert!(!is_network_failure("authentication was declined"));
+        assert!(!is_network_failure(
+            "Login failed: Request failed with status code 400"
+        ));
+        assert!(!is_network_failure(
+            "unable to verify the first certificate (UNABLE_TO_VERIFY_LEAF_SIGNATURE)"
+        ));
+        assert!(!is_network_failure(
+            "Claude Code on Windows requires either Git for Windows (for bash) or PowerShell."
+        ));
+        assert!(!is_network_failure(""));
+    }
+}

--- a/app/src-tauri/src/claude_login/runner.rs
+++ b/app/src-tauri/src/claude_login/runner.rs
@@ -16,8 +16,8 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdout};
 
+use super::exit_report::ExitReport;
 use super::resolve::{build_login_command, extract_visit_url};
-use super::shell_gate::is_shell_gate_failure;
 use super::{EVENT_DONE, EVENT_URL};
 
 /// Give up on the login if the CLI never returns (user closed the consent tab,
@@ -101,48 +101,11 @@ where
         }
         Ok(LoginOutcome::Exited(Ok(status))) => {
             let tail = collect_stderr(stderr_task).await;
-            // A signal death is never a user decision (declines exit with a
-            // code; our own cancel/timeout kills take the branches below) —
-            // it means the helper binary cannot run here at all, e.g. SIGILL
-            // from a pre-AVX2 CPU (HOUSTON-APP-543). Flag it so the frontend
-            // can degrade to the runtime's paste flow instead of toasting an
-            // error a retry can only reproduce.
-            let helper_unavailable = status.code().is_none();
-            let code = status
-                .code()
-                .map(|c| c.to_string())
-                .unwrap_or_else(|| signal_label(&status));
-            // The CLI ran but refused its Windows shell gate: the machine
-            // lacks a runnable Git Bash / PowerShell (HOUSTON-APP-4ZP). Same
-            // degrade path as an unrunnable helper; the frontend shows
-            // install-Git copy instead of the raw CLI text.
-            let shell_unavailable = is_shell_gate_failure(&tail);
-            let mut error = format!("Claude sign-in failed (exit {code})");
-            if !tail.trim().is_empty() {
-                error.push_str(": ");
-                error.push_str(tail.trim());
-            }
-            if helper_unavailable || shell_unavailable {
-                // WARN, not error: a signal death means this machine cannot run
-                // the helper (SIGILL on pre-AVX2, OOM kill, hardened kernel),
-                // a shell-gate refusal means it lacks a prerequisite, and the
-                // frontend already degrades both. A Sentry event per attempt
-                // from the same machines is noise (HOUSTON-APP-543 and -4ZP
-                // kept regressing on it); the breadcrumb + backend.log line
-                // keeps the diagnosis trail.
-                tracing::warn!("[claude-login] {error}");
-            } else {
-                tracing::error!("[claude-login] {error}");
-            }
-            emit(
-                EVENT_DONE,
-                json!({
-                    "success": false,
-                    "error": error,
-                    "helperUnavailable": helper_unavailable,
-                    "shellUnavailable": shell_unavailable,
-                }),
-            );
+            // Flavor decides the log level and the flags the frontend degrades
+            // on (unrunnable helper, shell gate, offline); see `exit_report`.
+            let report = ExitReport::classify(&status, &tail);
+            report.log();
+            emit(EVENT_DONE, report.payload());
         }
         Ok(LoginOutcome::Exited(Err(e))) => {
             let error = format!("Claude sign-in could not be monitored: {e}");
@@ -239,24 +202,6 @@ where
             }
         }
     }
-}
-
-/// Diagnostic label for a signal death: "signal <n>" on Unix (which signal
-/// separates SIGILL/pre-AVX2 from OOM kills and sandbox denials in triage),
-/// bare "signal" where the number is unavailable.
-fn signal_label(status: &ExitStatus) -> String {
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::ExitStatusExt;
-        if let Some(sig) = status.signal() {
-            return format!("signal {sig}");
-        }
-    }
-    // Windows ExitStatus::code() is always Some, so this arm is unreachable
-    // there in practice; keep the fn total for any future target.
-    #[cfg(not(unix))]
-    let _ = status;
-    "signal".to_string()
 }
 
 /// Read the next stdout line, or hang forever when there is no pipe. The `None`
@@ -426,6 +371,40 @@ mod tests {
         // helper-can't-run condition — it must never reroute to the paste flow.
         assert_eq!(done.1["helperUnavailable"], json!(false));
         assert_eq!(done.1["shellUnavailable"], json!(false));
+        assert_eq!(done.1["networkUnavailable"], json!(false));
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_login_flags_an_offline_exit_as_network_unavailable() {
+        // HOUSTON-APP-5E9: with no DNS the CLI exits 1 printing Node's raw
+        // socket error. The payload must carry the flag so the frontend shows
+        // its connectivity toast instead of the raw text, and the helper and
+        // shell verdicts stay clear (a retry once online just works).
+        let dir = unique_tmp_dir("offline");
+        let script = write_fake_claude(
+            &dir,
+            "claude",
+            "#!/bin/sh\n\
+             echo 'Login failed: getaddrinfo ETIMEOUT platform.claude.com' 1>&2\n\
+             exit 1\n",
+        );
+        let config_dir = dir.join("config");
+
+        let (events, emit) = collect();
+        run_login(&script, &config_dir, Arc::new(AtomicBool::new(false)), emit).await;
+
+        let got = events.lock().expect("events lock");
+        let done = got.last().expect("done event");
+        assert_eq!(done.0, EVENT_DONE);
+        assert_eq!(done.1["success"], json!(false));
+        assert_eq!(done.1["networkUnavailable"], json!(true));
+        assert_eq!(done.1["helperUnavailable"], json!(false));
+        assert_eq!(done.1["shellUnavailable"], json!(false));
+        let error = done.1["error"].as_str().expect("error string");
+        assert!(error.contains("getaddrinfo ETIMEOUT"), "error was: {error}");
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/app/src/lib/claude-login-failure.ts
+++ b/app/src/lib/claude-login-failure.ts
@@ -14,6 +14,10 @@
  *     its Windows shell gate (no runnable Git Bash / PowerShell;
  *     HOUSTON-APP-4ZP). A missing prerequisite, not a login failure: same
  *     paste-flow degrade on a remote engine, install-Git copy co-located.
+ *   * `networkUnavailable: true` — the CLI could not reach
+ *     `platform.claude.com` (device offline, DNS timeout; HOUSTON-APP-5E9).
+ *     A connectivity state, not a Houston failure: the authored offline toast
+ *     replaces the raw Node socket error, and the pending card clears.
  *   * anything else — a real login failure (declined, timed out); toast the
  *     reason verbatim.
  */
@@ -26,6 +30,8 @@ export interface ClaudeLoginDone {
   helperUnavailable?: boolean;
   /** The CLI refused its Windows shell gate: no runnable Git Bash / PowerShell. */
   shellUnavailable?: boolean;
+  /** The CLI could not reach platform.claude.com: offline or DNS failure. */
+  networkUnavailable?: boolean;
 }
 
 export type ClaudeLoginFailureRoute =
@@ -37,6 +43,8 @@ export type ClaudeLoginFailureRoute =
   | { kind: "helper-unsupported" }
   /** Co-located engine + CLI shell gate: install Git for Windows copy. */
   | { kind: "shell-unavailable" }
+  /** No route to platform.claude.com: the connectivity toast, any engine. */
+  | { kind: "offline"; error: string }
   /** A real login failure: surface the helper's reason. */
   | { kind: "error"; error: string };
 
@@ -53,6 +61,9 @@ export function classifyClaudeLoginFailure(
     return remoteEngine
       ? { kind: "paste-fallback", reason: done.error ?? "shell unavailable" }
       : { kind: "shell-unavailable" };
+  }
+  if (done.networkUnavailable) {
+    return { kind: "offline", error: done.error ?? "network unavailable" };
   }
   if (done.error === null) return { kind: "silent" };
   return { kind: "error", error: done.error };

--- a/app/src/lib/claude-login.ts
+++ b/app/src/lib/claude-login.ts
@@ -47,6 +47,7 @@ import {
   finishRemoteClaudeLogin,
 } from "./claude-login-remote";
 import { isRemoteEngine } from "./engine";
+import { showConnectivityErrorToast } from "./error-toast";
 import { publishLocalHoustonEvent } from "./events";
 import i18n from "./i18n";
 import {
@@ -195,6 +196,13 @@ export async function beginClaudeBrowserLogin(
                 false,
                 i18n.t("providers:claudeLogin.shellUnavailable"),
               );
+              break;
+            case "offline":
+              // The CLI never reached platform.claude.com (HOUSTON-APP-5E9):
+              // the authored connectivity toast, and a null-error announce so
+              // the pending card clears without the red sign-in-failed toast.
+              showConnectivityErrorToast("claude_login", route.error);
+              announce(frontendProviderId, false, null);
               break;
             default:
               announce(frontendProviderId, false, error);

--- a/app/tests/claude-login-failure.test.ts
+++ b/app/tests/claude-login-failure.test.ts
@@ -81,6 +81,26 @@ describe("classifyClaudeLoginFailure", () => {
     );
   });
 
+  it("routes an offline exit to the connectivity toast on any engine", () => {
+    // HOUSTON-APP-5E9: no DNS for platform.claude.com. Not a helper or shell
+    // problem (a retry once online just works), so never the paste flow.
+    const done = {
+      success: false,
+      error:
+        "Claude sign-in failed (exit 1): Login failed: getaddrinfo ETIMEOUT platform.claude.com",
+      helperUnavailable: false,
+      shellUnavailable: false,
+      networkUnavailable: true,
+    };
+    const route = {
+      kind: "offline",
+      error:
+        "Claude sign-in failed (exit 1): Login failed: getaddrinfo ETIMEOUT platform.claude.com",
+    };
+    deepStrictEqual(classifyClaudeLoginFailure(done, true), route);
+    deepStrictEqual(classifyClaudeLoginFailure(done, false), route);
+  });
+
   it("keeps a cancel silent", () => {
     deepStrictEqual(
       classifyClaudeLoginFailure({ success: false, error: null }, true),


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1775 (Sentry HOUSTON-APP-5E9; same family as HOUSTON-APP-56S and HOUSTON-APP-5AE).

**Root cause.** `claude auth login` has to reach `platform.claude.com` before it can print an authorize URL. With no DNS or no route it exits 1 and prints Node's raw socket error on stderr (`Login failed: getaddrinfo ETIMEOUT platform.claude.com`). The native runner (`claude_login/runner.rs`) logged every non-zero exit at `tracing::error!` unless it was a signal death or the Windows shell gate, so an offline device minted a standalone Sentry error per attempt. On the frontend the failure router treated the tail as a real login failure and toasted the raw CLI text verbatim to a non-technical user.

**Fix.**
- New `claude_login/network_gate.rs` recognizes a network-transport failure in the stderr tail (Node/undici codes: `getaddrinfo`, `ENOTFOUND`, `EAI_AGAIN`, `ETIMEOUT`/`ETIMEDOUT`, `ECONNREFUSED`, `ECONNRESET`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETDOWN`, `fetch failed`, `socket hang up`). TLS and HTTP-status failures are deliberately excluded and keep their surface.
- The exit classification moves out of `runner.rs` into `claude_login/exit_report.rs` (`ExitReport::classify`): expected states (unrunnable helper, shell gate, offline) log at WARN, everything else stays ERROR. The `claude-login://done` payload gains `networkUnavailable`.
- Frontend `classifyClaudeLoginFailure` gains an `offline` route; `claude-login.ts` sends it through `showConnectivityErrorToast` (the `offline` quiet class, burst-collapsed Sentry warning) and announces a null-error completion so the pending card clears without the red sign-in-failed toast.

## Before

1. On a desktop build, block DNS for `platform.claude.com` (e.g. add `0.0.0.0 platform.claude.com` to the hosts file, or disconnect the network).
2. Settings, Claude, Connect.
3. A red "Couldn't sign in to Claude" toast shows the raw text `Claude sign-in failed (exit 1): Login failed: getaddrinfo ... platform.claude.com`, and Sentry receives a new `[claude-login] Claude sign-in failed (exit 1): ...` error event from `houston_app::claude_login::runner`.

## After

1. Same setup.
2. Settings, Claude, Connect.
3. The informational "Houston, connection lost" connectivity toast shows, the Connect row stops spinning, and no red toast appears.
4. The backend log carries `WARN [claude-login] Claude sign-in failed (exit 1): Login failed: getaddrinfo ...` and Sentry gets only the `offline` quiet-class warning (breadcrumb trail intact), no new error issue.
5. Restore DNS and click Connect again: the normal browser sign-in proceeds.

## Verification

- `cargo test claude_login` (47 passed, incl. new `network_gate`, `exit_report`, and the runner's `run_login_flags_an_offline_exit_as_network_unavailable`)
- `cd app && pnpm test` (4311 passed), `pnpm tsgo --noEmit`, `pnpm check-locales`
- `pnpm check` (Biome) clean
