### PR TITLE
fix(runtime): take Claude tool args from the SDK's assistant block, not a re-parse (PRODUCT-1694)

### DIFF
--- a/packages/runtime/src/backends/claude/translate-blocks.ts
+++ b/packages/runtime/src/backends/claude/translate-blocks.ts
@@ -1,18 +1,29 @@
 import { clipToolResult, type WireEvent } from "@houston/runtime-client";
 import {
+  type AssistantContentBlock,
   type EventLike,
-  parseArgs,
+  parseDeltaJson,
   type ToolBlock,
   toolResultText,
+  toolStartFrame,
   type UserContentBlock,
+  unverifiedToolStart,
 } from "./translate-support";
 
 /** The per-turn content-block state behind a translator's stream handling. */
 export interface ContentBlockTracker {
   /** SDK `stream_event` frames → text/thinking deltas and tool_start. */
   onStreamEvent(event: EventLike): WireEvent[];
+  /**
+   * An `assistant` message's `tool_use` blocks carry the SDK's own parse of the
+   * tool input — the arguments the CLI actually ran the tool with. Records them
+   * per id, and settles any tool_start still waiting on that verdict.
+   */
+  onAssistantMessage(content: unknown): WireEvent[];
   /** A user message's `tool_result` blocks → tool_end for this turn's tools. */
   onUserMessage(content: unknown): WireEvent[];
+  /** The turn's result: settles every tool_start still waiting (loud). */
+  onTurnEnd(): WireEvent[];
 }
 
 /**
@@ -20,10 +31,23 @@ export interface ContentBlockTracker {
  * accumulates across `stream_event` frames (`includePartialMessages: true`), and
  * a tool_use_id→name map lets a later user-message `tool_result` resolve its
  * tool_end.
+ *
+ * Tool arguments come from the SDK's `assistant` message when it has arrived
+ * (it precedes our `content_block_stop` on every observed CLI), else from our
+ * own parse of the deltas. The model does stream invalid JSON (a stray `}`, an
+ * unescaped quote inside an HTML body, a `)` for a `}`): the CLI then never runs
+ * the tool, returns an InputValidationError to the model and lets it retry, so
+ * that is an EXPECTED state — logged as a breadcrumb, never a Sentry error
+ * (PRODUCT-1694). A stop whose deltas fail to parse before the SDK's verdict
+ * arrives waits for it; only a verdict that never comes is loud.
  */
 export function createContentBlockTracker(): ContentBlockTracker {
   const toolBlocks = new Map<number, ToolBlock>();
   const toolNameById = new Map<string, string>();
+  /** SDK-parsed inputs (by tool_use id) not yet consumed by a stop. */
+  const sdkInputById = new Map<string, unknown>();
+  /** Stops whose deltas failed to parse, waiting on the SDK's input. */
+  const awaitingSdkInput = new Map<string, ToolBlock>();
   // Block-boundary tracking (HOU-857): a turn's text arrives as flat deltas,
   // but the model emits DISTINCT content blocks (text → tool_use → text on the
   // next request). Downstream every consumer concatenates the deltas verbatim
@@ -79,11 +103,36 @@ export function createContentBlockTracker(): ContentBlockTracker {
       const tb = toolBlocks.get(event.index);
       if (!tb) return [];
       toolBlocks.delete(event.index);
-      return [
-        { type: "tool_start", data: { name: tb.name, args: parseArgs(tb) } },
-      ];
+      if (sdkInputById.has(tb.id)) {
+        const input = sdkInputById.get(tb.id);
+        sdkInputById.delete(tb.id);
+        return [toolStartFrame(tb, input)];
+      }
+      const parsed = parseDeltaJson(tb);
+      if (parsed.ok) return [toolStartFrame(tb, parsed.args)];
+      awaitingSdkInput.set(tb.id, tb);
+      return [];
     }
     return [];
+  }
+
+  function onAssistantMessage(content: unknown): WireEvent[] {
+    if (!Array.isArray(content)) return [];
+    const out: WireEvent[] = [];
+    for (const block of content as AssistantContentBlock[]) {
+      if (block?.type !== "tool_use" || !block.id) continue;
+      // Only blocks this turn streamed: a replayed (resume history) block has
+      // no stop coming to consume its input.
+      if (!toolNameById.has(block.id)) continue;
+      const waiting = awaitingSdkInput.get(block.id);
+      if (waiting) {
+        awaitingSdkInput.delete(block.id);
+        out.push(toolStartFrame(waiting, block.input));
+      } else {
+        sdkInputById.set(block.id, block.input);
+      }
+    }
+    return out;
   }
 
   function onUserMessage(content: unknown): WireEvent[] {
@@ -95,6 +144,14 @@ export function createContentBlockTracker(): ContentBlockTracker {
       // replayed/foreign result (e.g. resume history) and must not emit tool_end.
       const name = block.tool_use_id && toolNameById.get(block.tool_use_id);
       if (!name) continue;
+      // A result for a call still awaiting the SDK's verdict: settle it first so
+      // the tool_end has its tool_start.
+      const waiting =
+        block.tool_use_id && awaitingSdkInput.get(block.tool_use_id);
+      if (waiting) {
+        awaitingSdkInput.delete(waiting.id);
+        out.push(unverifiedToolStart(waiting));
+      }
       // Carry the result's text (clipped) so the mission log can show what
       // the tool returned — same contract as the pi backend (HOU-717).
       const content = toolResultText(block.content);
@@ -110,5 +167,12 @@ export function createContentBlockTracker(): ContentBlockTracker {
     return out;
   }
 
-  return { onStreamEvent, onUserMessage };
+  function onTurnEnd(): WireEvent[] {
+    const out = [...awaitingSdkInput.values()].map(unverifiedToolStart);
+    awaitingSdkInput.clear();
+    sdkInputById.clear();
+    return out;
+  }
+
+  return { onStreamEvent, onAssistantMessage, onUserMessage, onTurnEnd };
 }

--- a/packages/runtime/src/backends/claude/translate-support.ts
+++ b/packages/runtime/src/backends/claude/translate-support.ts
@@ -1,4 +1,4 @@
-import type { TokenUsage } from "@houston/runtime-client";
+import type { TokenUsage, WireEvent } from "@houston/runtime-client";
 
 /**
  * Normalize the Claude Agent SDK's token usage into Houston's `TokenUsage`,
@@ -43,45 +43,82 @@ export interface ToolBlock {
 }
 
 /**
- * The model occasionally garbles a `\uXXXX` escape in streamed tool input
- * (e.g. `\u22co` — `o` is not hex), which fails JSON.parse for the WHOLE
- * payload and loses every argument. Rewrite any escape with fewer than 4 hex
- * digits to U+FFFD so the rest of the input survives. Only true escapes
- * match: the leading group asserts an even backslash run before `\u`, so a
- * literal `\\u` in the text is left alone.
+ * The Claude Agent SDK's stand-in for tool input the model streamed as invalid
+ * JSON. The CLI never runs such a call: it hands the model an
+ * `InputValidationError` tool_result and lets it retry, and its `assistant`
+ * message carries this marker in place of the arguments (verified against
+ * claude-agent-sdk 0.3.257 with a fake API — PRODUCT-1694).
  */
-export function repairInvalidUnicodeEscapes(json: string): string {
-  return json.replace(
-    /((?:^|[^\\])(?:\\\\)*)\\u([0-9a-fA-F]{0,3})(?![0-9a-fA-F])/g,
-    "$1\\ufffd",
-  );
+export interface UnparsedToolInputMarker {
+  __unparsedToolInput: { raw?: string; len?: number };
 }
 
-/** Parse a completed tool call's accumulated input; never drops silently. */
-export function parseArgs(tb: ToolBlock): unknown {
-  if (!tb.json) return tb.input ?? {};
+export function isUnparsedToolInput(
+  input: unknown,
+): input is UnparsedToolInputMarker {
+  if (typeof input !== "object" || input === null) return false;
+  if (!("__unparsedToolInput" in input)) return false;
+  const marker = (input as UnparsedToolInputMarker).__unparsedToolInput;
+  return typeof marker === "object" && marker !== null;
+}
+
+export type DeltaParse =
+  | { ok: true; args: unknown }
+  | { ok: false; reason: string };
+
+/** Parse a tool call's accumulated `input_json_delta` fragments. */
+export function parseDeltaJson(tb: ToolBlock): DeltaParse {
+  if (!tb.json) return { ok: true, args: tb.input ?? {} };
   try {
-    return JSON.parse(tb.json);
+    return { ok: true, args: JSON.parse(tb.json) };
   } catch (err) {
-    const repaired = repairInvalidUnicodeEscapes(tb.json);
-    if (repaired !== tb.json) {
-      try {
-        const parsed = JSON.parse(repaired);
-        console.warn(
-          `[claude] repaired invalid \\u escape(s) in tool "${tb.name}" input JSON`,
-        );
-        return parsed;
-      } catch {
-        // Still unparseable — fall through to the loud report below.
-      }
-    }
-    console.error(
-      `[claude] failed to parse tool "${tb.name}" input JSON: ${
-        err instanceof Error ? err.message : String(err)
-      } :: ${tb.json}`,
-    );
-    return {};
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
   }
+}
+
+/**
+ * The tool_start frame for a completed call, from the SDK's own parse of its
+ * input. The unparsed marker means the CLI skipped the call and asked the model
+ * to retry — an expected model glitch, logged as a breadcrumb (console.warn is
+ * never a Sentry event) with the parse reason, and rendered as empty args.
+ */
+export function toolStartFrame(tb: ToolBlock, sdkInput: unknown): WireEvent {
+  let args = sdkInput;
+  if (isUnparsedToolInput(sdkInput)) {
+    const parsed = parseDeltaJson(tb);
+    const reason = parsed.ok ? "rejected by the SDK" : parsed.reason;
+    const len = sdkInput.__unparsedToolInput.len ?? tb.json.length;
+    console.warn(
+      `[claude] tool "${tb.name}" input was not valid JSON (${len} bytes); the SDK skipped the call and asked the model to retry: ${reason}`,
+    );
+    args = {};
+  }
+  return { type: "tool_start", data: { name: tb.name, args } };
+}
+
+/**
+ * A call whose deltas failed to parse and for which the SDK never delivered its
+ * `assistant` block: an unexpected shape, so it IS a reported error.
+ */
+export function unverifiedToolStart(tb: ToolBlock): WireEvent {
+  const parsed = parseDeltaJson(tb);
+  console.error(
+    `[claude] failed to parse tool "${tb.name}" input JSON and the SDK delivered no assistant block for it: ${
+      parsed.ok ? "parsed late" : parsed.reason
+    } :: ${tb.json.slice(0, 500)}`,
+  );
+  return { type: "tool_start", data: { name: tb.name, args: {} } };
+}
+
+/** A `tool_use` block off an SDK `assistant` message (external `BetaContentBlock`). */
+export interface AssistantContentBlock {
+  type?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
 }
 
 /**

--- a/packages/runtime/src/backends/claude/translate.test.ts
+++ b/packages/runtime/src/backends/claude/translate.test.ts
@@ -2,7 +2,6 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { WireEvent } from "@houston/runtime-client";
 import { beforeEach, expect, test, vi } from "vitest";
 import { createStreamTranslator, normalizeUsage } from "./translate";
-import { repairInvalidUnicodeEscapes } from "./translate-support";
 
 beforeEach(() => {
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -83,6 +82,27 @@ function assistantUsage(
     parent_tool_use_id: null,
     ...over,
   } as unknown as SDKMessage;
+}
+
+/** The SDK's `assistant` message for one completed tool_use block. */
+function assistantToolUse(
+  id: string,
+  name: string,
+  input: unknown,
+): SDKMessage {
+  return {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      model: "m",
+      content: [{ type: "tool_use", id, name, input }],
+    },
+    parent_tool_use_id: null,
+  } as unknown as SDKMessage;
+}
+/** What the SDK puts in place of tool input the model streamed as invalid JSON. */
+function unparsedMarker(raw: string): unknown {
+  return { __unparsedToolInput: { raw, len: raw.length } };
 }
 
 function collect(msgs: SDKMessage[]): { events: WireEvent[]; ctx: number[] } {
@@ -197,56 +217,151 @@ test("tool_use: accumulated input_json_delta parses into tool_start args at stop
   ]);
 });
 
-test("a model-garbled \\u escape is repaired instead of dropping the whole tool input", () => {
-  // Real payload shape from prod: Claude streamed `\u22co` — `o` is not hex —
-  // and the parse failure dropped every suggested action for the user.
-  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-  const err = vi.spyOn(console, "error").mockImplementation(() => {});
+test("the SDK's assistant tool_use input is the tool_start args when it precedes the stop", () => {
+  // Observed order on every CLI: the assistant block (with the SDK's parse of
+  // the input) arrives BEFORE our content_block_stop.
   const { events } = collect([
-    toolStart(0, "t1", "mcp__houston__suggest_actions"),
-    jsonDelta(0, '{"actions": [{"label": "Quitar tambi\\u00e9n \\u22co'),
-    jsonDelta(0, 'ALIANZA\\u22cb"}]}'),
+    toolStart(0, "t1", "Read"),
+    jsonDelta(0, '{"file_path":"a.txt"}'),
+    assistantToolUse("t1", "Read", { file_path: "a.txt" }),
     blockStop(0),
   ]);
   expect(events).toEqual([
     {
       type: "tool_start",
-      data: {
-        name: "mcp__houston__suggest_actions",
-        // é and ⋋ are valid and kept; the bad \u22c→ becomes U+FFFD.
-        args: { actions: [{ label: "Quitar también �oALIANZA⋋" }] },
-      },
+      data: { name: "Read", args: { file_path: "a.txt" } },
     },
   ]);
-  expect(warn).toHaveBeenCalled();
+});
+
+test("invalid tool JSON: the SDK's unparsed marker yields args:{} + a warn breadcrumb, never an error (PRODUCT-1694)", () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const err = vi.spyOn(console, "error").mockImplementation(() => {});
+  // Real prod shape: the model closed the payload with one `}` too many. The
+  // CLI never runs the tool; it hands the model an InputValidationError
+  // tool_result and the model retries.
+  const raw =
+    '{"action": "GOOGLEDRIVE_EDIT_FILE", "params": {"file_id": "x"}}}';
+  const { events } = collect([
+    toolStart(0, "t1", "mcp__houston__integration_execute"),
+    jsonDelta(0, raw.slice(0, 30)),
+    jsonDelta(0, raw.slice(30)),
+    assistantToolUse(
+      "t1",
+      "mcp__houston__integration_execute",
+      unparsedMarker(raw),
+    ),
+    blockStop(0),
+    toolResult("t1", true),
+  ]);
+  expect(events).toEqual([
+    {
+      type: "tool_start",
+      data: { name: "mcp__houston__integration_execute", args: {} },
+    },
+    {
+      type: "tool_end",
+      data: { name: "mcp__houston__integration_execute", isError: true },
+    },
+  ]);
+  expect(warn).toHaveBeenCalledTimes(1);
+  expect(String(warn.mock.calls[0]?.[0])).toContain(
+    "Unexpected non-whitespace character",
+  );
   expect(err).not.toHaveBeenCalled();
 });
 
-test("repairInvalidUnicodeEscapes touches only true, malformed escapes", () => {
-  // Valid escapes and literal backslash-u text pass through untouched.
-  expect(repairInvalidUnicodeEscapes('{"a":"\\u00e9 \\\\u22co"}')).toBe(
-    '{"a":"\\u00e9 \\\\u22co"}',
+test("a stop whose deltas fail to parse before the SDK's block arrives waits for it", () => {
+  const err = vi.spyOn(console, "error").mockImplementation(() => {});
+  const t = createStreamTranslator({ onContextTokens: () => {} });
+  const first = [
+    toolStart(0, "t1", "mcp__houston__suggest_actions"),
+    jsonDelta(0, '{"actions": [{"label": "Quitar tambi\\u00e9n \\u22co"}]}'),
+    blockStop(0),
+  ].flatMap((m) => t.translate(m));
+  expect(first).toEqual([]);
+  const settled = t.translate(
+    assistantToolUse("t1", "mcp__houston__suggest_actions", {
+      actions: [{ label: "repaired by the SDK" }],
+    }),
   );
-  // Truncated escape at end of string, and adjacent malformed escapes.
-  expect(repairInvalidUnicodeEscapes('"\\u12')).toBe('"\\ufffd');
-  expect(repairInvalidUnicodeEscapes('"\\uZZ\\uZZ"')).toBe(
-    '"\\ufffdZZ\\ufffdZZ"',
-  );
-  // Malformed escape at position 0 (the ^ alternative).
-  expect(repairInvalidUnicodeEscapes("\\uxy")).toBe("\\ufffdxy");
+  expect(settled).toEqual([
+    {
+      type: "tool_start",
+      data: {
+        name: "mcp__houston__suggest_actions",
+        args: { actions: [{ label: "repaired by the SDK" }] },
+      },
+    },
+  ]);
+  expect(err).not.toHaveBeenCalled();
 });
 
-test("tool_start with unparseable JSON emits args:{} and logs (never a silent drop)", () => {
-  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+test("an assistant tool_use for a block this turn never started (replayed history) is ignored", () => {
+  const { events } = collect([
+    assistantToolUse("old", "Read", { file_path: "history.txt" }),
+    toolStart(0, "t1", "Read"),
+    jsonDelta(0, '{"file_path":"a.txt"}'),
+    blockStop(0),
+  ]);
+  expect(events).toEqual([
+    {
+      type: "tool_start",
+      data: { name: "Read", args: { file_path: "a.txt" } },
+    },
+  ]);
+});
+
+test("a malformed unparsed marker (null payload) still settles to args:{}", () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const { events } = collect([
+    toolStart(0, "t1", "Edit"),
+    jsonDelta(0, "{not json"),
+    assistantToolUse("t1", "Edit", { __unparsedToolInput: null }),
+    blockStop(0),
+  ]);
+  // Not the marker shape → the SDK's input is taken verbatim; nothing throws.
+  expect(events).toEqual([
+    {
+      type: "tool_start",
+      data: { name: "Edit", args: { __unparsedToolInput: null } },
+    },
+  ]);
+  expect(warn).not.toHaveBeenCalled();
+});
+
+test("a tool_result for a call the SDK never verified settles it loudly before the tool_end", () => {
+  const err = vi.spyOn(console, "error").mockImplementation(() => {});
   const { events } = collect([
     toolStart(0, "t9", "Edit"),
     jsonDelta(0, "{not json"),
     blockStop(0),
+    toolResult("t9", true),
   ]);
   expect(events).toEqual([
     { type: "tool_start", data: { name: "Edit", args: {} } },
+    { type: "tool_end", data: { name: "Edit", isError: true } },
   ]);
-  expect(spy).toHaveBeenCalled();
+  expect(err).toHaveBeenCalledTimes(1);
+  expect(String(err.mock.calls[0]?.[0])).toContain(
+    "delivered no assistant block",
+  );
+});
+
+test("the turn result settles an unverified call loudly (never a silent drop)", () => {
+  const err = vi.spyOn(console, "error").mockImplementation(() => {});
+  const { events } = collect([
+    toolStart(0, "t9", "Edit"),
+    jsonDelta(0, "{not json"),
+    blockStop(0),
+    result({ input_tokens: 10, output_tokens: 2 }),
+  ]);
+  expect(events[0]).toEqual({
+    type: "tool_start",
+    data: { name: "Edit", args: {} },
+  });
+  expect(events.map((e) => e.type)).toEqual(["tool_start", "usage"]);
+  expect(err).toHaveBeenCalledTimes(1);
 });
 
 test("tool_result maps to tool_end using the buffered tool_use_id → name map", () => {

--- a/packages/runtime/src/backends/claude/translate.ts
+++ b/packages/runtime/src/backends/claude/translate.ts
@@ -75,9 +75,12 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
     if (!msg.error && msg.parent_tool_use_id === null) {
       usage.noteRequestUsage(msg.message?.usage);
     }
-    if (!msg.error || emittedError) return [];
-    emittedError = true;
+    // The message's tool_use blocks carry the SDK's own parse of each tool's
+    // input — the arguments the tool actually ran with (translate-blocks.ts).
     const content = msg.message?.content;
+    const started = blocks.onAssistantMessage(content);
+    if (!msg.error || emittedError) return started;
+    emittedError = true;
     const text = Array.isArray(content)
       ? content
           .filter((b) => b?.type === "text")
@@ -85,6 +88,7 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
           .join("")
       : "";
     return [
+      ...started,
       {
         type: "provider_error",
         data: mapSdkError(msg.error, {
@@ -98,7 +102,7 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
   }
 
   function onResult(msg: ResultMsg): WireEvent[] {
-    const out: WireEvent[] = [];
+    const out: WireEvent[] = blocks.onTurnEnd();
     const turnUsage = usage.turnUsage(msg.usage);
     if (turnUsage) out.push({ type: "usage", data: turnUsage });
     if (msg.subtype !== "success" && !emittedError) {


### PR DESCRIPTION
## Summary

Fixes PRODUCT-1694 (Sentry HOUSTON-APP-4ZA, 75 users / 181 events): `[claude] failed to parse tool "mcp__houston__integration_execute" input JSON`.

**Root cause.** The Claude translator re-parsed every tool call's `input_json_delta` bytes itself and `console.error`'d (a Sentry event) when `JSON.parse` failed. The model does stream invalid tool JSON now and then: a stray `}`, a `)` for a `}`, an unescaped quote inside an HTML email body, a raw control character. 38 of the last 60 events were `integration_execute` payloads (Gmail bodies, base64 files); the rest were `suggest_actions`, `ask_user`, `Read`, `Write`, `Edit`. Nothing in Houston produces the bad bytes.

Claude Code already handles that state. Verified against `@anthropic-ai/claude-agent-sdk` 0.3.257 by spawning the real CLI against a fake `ANTHROPIC_BASE_URL` that streams malformed tool JSON, with an in-process MCP tool that logs its args:

- The CLI never runs the tool. Its `assistant` message carries `input: { __unparsedToolInput: { raw, len } }` in place of the arguments, and it feeds the model an `InputValidationError ... Retry with valid JSON` tool_result, so the model retries.
- The SDK's `assistant` message for a block arrives BEFORE our `content_block_stop` stream event, for valid, truncated and control-character inputs alike.

So the Sentry error reported a state upstream had already resolved, and Houston's own parse could never disagree usefully with the CLI's.

**Fix.** `translate-blocks.ts` takes `tool_start` args from the SDK's assistant block when it has arrived (the arguments the tool actually ran with) and only falls back to its own delta parse otherwise. The unparsed marker is an expected state: a `console.warn` breadcrumb (never a Sentry event) naming the tool, byte length and parse reason, rendered as empty args (the feed keeps showing the failed attempt followed by the model's retry, as today). A stop whose deltas fail to parse before the SDK's block arrives waits for it; only a verdict that never comes (settled on the tool_result or the turn result) is still a `console.error`, with a new message so a re-file is distinguishable. SDK inputs are only accepted for blocks this turn streamed, and the maps clear at turn end.

The PRODUCT-1589 unicode-escape repair is retired: it only ever repaired the feed's display while the CLI had already refused the call (chips come from the MCP tool call, not from `tool_start` args).

## Verification

Before (main): run the translator against the real prod payload shape and it logs an error.

```ts
// packages/runtime/src/backends/claude/translate.test.ts on main
collect([toolStart(0,"t1","mcp__houston__integration_execute"),
  jsonDelta(0,'{"action":"X","params":{}}}'), blockStop(0)]);
// → console.error "[claude] failed to parse tool ... Unexpected non-whitespace character after JSON"
```

After (this branch):

```
pnpm --filter @houston/runtime test src/backends/claude/translate.test.ts   # 26 pass
pnpm --filter @houston/runtime test                                          # 2093 pass
pnpm check                                                                   # exit 0
```

New tests cover: SDK input preceding the stop wins; the unparsed marker → `args: {}` + one warn, no error; a stop that fails before the SDK block waits for it; a tool_result or turn result for a never-verified call settles it loudly; replayed-history blocks are ignored; a `null` marker payload does not throw.

End-to-end check after deploy: Sentry issue 4ZA gets no new events on the fixed engine sha; the engine log shows `[claude] tool "<name>" input was not valid JSON (<n> bytes); the SDK skipped the call and asked the model to retry: <reason>` lines instead. A new event titled `... the SDK delivered no assistant block for it` would be a genuinely new shape worth a ticket.

Fake-API reproduction (run from `packages/runtime`): spawn `query()` from `@anthropic-ai/claude-agent-sdk` with `env: { ANTHROPIC_API_KEY: "sk-test", ANTHROPIC_BASE_URL: <local http server> }`, `includePartialMessages: true`, an in-process `createSdkMcpServer` tool that logs its args, and serve SSE `input_json_delta` frames whose concatenation is `{"action": "X", "params": {}}}`; the handler never runs and the `user` tool_result carries the InputValidationError text.
