### PR TITLE
fix(runtime): stall abort surfaces the typed stall card, boot settle never repeats a turn (PRODUCT-1778)

### DIFF
--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -73,7 +73,7 @@ import {
 import { reportMissionSettle } from "./mission-settle";
 import { switchNeedsCompaction } from "./provider-switch";
 import { renderReplayPreamble, replayCharBudget } from "./replay-transcript";
-import { createStallWatchdog } from "./stall-watchdog";
+import { createStallWatchdog, isAbortEcho } from "./stall-watchdog";
 import {
   clearInflightMarker,
   noteInflightTool,
@@ -229,6 +229,14 @@ export async function execTurn(
     timeoutMs: config.turnStallTimeoutMs,
     onStall: () => {
       stalled = true;
+      // The only log line a watchdog cut leaves: pi's echo below is logged as
+      // an ordinary (expected) provider_error, so without this a 300 s gap in
+      // the tool log is the sole clue that the turn was aborted here.
+      console.warn(
+        `[turn] stall watchdog aborted the turn: no provider event for ${Math.round(
+          config.turnStallTimeoutMs / 1000,
+        )}s (conversation=${id} turn=${turnId})`,
+      );
       // Fire-and-forget: the awaited prompt() resolves once pi unwinds the
       // aborted stream; that resolution, not this call, advances the turn.
       void conv.session.abort();
@@ -279,7 +287,19 @@ export async function execTurn(
           // Already clipped at the backend — persist for reload replay.
           if (wire.data.content) t.result = wire.data.content;
         }
-      } else if (wire.type === "provider_error") providerError = wire.data;
+      } else if (wire.type === "provider_error") {
+        // Our OWN abort (the watchdog's, or the user's Stop), echoed back by
+        // pi as an unclassifiable error: drop it, never publish it. The turn's
+        // surface is the synthesized "stopped responding" card after prompt()
+        // resolves, or the "Stopped by user" frame cancelTurn already sent
+        // (stall-watchdog.ts, PRODUCT-1778).
+        if (
+          (stalled || conv.stoppedTurnId === turnId) &&
+          isAbortEcho(wire.data)
+        )
+          return;
+        providerError = wire.data;
+      }
       // Every event proves the provider is alive → reset the stall clock (the
       // watchdog suspends itself while a tool runs and re-arms when it ends).
       watchdog.onEvent(wire);

--- a/packages/runtime/src/session/settle-interrupted-turns.test.ts
+++ b/packages/runtime/src/session/settle-interrupted-turns.test.ts
@@ -128,6 +128,73 @@ describe("settleInterruptedTurns", () => {
     expect(report).not.toHaveBeenCalled();
   });
 
+  it("a marker re-delivered for a turn already settled writes no second reply and reports nothing (PRODUCT-1778)", () => {
+    const { dataDir, write, read } = seed();
+    // The replacement pod settled this turn on its first boot; the evicted pod,
+    // still draining the same turn, then re-shipped the marker through the
+    // store sync. The next boot finds the marker AND the reply it already wrote.
+    write("moved", [
+      { role: "user", content: "render it", ts: 1, turnId: "t-moved" },
+      {
+        role: "assistant",
+        content: "",
+        ts: 2,
+        turnId: "t-moved",
+        interrupted: { cause: "engine_restart", tool: "read" },
+      },
+    ]);
+    writeInflightMarker(dataDir, {
+      conversationId: "moved",
+      turnId: "t-moved",
+      startedAt: 0,
+      tool: "bash",
+      fenced: true,
+    });
+    const report = vi.fn();
+    const settleMission = vi.fn();
+    const settled = settleInterruptedTurns({
+      dataDir,
+      report,
+      settleMission,
+    });
+    expect(settled).toEqual([]);
+    expect(report).not.toHaveBeenCalled();
+    expect(settleMission).not.toHaveBeenCalled();
+    expect(
+      read("moved").messages.filter((m) => m.interrupted !== undefined),
+    ).toHaveLength(1);
+    expect(listInflightMarkers(dataDir)).toEqual([]);
+  });
+
+  it("a marker for a NEW turn on a conversation with an older interrupted reply still settles", () => {
+    const { dataDir, write, read } = seed();
+    write("again", [
+      { role: "user", content: "first", ts: 1, turnId: "t-old" },
+      {
+        role: "assistant",
+        content: "",
+        ts: 2,
+        turnId: "t-old",
+        interrupted: { cause: "engine_restart" },
+      },
+      { role: "user", content: "continue", ts: 3, turnId: "t-new" },
+    ]);
+    writeInflightMarker(dataDir, {
+      conversationId: "again",
+      turnId: "t-new",
+      startedAt: 0,
+      fenced: false,
+    });
+    const report = vi.fn();
+    settleInterruptedTurns({ dataDir, report, settleMission: () => {} });
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(read("again").messages.at(-1)).toMatchObject({
+      role: "assistant",
+      turnId: "t-new",
+      interrupted: { cause: "engine_restart" },
+    });
+  });
+
   it("a second boot after the settle is quiet (idempotent)", () => {
     const { dataDir, write, read } = seed();
     write("once", [{ role: "user", content: "go", ts: 1, turnId: "t-once" }]);

--- a/packages/runtime/src/session/settle-interrupted-turns.ts
+++ b/packages/runtime/src/session/settle-interrupted-turns.ts
@@ -1,5 +1,8 @@
 import { join } from "node:path";
-import { appendAssistantMessageAt } from "../store/conversation-file";
+import {
+  appendAssistantMessageAt,
+  loadConversation,
+} from "../store/conversation-file";
 import { reportMissionSettle } from "./mission-settle";
 import {
   clearInflightMarker,
@@ -82,6 +85,16 @@ export function settleInterruptedTurns(
   const conversationsDir = join(opts.dataDir, "conversations");
   const settled: InflightTurnMarker[] = [];
   for (const marker of listInflightMarkers(opts.dataDir)) {
+    // A marker for a turn this conversation already carries an interrupted
+    // reply for is a re-delivery, not a second death: on a managed pod the
+    // replacement boots while the evicted pod is still draining the turn, and
+    // that pod's store sync re-ships the marker the replacement just cleared.
+    // The next boot found it again and wrote a second "had to restart" line
+    // for the one turn (PRODUCT-1778). Drop the marker, settle nothing twice.
+    if (alreadySettled(conversationsDir, marker)) {
+      clearInflightMarker(opts.dataDir, marker.conversationId);
+      continue;
+    }
     // The reply first, the marker last: a crash between the two re-settles
     // (a second `interrupted` reply) rather than losing the settle. A missing
     // conversation (deleted while the turn ran) has nothing to settle into;
@@ -107,4 +120,19 @@ export function settleInterruptedTurns(
     settled.push(marker);
   }
   return settled;
+}
+
+function alreadySettled(
+  conversationsDir: string,
+  marker: InflightTurnMarker,
+): boolean {
+  const conv = loadConversation(conversationsDir, marker.conversationId);
+  return (
+    conv?.messages.some(
+      (m) =>
+        m.role === "assistant" &&
+        m.turnId === marker.turnId &&
+        m.interrupted !== undefined,
+    ) ?? false
+  );
 }

--- a/packages/runtime/src/session/stall-watchdog.test.ts
+++ b/packages/runtime/src/session/stall-watchdog.test.ts
@@ -1,6 +1,6 @@
 import type { WireEvent } from "@houston/runtime-client";
 import { afterEach, expect, test, vi } from "vitest";
-import { createStallWatchdog } from "./stall-watchdog";
+import { createStallWatchdog, isAbortEcho } from "./stall-watchdog";
 
 /**
  * The stall watchdog is the stalled-provider backstop: it fires `onStall` when a turn's
@@ -157,4 +157,29 @@ test("touch never re-arms the clock while a tool is running", () => {
   wd.onEvent(toolEnd("bash"));
   vi.advanceTimersByTime(1000);
   expect(stalls).toBe(1);
+});
+
+test("isAbortEcho matches only pi's echo of an abort, never a real provider failure", () => {
+  expect(
+    isAbortEcho({
+      kind: "unknown",
+      provider: "azure-openai-responses",
+      raw_excerpt: "This operation was aborted",
+    }),
+  ).toBe(true);
+  expect(
+    isAbortEcho({
+      kind: "unknown",
+      provider: "azure-openai-responses",
+      raw_excerpt: "The server had an error processing your request.",
+    }),
+  ).toBe(false);
+  expect(
+    isAbortEcho({
+      kind: "provider_internal",
+      provider: "azure-openai-responses",
+      http_status: null,
+      message: "This operation was aborted",
+    }),
+  ).toBe(false);
 });

--- a/packages/runtime/src/session/stall-watchdog.ts
+++ b/packages/runtime/src/session/stall-watchdog.ts
@@ -1,4 +1,23 @@
-import type { WireEvent } from "@houston/runtime-client";
+import type { ProviderError, WireEvent } from "@houston/runtime-client";
+
+/**
+ * Whether a provider_error frame is our OWN abort coming back: pi does not
+ * resolve an aborted request as a neutral `aborted` turn when the abort lands
+ * while the response is still pending — it ends the assistant message with
+ * stopReason `error` and the AbortError's text ("This operation was aborted")
+ * as the reason, which the classifier can only call `unknown`. Letting that
+ * frame stand painted "Houston could not classify this Azure OpenAI error"
+ * over a turn the watchdog cut for silence (PRODUCT-1778); the turn's honest
+ * surface is the synthesized "stopped responding" card (or, for a user Stop,
+ * the "Stopped by user" frame). Only ever consulted for an abort THIS turn
+ * issued — a genuine provider abort on an untouched turn still surfaces.
+ */
+export function isAbortEcho(error: ProviderError): boolean {
+  return (
+    error.kind === "unknown" &&
+    /operation was aborted/i.test(error.raw_excerpt ?? "")
+  );
+}
 
 /**
  * Guards a turn's model round-trip against a provider that goes silent — an SSE

--- a/packages/runtime/src/session/turn-resilience.test.ts
+++ b/packages/runtime/src/session/turn-resilience.test.ts
@@ -94,6 +94,49 @@ class StallSession implements HarnessSession {
   }
 }
 
+/** pi's REAL shape for a watchdog abort that lands while the response is still
+ *  pending: the request's AbortError comes back as an errored assistant turn,
+ *  which the wire classifies as an `unknown` provider_error ("This operation
+ *  was aborted") BEFORE prompt() resolves. Emits nothing until then. */
+class StallEchoSession implements HarnessSession {
+  aborted = false;
+  private listeners = new Set<(e: WireEvent) => void>();
+  private resolvePrompt: (() => void) | undefined;
+  subscribe(l: (e: WireEvent) => void): () => void {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+  prompt(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.resolvePrompt = resolve;
+    });
+  }
+  async abort(): Promise<void> {
+    this.aborted = true;
+    for (const l of this.listeners)
+      l({
+        type: "provider_error",
+        data: {
+          kind: "unknown",
+          provider: "azure-openai-responses",
+          raw_excerpt: "This operation was aborted",
+        },
+      });
+    this.resolvePrompt?.();
+  }
+  dispose(): void {
+    this.listeners.clear();
+  }
+  async setModel(): Promise<void> {}
+  async compact(): Promise<undefined> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 100 };
+  }
+}
+
 /** A session whose model spends longer than the stall window streaming a tool
  *  call's INPUT — pure toolcall_delta traffic, which maps to no WireEvent — and
  *  then answers. Only the liveness channel ticks during that stretch. */
@@ -222,6 +265,41 @@ test("a turn whose provider goes silent is aborted at the stall window and surfa
   expect(events.some((e) => e.type === "done")).toBe(false);
 });
 
+test("a stalled turn whose abort echoes back as an unclassifiable provider error still surfaces the typed stall card, once (PRODUCT-1778)", async () => {
+  vi.useFakeTimers();
+  state.model = OPENAI;
+  const session = new StallEchoSession();
+  const conv = convWith(session);
+  appendUserMessage("conv-stall-echo", "hi", { turnId: "turn-echo" });
+
+  const events: WireEvent[] = [];
+  const unsub = subscribe("conv-stall-echo", (e) => events.push(e));
+  const done = execTurn(conv, "conv-stall-echo", "turn-echo", "hi", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  await vi.advanceTimersByTimeAsync(0);
+  await vi.advanceTimersByTimeAsync(STALL_MS);
+  await done;
+  unsub();
+
+  expect(session.aborted).toBe(true);
+  const errors = events.filter(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+  // Exactly one card, and it is the honest one: "stopped responding", not
+  // "Houston could not classify this Azure OpenAI error / This operation was
+  // aborted" (the echo of our own abort).
+  expect(errors).toHaveLength(1);
+  expect(errors[0]?.data.kind).toBe("provider_internal");
+  expect(events.some((e) => e.type === "done")).toBe(false);
+  // The persisted reply carries the same typed error, so a reload agrees.
+  const messages = getHistory("conv-stall-echo")?.messages ?? [];
+  expect(messages.at(-1)?.providerError?.kind).toBe("provider_internal");
+});
+
 test("a turn streaming a long tool input (wire-silent, liveness ticking) is never aborted as stalled (PRODUCT-1632)", async () => {
   vi.useFakeTimers();
   state.model = OPENAI;
@@ -280,6 +358,36 @@ test("a turn both stalled AND stopped settles as a user stop, never a synthesize
   // The persisted message records the stop and carries NO provider error.
   const messages = getHistory("conv-stall-stop")?.messages ?? [];
   const last = messages[messages.length - 1];
+  expect(last?.stopped).toBe(true);
+  expect(last?.providerError).toBeUndefined();
+});
+
+test("a user-stopped turn whose abort echoes back as an unclassifiable provider error settles as a plain stop (PRODUCT-1778)", async () => {
+  vi.useFakeTimers();
+  state.model = OPENAI;
+  const session = new StallEchoSession();
+  const conv = convWith(session);
+  (conv as { stoppedTurnId?: string }).stoppedTurnId = "turn-stop-echo";
+  appendUserMessage("conv-stop-echo", "hi", { turnId: "turn-stop-echo" });
+
+  const events: WireEvent[] = [];
+  const unsub = subscribe("conv-stop-echo", (e) => events.push(e));
+  const done = execTurn(conv, "conv-stop-echo", "turn-stop-echo", "hi", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  await vi.advanceTimersByTimeAsync(0);
+  // cancelTurn's abort resolves the pending prompt() the same way; pi echoes
+  // the AbortError as an errored turn first.
+  await session.abort();
+  await done;
+  unsub();
+
+  // No red card over the stop: not the echo, not a synthesized stall error.
+  expect(events.some((e) => e.type === "provider_error")).toBe(false);
+  expect(events.some((e) => e.type === "done")).toBe(false);
+  const last = (getHistory("conv-stop-echo")?.messages ?? []).at(-1);
   expect(last?.stopped).toBe(true);
   expect(last?.providerError).toBeUndefined();
 });


### PR DESCRIPTION
## Summary

PRODUCT-1778 (agent "marketing" / Personal/Marketing Manager, org `af7f7acbd3ebbf75`). Two things happened to this user today and neither was memory: the pod has the 3Gi limit, `memory.events` shows zero OOM kills, and the kernel victim lists for the failure window contain no process from this pod.

**Symptom 1: "Houston could not classify this Azure OpenAI error / Raw output: This operation was aborted".** The pi session transcript shows tool results landing at 19:03:16Z and then nothing from Azure gpt-6-astra until the stall watchdog fired at 19:08:16Z (exactly 300 s, `HOUSTON_TURN_STALL_TIMEOUT_MS`). pi does not resolve an abort that lands while the response is still pending as a neutral `aborted` turn: it ends the assistant message with stopReason `error` and the AbortError text as the reason, which the classifier can only call `unknown`. That frame was published to the client and set `providerError` before the synthesized "The AI provider stopped responding (no response for 300s)" card could run (`stalled && !providerError`), so the honest card never appeared. The runtime also left no log line for the cut; the only clue was the 300 s gap in the tool log.

**Symptom 2: "Your agent had to restart" (twice for one turn).** A GKE node-pool auto-upgrade (`UPGRADE_NODES` on `primary-n4-nv`, started 19:56Z) drained every node in turn. The pod got SIGTERM at 20:08:13Z mid-turn; the runtime drained for the full 480 s in the old pod, but the ReplicaSet booted a replacement one second later, which found the in-flight marker and settled the turn as interrupted. The evicted pod's store sync then re-shipped the marker it had kept alive, so the next replacement (second eviction, 20:36:57Z) settled the same turn again and Sentry got a second `EngineRestartedMidTurnError` for a pod that never ran it.

## Changes

- `stall-watchdog.ts`: `isAbortEcho()` recognises pi's echo of our own abort (`kind=unknown`, "operation was aborted").
- `exec-turn.ts`: when the turn was stalled (or the user stopped it) and the provider_error frame is that echo, drop it: never published, never persisted. The synthesized `provider_internal` stall card (or the "Stopped by user" frame) is the turn's only surface. The watchdog now logs `[turn] stall watchdog aborted the turn: no provider event for Ns`.
- `settle-interrupted-turns.ts`: a marker for a turn whose conversation already carries an interrupted reply is a re-delivery, not a second death: the marker clears, nothing is appended or reported.

Not in this PR (cloud/infra, flagged in the Linear issue): the node upgrade itself. Agent pods have no PDB and a 600 s termination grace, so any turn longer than the drain budget dies under a node drain regardless of what the engine does.

## Verification

Before the fix (reproduces on `main`):
1. Run a turn on a pi provider and make the stream go silent for longer than `HOUSTON_TURN_STALL_TIMEOUT_MS` while the response is pending (the new `StallEchoSession` in `turn-resilience.test.ts` models pi's exact shape). The chat shows the red "could not classify this … error / This operation was aborted" card; the persisted assistant message carries `providerError.kind = "unknown"`.
2. Write an in-flight marker for a turn whose conversation already has an `interrupted` assistant reply (the new settle test) and boot: a second "had to restart" reply is appended and a second Sentry report fires.

After the fix:
1. Same silent stream: exactly one provider_error frame, `kind = "provider_internal"` ("The AI provider stopped responding (no response for 300s)"), the persisted message matches, and the runtime log carries the `stall watchdog aborted the turn` line.
2. Same re-delivered marker: the marker clears, no reply is appended, no report is sent; a marker for a NEW turn on the same conversation still settles.

```
pnpm --filter @houston/runtime test   # 2099 passed, 1 skipped
pnpm --filter @houston/runtime typecheck
pnpm check
```
The new stall-echo test fails on `main` (`expected 'unknown' to be 'provider_internal'`) and passes with the fix.
